### PR TITLE
Add AWS_SESSION_TOKEN support

### DIFF
--- a/aws/auth.go
+++ b/aws/auth.go
@@ -26,6 +26,11 @@ var (
 // EnvCreds returns the AWS credentials from the process's environment, or an
 // error if none are found.
 func EnvCreds() (Credentials, error) {
+	token := os.Getenv("AWS_SESSION_TOKEN")
+	if token != "" {
+		return Creds("", "", os.Getenv("AWS_SESSION_TOKEN")), nil
+	}
+
 	id := os.Getenv("AWS_ACCESS_KEY_ID")
 	if id == "" {
 		id = os.Getenv("AWS_ACCESS_KEY")
@@ -44,7 +49,7 @@ func EnvCreds() (Credentials, error) {
 		return nil, ErrSecretAccessKeyNotFound
 	}
 
-	return Creds(id, secret, ""), nil
+	return Creds(id, secret, token), nil
 }
 
 // Creds returns a static set of credentials.

--- a/aws/auth_test.go
+++ b/aws/auth_test.go
@@ -1,0 +1,37 @@
+package aws
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnvAuth(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("AWS_SECRET_KEY", "secret")
+	os.Setenv("AWS_ACCESS_KEY", "access")
+	auth, err := EnvCreds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.SecretAccessKey() != "secret" {
+		t.Fatalf("Expected secret key 'secret', got %s.", auth.SecretAccessKey())
+	}
+	if auth.AccessKeyID() != "access" {
+		t.Fatalf("Expected access key 'access', got %s.", auth.AccessKeyID())
+	}
+	if auth.SecurityToken() != "" {
+		t.Fatalf("Expected security token '', got %s.", auth.SecurityToken())
+	}
+}
+
+func TestEnvAuthWithOnlySecurityToken(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("AWS_SESSION_TOKEN", "token")
+	auth, err := EnvCreds()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.SecurityToken() != "token" {
+		t.Fatalf("Expected security token 'token', got %s.", auth.SecurityToken())
+	}
+}


### PR DESCRIPTION
We use MFA access only @ Simple, so we need dis to get started.
- if AWS_SESSION_TOKEN is set, just use that.
- wrote a test.

Fixes https://github.com/stripe/aws-go/issues/4.
