### PR TITLE
Handle slices in loadValues

### DIFF
--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -81,6 +81,15 @@ func (c *EC2Client) loadValues(v url.Values, i interface{}, prefix string) error
 		value = value.Elem()
 	}
 
+	if value.Kind() == reflect.Slice {
+		for i := 0; i < value.Len(); i++ {
+			if err := c.loadValues(v, value.Index(i), prefix); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	return c.loadStruct(v, value, prefix)
 }
 


### PR DESCRIPTION
Fixes following panic on RunInstances call, and others that have none `string` slices

panic: reflect: call of reflect.Value.NumField on slice Value [recovered]
    panic: reflect: call of reflect.Value.NumField on slice Value

goroutine 7 [running]:
testing.func·006()
    /home/ortutay/go/src/testing/testing.go:441 +0x181
reflect.flag.mustBe(0x57, 0x19)
    /home/ortutay/go/src/reflect/value.go:195 +0xb8
reflect.Value.NumField(0x68bc40, 0xc20801e660, 0x57, 0x7f6517372968)
    /home/ortutay/go/src/reflect/value.go:1117 +0x31
github.com/stripe/aws-go/aws.(_EC2Client).loadStruct(0xc208030300, 0xc20803d080, 0x68bc40, 0xc20801e660, 0x57, 0x84e795, 0x12, 0x0, 0x0)
    /home/ortutay/gocode/src/github.com/stripe/aws-go/aws/ec2.go:95 +0x3d9
github.com/stripe/aws-go/aws.(_EC2Client).loadValues(0xc208030300, 0xc20803d080, 0x68bc40, 0xc20801e660, 0x84e795, 0x12, 0x0, 0x0)
    /home/ortutay/gocode/src/github.com/stripe/aws-go/aws/ec2.go:84 +0xfd
github.com/stripe/aws-go/aws.(_EC2Client).loadStruct(0xc208030300, 0xc20803d080, 0x78ece0, 0xc20805c300, 0xd9, 0x0, 0x0, 0x0, 0x0)
    /home/ortutay/gocode/src/github.com/stripe/aws-go/aws/ec2.go:137 +0xdcb
github.com/stripe/aws-go/aws.(_EC2Client).loadValues(0xc208030300, 0xc20803d080, 0x680a20, 0xc20805c300, 0x0, 0x0, 0x0, 0x0)
    /home/ortutay/gocode/src/github.com/stripe/aws-go/aws/ec2.go:84 +0xfd
github.com/stripe/aws-go/aws.(_EC2Client).Do(0xc208030300, 0x7c3830, 0xc, 0x7aa7f0, 0x4, 0x7a5d30, 0x1, 0x680a20, 0xc20805c300, 0x680300, ...)
    /home/ortutay/gocode/src/github.com/stripe/aws-go/aws/ec2.go:25 +0x232
github.com/stripe/aws-go/gen/ec2.(_EC2).RunInstances(0xc20802c070, 0xc20805c300, 0xc20802e690, 0x0, 0x0)
    /home/ortutay/gocode/src/github.com/stripe/aws-go/gen/ec2/ec2.go:1967 +0xea
