### PR TITLE
Name of a member should not go into struct tags

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -140,8 +140,6 @@ func (m Member) QueryTag(wrapper string) string {
 
 	if m.LocationName != "" {
 		path = append(path, m.LocationName)
-	} else {
-		path = append(path, m.Name)
 	}
 
 	if m.Shape().ShapeType == "list" {


### PR DESCRIPTION
The current XML struct tag of sqs.ReceiveMessageResult.Messages is wrong
`xml:"ReceiveMessageResult>Messages>Message"` when it should be
`xml:"ReceiveMessageResult>Message"`.
The cause of this bug is due to the incorrect inclusion of Name in the
generated model struct tags.
