### PR TITLE
Don't require a session token for profile creds.

### DIFF
--- a/aws/auth.go
+++ b/aws/auth.go
@@ -171,10 +171,7 @@ func (p *profileProvider) Credentials() (*Credentials, error) {
 		return nil, errors.NotFoundf("profile %s in %s did not contain aws_secret_access_key", p.profile, p.filename)
 	}
 
-	securityToken, ok := profile["aws_session_token"]
-	if !ok {
-		return nil, errors.NotFoundf("profile %s in %s did not contain aws_session_token", p.profile, p.filename)
-	}
+	securityToken := profile["aws_session_token"]
 
 	p.creds = Credentials{
 		AccessKeyID:     accessKeyID,

--- a/aws/auth_test.go
+++ b/aws/auth_test.go
@@ -152,6 +152,30 @@ func TestProfileCreds(t *testing.T) {
 	}
 }
 
+func TestProfileCredsWithoutToken(t *testing.T) {
+	prov, err := ProfileCreds("example.ini", "no_token", 10*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := prov.Credentials()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, want := creds.AccessKeyID, "accessKey"; v != want {
+		t.Errorf("AcccessKeyID was %v, but expected %v", v, want)
+	}
+
+	if v, want := creds.SecretAccessKey, "secret"; v != want {
+		t.Errorf("SecretAccessKey was %v, but expected %v", v, want)
+	}
+
+	if v, want := creds.SecurityToken, ""; v != want {
+		t.Errorf("SecurityToken was %v, but expected %v", v, want)
+	}
+}
+
 func BenchmarkProfileCreds(b *testing.B) {
 	prov, err := ProfileCreds("example.ini", "", 10*time.Minute)
 	if err != nil {

--- a/aws/example.ini
+++ b/aws/example.ini
@@ -2,3 +2,7 @@
 aws_access_key_id = accessKey
 aws_secret_access_key = secret
 aws_session_token = token
+
+[no_token]
+aws_access_key_id = accessKey
+aws_secret_access_key = secret


### PR DESCRIPTION
If `aws.ProfileCreds()` is meant to support the file created by awscli's `aws configure` I don't think a session token should be required.
