### PR TITLE
Encode time.Time fields as ISO8601 in UTC

### DIFF
--- a/aws/query.go
+++ b/aws/query.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // QueryClient is the underlying client for Query APIs.
@@ -201,6 +202,11 @@ func (c *QueryClient) loadValue(v url.Values, value reflect.Value, name string) 
 	case FloatValue:
 		if casted != nil {
 			v.Set(name, strconv.FormatFloat(float64(*casted), 'f', -1, 32))
+		}
+	case time.Time:
+		if !casted.IsZero() {
+			const ISO8601UTC = "2006-01-02T15:04:05Z"
+			v.Set(name, casted.UTC().Format(ISO8601UTC))
 		}
 	case []string:
 		if len(casted) != 0 {

--- a/aws/query_test.go
+++ b/aws/query_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stripe/aws-go/aws"
 )
@@ -56,6 +57,7 @@ func TestQueryRequest(t *testing.T) {
 		PresentLong:        aws.Long(2),
 		PresentDouble:      aws.Double(1.2),
 		PresentFloat:       aws.Float(2.3),
+		PresentTime:        time.Date(2001, 1, 1, 2, 1, 1, 0, time.FixedZone("UTC+1", 3600)),
 		PresentSlice:       []string{"one", "two"},
 		PresentStruct:      &EmbeddedStruct{Value: aws.String("v")},
 		PresentStructSlice: []EmbeddedStruct{{Value: aws.String("p")}},
@@ -101,6 +103,7 @@ func TestQueryRequest(t *testing.T) {
 		"PresentLong":                       []string{"2"},
 		"PresentDouble":                     []string{"1.2"},
 		"PresentFloat":                      []string{"2.3"},
+		"PresentTime":                       []string{"2001-01-01T01:01:01Z"},
 		"PresentSlice.member.1":             []string{"one"},
 		"PresentSlice.member.2":             []string{"two"},
 		"PresentStruct.Value":               []string{"v"},
@@ -207,6 +210,9 @@ type fakeQueryRequest struct {
 
 	PresentBoolean aws.BooleanValue `xml:"PresentBoolean"`
 	MissingBoolean aws.BooleanValue `xml:"MissingBoolean"`
+
+	PresentTime time.Time `xml:"PresentTime"`
+	MissingTime time.Time `xml:"MissingTime"`
 
 	PresentSlice []string `xml:"PresentSlice"`
 	MissingSlice []string `xml:"MissingSlice"`


### PR DESCRIPTION
CloudWatch requires time.Time fields ISO8601. Other APIs may require
different encodings not covered in this commit.

time.Time.IsZero() is used to check for presence of the field instead of
reflect.Value.IsValid() because the latter returns true for time.Time
zero values.

Time zone conversion to UTC is covered in the date choices in
query_test.go.

Fixes #27
