### PR TITLE
Fix XMLName conflicts

### DIFF
--- a/aws/xml.go
+++ b/aws/xml.go
@@ -25,8 +25,17 @@ func MarshalXML(v interface{}, e *xml.Encoder, start xml.StartElement) error {
 		// detect xml.Name, if any
 		for i := 0; i < value.NumField(); i++ {
 			f := t.Field(i)
+			v := value.Field(i)
 			if f.Type == xmlName {
 				rootInfo = parseXMLTag(f.Tag.Get("xml"))
+				if rootInfo.name == "" {
+					// name not in tag, try value
+					name := v.Interface().(xml.Name)
+					rootInfo = xmlFieldInfo{
+						name: name.Local,
+						ns:   name.Space,
+					}
+				}
 			}
 		}
 

--- a/gen/cloudfront/cloudfront.go
+++ b/gen/cloudfront/cloudfront.go
@@ -58,6 +58,12 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentity(req *CreateCloudFrontO
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.CloudFrontOriginAccessIdentityConfig.XMLName = xml.Name{
+		Space: "http://cloudfront.amazonaws.com/doc/2014-10-21/",
+		Local: "CloudFrontOriginAccessIdentityConfig",
+	}
+
 	b, err := xml.Marshal(req.CloudFrontOriginAccessIdentityConfig)
 	if err != nil {
 		return
@@ -115,6 +121,12 @@ func (c *CloudFront) CreateDistribution(req *CreateDistributionRequest) (resp *C
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.DistributionConfig.XMLName = xml.Name{
+		Space: "http://cloudfront.amazonaws.com/doc/2014-10-21/",
+		Local: "DistributionConfig",
+	}
+
 	b, err := xml.Marshal(req.DistributionConfig)
 	if err != nil {
 		return
@@ -172,6 +184,12 @@ func (c *CloudFront) CreateInvalidation(req *CreateInvalidationRequest) (resp *C
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.InvalidationBatch.XMLName = xml.Name{
+		Space: "http://cloudfront.amazonaws.com/doc/2014-10-21/",
+		Local: "InvalidationBatch",
+	}
+
 	b, err := xml.Marshal(req.InvalidationBatch)
 	if err != nil {
 		return
@@ -228,6 +246,12 @@ func (c *CloudFront) CreateStreamingDistribution(req *CreateStreamingDistributio
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.StreamingDistributionConfig.XMLName = xml.Name{
+		Space: "http://cloudfront.amazonaws.com/doc/2014-10-21/",
+		Local: "StreamingDistributionConfig",
+	}
+
 	b, err := xml.Marshal(req.StreamingDistributionConfig)
 	if err != nil {
 		return
@@ -950,6 +974,12 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentity(req *UpdateCloudFrontO
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.CloudFrontOriginAccessIdentityConfig.XMLName = xml.Name{
+		Space: "http://cloudfront.amazonaws.com/doc/2014-10-21/",
+		Local: "CloudFrontOriginAccessIdentityConfig",
+	}
+
 	b, err := xml.Marshal(req.CloudFrontOriginAccessIdentityConfig)
 	if err != nil {
 		return
@@ -1010,6 +1040,12 @@ func (c *CloudFront) UpdateDistribution(req *UpdateDistributionRequest) (resp *U
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.DistributionConfig.XMLName = xml.Name{
+		Space: "http://cloudfront.amazonaws.com/doc/2014-10-21/",
+		Local: "DistributionConfig",
+	}
+
 	b, err := xml.Marshal(req.DistributionConfig)
 	if err != nil {
 		return
@@ -1070,6 +1106,12 @@ func (c *CloudFront) UpdateStreamingDistribution(req *UpdateStreamingDistributio
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.StreamingDistributionConfig.XMLName = xml.Name{
+		Space: "http://cloudfront.amazonaws.com/doc/2014-10-21/",
+		Local: "StreamingDistributionConfig",
+	}
+
 	b, err := xml.Marshal(req.StreamingDistributionConfig)
 	if err != nil {
 		return
@@ -1124,7 +1166,7 @@ func (c *CloudFront) UpdateStreamingDistribution(req *UpdateStreamingDistributio
 
 // ActiveTrustedSigners is undocumented.
 type ActiveTrustedSigners struct {
-	XMLName xml.Name `xml:"ActiveTrustedSigners"`
+	XMLName xml.Name
 
 	Enabled  aws.BooleanValue `xml:"Enabled"`
 	Items    []Signer         `xml:"Items>Signer,omitempty"`
@@ -1137,7 +1179,7 @@ func (v *ActiveTrustedSigners) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // Aliases is undocumented.
 type Aliases struct {
-	XMLName xml.Name `xml:"Aliases"`
+	XMLName xml.Name
 
 	Items    []string         `xml:"Items>CNAME,omitempty"`
 	Quantity aws.IntegerValue `xml:"Quantity"`
@@ -1149,7 +1191,7 @@ func (v *Aliases) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // AllowedMethods is undocumented.
 type AllowedMethods struct {
-	XMLName xml.Name `xml:"AllowedMethods"`
+	XMLName xml.Name
 
 	CachedMethods *CachedMethods   `xml:"CachedMethods,omitempty"`
 	Items         []string         `xml:"Items>Method,omitempty"`
@@ -1162,7 +1204,7 @@ func (v *AllowedMethods) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 
 // CacheBehavior is undocumented.
 type CacheBehavior struct {
-	XMLName xml.Name `xml:"CacheBehavior"`
+	XMLName xml.Name
 
 	AllowedMethods       *AllowedMethods  `xml:"AllowedMethods,omitempty"`
 	ForwardedValues      *ForwardedValues `xml:"ForwardedValues,omitempty"`
@@ -1180,7 +1222,7 @@ func (v *CacheBehavior) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 
 // CacheBehaviors is undocumented.
 type CacheBehaviors struct {
-	XMLName xml.Name `xml:"CacheBehaviors"`
+	XMLName xml.Name
 
 	Items    []CacheBehavior  `xml:"Items>CacheBehavior,omitempty"`
 	Quantity aws.IntegerValue `xml:"Quantity"`
@@ -1192,7 +1234,7 @@ func (v *CacheBehaviors) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 
 // CachedMethods is undocumented.
 type CachedMethods struct {
-	XMLName xml.Name `xml:"CachedMethods"`
+	XMLName xml.Name
 
 	Items    []string         `xml:"Items>Method,omitempty"`
 	Quantity aws.IntegerValue `xml:"Quantity"`
@@ -1204,7 +1246,7 @@ func (v *CachedMethods) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 
 // CloudFrontOriginAccessIdentity is undocumented.
 type CloudFrontOriginAccessIdentity struct {
-	XMLName xml.Name `xml:"CloudFrontOriginAccessIdentity"`
+	XMLName xml.Name
 
 	CloudFrontOriginAccessIdentityConfig *CloudFrontOriginAccessIdentityConfig `xml:"CloudFrontOriginAccessIdentityConfig,omitempty"`
 	ID                                   aws.StringValue                       `xml:"Id"`
@@ -1217,7 +1259,7 @@ func (v *CloudFrontOriginAccessIdentity) MarshalXML(e *xml.Encoder, start xml.St
 
 // CloudFrontOriginAccessIdentityConfig is undocumented.
 type CloudFrontOriginAccessIdentityConfig struct {
-	XMLName xml.Name `xml:"CloudFrontOriginAccessIdentityConfig"`
+	XMLName xml.Name
 
 	CallerReference aws.StringValue `xml:"CallerReference"`
 	Comment         aws.StringValue `xml:"Comment"`
@@ -1229,7 +1271,7 @@ func (v *CloudFrontOriginAccessIdentityConfig) MarshalXML(e *xml.Encoder, start 
 
 // CloudFrontOriginAccessIdentityList is undocumented.
 type CloudFrontOriginAccessIdentityList struct {
-	XMLName xml.Name `xml:"CloudFrontOriginAccessIdentityList"`
+	XMLName xml.Name
 
 	IsTruncated aws.BooleanValue                        `xml:"IsTruncated"`
 	Items       []CloudFrontOriginAccessIdentitySummary `xml:"Items>CloudFrontOriginAccessIdentitySummary,omitempty"`
@@ -1245,7 +1287,7 @@ func (v *CloudFrontOriginAccessIdentityList) MarshalXML(e *xml.Encoder, start xm
 
 // CloudFrontOriginAccessIdentitySummary is undocumented.
 type CloudFrontOriginAccessIdentitySummary struct {
-	XMLName xml.Name `xml:"CloudFrontOriginAccessIdentitySummary"`
+	XMLName xml.Name
 
 	Comment           aws.StringValue `xml:"Comment"`
 	ID                aws.StringValue `xml:"Id"`
@@ -1258,7 +1300,7 @@ func (v *CloudFrontOriginAccessIdentitySummary) MarshalXML(e *xml.Encoder, start
 
 // CookieNames is undocumented.
 type CookieNames struct {
-	XMLName xml.Name `xml:"CookieNames"`
+	XMLName xml.Name
 
 	Items    []string         `xml:"Items>Name,omitempty"`
 	Quantity aws.IntegerValue `xml:"Quantity"`
@@ -1270,7 +1312,7 @@ func (v *CookieNames) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // CookiePreference is undocumented.
 type CookiePreference struct {
-	XMLName xml.Name `xml:"CookiePreference"`
+	XMLName xml.Name
 
 	Forward          aws.StringValue `xml:"Forward"`
 	WhitelistedNames *CookieNames    `xml:"WhitelistedNames,omitempty"`
@@ -1282,7 +1324,7 @@ func (v *CookiePreference) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // CreateCloudFrontOriginAccessIdentityRequest is undocumented.
 type CreateCloudFrontOriginAccessIdentityRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	CloudFrontOriginAccessIdentityConfig *CloudFrontOriginAccessIdentityConfig `xml:"CloudFrontOriginAccessIdentityConfig,omitempty"`
 }
@@ -1293,7 +1335,7 @@ func (v *CreateCloudFrontOriginAccessIdentityRequest) MarshalXML(e *xml.Encoder,
 
 // CreateCloudFrontOriginAccessIdentityResult is undocumented.
 type CreateCloudFrontOriginAccessIdentityResult struct {
-	XMLName xml.Name `xml:"CreateCloudFrontOriginAccessIdentityResult"`
+	XMLName xml.Name
 
 	CloudFrontOriginAccessIdentity *CloudFrontOriginAccessIdentity `xml:"CloudFrontOriginAccessIdentity,omitempty"`
 	ETag                           aws.StringValue                 `xml:"-"`
@@ -1306,7 +1348,7 @@ func (v *CreateCloudFrontOriginAccessIdentityResult) MarshalXML(e *xml.Encoder, 
 
 // CreateDistributionRequest is undocumented.
 type CreateDistributionRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	DistributionConfig *DistributionConfig `xml:"DistributionConfig,omitempty"`
 }
@@ -1317,7 +1359,7 @@ func (v *CreateDistributionRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // CreateDistributionResult is undocumented.
 type CreateDistributionResult struct {
-	XMLName xml.Name `xml:"CreateDistributionResult"`
+	XMLName xml.Name
 
 	Distribution *Distribution   `xml:"Distribution,omitempty"`
 	ETag         aws.StringValue `xml:"-"`
@@ -1330,7 +1372,7 @@ func (v *CreateDistributionResult) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // CreateInvalidationRequest is undocumented.
 type CreateInvalidationRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	DistributionID    aws.StringValue    `xml:"-"`
 	InvalidationBatch *InvalidationBatch `xml:"InvalidationBatch,omitempty"`
@@ -1342,7 +1384,7 @@ func (v *CreateInvalidationRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // CreateInvalidationResult is undocumented.
 type CreateInvalidationResult struct {
-	XMLName xml.Name `xml:"CreateInvalidationResult"`
+	XMLName xml.Name
 
 	Invalidation *Invalidation   `xml:"Invalidation,omitempty"`
 	Location     aws.StringValue `xml:"-"`
@@ -1354,7 +1396,7 @@ func (v *CreateInvalidationResult) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // CreateStreamingDistributionRequest is undocumented.
 type CreateStreamingDistributionRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	StreamingDistributionConfig *StreamingDistributionConfig `xml:"StreamingDistributionConfig,omitempty"`
 }
@@ -1365,7 +1407,7 @@ func (v *CreateStreamingDistributionRequest) MarshalXML(e *xml.Encoder, start xm
 
 // CreateStreamingDistributionResult is undocumented.
 type CreateStreamingDistributionResult struct {
-	XMLName xml.Name `xml:"CreateStreamingDistributionResult"`
+	XMLName xml.Name
 
 	ETag                  aws.StringValue        `xml:"-"`
 	Location              aws.StringValue        `xml:"-"`
@@ -1378,7 +1420,7 @@ func (v *CreateStreamingDistributionResult) MarshalXML(e *xml.Encoder, start xml
 
 // CustomErrorResponse is undocumented.
 type CustomErrorResponse struct {
-	XMLName xml.Name `xml:"CustomErrorResponse"`
+	XMLName xml.Name
 
 	ErrorCachingMinTTL aws.LongValue    `xml:"ErrorCachingMinTTL"`
 	ErrorCode          aws.IntegerValue `xml:"ErrorCode"`
@@ -1392,7 +1434,7 @@ func (v *CustomErrorResponse) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // CustomErrorResponses is undocumented.
 type CustomErrorResponses struct {
-	XMLName xml.Name `xml:"CustomErrorResponses"`
+	XMLName xml.Name
 
 	Items    []CustomErrorResponse `xml:"Items>CustomErrorResponse,omitempty"`
 	Quantity aws.IntegerValue      `xml:"Quantity"`
@@ -1404,7 +1446,7 @@ func (v *CustomErrorResponses) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // CustomOriginConfig is undocumented.
 type CustomOriginConfig struct {
-	XMLName xml.Name `xml:"CustomOriginConfig"`
+	XMLName xml.Name
 
 	HTTPPort             aws.IntegerValue `xml:"HTTPPort"`
 	HTTPSPort            aws.IntegerValue `xml:"HTTPSPort"`
@@ -1417,7 +1459,7 @@ func (v *CustomOriginConfig) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // DefaultCacheBehavior is undocumented.
 type DefaultCacheBehavior struct {
-	XMLName xml.Name `xml:"DefaultCacheBehavior"`
+	XMLName xml.Name
 
 	AllowedMethods       *AllowedMethods  `xml:"AllowedMethods,omitempty"`
 	ForwardedValues      *ForwardedValues `xml:"ForwardedValues,omitempty"`
@@ -1434,7 +1476,7 @@ func (v *DefaultCacheBehavior) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // DeleteCloudFrontOriginAccessIdentityRequest is undocumented.
 type DeleteCloudFrontOriginAccessIdentityRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID      aws.StringValue `xml:"-"`
 	IfMatch aws.StringValue `xml:"-"`
@@ -1446,7 +1488,7 @@ func (v *DeleteCloudFrontOriginAccessIdentityRequest) MarshalXML(e *xml.Encoder,
 
 // DeleteDistributionRequest is undocumented.
 type DeleteDistributionRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID      aws.StringValue `xml:"-"`
 	IfMatch aws.StringValue `xml:"-"`
@@ -1458,7 +1500,7 @@ func (v *DeleteDistributionRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // DeleteStreamingDistributionRequest is undocumented.
 type DeleteStreamingDistributionRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID      aws.StringValue `xml:"-"`
 	IfMatch aws.StringValue `xml:"-"`
@@ -1470,7 +1512,7 @@ func (v *DeleteStreamingDistributionRequest) MarshalXML(e *xml.Encoder, start xm
 
 // Distribution is undocumented.
 type Distribution struct {
-	XMLName xml.Name `xml:"Distribution"`
+	XMLName xml.Name
 
 	ActiveTrustedSigners          *ActiveTrustedSigners `xml:"ActiveTrustedSigners,omitempty"`
 	DistributionConfig            *DistributionConfig   `xml:"DistributionConfig,omitempty"`
@@ -1487,7 +1529,7 @@ func (v *Distribution) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 
 // DistributionConfig is undocumented.
 type DistributionConfig struct {
-	XMLName xml.Name `xml:"DistributionConfig"`
+	XMLName xml.Name
 
 	Aliases              *Aliases              `xml:"Aliases,omitempty"`
 	CacheBehaviors       *CacheBehaviors       `xml:"CacheBehaviors,omitempty"`
@@ -1510,7 +1552,7 @@ func (v *DistributionConfig) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // DistributionList is undocumented.
 type DistributionList struct {
-	XMLName xml.Name `xml:"DistributionList"`
+	XMLName xml.Name
 
 	IsTruncated aws.BooleanValue      `xml:"IsTruncated"`
 	Items       []DistributionSummary `xml:"Items>DistributionSummary,omitempty"`
@@ -1526,7 +1568,7 @@ func (v *DistributionList) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // DistributionSummary is undocumented.
 type DistributionSummary struct {
-	XMLName xml.Name `xml:"DistributionSummary"`
+	XMLName xml.Name
 
 	Aliases              *Aliases              `xml:"Aliases,omitempty"`
 	CacheBehaviors       *CacheBehaviors       `xml:"CacheBehaviors,omitempty"`
@@ -1550,7 +1592,7 @@ func (v *DistributionSummary) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // ForwardedValues is undocumented.
 type ForwardedValues struct {
-	XMLName xml.Name `xml:"ForwardedValues"`
+	XMLName xml.Name
 
 	Cookies     *CookiePreference `xml:"Cookies,omitempty"`
 	Headers     *Headers          `xml:"Headers,omitempty"`
@@ -1563,7 +1605,7 @@ func (v *ForwardedValues) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 
 // GeoRestriction is undocumented.
 type GeoRestriction struct {
-	XMLName xml.Name `xml:"GeoRestriction"`
+	XMLName xml.Name
 
 	Items           []string         `xml:"Items>Location,omitempty"`
 	Quantity        aws.IntegerValue `xml:"Quantity"`
@@ -1583,7 +1625,7 @@ const (
 
 // GetCloudFrontOriginAccessIdentityConfigRequest is undocumented.
 type GetCloudFrontOriginAccessIdentityConfigRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1594,7 +1636,7 @@ func (v *GetCloudFrontOriginAccessIdentityConfigRequest) MarshalXML(e *xml.Encod
 
 // GetCloudFrontOriginAccessIdentityConfigResult is undocumented.
 type GetCloudFrontOriginAccessIdentityConfigResult struct {
-	XMLName xml.Name `xml:"GetCloudFrontOriginAccessIdentityConfigResult"`
+	XMLName xml.Name
 
 	CloudFrontOriginAccessIdentityConfig *CloudFrontOriginAccessIdentityConfig `xml:"CloudFrontOriginAccessIdentityConfig,omitempty"`
 	ETag                                 aws.StringValue                       `xml:"-"`
@@ -1606,7 +1648,7 @@ func (v *GetCloudFrontOriginAccessIdentityConfigResult) MarshalXML(e *xml.Encode
 
 // GetCloudFrontOriginAccessIdentityRequest is undocumented.
 type GetCloudFrontOriginAccessIdentityRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1617,7 +1659,7 @@ func (v *GetCloudFrontOriginAccessIdentityRequest) MarshalXML(e *xml.Encoder, st
 
 // GetCloudFrontOriginAccessIdentityResult is undocumented.
 type GetCloudFrontOriginAccessIdentityResult struct {
-	XMLName xml.Name `xml:"GetCloudFrontOriginAccessIdentityResult"`
+	XMLName xml.Name
 
 	CloudFrontOriginAccessIdentity *CloudFrontOriginAccessIdentity `xml:"CloudFrontOriginAccessIdentity,omitempty"`
 	ETag                           aws.StringValue                 `xml:"-"`
@@ -1629,7 +1671,7 @@ func (v *GetCloudFrontOriginAccessIdentityResult) MarshalXML(e *xml.Encoder, sta
 
 // GetDistributionConfigRequest is undocumented.
 type GetDistributionConfigRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1640,7 +1682,7 @@ func (v *GetDistributionConfigRequest) MarshalXML(e *xml.Encoder, start xml.Star
 
 // GetDistributionConfigResult is undocumented.
 type GetDistributionConfigResult struct {
-	XMLName xml.Name `xml:"GetDistributionConfigResult"`
+	XMLName xml.Name
 
 	DistributionConfig *DistributionConfig `xml:"DistributionConfig,omitempty"`
 	ETag               aws.StringValue     `xml:"-"`
@@ -1652,7 +1694,7 @@ func (v *GetDistributionConfigResult) MarshalXML(e *xml.Encoder, start xml.Start
 
 // GetDistributionRequest is undocumented.
 type GetDistributionRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1663,7 +1705,7 @@ func (v *GetDistributionRequest) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetDistributionResult is undocumented.
 type GetDistributionResult struct {
-	XMLName xml.Name `xml:"GetDistributionResult"`
+	XMLName xml.Name
 
 	Distribution *Distribution   `xml:"Distribution,omitempty"`
 	ETag         aws.StringValue `xml:"-"`
@@ -1675,7 +1717,7 @@ func (v *GetDistributionResult) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // GetInvalidationRequest is undocumented.
 type GetInvalidationRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	DistributionID aws.StringValue `xml:"-"`
 	ID             aws.StringValue `xml:"-"`
@@ -1687,7 +1729,7 @@ func (v *GetInvalidationRequest) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetInvalidationResult is undocumented.
 type GetInvalidationResult struct {
-	XMLName xml.Name `xml:"GetInvalidationResult"`
+	XMLName xml.Name
 
 	Invalidation *Invalidation `xml:"Invalidation,omitempty"`
 }
@@ -1698,7 +1740,7 @@ func (v *GetInvalidationResult) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // GetStreamingDistributionConfigRequest is undocumented.
 type GetStreamingDistributionConfigRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1709,7 +1751,7 @@ func (v *GetStreamingDistributionConfigRequest) MarshalXML(e *xml.Encoder, start
 
 // GetStreamingDistributionConfigResult is undocumented.
 type GetStreamingDistributionConfigResult struct {
-	XMLName xml.Name `xml:"GetStreamingDistributionConfigResult"`
+	XMLName xml.Name
 
 	ETag                        aws.StringValue              `xml:"-"`
 	StreamingDistributionConfig *StreamingDistributionConfig `xml:"StreamingDistributionConfig,omitempty"`
@@ -1721,7 +1763,7 @@ func (v *GetStreamingDistributionConfigResult) MarshalXML(e *xml.Encoder, start 
 
 // GetStreamingDistributionRequest is undocumented.
 type GetStreamingDistributionRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1732,7 +1774,7 @@ func (v *GetStreamingDistributionRequest) MarshalXML(e *xml.Encoder, start xml.S
 
 // GetStreamingDistributionResult is undocumented.
 type GetStreamingDistributionResult struct {
-	XMLName xml.Name `xml:"GetStreamingDistributionResult"`
+	XMLName xml.Name
 
 	ETag                  aws.StringValue        `xml:"-"`
 	StreamingDistribution *StreamingDistribution `xml:"StreamingDistribution,omitempty"`
@@ -1744,7 +1786,7 @@ func (v *GetStreamingDistributionResult) MarshalXML(e *xml.Encoder, start xml.St
 
 // Headers is undocumented.
 type Headers struct {
-	XMLName xml.Name `xml:"Headers"`
+	XMLName xml.Name
 
 	Items    []string         `xml:"Items>Name,omitempty"`
 	Quantity aws.IntegerValue `xml:"Quantity"`
@@ -1756,7 +1798,7 @@ func (v *Headers) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Invalidation is undocumented.
 type Invalidation struct {
-	XMLName xml.Name `xml:"Invalidation"`
+	XMLName xml.Name
 
 	CreateTime        time.Time          `xml:"CreateTime"`
 	ID                aws.StringValue    `xml:"Id"`
@@ -1770,7 +1812,7 @@ func (v *Invalidation) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 
 // InvalidationBatch is undocumented.
 type InvalidationBatch struct {
-	XMLName xml.Name `xml:"InvalidationBatch"`
+	XMLName xml.Name
 
 	CallerReference aws.StringValue `xml:"CallerReference"`
 	Paths           *Paths          `xml:"Paths,omitempty"`
@@ -1782,7 +1824,7 @@ func (v *InvalidationBatch) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // InvalidationList is undocumented.
 type InvalidationList struct {
-	XMLName xml.Name `xml:"InvalidationList"`
+	XMLName xml.Name
 
 	IsTruncated aws.BooleanValue      `xml:"IsTruncated"`
 	Items       []InvalidationSummary `xml:"Items>InvalidationSummary,omitempty"`
@@ -1798,7 +1840,7 @@ func (v *InvalidationList) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // InvalidationSummary is undocumented.
 type InvalidationSummary struct {
-	XMLName xml.Name `xml:"InvalidationSummary"`
+	XMLName xml.Name
 
 	CreateTime time.Time       `xml:"CreateTime"`
 	ID         aws.StringValue `xml:"Id"`
@@ -1818,7 +1860,7 @@ const (
 
 // KeyPairIDs is undocumented.
 type KeyPairIDs struct {
-	XMLName xml.Name `xml:"KeyPairIds"`
+	XMLName xml.Name
 
 	Items    []string         `xml:"Items>KeyPairId,omitempty"`
 	Quantity aws.IntegerValue `xml:"Quantity"`
@@ -1830,7 +1872,7 @@ func (v *KeyPairIDs) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // ListCloudFrontOriginAccessIdentitiesRequest is undocumented.
 type ListCloudFrontOriginAccessIdentitiesRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Marker   aws.StringValue `xml:"-"`
 	MaxItems aws.StringValue `xml:"-"`
@@ -1842,7 +1884,7 @@ func (v *ListCloudFrontOriginAccessIdentitiesRequest) MarshalXML(e *xml.Encoder,
 
 // ListCloudFrontOriginAccessIdentitiesResult is undocumented.
 type ListCloudFrontOriginAccessIdentitiesResult struct {
-	XMLName xml.Name `xml:"ListCloudFrontOriginAccessIdentitiesResult"`
+	XMLName xml.Name
 
 	CloudFrontOriginAccessIdentityList *CloudFrontOriginAccessIdentityList `xml:"CloudFrontOriginAccessIdentityList,omitempty"`
 }
@@ -1853,7 +1895,7 @@ func (v *ListCloudFrontOriginAccessIdentitiesResult) MarshalXML(e *xml.Encoder, 
 
 // ListDistributionsRequest is undocumented.
 type ListDistributionsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Marker   aws.StringValue `xml:"-"`
 	MaxItems aws.StringValue `xml:"-"`
@@ -1865,7 +1907,7 @@ func (v *ListDistributionsRequest) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // ListDistributionsResult is undocumented.
 type ListDistributionsResult struct {
-	XMLName xml.Name `xml:"ListDistributionsResult"`
+	XMLName xml.Name
 
 	DistributionList *DistributionList `xml:"DistributionList,omitempty"`
 }
@@ -1876,7 +1918,7 @@ func (v *ListDistributionsResult) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // ListInvalidationsRequest is undocumented.
 type ListInvalidationsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	DistributionID aws.StringValue `xml:"-"`
 	Marker         aws.StringValue `xml:"-"`
@@ -1889,7 +1931,7 @@ func (v *ListInvalidationsRequest) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // ListInvalidationsResult is undocumented.
 type ListInvalidationsResult struct {
-	XMLName xml.Name `xml:"ListInvalidationsResult"`
+	XMLName xml.Name
 
 	InvalidationList *InvalidationList `xml:"InvalidationList,omitempty"`
 }
@@ -1900,7 +1942,7 @@ func (v *ListInvalidationsResult) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // ListStreamingDistributionsRequest is undocumented.
 type ListStreamingDistributionsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Marker   aws.StringValue `xml:"-"`
 	MaxItems aws.StringValue `xml:"-"`
@@ -1912,7 +1954,7 @@ func (v *ListStreamingDistributionsRequest) MarshalXML(e *xml.Encoder, start xml
 
 // ListStreamingDistributionsResult is undocumented.
 type ListStreamingDistributionsResult struct {
-	XMLName xml.Name `xml:"ListStreamingDistributionsResult"`
+	XMLName xml.Name
 
 	StreamingDistributionList *StreamingDistributionList `xml:"StreamingDistributionList,omitempty"`
 }
@@ -1923,7 +1965,7 @@ func (v *ListStreamingDistributionsResult) MarshalXML(e *xml.Encoder, start xml.
 
 // LoggingConfig is undocumented.
 type LoggingConfig struct {
-	XMLName xml.Name `xml:"LoggingConfig"`
+	XMLName xml.Name
 
 	Bucket         aws.StringValue  `xml:"Bucket"`
 	Enabled        aws.BooleanValue `xml:"Enabled"`
@@ -1954,7 +1996,7 @@ const (
 
 // Origin is undocumented.
 type Origin struct {
-	XMLName xml.Name `xml:"Origin"`
+	XMLName xml.Name
 
 	CustomOriginConfig *CustomOriginConfig `xml:"CustomOriginConfig,omitempty"`
 	DomainName         aws.StringValue     `xml:"DomainName"`
@@ -1974,7 +2016,7 @@ const (
 
 // Origins is undocumented.
 type Origins struct {
-	XMLName xml.Name `xml:"Origins"`
+	XMLName xml.Name
 
 	Items    []Origin         `xml:"Items>Origin,omitempty"`
 	Quantity aws.IntegerValue `xml:"Quantity"`
@@ -1986,7 +2028,7 @@ func (v *Origins) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Paths is undocumented.
 type Paths struct {
-	XMLName xml.Name `xml:"Paths"`
+	XMLName xml.Name
 
 	Items    []string         `xml:"Items>Path,omitempty"`
 	Quantity aws.IntegerValue `xml:"Quantity"`
@@ -2005,7 +2047,7 @@ const (
 
 // Restrictions is undocumented.
 type Restrictions struct {
-	XMLName xml.Name `xml:"Restrictions"`
+	XMLName xml.Name
 
 	GeoRestriction *GeoRestriction `xml:"GeoRestriction,omitempty"`
 }
@@ -2016,7 +2058,7 @@ func (v *Restrictions) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 
 // S3Origin is undocumented.
 type S3Origin struct {
-	XMLName xml.Name `xml:"S3Origin"`
+	XMLName xml.Name
 
 	DomainName           aws.StringValue `xml:"DomainName"`
 	OriginAccessIdentity aws.StringValue `xml:"OriginAccessIdentity"`
@@ -2028,7 +2070,7 @@ func (v *S3Origin) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // S3OriginConfig is undocumented.
 type S3OriginConfig struct {
-	XMLName xml.Name `xml:"S3OriginConfig"`
+	XMLName xml.Name
 
 	OriginAccessIdentity aws.StringValue `xml:"OriginAccessIdentity"`
 }
@@ -2045,7 +2087,7 @@ const (
 
 // Signer is undocumented.
 type Signer struct {
-	XMLName xml.Name `xml:"Signer"`
+	XMLName xml.Name
 
 	AWSAccountNumber aws.StringValue `xml:"AwsAccountNumber"`
 	KeyPairIDs       *KeyPairIDs     `xml:"KeyPairIds,omitempty"`
@@ -2057,7 +2099,7 @@ func (v *Signer) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // StreamingDistribution is undocumented.
 type StreamingDistribution struct {
-	XMLName xml.Name `xml:"StreamingDistribution"`
+	XMLName xml.Name
 
 	ActiveTrustedSigners        *ActiveTrustedSigners        `xml:"ActiveTrustedSigners,omitempty"`
 	DomainName                  aws.StringValue              `xml:"DomainName"`
@@ -2073,7 +2115,7 @@ func (v *StreamingDistribution) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // StreamingDistributionConfig is undocumented.
 type StreamingDistributionConfig struct {
-	XMLName xml.Name `xml:"StreamingDistributionConfig"`
+	XMLName xml.Name
 
 	Aliases         *Aliases                `xml:"Aliases,omitempty"`
 	CallerReference aws.StringValue         `xml:"CallerReference"`
@@ -2091,7 +2133,7 @@ func (v *StreamingDistributionConfig) MarshalXML(e *xml.Encoder, start xml.Start
 
 // StreamingDistributionList is undocumented.
 type StreamingDistributionList struct {
-	XMLName xml.Name `xml:"StreamingDistributionList"`
+	XMLName xml.Name
 
 	IsTruncated aws.BooleanValue               `xml:"IsTruncated"`
 	Items       []StreamingDistributionSummary `xml:"Items>StreamingDistributionSummary,omitempty"`
@@ -2107,7 +2149,7 @@ func (v *StreamingDistributionList) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // StreamingDistributionSummary is undocumented.
 type StreamingDistributionSummary struct {
-	XMLName xml.Name `xml:"StreamingDistributionSummary"`
+	XMLName xml.Name
 
 	Aliases          *Aliases         `xml:"Aliases,omitempty"`
 	Comment          aws.StringValue  `xml:"Comment"`
@@ -2127,7 +2169,7 @@ func (v *StreamingDistributionSummary) MarshalXML(e *xml.Encoder, start xml.Star
 
 // StreamingLoggingConfig is undocumented.
 type StreamingLoggingConfig struct {
-	XMLName xml.Name `xml:"StreamingLoggingConfig"`
+	XMLName xml.Name
 
 	Bucket  aws.StringValue  `xml:"Bucket"`
 	Enabled aws.BooleanValue `xml:"Enabled"`
@@ -2140,7 +2182,7 @@ func (v *StreamingLoggingConfig) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // TrustedSigners is undocumented.
 type TrustedSigners struct {
-	XMLName xml.Name `xml:"TrustedSigners"`
+	XMLName xml.Name
 
 	Enabled  aws.BooleanValue `xml:"Enabled"`
 	Items    []string         `xml:"Items>AwsAccountNumber,omitempty"`
@@ -2153,7 +2195,7 @@ func (v *TrustedSigners) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 
 // UpdateCloudFrontOriginAccessIdentityRequest is undocumented.
 type UpdateCloudFrontOriginAccessIdentityRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	CloudFrontOriginAccessIdentityConfig *CloudFrontOriginAccessIdentityConfig `xml:"CloudFrontOriginAccessIdentityConfig,omitempty"`
 	ID                                   aws.StringValue                       `xml:"-"`
@@ -2166,7 +2208,7 @@ func (v *UpdateCloudFrontOriginAccessIdentityRequest) MarshalXML(e *xml.Encoder,
 
 // UpdateCloudFrontOriginAccessIdentityResult is undocumented.
 type UpdateCloudFrontOriginAccessIdentityResult struct {
-	XMLName xml.Name `xml:"UpdateCloudFrontOriginAccessIdentityResult"`
+	XMLName xml.Name
 
 	CloudFrontOriginAccessIdentity *CloudFrontOriginAccessIdentity `xml:"CloudFrontOriginAccessIdentity,omitempty"`
 	ETag                           aws.StringValue                 `xml:"-"`
@@ -2178,7 +2220,7 @@ func (v *UpdateCloudFrontOriginAccessIdentityResult) MarshalXML(e *xml.Encoder, 
 
 // UpdateDistributionRequest is undocumented.
 type UpdateDistributionRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	DistributionConfig *DistributionConfig `xml:"DistributionConfig,omitempty"`
 	ID                 aws.StringValue     `xml:"-"`
@@ -2191,7 +2233,7 @@ func (v *UpdateDistributionRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // UpdateDistributionResult is undocumented.
 type UpdateDistributionResult struct {
-	XMLName xml.Name `xml:"UpdateDistributionResult"`
+	XMLName xml.Name
 
 	Distribution *Distribution   `xml:"Distribution,omitempty"`
 	ETag         aws.StringValue `xml:"-"`
@@ -2203,7 +2245,7 @@ func (v *UpdateDistributionResult) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // UpdateStreamingDistributionRequest is undocumented.
 type UpdateStreamingDistributionRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID                          aws.StringValue              `xml:"-"`
 	IfMatch                     aws.StringValue              `xml:"-"`
@@ -2216,7 +2258,7 @@ func (v *UpdateStreamingDistributionRequest) MarshalXML(e *xml.Encoder, start xm
 
 // UpdateStreamingDistributionResult is undocumented.
 type UpdateStreamingDistributionResult struct {
-	XMLName xml.Name `xml:"UpdateStreamingDistributionResult"`
+	XMLName xml.Name
 
 	ETag                  aws.StringValue        `xml:"-"`
 	StreamingDistribution *StreamingDistribution `xml:"StreamingDistribution,omitempty"`
@@ -2228,7 +2270,7 @@ func (v *UpdateStreamingDistributionResult) MarshalXML(e *xml.Encoder, start xml
 
 // ViewerCertificate is undocumented.
 type ViewerCertificate struct {
-	XMLName xml.Name `xml:"ViewerCertificate"`
+	XMLName xml.Name
 
 	CloudFrontDefaultCertificate aws.BooleanValue `xml:"CloudFrontDefaultCertificate"`
 	IAMCertificateID             aws.StringValue  `xml:"IAMCertificateId"`

--- a/gen/route53/route53.go
+++ b/gen/route53/route53.go
@@ -66,6 +66,10 @@ func (c *Route53) AssociateVPCWithHostedZone(req *AssociateVPCWithHostedZoneRequ
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "AssociateVPCWithHostedZoneRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -136,6 +140,10 @@ func (c *Route53) ChangeResourceRecordSets(req *ChangeResourceRecordSetsRequest)
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "ChangeResourceRecordSetsRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -186,6 +194,10 @@ func (c *Route53) ChangeTagsForResource(req *ChangeTagsForResourceRequest) (resp
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "ChangeTagsForResourceRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -246,6 +258,10 @@ func (c *Route53) CreateHealthCheck(req *CreateHealthCheckRequest) (resp *Create
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "CreateHealthCheckRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -312,6 +328,10 @@ func (c *Route53) CreateHostedZone(req *CreateHostedZoneRequest) (resp *CreateHo
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "CreateHostedZoneRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -370,6 +390,10 @@ func (c *Route53) CreateReusableDelegationSet(req *CreateReusableDelegationSetRe
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "CreateReusableDelegationSetRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -584,6 +608,10 @@ func (c *Route53) DisassociateVPCFromHostedZone(req *DisassociateVPCFromHostedZo
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "DisassociateVPCFromHostedZoneRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -1411,6 +1439,10 @@ func (c *Route53) ListTagsForResources(req *ListTagsForResourcesRequest) (resp *
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "ListTagsForResourcesRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -1466,6 +1498,10 @@ func (c *Route53) UpdateHealthCheck(req *UpdateHealthCheckRequest) (resp *Update
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "UpdateHealthCheckRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -1520,6 +1556,10 @@ func (c *Route53) UpdateHostedZoneComment(req *UpdateHostedZoneCommentRequest) (
 	var contentType string
 
 	contentType = "application/xml"
+	req.XMLName = xml.Name{
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+		Local: "UpdateHostedZoneCommentRequest",
+	}
 	b, err := xml.Marshal(req)
 	if err != nil {
 		return
@@ -1564,7 +1604,7 @@ func (c *Route53) UpdateHostedZoneComment(req *UpdateHostedZoneCommentRequest) (
 
 // AliasTarget is undocumented.
 type AliasTarget struct {
-	XMLName xml.Name `xml:"AliasTarget"`
+	XMLName xml.Name
 
 	DNSName              aws.StringValue  `xml:"DNSName"`
 	EvaluateTargetHealth aws.BooleanValue `xml:"EvaluateTargetHealth"`
@@ -1577,7 +1617,7 @@ func (v *AliasTarget) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // AssociateVPCWithHostedZoneRequest is undocumented.
 type AssociateVPCWithHostedZoneRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ AssociateVPCWithHostedZoneRequest"`
+	XMLName xml.Name
 
 	Comment      aws.StringValue `xml:"Comment"`
 	HostedZoneID aws.StringValue `xml:"-"`
@@ -1590,7 +1630,7 @@ func (v *AssociateVPCWithHostedZoneRequest) MarshalXML(e *xml.Encoder, start xml
 
 // AssociateVPCWithHostedZoneResponse is undocumented.
 type AssociateVPCWithHostedZoneResponse struct {
-	XMLName xml.Name `xml:"AssociateVPCWithHostedZoneResponse"`
+	XMLName xml.Name
 
 	ChangeInfo *ChangeInfo `xml:"ChangeInfo,omitempty"`
 }
@@ -1601,7 +1641,7 @@ func (v *AssociateVPCWithHostedZoneResponse) MarshalXML(e *xml.Encoder, start xm
 
 // Change is undocumented.
 type Change struct {
-	XMLName xml.Name `xml:"Change"`
+	XMLName xml.Name
 
 	Action            aws.StringValue    `xml:"Action"`
 	ResourceRecordSet *ResourceRecordSet `xml:"ResourceRecordSet,omitempty"`
@@ -1620,7 +1660,7 @@ const (
 
 // ChangeBatch is undocumented.
 type ChangeBatch struct {
-	XMLName xml.Name `xml:"ChangeBatch"`
+	XMLName xml.Name
 
 	Changes []Change        `xml:"Changes>Change,omitempty"`
 	Comment aws.StringValue `xml:"Comment"`
@@ -1632,7 +1672,7 @@ func (v *ChangeBatch) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // ChangeInfo is undocumented.
 type ChangeInfo struct {
-	XMLName xml.Name `xml:"ChangeInfo"`
+	XMLName xml.Name
 
 	Comment     aws.StringValue `xml:"Comment"`
 	ID          aws.StringValue `xml:"Id"`
@@ -1646,7 +1686,7 @@ func (v *ChangeInfo) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // ChangeResourceRecordSetsRequest is undocumented.
 type ChangeResourceRecordSetsRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ ChangeResourceRecordSetsRequest"`
+	XMLName xml.Name
 
 	ChangeBatch  *ChangeBatch    `xml:"ChangeBatch,omitempty"`
 	HostedZoneID aws.StringValue `xml:"-"`
@@ -1658,7 +1698,7 @@ func (v *ChangeResourceRecordSetsRequest) MarshalXML(e *xml.Encoder, start xml.S
 
 // ChangeResourceRecordSetsResponse is undocumented.
 type ChangeResourceRecordSetsResponse struct {
-	XMLName xml.Name `xml:"ChangeResourceRecordSetsResponse"`
+	XMLName xml.Name
 
 	ChangeInfo *ChangeInfo `xml:"ChangeInfo,omitempty"`
 }
@@ -1675,7 +1715,7 @@ const (
 
 // ChangeTagsForResourceRequest is undocumented.
 type ChangeTagsForResourceRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ ChangeTagsForResourceRequest"`
+	XMLName xml.Name
 
 	AddTags       []Tag           `xml:"AddTags>Tag,omitempty"`
 	RemoveTagKeys []string        `xml:"RemoveTagKeys>Key,omitempty"`
@@ -1689,7 +1729,7 @@ func (v *ChangeTagsForResourceRequest) MarshalXML(e *xml.Encoder, start xml.Star
 
 // ChangeTagsForResourceResponse is undocumented.
 type ChangeTagsForResourceResponse struct {
-	XMLName xml.Name `xml:"ChangeTagsForResourceResponse"`
+	XMLName xml.Name
 }
 
 func (v *ChangeTagsForResourceResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -1698,7 +1738,7 @@ func (v *ChangeTagsForResourceResponse) MarshalXML(e *xml.Encoder, start xml.Sta
 
 // CreateHealthCheckRequest is undocumented.
 type CreateHealthCheckRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ CreateHealthCheckRequest"`
+	XMLName xml.Name
 
 	CallerReference   aws.StringValue    `xml:"CallerReference"`
 	HealthCheckConfig *HealthCheckConfig `xml:"HealthCheckConfig,omitempty"`
@@ -1710,7 +1750,7 @@ func (v *CreateHealthCheckRequest) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // CreateHealthCheckResponse is undocumented.
 type CreateHealthCheckResponse struct {
-	XMLName xml.Name `xml:"CreateHealthCheckResponse"`
+	XMLName xml.Name
 
 	HealthCheck *HealthCheck    `xml:"HealthCheck,omitempty"`
 	Location    aws.StringValue `xml:"-"`
@@ -1722,7 +1762,7 @@ func (v *CreateHealthCheckResponse) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // CreateHostedZoneRequest is undocumented.
 type CreateHostedZoneRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ CreateHostedZoneRequest"`
+	XMLName xml.Name
 
 	CallerReference  aws.StringValue   `xml:"CallerReference"`
 	DelegationSetID  aws.StringValue   `xml:"DelegationSetId"`
@@ -1737,7 +1777,7 @@ func (v *CreateHostedZoneRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // CreateHostedZoneResponse is undocumented.
 type CreateHostedZoneResponse struct {
-	XMLName xml.Name `xml:"CreateHostedZoneResponse"`
+	XMLName xml.Name
 
 	ChangeInfo    *ChangeInfo     `xml:"ChangeInfo,omitempty"`
 	DelegationSet *DelegationSet  `xml:"DelegationSet,omitempty"`
@@ -1752,7 +1792,7 @@ func (v *CreateHostedZoneResponse) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // CreateReusableDelegationSetRequest is undocumented.
 type CreateReusableDelegationSetRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ CreateReusableDelegationSetRequest"`
+	XMLName xml.Name
 
 	CallerReference aws.StringValue `xml:"CallerReference"`
 	HostedZoneID    aws.StringValue `xml:"HostedZoneId"`
@@ -1764,7 +1804,7 @@ func (v *CreateReusableDelegationSetRequest) MarshalXML(e *xml.Encoder, start xm
 
 // CreateReusableDelegationSetResponse is undocumented.
 type CreateReusableDelegationSetResponse struct {
-	XMLName xml.Name `xml:"CreateReusableDelegationSetResponse"`
+	XMLName xml.Name
 
 	DelegationSet *DelegationSet  `xml:"DelegationSet,omitempty"`
 	Location      aws.StringValue `xml:"-"`
@@ -1776,7 +1816,7 @@ func (v *CreateReusableDelegationSetResponse) MarshalXML(e *xml.Encoder, start x
 
 // DelegationSet is undocumented.
 type DelegationSet struct {
-	XMLName xml.Name `xml:"DelegationSet"`
+	XMLName xml.Name
 
 	CallerReference aws.StringValue `xml:"CallerReference"`
 	ID              aws.StringValue `xml:"Id"`
@@ -1789,7 +1829,7 @@ func (v *DelegationSet) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 
 // DeleteHealthCheckRequest is undocumented.
 type DeleteHealthCheckRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	HealthCheckID aws.StringValue `xml:"-"`
 }
@@ -1800,7 +1840,7 @@ func (v *DeleteHealthCheckRequest) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // DeleteHealthCheckResponse is undocumented.
 type DeleteHealthCheckResponse struct {
-	XMLName xml.Name `xml:"DeleteHealthCheckResponse"`
+	XMLName xml.Name
 }
 
 func (v *DeleteHealthCheckResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -1809,7 +1849,7 @@ func (v *DeleteHealthCheckResponse) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // DeleteHostedZoneRequest is undocumented.
 type DeleteHostedZoneRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1820,7 +1860,7 @@ func (v *DeleteHostedZoneRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // DeleteHostedZoneResponse is undocumented.
 type DeleteHostedZoneResponse struct {
-	XMLName xml.Name `xml:"DeleteHostedZoneResponse"`
+	XMLName xml.Name
 
 	ChangeInfo *ChangeInfo `xml:"ChangeInfo,omitempty"`
 }
@@ -1831,7 +1871,7 @@ func (v *DeleteHostedZoneResponse) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // DeleteReusableDelegationSetRequest is undocumented.
 type DeleteReusableDelegationSetRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1842,7 +1882,7 @@ func (v *DeleteReusableDelegationSetRequest) MarshalXML(e *xml.Encoder, start xm
 
 // DeleteReusableDelegationSetResponse is undocumented.
 type DeleteReusableDelegationSetResponse struct {
-	XMLName xml.Name `xml:"DeleteReusableDelegationSetResponse"`
+	XMLName xml.Name
 }
 
 func (v *DeleteReusableDelegationSetResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -1851,7 +1891,7 @@ func (v *DeleteReusableDelegationSetResponse) MarshalXML(e *xml.Encoder, start x
 
 // DisassociateVPCFromHostedZoneRequest is undocumented.
 type DisassociateVPCFromHostedZoneRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ DisassociateVPCFromHostedZoneRequest"`
+	XMLName xml.Name
 
 	Comment      aws.StringValue `xml:"Comment"`
 	HostedZoneID aws.StringValue `xml:"-"`
@@ -1864,7 +1904,7 @@ func (v *DisassociateVPCFromHostedZoneRequest) MarshalXML(e *xml.Encoder, start 
 
 // DisassociateVPCFromHostedZoneResponse is undocumented.
 type DisassociateVPCFromHostedZoneResponse struct {
-	XMLName xml.Name `xml:"DisassociateVPCFromHostedZoneResponse"`
+	XMLName xml.Name
 
 	ChangeInfo *ChangeInfo `xml:"ChangeInfo,omitempty"`
 }
@@ -1875,7 +1915,7 @@ func (v *DisassociateVPCFromHostedZoneResponse) MarshalXML(e *xml.Encoder, start
 
 // GeoLocation is undocumented.
 type GeoLocation struct {
-	XMLName xml.Name `xml:"GeoLocation"`
+	XMLName xml.Name
 
 	ContinentCode   aws.StringValue `xml:"ContinentCode"`
 	CountryCode     aws.StringValue `xml:"CountryCode"`
@@ -1888,7 +1928,7 @@ func (v *GeoLocation) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // GeoLocationDetails is undocumented.
 type GeoLocationDetails struct {
-	XMLName xml.Name `xml:"GeoLocationDetails"`
+	XMLName xml.Name
 
 	ContinentCode   aws.StringValue `xml:"ContinentCode"`
 	ContinentName   aws.StringValue `xml:"ContinentName"`
@@ -1904,7 +1944,7 @@ func (v *GeoLocationDetails) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // GetChangeRequest is undocumented.
 type GetChangeRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -1915,7 +1955,7 @@ func (v *GetChangeRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // GetChangeResponse is undocumented.
 type GetChangeResponse struct {
-	XMLName xml.Name `xml:"GetChangeResponse"`
+	XMLName xml.Name
 
 	ChangeInfo *ChangeInfo `xml:"ChangeInfo,omitempty"`
 }
@@ -1926,7 +1966,7 @@ func (v *GetChangeResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // GetCheckerIPRangesRequest is undocumented.
 type GetCheckerIPRangesRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 }
 
 func (v *GetCheckerIPRangesRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -1935,7 +1975,7 @@ func (v *GetCheckerIPRangesRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // GetCheckerIPRangesResponse is undocumented.
 type GetCheckerIPRangesResponse struct {
-	XMLName xml.Name `xml:"GetCheckerIpRangesResponse"`
+	XMLName xml.Name
 
 	CheckerIPRanges []string `xml:"CheckerIpRanges,omitempty"`
 }
@@ -1946,7 +1986,7 @@ func (v *GetCheckerIPRangesResponse) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // GetGeoLocationRequest is undocumented.
 type GetGeoLocationRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ContinentCode   aws.StringValue `xml:"-"`
 	CountryCode     aws.StringValue `xml:"-"`
@@ -1959,7 +1999,7 @@ func (v *GetGeoLocationRequest) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // GetGeoLocationResponse is undocumented.
 type GetGeoLocationResponse struct {
-	XMLName xml.Name `xml:"GetGeoLocationResponse"`
+	XMLName xml.Name
 
 	GeoLocationDetails *GeoLocationDetails `xml:"GeoLocationDetails,omitempty"`
 }
@@ -1970,7 +2010,7 @@ func (v *GetGeoLocationResponse) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetHealthCheckCountRequest is undocumented.
 type GetHealthCheckCountRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 }
 
 func (v *GetHealthCheckCountRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -1979,7 +2019,7 @@ func (v *GetHealthCheckCountRequest) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // GetHealthCheckCountResponse is undocumented.
 type GetHealthCheckCountResponse struct {
-	XMLName xml.Name `xml:"GetHealthCheckCountResponse"`
+	XMLName xml.Name
 
 	HealthCheckCount aws.LongValue `xml:"HealthCheckCount"`
 }
@@ -1990,7 +2030,7 @@ func (v *GetHealthCheckCountResponse) MarshalXML(e *xml.Encoder, start xml.Start
 
 // GetHealthCheckLastFailureReasonRequest is undocumented.
 type GetHealthCheckLastFailureReasonRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	HealthCheckID aws.StringValue `xml:"-"`
 }
@@ -2001,7 +2041,7 @@ func (v *GetHealthCheckLastFailureReasonRequest) MarshalXML(e *xml.Encoder, star
 
 // GetHealthCheckLastFailureReasonResponse is undocumented.
 type GetHealthCheckLastFailureReasonResponse struct {
-	XMLName xml.Name `xml:"GetHealthCheckLastFailureReasonResponse"`
+	XMLName xml.Name
 
 	HealthCheckObservations []HealthCheckObservation `xml:"HealthCheckObservations>HealthCheckObservation,omitempty"`
 }
@@ -2012,7 +2052,7 @@ func (v *GetHealthCheckLastFailureReasonResponse) MarshalXML(e *xml.Encoder, sta
 
 // GetHealthCheckRequest is undocumented.
 type GetHealthCheckRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	HealthCheckID aws.StringValue `xml:"-"`
 }
@@ -2023,7 +2063,7 @@ func (v *GetHealthCheckRequest) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // GetHealthCheckResponse is undocumented.
 type GetHealthCheckResponse struct {
-	XMLName xml.Name `xml:"GetHealthCheckResponse"`
+	XMLName xml.Name
 
 	HealthCheck *HealthCheck `xml:"HealthCheck,omitempty"`
 }
@@ -2034,7 +2074,7 @@ func (v *GetHealthCheckResponse) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetHealthCheckStatusRequest is undocumented.
 type GetHealthCheckStatusRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	HealthCheckID aws.StringValue `xml:"-"`
 }
@@ -2045,7 +2085,7 @@ func (v *GetHealthCheckStatusRequest) MarshalXML(e *xml.Encoder, start xml.Start
 
 // GetHealthCheckStatusResponse is undocumented.
 type GetHealthCheckStatusResponse struct {
-	XMLName xml.Name `xml:"GetHealthCheckStatusResponse"`
+	XMLName xml.Name
 
 	HealthCheckObservations []HealthCheckObservation `xml:"HealthCheckObservations>HealthCheckObservation,omitempty"`
 }
@@ -2056,7 +2096,7 @@ func (v *GetHealthCheckStatusResponse) MarshalXML(e *xml.Encoder, start xml.Star
 
 // GetHostedZoneRequest is undocumented.
 type GetHostedZoneRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -2067,7 +2107,7 @@ func (v *GetHostedZoneRequest) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // GetHostedZoneResponse is undocumented.
 type GetHostedZoneResponse struct {
-	XMLName xml.Name `xml:"GetHostedZoneResponse"`
+	XMLName xml.Name
 
 	DelegationSet *DelegationSet `xml:"DelegationSet,omitempty"`
 	HostedZone    *HostedZone    `xml:"HostedZone,omitempty"`
@@ -2080,7 +2120,7 @@ func (v *GetHostedZoneResponse) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // GetReusableDelegationSetRequest is undocumented.
 type GetReusableDelegationSetRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ID aws.StringValue `xml:"-"`
 }
@@ -2091,7 +2131,7 @@ func (v *GetReusableDelegationSetRequest) MarshalXML(e *xml.Encoder, start xml.S
 
 // GetReusableDelegationSetResponse is undocumented.
 type GetReusableDelegationSetResponse struct {
-	XMLName xml.Name `xml:"GetReusableDelegationSetResponse"`
+	XMLName xml.Name
 
 	DelegationSet *DelegationSet `xml:"DelegationSet,omitempty"`
 }
@@ -2102,7 +2142,7 @@ func (v *GetReusableDelegationSetResponse) MarshalXML(e *xml.Encoder, start xml.
 
 // HealthCheck is undocumented.
 type HealthCheck struct {
-	XMLName xml.Name `xml:"HealthCheck"`
+	XMLName xml.Name
 
 	CallerReference    aws.StringValue    `xml:"CallerReference"`
 	HealthCheckConfig  *HealthCheckConfig `xml:"HealthCheckConfig,omitempty"`
@@ -2116,7 +2156,7 @@ func (v *HealthCheck) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // HealthCheckConfig is undocumented.
 type HealthCheckConfig struct {
-	XMLName xml.Name `xml:"HealthCheckConfig"`
+	XMLName xml.Name
 
 	FailureThreshold         aws.IntegerValue `xml:"FailureThreshold"`
 	FullyQualifiedDomainName aws.StringValue  `xml:"FullyQualifiedDomainName"`
@@ -2134,7 +2174,7 @@ func (v *HealthCheckConfig) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // HealthCheckObservation is undocumented.
 type HealthCheckObservation struct {
-	XMLName xml.Name `xml:"HealthCheckObservation"`
+	XMLName xml.Name
 
 	IPAddress    aws.StringValue `xml:"IPAddress"`
 	StatusReport *StatusReport   `xml:"StatusReport,omitempty"`
@@ -2155,7 +2195,7 @@ const (
 
 // HostedZone is undocumented.
 type HostedZone struct {
-	XMLName xml.Name `xml:"HostedZone"`
+	XMLName xml.Name
 
 	CallerReference        aws.StringValue   `xml:"CallerReference"`
 	Config                 *HostedZoneConfig `xml:"Config,omitempty"`
@@ -2170,7 +2210,7 @@ func (v *HostedZone) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // HostedZoneConfig is undocumented.
 type HostedZoneConfig struct {
-	XMLName xml.Name `xml:"HostedZoneConfig"`
+	XMLName xml.Name
 
 	Comment     aws.StringValue  `xml:"Comment"`
 	PrivateZone aws.BooleanValue `xml:"PrivateZone"`
@@ -2182,7 +2222,7 @@ func (v *HostedZoneConfig) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // ListGeoLocationsRequest is undocumented.
 type ListGeoLocationsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	MaxItems             aws.StringValue `xml:"-"`
 	StartContinentCode   aws.StringValue `xml:"-"`
@@ -2196,7 +2236,7 @@ func (v *ListGeoLocationsRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // ListGeoLocationsResponse is undocumented.
 type ListGeoLocationsResponse struct {
-	XMLName xml.Name `xml:"ListGeoLocationsResponse"`
+	XMLName xml.Name
 
 	GeoLocationDetailsList []GeoLocationDetails `xml:"GeoLocationDetailsList>GeoLocationDetails,omitempty"`
 	IsTruncated            aws.BooleanValue     `xml:"IsTruncated"`
@@ -2212,7 +2252,7 @@ func (v *ListGeoLocationsResponse) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // ListHealthChecksRequest is undocumented.
 type ListHealthChecksRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Marker   aws.StringValue `xml:"-"`
 	MaxItems aws.StringValue `xml:"-"`
@@ -2224,7 +2264,7 @@ func (v *ListHealthChecksRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // ListHealthChecksResponse is undocumented.
 type ListHealthChecksResponse struct {
-	XMLName xml.Name `xml:"ListHealthChecksResponse"`
+	XMLName xml.Name
 
 	HealthChecks []HealthCheck    `xml:"HealthChecks>HealthCheck,omitempty"`
 	IsTruncated  aws.BooleanValue `xml:"IsTruncated"`
@@ -2239,7 +2279,7 @@ func (v *ListHealthChecksResponse) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // ListHostedZonesRequest is undocumented.
 type ListHostedZonesRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	DelegationSetID aws.StringValue `xml:"-"`
 	Marker          aws.StringValue `xml:"-"`
@@ -2252,7 +2292,7 @@ func (v *ListHostedZonesRequest) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // ListHostedZonesResponse is undocumented.
 type ListHostedZonesResponse struct {
-	XMLName xml.Name `xml:"ListHostedZonesResponse"`
+	XMLName xml.Name
 
 	HostedZones []HostedZone     `xml:"HostedZones>HostedZone,omitempty"`
 	IsTruncated aws.BooleanValue `xml:"IsTruncated"`
@@ -2267,7 +2307,7 @@ func (v *ListHostedZonesResponse) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // ListResourceRecordSetsRequest is undocumented.
 type ListResourceRecordSetsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	HostedZoneID          aws.StringValue `xml:"-"`
 	MaxItems              aws.StringValue `xml:"-"`
@@ -2282,7 +2322,7 @@ func (v *ListResourceRecordSetsRequest) MarshalXML(e *xml.Encoder, start xml.Sta
 
 // ListResourceRecordSetsResponse is undocumented.
 type ListResourceRecordSetsResponse struct {
-	XMLName xml.Name `xml:"ListResourceRecordSetsResponse"`
+	XMLName xml.Name
 
 	IsTruncated          aws.BooleanValue    `xml:"IsTruncated"`
 	MaxItems             aws.StringValue     `xml:"MaxItems"`
@@ -2298,7 +2338,7 @@ func (v *ListResourceRecordSetsResponse) MarshalXML(e *xml.Encoder, start xml.St
 
 // ListReusableDelegationSetsRequest is undocumented.
 type ListReusableDelegationSetsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Marker   aws.StringValue `xml:"-"`
 	MaxItems aws.StringValue `xml:"-"`
@@ -2310,7 +2350,7 @@ func (v *ListReusableDelegationSetsRequest) MarshalXML(e *xml.Encoder, start xml
 
 // ListReusableDelegationSetsResponse is undocumented.
 type ListReusableDelegationSetsResponse struct {
-	XMLName xml.Name `xml:"ListReusableDelegationSetsResponse"`
+	XMLName xml.Name
 
 	DelegationSets []DelegationSet  `xml:"DelegationSets>DelegationSet,omitempty"`
 	IsTruncated    aws.BooleanValue `xml:"IsTruncated"`
@@ -2325,7 +2365,7 @@ func (v *ListReusableDelegationSetsResponse) MarshalXML(e *xml.Encoder, start xm
 
 // ListTagsForResourceRequest is undocumented.
 type ListTagsForResourceRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ResourceID   aws.StringValue `xml:"-"`
 	ResourceType aws.StringValue `xml:"-"`
@@ -2337,7 +2377,7 @@ func (v *ListTagsForResourceRequest) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // ListTagsForResourceResponse is undocumented.
 type ListTagsForResourceResponse struct {
-	XMLName xml.Name `xml:"ListTagsForResourceResponse"`
+	XMLName xml.Name
 
 	ResourceTagSet *ResourceTagSet `xml:"ResourceTagSet,omitempty"`
 }
@@ -2348,7 +2388,7 @@ func (v *ListTagsForResourceResponse) MarshalXML(e *xml.Encoder, start xml.Start
 
 // ListTagsForResourcesRequest is undocumented.
 type ListTagsForResourcesRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ ListTagsForResourcesRequest"`
+	XMLName xml.Name
 
 	ResourceIDs  []string        `xml:"ResourceIds>ResourceId,omitempty"`
 	ResourceType aws.StringValue `xml:"-"`
@@ -2360,7 +2400,7 @@ func (v *ListTagsForResourcesRequest) MarshalXML(e *xml.Encoder, start xml.Start
 
 // ListTagsForResourcesResponse is undocumented.
 type ListTagsForResourcesResponse struct {
-	XMLName xml.Name `xml:"ListTagsForResourcesResponse"`
+	XMLName xml.Name
 
 	ResourceTagSets []ResourceTagSet `xml:"ResourceTagSets>ResourceTagSet,omitempty"`
 }
@@ -2385,7 +2425,7 @@ const (
 
 // ResourceRecord is undocumented.
 type ResourceRecord struct {
-	XMLName xml.Name `xml:"ResourceRecord"`
+	XMLName xml.Name
 
 	Value aws.StringValue `xml:"Value"`
 }
@@ -2396,7 +2436,7 @@ func (v *ResourceRecord) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 
 // ResourceRecordSet is undocumented.
 type ResourceRecordSet struct {
-	XMLName xml.Name `xml:"ResourceRecordSet"`
+	XMLName xml.Name
 
 	AliasTarget     *AliasTarget     `xml:"AliasTarget,omitempty"`
 	Failover        aws.StringValue  `xml:"Failover"`
@@ -2437,7 +2477,7 @@ const (
 
 // ResourceTagSet is undocumented.
 type ResourceTagSet struct {
-	XMLName xml.Name `xml:"ResourceTagSet"`
+	XMLName xml.Name
 
 	ResourceID   aws.StringValue `xml:"ResourceId"`
 	ResourceType aws.StringValue `xml:"ResourceType"`
@@ -2450,7 +2490,7 @@ func (v *ResourceTagSet) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 
 // StatusReport is undocumented.
 type StatusReport struct {
-	XMLName xml.Name `xml:"StatusReport"`
+	XMLName xml.Name
 
 	CheckedTime time.Time       `xml:"CheckedTime"`
 	Status      aws.StringValue `xml:"Status"`
@@ -2462,7 +2502,7 @@ func (v *StatusReport) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 
 // Tag is undocumented.
 type Tag struct {
-	XMLName xml.Name `xml:"Tag"`
+	XMLName xml.Name
 
 	Key   aws.StringValue `xml:"Key"`
 	Value aws.StringValue `xml:"Value"`
@@ -2480,7 +2520,7 @@ const (
 
 // UpdateHealthCheckRequest is undocumented.
 type UpdateHealthCheckRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ UpdateHealthCheckRequest"`
+	XMLName xml.Name
 
 	FailureThreshold         aws.IntegerValue `xml:"FailureThreshold"`
 	FullyQualifiedDomainName aws.StringValue  `xml:"FullyQualifiedDomainName"`
@@ -2498,7 +2538,7 @@ func (v *UpdateHealthCheckRequest) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // UpdateHealthCheckResponse is undocumented.
 type UpdateHealthCheckResponse struct {
-	XMLName xml.Name `xml:"UpdateHealthCheckResponse"`
+	XMLName xml.Name
 
 	HealthCheck *HealthCheck `xml:"HealthCheck,omitempty"`
 }
@@ -2509,7 +2549,7 @@ func (v *UpdateHealthCheckResponse) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // UpdateHostedZoneCommentRequest is undocumented.
 type UpdateHostedZoneCommentRequest struct {
-	XMLName xml.Name `xml:"https://route53.amazonaws.com/doc/2013-04-01/ UpdateHostedZoneCommentRequest"`
+	XMLName xml.Name
 
 	Comment aws.StringValue `xml:"Comment"`
 	ID      aws.StringValue `xml:"-"`
@@ -2521,7 +2561,7 @@ func (v *UpdateHostedZoneCommentRequest) MarshalXML(e *xml.Encoder, start xml.St
 
 // UpdateHostedZoneCommentResponse is undocumented.
 type UpdateHostedZoneCommentResponse struct {
-	XMLName xml.Name `xml:"UpdateHostedZoneCommentResponse"`
+	XMLName xml.Name
 
 	HostedZone *HostedZone `xml:"HostedZone,omitempty"`
 }
@@ -2532,7 +2572,7 @@ func (v *UpdateHostedZoneCommentResponse) MarshalXML(e *xml.Encoder, start xml.S
 
 // VPC is undocumented.
 type VPC struct {
-	XMLName xml.Name `xml:"VPC"`
+	XMLName xml.Name
 
 	VPCID     aws.StringValue `xml:"VPCId"`
 	VPCRegion aws.StringValue `xml:"VPCRegion"`

--- a/gen/s3/s3.go
+++ b/gen/s3/s3.go
@@ -109,6 +109,12 @@ func (c *S3) CompleteMultipartUpload(req *CompleteMultipartUploadRequest) (resp 
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.MultipartUpload.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "CompleteMultipartUpload",
+	}
+
 	b, err := xml.Marshal(req.MultipartUpload)
 	if err != nil {
 		return
@@ -385,6 +391,12 @@ func (c *S3) CreateBucket(req *CreateBucketRequest) (resp *CreateBucketOutput, e
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.CreateBucketConfiguration.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "CreateBucketConfiguration",
+	}
+
 	b, err := xml.Marshal(req.CreateBucketConfiguration)
 	if err != nil {
 		return
@@ -929,6 +941,12 @@ func (c *S3) DeleteObjects(req *DeleteObjectsRequest) (resp *DeleteObjectsOutput
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.Delete.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "Delete",
+	}
+
 	b, err := xml.Marshal(req.Delete)
 	if err != nil {
 		return
@@ -2391,6 +2409,12 @@ func (c *S3) PutBucketACL(req *PutBucketACLRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.AccessControlPolicy.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "AccessControlPolicy",
+	}
+
 	b, err := xml.Marshal(req.AccessControlPolicy)
 	if err != nil {
 		return
@@ -2465,6 +2489,12 @@ func (c *S3) PutBucketCORS(req *PutBucketCORSRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.CORSConfiguration.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "CORSConfiguration",
+	}
+
 	b, err := xml.Marshal(req.CORSConfiguration)
 	if err != nil {
 		return
@@ -2516,6 +2546,12 @@ func (c *S3) PutBucketLifecycle(req *PutBucketLifecycleRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.LifecycleConfiguration.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "LifecycleConfiguration",
+	}
+
 	b, err := xml.Marshal(req.LifecycleConfiguration)
 	if err != nil {
 		return
@@ -2568,6 +2604,12 @@ func (c *S3) PutBucketLogging(req *PutBucketLoggingRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.BucketLoggingStatus.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "BucketLoggingStatus",
+	}
+
 	b, err := xml.Marshal(req.BucketLoggingStatus)
 	if err != nil {
 		return
@@ -2619,6 +2661,12 @@ func (c *S3) PutBucketNotification(req *PutBucketNotificationRequest) (err error
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.NotificationConfiguration.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "NotificationConfiguration",
+	}
+
 	b, err := xml.Marshal(req.NotificationConfiguration)
 	if err != nil {
 		return
@@ -2670,6 +2718,7 @@ func (c *S3) PutBucketPolicy(req *PutBucketPolicyRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
 	b, err := xml.Marshal(req.Policy)
 	if err != nil {
 		return
@@ -2724,6 +2773,12 @@ func (c *S3) PutBucketRequestPayment(req *PutBucketRequestPaymentRequest) (err e
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.RequestPaymentConfiguration.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "RequestPaymentConfiguration",
+	}
+
 	b, err := xml.Marshal(req.RequestPaymentConfiguration)
 	if err != nil {
 		return
@@ -2774,6 +2829,12 @@ func (c *S3) PutBucketTagging(req *PutBucketTaggingRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.Tagging.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "Tagging",
+	}
+
 	b, err := xml.Marshal(req.Tagging)
 	if err != nil {
 		return
@@ -2825,6 +2886,12 @@ func (c *S3) PutBucketVersioning(req *PutBucketVersioningRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.VersioningConfiguration.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "VersioningConfiguration",
+	}
+
 	b, err := xml.Marshal(req.VersioningConfiguration)
 	if err != nil {
 		return
@@ -2879,6 +2946,12 @@ func (c *S3) PutBucketWebsite(req *PutBucketWebsiteRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.WebsiteConfiguration.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "WebsiteConfiguration",
+	}
+
 	b, err := xml.Marshal(req.WebsiteConfiguration)
 	if err != nil {
 		return
@@ -3102,6 +3175,12 @@ func (c *S3) PutObjectACL(req *PutObjectACLRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.AccessControlPolicy.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "AccessControlPolicy",
+	}
+
 	b, err := xml.Marshal(req.AccessControlPolicy)
 	if err != nil {
 		return
@@ -3181,6 +3260,12 @@ func (c *S3) RestoreObject(req *RestoreObjectRequest) (err error) {
 	var contentType string
 
 	contentType = "application/xml"
+
+	req.RestoreRequest.XMLName = xml.Name{
+		Space: "http://s3.amazonaws.com/doc/2006-03-01/",
+		Local: "RestoreRequest",
+	}
+
 	b, err := xml.Marshal(req.RestoreRequest)
 	if err != nil {
 		return
@@ -3478,7 +3563,7 @@ func (c *S3) UploadPartCopy(req *UploadPartCopyRequest) (resp *UploadPartCopyOut
 
 // AbortMultipartUploadRequest is undocumented.
 type AbortMultipartUploadRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket   aws.StringValue `xml:"-"`
 	Key      aws.StringValue `xml:"-"`
@@ -3491,7 +3576,7 @@ func (v *AbortMultipartUploadRequest) MarshalXML(e *xml.Encoder, start xml.Start
 
 // AccessControlPolicy is undocumented.
 type AccessControlPolicy struct {
-	XMLName xml.Name `xml:"AccessControlPolicy"`
+	XMLName xml.Name
 
 	Grants []Grant `xml:"AccessControlList>Grant,omitempty"`
 	Owner  *Owner  `xml:"Owner,omitempty"`
@@ -3503,7 +3588,7 @@ func (v *AccessControlPolicy) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // Bucket is undocumented.
 type Bucket struct {
-	XMLName xml.Name `xml:"Bucket"`
+	XMLName xml.Name
 
 	CreationDate time.Time       `xml:"CreationDate"`
 	Name         aws.StringValue `xml:"Name"`
@@ -3537,7 +3622,7 @@ const (
 
 // BucketLoggingStatus is undocumented.
 type BucketLoggingStatus struct {
-	XMLName xml.Name `xml:"BucketLoggingStatus"`
+	XMLName xml.Name
 
 	LoggingEnabled *LoggingEnabled `xml:"LoggingEnabled,omitempty"`
 }
@@ -3561,7 +3646,7 @@ const (
 
 // CORSConfiguration is undocumented.
 type CORSConfiguration struct {
-	XMLName xml.Name `xml:"CORSConfiguration"`
+	XMLName xml.Name
 
 	CORSRules []CORSRule `xml:"CORSRule,omitempty"`
 }
@@ -3572,7 +3657,7 @@ func (v *CORSConfiguration) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // CORSRule is undocumented.
 type CORSRule struct {
-	XMLName xml.Name `xml:"CORSRule"`
+	XMLName xml.Name
 
 	AllowedHeaders []string         `xml:"AllowedHeader,omitempty"`
 	AllowedMethods []string         `xml:"AllowedMethod,omitempty"`
@@ -3587,7 +3672,7 @@ func (v *CORSRule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // CloudFunctionConfiguration is undocumented.
 type CloudFunctionConfiguration struct {
-	XMLName xml.Name `xml:"CloudFunctionConfiguration"`
+	XMLName xml.Name
 
 	CloudFunction  aws.StringValue `xml:"CloudFunction"`
 	Event          aws.StringValue `xml:"Event"`
@@ -3602,7 +3687,7 @@ func (v *CloudFunctionConfiguration) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // CommonPrefix is undocumented.
 type CommonPrefix struct {
-	XMLName xml.Name `xml:"CommonPrefix"`
+	XMLName xml.Name
 
 	Prefix aws.StringValue `xml:"Prefix"`
 }
@@ -3613,7 +3698,7 @@ func (v *CommonPrefix) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 
 // CompleteMultipartUploadOutput is undocumented.
 type CompleteMultipartUploadOutput struct {
-	XMLName xml.Name `xml:"CompleteMultipartUploadOutput"`
+	XMLName xml.Name
 
 	Bucket               aws.StringValue `xml:"Bucket"`
 	ETag                 aws.StringValue `xml:"ETag"`
@@ -3631,7 +3716,7 @@ func (v *CompleteMultipartUploadOutput) MarshalXML(e *xml.Encoder, start xml.Sta
 
 // CompleteMultipartUploadRequest is undocumented.
 type CompleteMultipartUploadRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket          aws.StringValue           `xml:"-"`
 	Key             aws.StringValue           `xml:"-"`
@@ -3645,7 +3730,7 @@ func (v *CompleteMultipartUploadRequest) MarshalXML(e *xml.Encoder, start xml.St
 
 // CompletedMultipartUpload is undocumented.
 type CompletedMultipartUpload struct {
-	XMLName xml.Name `xml:"CompletedMultipartUpload"`
+	XMLName xml.Name
 
 	Parts []CompletedPart `xml:"Part,omitempty"`
 }
@@ -3656,7 +3741,7 @@ func (v *CompletedMultipartUpload) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // CompletedPart is undocumented.
 type CompletedPart struct {
-	XMLName xml.Name `xml:"CompletedPart"`
+	XMLName xml.Name
 
 	ETag       aws.StringValue  `xml:"ETag"`
 	PartNumber aws.IntegerValue `xml:"PartNumber"`
@@ -3668,7 +3753,7 @@ func (v *CompletedPart) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 
 // Condition is undocumented.
 type Condition struct {
-	XMLName xml.Name `xml:"Condition"`
+	XMLName xml.Name
 
 	HTTPErrorCodeReturnedEquals aws.StringValue `xml:"HttpErrorCodeReturnedEquals"`
 	KeyPrefixEquals             aws.StringValue `xml:"KeyPrefixEquals"`
@@ -3680,7 +3765,7 @@ func (v *Condition) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // CopyObjectOutput is undocumented.
 type CopyObjectOutput struct {
-	XMLName xml.Name `xml:"CopyObjectOutput"`
+	XMLName xml.Name
 
 	CopyObjectResult     *CopyObjectResult `xml:"CopyObjectResult,omitempty"`
 	CopySourceVersionID  aws.StringValue   `xml:"-"`
@@ -3697,7 +3782,7 @@ func (v *CopyObjectOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // CopyObjectRequest is undocumented.
 type CopyObjectRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ACL                            aws.StringValue   `xml:"-"`
 	Bucket                         aws.StringValue   `xml:"-"`
@@ -3737,7 +3822,7 @@ func (v *CopyObjectRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // CopyObjectResult is undocumented.
 type CopyObjectResult struct {
-	XMLName xml.Name `xml:"CopyObjectResult"`
+	XMLName xml.Name
 
 	ETag         aws.StringValue `xml:"ETag"`
 	LastModified time.Time       `xml:"LastModified"`
@@ -3749,7 +3834,7 @@ func (v *CopyObjectResult) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // CopyPartResult is undocumented.
 type CopyPartResult struct {
-	XMLName xml.Name `xml:"CopyPartResult"`
+	XMLName xml.Name
 
 	ETag         aws.StringValue `xml:"ETag"`
 	LastModified time.Time       `xml:"LastModified"`
@@ -3761,7 +3846,7 @@ func (v *CopyPartResult) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 
 // CreateBucketConfiguration is undocumented.
 type CreateBucketConfiguration struct {
-	XMLName xml.Name `xml:"CreateBucketConfiguration"`
+	XMLName xml.Name
 
 	LocationConstraint aws.StringValue `xml:"LocationConstraint"`
 }
@@ -3772,7 +3857,7 @@ func (v *CreateBucketConfiguration) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // CreateBucketOutput is undocumented.
 type CreateBucketOutput struct {
-	XMLName xml.Name `xml:"CreateBucketOutput"`
+	XMLName xml.Name
 
 	Location aws.StringValue `xml:"-"`
 }
@@ -3783,7 +3868,7 @@ func (v *CreateBucketOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // CreateBucketRequest is undocumented.
 type CreateBucketRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ACL                       aws.StringValue            `xml:"-"`
 	Bucket                    aws.StringValue            `xml:"-"`
@@ -3801,7 +3886,7 @@ func (v *CreateBucketRequest) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // CreateMultipartUploadOutput is undocumented.
 type CreateMultipartUploadOutput struct {
-	XMLName xml.Name `xml:"CreateMultipartUploadOutput"`
+	XMLName xml.Name
 
 	Bucket               aws.StringValue `xml:"Bucket"`
 	Key                  aws.StringValue `xml:"Key"`
@@ -3818,7 +3903,7 @@ func (v *CreateMultipartUploadOutput) MarshalXML(e *xml.Encoder, start xml.Start
 
 // CreateMultipartUploadRequest is undocumented.
 type CreateMultipartUploadRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ACL                     aws.StringValue   `xml:"-"`
 	Bucket                  aws.StringValue   `xml:"-"`
@@ -3849,7 +3934,7 @@ func (v *CreateMultipartUploadRequest) MarshalXML(e *xml.Encoder, start xml.Star
 
 // Delete is undocumented.
 type Delete struct {
-	XMLName xml.Name `xml:"Delete"`
+	XMLName xml.Name
 
 	Objects []ObjectIdentifier `xml:"Object,omitempty"`
 	Quiet   aws.BooleanValue   `xml:"Quiet"`
@@ -3861,7 +3946,7 @@ func (v *Delete) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // DeleteBucketCORSRequest is undocumented.
 type DeleteBucketCORSRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -3872,7 +3957,7 @@ func (v *DeleteBucketCORSRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // DeleteBucketLifecycleRequest is undocumented.
 type DeleteBucketLifecycleRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -3883,7 +3968,7 @@ func (v *DeleteBucketLifecycleRequest) MarshalXML(e *xml.Encoder, start xml.Star
 
 // DeleteBucketPolicyRequest is undocumented.
 type DeleteBucketPolicyRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -3894,7 +3979,7 @@ func (v *DeleteBucketPolicyRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // DeleteBucketRequest is undocumented.
 type DeleteBucketRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -3905,7 +3990,7 @@ func (v *DeleteBucketRequest) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // DeleteBucketTaggingRequest is undocumented.
 type DeleteBucketTaggingRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -3916,7 +4001,7 @@ func (v *DeleteBucketTaggingRequest) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // DeleteBucketWebsiteRequest is undocumented.
 type DeleteBucketWebsiteRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -3927,7 +4012,7 @@ func (v *DeleteBucketWebsiteRequest) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // DeleteMarkerEntry is undocumented.
 type DeleteMarkerEntry struct {
-	XMLName xml.Name `xml:"DeleteMarkerEntry"`
+	XMLName xml.Name
 
 	IsLatest     aws.BooleanValue `xml:"IsLatest"`
 	Key          aws.StringValue  `xml:"Key"`
@@ -3942,7 +4027,7 @@ func (v *DeleteMarkerEntry) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // DeleteObjectOutput is undocumented.
 type DeleteObjectOutput struct {
-	XMLName xml.Name `xml:"DeleteObjectOutput"`
+	XMLName xml.Name
 
 	DeleteMarker aws.BooleanValue `xml:"-"`
 	VersionID    aws.StringValue  `xml:"-"`
@@ -3954,7 +4039,7 @@ func (v *DeleteObjectOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // DeleteObjectRequest is undocumented.
 type DeleteObjectRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket    aws.StringValue `xml:"-"`
 	Key       aws.StringValue `xml:"-"`
@@ -3968,7 +4053,7 @@ func (v *DeleteObjectRequest) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // DeleteObjectsOutput is undocumented.
 type DeleteObjectsOutput struct {
-	XMLName xml.Name `xml:"DeleteObjectsOutput"`
+	XMLName xml.Name
 
 	Deleted []DeletedObject `xml:"Deleted,omitempty"`
 	Errors  []Error         `xml:"Error,omitempty"`
@@ -3980,7 +4065,7 @@ func (v *DeleteObjectsOutput) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // DeleteObjectsRequest is undocumented.
 type DeleteObjectsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 	Delete *Delete         `xml:"Delete,omitempty"`
@@ -3993,7 +4078,7 @@ func (v *DeleteObjectsRequest) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // DeletedObject is undocumented.
 type DeletedObject struct {
-	XMLName xml.Name `xml:"DeletedObject"`
+	XMLName xml.Name
 
 	DeleteMarker          aws.BooleanValue `xml:"DeleteMarker"`
 	DeleteMarkerVersionID aws.StringValue  `xml:"DeleteMarkerVersionId"`
@@ -4012,7 +4097,7 @@ const (
 
 // Error is undocumented.
 type Error struct {
-	XMLName xml.Name `xml:"Error"`
+	XMLName xml.Name
 
 	Code      aws.StringValue `xml:"Code"`
 	Key       aws.StringValue `xml:"Key"`
@@ -4026,7 +4111,7 @@ func (v *Error) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // ErrorDocument is undocumented.
 type ErrorDocument struct {
-	XMLName xml.Name `xml:"ErrorDocument"`
+	XMLName xml.Name
 
 	Key aws.StringValue `xml:"Key"`
 }
@@ -4052,7 +4137,7 @@ const (
 
 // GetBucketACLOutput is undocumented.
 type GetBucketACLOutput struct {
-	XMLName xml.Name `xml:"GetBucketAclOutput"`
+	XMLName xml.Name
 
 	Grants []Grant `xml:"AccessControlList>Grant,omitempty"`
 	Owner  *Owner  `xml:"Owner,omitempty"`
@@ -4064,7 +4149,7 @@ func (v *GetBucketACLOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // GetBucketACLRequest is undocumented.
 type GetBucketACLRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4075,7 +4160,7 @@ func (v *GetBucketACLRequest) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // GetBucketCORSOutput is undocumented.
 type GetBucketCORSOutput struct {
-	XMLName xml.Name `xml:"GetBucketCorsOutput"`
+	XMLName xml.Name
 
 	CORSRules []CORSRule `xml:"CORSRule,omitempty"`
 }
@@ -4086,7 +4171,7 @@ func (v *GetBucketCORSOutput) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // GetBucketCORSRequest is undocumented.
 type GetBucketCORSRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4097,7 +4182,7 @@ func (v *GetBucketCORSRequest) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // GetBucketLifecycleOutput is undocumented.
 type GetBucketLifecycleOutput struct {
-	XMLName xml.Name `xml:"GetBucketLifecycleOutput"`
+	XMLName xml.Name
 
 	Rules []Rule `xml:"Rule,omitempty"`
 }
@@ -4108,7 +4193,7 @@ func (v *GetBucketLifecycleOutput) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // GetBucketLifecycleRequest is undocumented.
 type GetBucketLifecycleRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4119,7 +4204,7 @@ func (v *GetBucketLifecycleRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // GetBucketLocationOutput is undocumented.
 type GetBucketLocationOutput struct {
-	XMLName xml.Name `xml:"GetBucketLocationOutput"`
+	XMLName xml.Name
 
 	LocationConstraint aws.StringValue `xml:"LocationConstraint"`
 }
@@ -4130,7 +4215,7 @@ func (v *GetBucketLocationOutput) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // GetBucketLocationRequest is undocumented.
 type GetBucketLocationRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4141,7 +4226,7 @@ func (v *GetBucketLocationRequest) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // GetBucketLoggingOutput is undocumented.
 type GetBucketLoggingOutput struct {
-	XMLName xml.Name `xml:"GetBucketLoggingOutput"`
+	XMLName xml.Name
 
 	LoggingEnabled *LoggingEnabled `xml:"LoggingEnabled,omitempty"`
 }
@@ -4152,7 +4237,7 @@ func (v *GetBucketLoggingOutput) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetBucketLoggingRequest is undocumented.
 type GetBucketLoggingRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4163,7 +4248,7 @@ func (v *GetBucketLoggingRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // GetBucketNotificationOutput is undocumented.
 type GetBucketNotificationOutput struct {
-	XMLName xml.Name `xml:"GetBucketNotificationOutput"`
+	XMLName xml.Name
 
 	CloudFunctionConfiguration *CloudFunctionConfiguration `xml:"CloudFunctionConfiguration,omitempty"`
 	QueueConfiguration         *QueueConfiguration         `xml:"QueueConfiguration,omitempty"`
@@ -4176,7 +4261,7 @@ func (v *GetBucketNotificationOutput) MarshalXML(e *xml.Encoder, start xml.Start
 
 // GetBucketNotificationRequest is undocumented.
 type GetBucketNotificationRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4187,7 +4272,7 @@ func (v *GetBucketNotificationRequest) MarshalXML(e *xml.Encoder, start xml.Star
 
 // GetBucketPolicyOutput is undocumented.
 type GetBucketPolicyOutput struct {
-	XMLName xml.Name `xml:"GetBucketPolicyOutput"`
+	XMLName xml.Name
 
 	Policy aws.StringValue `xml:"Policy"`
 }
@@ -4198,7 +4283,7 @@ func (v *GetBucketPolicyOutput) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // GetBucketPolicyRequest is undocumented.
 type GetBucketPolicyRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4209,7 +4294,7 @@ func (v *GetBucketPolicyRequest) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetBucketRequestPaymentOutput is undocumented.
 type GetBucketRequestPaymentOutput struct {
-	XMLName xml.Name `xml:"GetBucketRequestPaymentOutput"`
+	XMLName xml.Name
 
 	Payer aws.StringValue `xml:"Payer"`
 }
@@ -4220,7 +4305,7 @@ func (v *GetBucketRequestPaymentOutput) MarshalXML(e *xml.Encoder, start xml.Sta
 
 // GetBucketRequestPaymentRequest is undocumented.
 type GetBucketRequestPaymentRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4231,7 +4316,7 @@ func (v *GetBucketRequestPaymentRequest) MarshalXML(e *xml.Encoder, start xml.St
 
 // GetBucketTaggingOutput is undocumented.
 type GetBucketTaggingOutput struct {
-	XMLName xml.Name `xml:"GetBucketTaggingOutput"`
+	XMLName xml.Name
 
 	TagSet []Tag `xml:"TagSet>Tag,omitempty"`
 }
@@ -4242,7 +4327,7 @@ func (v *GetBucketTaggingOutput) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetBucketTaggingRequest is undocumented.
 type GetBucketTaggingRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4253,7 +4338,7 @@ func (v *GetBucketTaggingRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // GetBucketVersioningOutput is undocumented.
 type GetBucketVersioningOutput struct {
-	XMLName xml.Name `xml:"GetBucketVersioningOutput"`
+	XMLName xml.Name
 
 	MFADelete aws.StringValue `xml:"MfaDelete"`
 	Status    aws.StringValue `xml:"Status"`
@@ -4265,7 +4350,7 @@ func (v *GetBucketVersioningOutput) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // GetBucketVersioningRequest is undocumented.
 type GetBucketVersioningRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4276,7 +4361,7 @@ func (v *GetBucketVersioningRequest) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // GetBucketWebsiteOutput is undocumented.
 type GetBucketWebsiteOutput struct {
-	XMLName xml.Name `xml:"GetBucketWebsiteOutput"`
+	XMLName xml.Name
 
 	ErrorDocument         *ErrorDocument         `xml:"ErrorDocument,omitempty"`
 	IndexDocument         *IndexDocument         `xml:"IndexDocument,omitempty"`
@@ -4290,7 +4375,7 @@ func (v *GetBucketWebsiteOutput) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetBucketWebsiteRequest is undocumented.
 type GetBucketWebsiteRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4301,7 +4386,7 @@ func (v *GetBucketWebsiteRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // GetObjectACLOutput is undocumented.
 type GetObjectACLOutput struct {
-	XMLName xml.Name `xml:"GetObjectAclOutput"`
+	XMLName xml.Name
 
 	Grants []Grant `xml:"AccessControlList>Grant,omitempty"`
 	Owner  *Owner  `xml:"Owner,omitempty"`
@@ -4313,7 +4398,7 @@ func (v *GetObjectACLOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // GetObjectACLRequest is undocumented.
 type GetObjectACLRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket    aws.StringValue `xml:"-"`
 	Key       aws.StringValue `xml:"-"`
@@ -4326,7 +4411,7 @@ func (v *GetObjectACLRequest) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // GetObjectOutput is undocumented.
 type GetObjectOutput struct {
-	XMLName xml.Name `xml:"GetObjectOutput"`
+	XMLName xml.Name
 
 	AcceptRanges            aws.StringValue   `xml:"-"`
 	Body                    io.ReadCloser     `xml:"-"`
@@ -4358,7 +4443,7 @@ func (v *GetObjectOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 
 // GetObjectRequest is undocumented.
 type GetObjectRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket                     aws.StringValue `xml:"-"`
 	IfMatch                    aws.StringValue `xml:"-"`
@@ -4385,7 +4470,7 @@ func (v *GetObjectRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // GetObjectTorrentOutput is undocumented.
 type GetObjectTorrentOutput struct {
-	XMLName xml.Name `xml:"GetObjectTorrentOutput"`
+	XMLName xml.Name
 
 	Body io.ReadCloser `xml:"-"`
 }
@@ -4396,7 +4481,7 @@ func (v *GetObjectTorrentOutput) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // GetObjectTorrentRequest is undocumented.
 type GetObjectTorrentRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 	Key    aws.StringValue `xml:"-"`
@@ -4408,7 +4493,7 @@ func (v *GetObjectTorrentRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // Grant is undocumented.
 type Grant struct {
-	XMLName xml.Name `xml:"Grant"`
+	XMLName xml.Name
 
 	Grantee    *Grantee        `xml:"Grantee,omitempty"`
 	Permission aws.StringValue `xml:"Permission"`
@@ -4420,7 +4505,7 @@ func (v *Grant) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Grantee is undocumented.
 type Grantee struct {
-	XMLName xml.Name `xml:"Grantee"`
+	XMLName xml.Name
 
 	DisplayName  aws.StringValue `xml:"DisplayName"`
 	EmailAddress aws.StringValue `xml:"EmailAddress"`
@@ -4435,7 +4520,7 @@ func (v *Grantee) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // HeadBucketRequest is undocumented.
 type HeadBucketRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket aws.StringValue `xml:"-"`
 }
@@ -4446,7 +4531,7 @@ func (v *HeadBucketRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // HeadObjectOutput is undocumented.
 type HeadObjectOutput struct {
-	XMLName xml.Name `xml:"HeadObjectOutput"`
+	XMLName xml.Name
 
 	AcceptRanges            aws.StringValue   `xml:"-"`
 	CacheControl            aws.StringValue   `xml:"-"`
@@ -4477,7 +4562,7 @@ func (v *HeadObjectOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // HeadObjectRequest is undocumented.
 type HeadObjectRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket               aws.StringValue `xml:"-"`
 	IfMatch              aws.StringValue `xml:"-"`
@@ -4498,7 +4583,7 @@ func (v *HeadObjectRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // IndexDocument is undocumented.
 type IndexDocument struct {
-	XMLName xml.Name `xml:"IndexDocument"`
+	XMLName xml.Name
 
 	Suffix aws.StringValue `xml:"Suffix"`
 }
@@ -4509,7 +4594,7 @@ func (v *IndexDocument) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 
 // Initiator is undocumented.
 type Initiator struct {
-	XMLName xml.Name `xml:"Initiator"`
+	XMLName xml.Name
 
 	DisplayName aws.StringValue `xml:"DisplayName"`
 	ID          aws.StringValue `xml:"ID"`
@@ -4521,7 +4606,7 @@ func (v *Initiator) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // LifecycleConfiguration is undocumented.
 type LifecycleConfiguration struct {
-	XMLName xml.Name `xml:"LifecycleConfiguration"`
+	XMLName xml.Name
 
 	Rules []Rule `xml:"Rule,omitempty"`
 }
@@ -4532,7 +4617,7 @@ func (v *LifecycleConfiguration) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // LifecycleExpiration is undocumented.
 type LifecycleExpiration struct {
-	XMLName xml.Name `xml:"LifecycleExpiration"`
+	XMLName xml.Name
 
 	Date time.Time        `xml:"Date"`
 	Days aws.IntegerValue `xml:"Days"`
@@ -4544,7 +4629,7 @@ func (v *LifecycleExpiration) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // ListBucketsOutput is undocumented.
 type ListBucketsOutput struct {
-	XMLName xml.Name `xml:"ListBucketsOutput"`
+	XMLName xml.Name
 
 	Buckets []Bucket `xml:"Buckets>Bucket,omitempty"`
 	Owner   *Owner   `xml:"Owner,omitempty"`
@@ -4556,7 +4641,7 @@ func (v *ListBucketsOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // ListMultipartUploadsOutput is undocumented.
 type ListMultipartUploadsOutput struct {
-	XMLName xml.Name `xml:"ListMultipartUploadsOutput"`
+	XMLName xml.Name
 
 	Bucket             aws.StringValue   `xml:"Bucket"`
 	CommonPrefixes     []CommonPrefix    `xml:"CommonPrefixes,omitempty"`
@@ -4578,7 +4663,7 @@ func (v *ListMultipartUploadsOutput) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // ListMultipartUploadsRequest is undocumented.
 type ListMultipartUploadsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket         aws.StringValue  `xml:"-"`
 	Delimiter      aws.StringValue  `xml:"-"`
@@ -4595,7 +4680,7 @@ func (v *ListMultipartUploadsRequest) MarshalXML(e *xml.Encoder, start xml.Start
 
 // ListObjectVersionsOutput is undocumented.
 type ListObjectVersionsOutput struct {
-	XMLName xml.Name `xml:"ListObjectVersionsOutput"`
+	XMLName xml.Name
 
 	CommonPrefixes      []CommonPrefix      `xml:"CommonPrefixes,omitempty"`
 	DeleteMarkers       []DeleteMarkerEntry `xml:"DeleteMarker,omitempty"`
@@ -4618,7 +4703,7 @@ func (v *ListObjectVersionsOutput) MarshalXML(e *xml.Encoder, start xml.StartEle
 
 // ListObjectVersionsRequest is undocumented.
 type ListObjectVersionsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket          aws.StringValue  `xml:"-"`
 	Delimiter       aws.StringValue  `xml:"-"`
@@ -4635,7 +4720,7 @@ func (v *ListObjectVersionsRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // ListObjectsOutput is undocumented.
 type ListObjectsOutput struct {
-	XMLName xml.Name `xml:"ListObjectsOutput"`
+	XMLName xml.Name
 
 	CommonPrefixes []CommonPrefix   `xml:"CommonPrefixes,omitempty"`
 	Contents       []Object         `xml:"Contents,omitempty"`
@@ -4655,7 +4740,7 @@ func (v *ListObjectsOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // ListObjectsRequest is undocumented.
 type ListObjectsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket       aws.StringValue  `xml:"-"`
 	Delimiter    aws.StringValue  `xml:"-"`
@@ -4671,7 +4756,7 @@ func (v *ListObjectsRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // ListPartsOutput is undocumented.
 type ListPartsOutput struct {
-	XMLName xml.Name `xml:"ListPartsOutput"`
+	XMLName xml.Name
 
 	Bucket               aws.StringValue  `xml:"Bucket"`
 	Initiator            *Initiator       `xml:"Initiator,omitempty"`
@@ -4692,7 +4777,7 @@ func (v *ListPartsOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 
 // ListPartsRequest is undocumented.
 type ListPartsRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket           aws.StringValue  `xml:"-"`
 	Key              aws.StringValue  `xml:"-"`
@@ -4707,7 +4792,7 @@ func (v *ListPartsRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // LoggingEnabled is undocumented.
 type LoggingEnabled struct {
-	XMLName xml.Name `xml:"LoggingEnabled"`
+	XMLName xml.Name
 
 	TargetBucket aws.StringValue `xml:"TargetBucket"`
 	TargetGrants []TargetGrant   `xml:"TargetGrants>Grant,omitempty"`
@@ -4738,7 +4823,7 @@ const (
 
 // MultipartUpload is undocumented.
 type MultipartUpload struct {
-	XMLName xml.Name `xml:"MultipartUpload"`
+	XMLName xml.Name
 
 	Initiated    time.Time       `xml:"Initiated"`
 	Initiator    *Initiator      `xml:"Initiator,omitempty"`
@@ -4754,7 +4839,7 @@ func (v *MultipartUpload) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 
 // NoncurrentVersionExpiration is undocumented.
 type NoncurrentVersionExpiration struct {
-	XMLName xml.Name `xml:"NoncurrentVersionExpiration"`
+	XMLName xml.Name
 
 	NoncurrentDays aws.IntegerValue `xml:"NoncurrentDays"`
 }
@@ -4765,7 +4850,7 @@ func (v *NoncurrentVersionExpiration) MarshalXML(e *xml.Encoder, start xml.Start
 
 // NoncurrentVersionTransition is undocumented.
 type NoncurrentVersionTransition struct {
-	XMLName xml.Name `xml:"NoncurrentVersionTransition"`
+	XMLName xml.Name
 
 	NoncurrentDays aws.IntegerValue `xml:"NoncurrentDays"`
 	StorageClass   aws.StringValue  `xml:"StorageClass"`
@@ -4777,7 +4862,7 @@ func (v *NoncurrentVersionTransition) MarshalXML(e *xml.Encoder, start xml.Start
 
 // NotificationConfiguration is undocumented.
 type NotificationConfiguration struct {
-	XMLName xml.Name `xml:"NotificationConfiguration"`
+	XMLName xml.Name
 
 	CloudFunctionConfiguration *CloudFunctionConfiguration `xml:"CloudFunctionConfiguration,omitempty"`
 	QueueConfiguration         *QueueConfiguration         `xml:"QueueConfiguration,omitempty"`
@@ -4790,7 +4875,7 @@ func (v *NotificationConfiguration) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // Object is undocumented.
 type Object struct {
-	XMLName xml.Name `xml:"Object"`
+	XMLName xml.Name
 
 	ETag         aws.StringValue  `xml:"ETag"`
 	Key          aws.StringValue  `xml:"Key"`
@@ -4816,7 +4901,7 @@ const (
 
 // ObjectIdentifier is undocumented.
 type ObjectIdentifier struct {
-	XMLName xml.Name `xml:"ObjectIdentifier"`
+	XMLName xml.Name
 
 	Key       aws.StringValue `xml:"Key"`
 	VersionID aws.StringValue `xml:"VersionId"`
@@ -4835,7 +4920,7 @@ const (
 
 // ObjectVersion is undocumented.
 type ObjectVersion struct {
-	XMLName xml.Name `xml:"ObjectVersion"`
+	XMLName xml.Name
 
 	ETag         aws.StringValue  `xml:"ETag"`
 	IsLatest     aws.BooleanValue `xml:"IsLatest"`
@@ -4858,7 +4943,7 @@ const (
 
 // Owner is undocumented.
 type Owner struct {
-	XMLName xml.Name `xml:"Owner"`
+	XMLName xml.Name
 
 	DisplayName aws.StringValue `xml:"DisplayName"`
 	ID          aws.StringValue `xml:"ID"`
@@ -4870,7 +4955,7 @@ func (v *Owner) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Part is undocumented.
 type Part struct {
-	XMLName xml.Name `xml:"Part"`
+	XMLName xml.Name
 
 	ETag         aws.StringValue  `xml:"ETag"`
 	LastModified time.Time        `xml:"LastModified"`
@@ -4905,7 +4990,7 @@ const (
 
 // PutBucketACLRequest is undocumented.
 type PutBucketACLRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ACL                 aws.StringValue      `xml:"-"`
 	AccessControlPolicy *AccessControlPolicy `xml:"AccessControlPolicy,omitempty"`
@@ -4924,7 +5009,7 @@ func (v *PutBucketACLRequest) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // PutBucketCORSRequest is undocumented.
 type PutBucketCORSRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket            aws.StringValue    `xml:"-"`
 	CORSConfiguration *CORSConfiguration `xml:"CORSConfiguration,omitempty"`
@@ -4937,7 +5022,7 @@ func (v *PutBucketCORSRequest) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // PutBucketLifecycleRequest is undocumented.
 type PutBucketLifecycleRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket                 aws.StringValue         `xml:"-"`
 	ContentMD5             aws.StringValue         `xml:"-"`
@@ -4950,7 +5035,7 @@ func (v *PutBucketLifecycleRequest) MarshalXML(e *xml.Encoder, start xml.StartEl
 
 // PutBucketLoggingRequest is undocumented.
 type PutBucketLoggingRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket              aws.StringValue      `xml:"-"`
 	BucketLoggingStatus *BucketLoggingStatus `xml:"BucketLoggingStatus,omitempty"`
@@ -4963,7 +5048,7 @@ func (v *PutBucketLoggingRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // PutBucketNotificationRequest is undocumented.
 type PutBucketNotificationRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket                    aws.StringValue            `xml:"-"`
 	ContentMD5                aws.StringValue            `xml:"-"`
@@ -4976,7 +5061,7 @@ func (v *PutBucketNotificationRequest) MarshalXML(e *xml.Encoder, start xml.Star
 
 // PutBucketPolicyRequest is undocumented.
 type PutBucketPolicyRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket     aws.StringValue `xml:"-"`
 	ContentMD5 aws.StringValue `xml:"-"`
@@ -4989,7 +5074,7 @@ func (v *PutBucketPolicyRequest) MarshalXML(e *xml.Encoder, start xml.StartEleme
 
 // PutBucketRequestPaymentRequest is undocumented.
 type PutBucketRequestPaymentRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket                      aws.StringValue              `xml:"-"`
 	ContentMD5                  aws.StringValue              `xml:"-"`
@@ -5002,7 +5087,7 @@ func (v *PutBucketRequestPaymentRequest) MarshalXML(e *xml.Encoder, start xml.St
 
 // PutBucketTaggingRequest is undocumented.
 type PutBucketTaggingRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket     aws.StringValue `xml:"-"`
 	ContentMD5 aws.StringValue `xml:"-"`
@@ -5015,7 +5100,7 @@ func (v *PutBucketTaggingRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // PutBucketVersioningRequest is undocumented.
 type PutBucketVersioningRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket                  aws.StringValue          `xml:"-"`
 	ContentMD5              aws.StringValue          `xml:"-"`
@@ -5029,7 +5114,7 @@ func (v *PutBucketVersioningRequest) MarshalXML(e *xml.Encoder, start xml.StartE
 
 // PutBucketWebsiteRequest is undocumented.
 type PutBucketWebsiteRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket               aws.StringValue       `xml:"-"`
 	ContentMD5           aws.StringValue       `xml:"-"`
@@ -5042,7 +5127,7 @@ func (v *PutBucketWebsiteRequest) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // PutObjectACLRequest is undocumented.
 type PutObjectACLRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ACL                 aws.StringValue      `xml:"-"`
 	AccessControlPolicy *AccessControlPolicy `xml:"AccessControlPolicy,omitempty"`
@@ -5062,7 +5147,7 @@ func (v *PutObjectACLRequest) MarshalXML(e *xml.Encoder, start xml.StartElement)
 
 // PutObjectOutput is undocumented.
 type PutObjectOutput struct {
-	XMLName xml.Name `xml:"PutObjectOutput"`
+	XMLName xml.Name
 
 	ETag                 aws.StringValue `xml:"-"`
 	Expiration           aws.StringValue `xml:"-"`
@@ -5079,7 +5164,7 @@ func (v *PutObjectOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) err
 
 // PutObjectRequest is undocumented.
 type PutObjectRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	ACL                     aws.StringValue   `xml:"-"`
 	Body                    io.ReadCloser     `xml:"-"`
@@ -5113,7 +5198,7 @@ func (v *PutObjectRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // QueueConfiguration is undocumented.
 type QueueConfiguration struct {
-	XMLName xml.Name `xml:"QueueConfiguration"`
+	XMLName xml.Name
 
 	Event  aws.StringValue `xml:"Event"`
 	Events []string        `xml:"Event,omitempty"`
@@ -5127,7 +5212,7 @@ func (v *QueueConfiguration) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // Redirect is undocumented.
 type Redirect struct {
-	XMLName xml.Name `xml:"Redirect"`
+	XMLName xml.Name
 
 	HostName             aws.StringValue `xml:"HostName"`
 	HTTPRedirectCode     aws.StringValue `xml:"HttpRedirectCode"`
@@ -5142,7 +5227,7 @@ func (v *Redirect) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // RedirectAllRequestsTo is undocumented.
 type RedirectAllRequestsTo struct {
-	XMLName xml.Name `xml:"RedirectAllRequestsTo"`
+	XMLName xml.Name
 
 	HostName aws.StringValue `xml:"HostName"`
 	Protocol aws.StringValue `xml:"Protocol"`
@@ -5154,7 +5239,7 @@ func (v *RedirectAllRequestsTo) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // RequestPaymentConfiguration is undocumented.
 type RequestPaymentConfiguration struct {
-	XMLName xml.Name `xml:"RequestPaymentConfiguration"`
+	XMLName xml.Name
 
 	Payer aws.StringValue `xml:"Payer"`
 }
@@ -5165,7 +5250,7 @@ func (v *RequestPaymentConfiguration) MarshalXML(e *xml.Encoder, start xml.Start
 
 // RestoreObjectRequest is undocumented.
 type RestoreObjectRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket         aws.StringValue `xml:"-"`
 	Key            aws.StringValue `xml:"-"`
@@ -5179,7 +5264,7 @@ func (v *RestoreObjectRequest) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // RestoreRequest is undocumented.
 type RestoreRequest struct {
-	XMLName xml.Name `xml:"RestoreRequest"`
+	XMLName xml.Name
 
 	Days aws.IntegerValue `xml:"Days"`
 }
@@ -5190,7 +5275,7 @@ func (v *RestoreRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 
 // RoutingRule is undocumented.
 type RoutingRule struct {
-	XMLName xml.Name `xml:"RoutingRule"`
+	XMLName xml.Name
 
 	Condition *Condition `xml:"Condition,omitempty"`
 	Redirect  *Redirect  `xml:"Redirect,omitempty"`
@@ -5202,7 +5287,7 @@ func (v *RoutingRule) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Rule is undocumented.
 type Rule struct {
-	XMLName xml.Name `xml:"Rule"`
+	XMLName xml.Name
 
 	Expiration                  *LifecycleExpiration         `xml:"Expiration,omitempty"`
 	ID                          aws.StringValue              `xml:"ID"`
@@ -5230,7 +5315,7 @@ const (
 
 // Tag is undocumented.
 type Tag struct {
-	XMLName xml.Name `xml:"Tag"`
+	XMLName xml.Name
 
 	Key   aws.StringValue `xml:"Key"`
 	Value aws.StringValue `xml:"Value"`
@@ -5242,7 +5327,7 @@ func (v *Tag) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Tagging is undocumented.
 type Tagging struct {
-	XMLName xml.Name `xml:"Tagging"`
+	XMLName xml.Name
 
 	TagSet []Tag `xml:"TagSet>Tag,omitempty"`
 }
@@ -5253,7 +5338,7 @@ func (v *Tagging) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // TargetGrant is undocumented.
 type TargetGrant struct {
-	XMLName xml.Name `xml:"TargetGrant"`
+	XMLName xml.Name
 
 	Grantee    *Grantee        `xml:"Grantee,omitempty"`
 	Permission aws.StringValue `xml:"Permission"`
@@ -5265,7 +5350,7 @@ func (v *TargetGrant) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // TopicConfiguration is undocumented.
 type TopicConfiguration struct {
-	XMLName xml.Name `xml:"TopicConfiguration"`
+	XMLName xml.Name
 
 	Event  aws.StringValue `xml:"Event"`
 	Events []string        `xml:"Event,omitempty"`
@@ -5279,7 +5364,7 @@ func (v *TopicConfiguration) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 
 // Transition is undocumented.
 type Transition struct {
-	XMLName xml.Name `xml:"Transition"`
+	XMLName xml.Name
 
 	Date         time.Time        `xml:"Date"`
 	Days         aws.IntegerValue `xml:"Days"`
@@ -5304,7 +5389,7 @@ const (
 
 // UploadPartCopyOutput is undocumented.
 type UploadPartCopyOutput struct {
-	XMLName xml.Name `xml:"UploadPartCopyOutput"`
+	XMLName xml.Name
 
 	CopyPartResult       *CopyPartResult `xml:"CopyPartResult,omitempty"`
 	CopySourceVersionID  aws.StringValue `xml:"-"`
@@ -5320,7 +5405,7 @@ func (v *UploadPartCopyOutput) MarshalXML(e *xml.Encoder, start xml.StartElement
 
 // UploadPartCopyRequest is undocumented.
 type UploadPartCopyRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Bucket                         aws.StringValue  `xml:"-"`
 	CopySource                     aws.StringValue  `xml:"-"`
@@ -5346,7 +5431,7 @@ func (v *UploadPartCopyRequest) MarshalXML(e *xml.Encoder, start xml.StartElemen
 
 // UploadPartOutput is undocumented.
 type UploadPartOutput struct {
-	XMLName xml.Name `xml:"UploadPartOutput"`
+	XMLName xml.Name
 
 	ETag                 aws.StringValue `xml:"-"`
 	SSECustomerAlgorithm aws.StringValue `xml:"-"`
@@ -5361,7 +5446,7 @@ func (v *UploadPartOutput) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 
 // UploadPartRequest is undocumented.
 type UploadPartRequest struct {
-	XMLName xml.Name `xml:""`
+	XMLName xml.Name
 
 	Body                 io.ReadCloser    `xml:"-"`
 	Bucket               aws.StringValue  `xml:"-"`
@@ -5381,7 +5466,7 @@ func (v *UploadPartRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 
 // VersioningConfiguration is undocumented.
 type VersioningConfiguration struct {
-	XMLName xml.Name `xml:"VersioningConfiguration"`
+	XMLName xml.Name
 
 	MFADelete aws.StringValue `xml:"MfaDelete"`
 	Status    aws.StringValue `xml:"Status"`
@@ -5393,7 +5478,7 @@ func (v *VersioningConfiguration) MarshalXML(e *xml.Encoder, start xml.StartElem
 
 // WebsiteConfiguration is undocumented.
 type WebsiteConfiguration struct {
-	XMLName xml.Name `xml:"WebsiteConfiguration"`
+	XMLName xml.Name
 
 	ErrorDocument         *ErrorDocument         `xml:"ErrorDocument,omitempty"`
 	IndexDocument         *IndexDocument         `xml:"IndexDocument,omitempty"`

--- a/internal/route53_serialization_test.go
+++ b/internal/route53_serialization_test.go
@@ -31,7 +31,36 @@ func TestRoute53RequestSerialization(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+	expected := `<ChangeResourceRecordSetsRequest>
+  <ChangeBatch>
+    <Changes>
+      <Change>
+        <Action>dance</Action>
+        <ResourceRecordSet>
+          <AliasTarget>
+            <EvaluateTargetHealth>false</EvaluateTargetHealth>
+          </AliasTarget>
+        </ResourceRecordSet>
+      </Change>
+    </Changes>
+    <Comment>hello</Comment>
+  </ChangeBatch>
+</ChangeResourceRecordSetsRequest>`
+
+	if v, want := string(out), expected; v != want {
+		t.Errorf("Was \n%s\n but expected \n%s", v, want)
+	}
+
+	// Supply a value to XMLName to override the default marshaler tag behavior
+	r.XMLName = xml.Name{
+		Local: "ChangeResourceRecordSetsRequest",
+		Space: "https://route53.amazonaws.com/doc/2013-04-01/",
+	}
+	out, err = xml.MarshalIndent(r, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = `<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
   <ChangeBatch>
     <Changes>
       <Change>

--- a/model/model.go
+++ b/model/model.go
@@ -418,18 +418,6 @@ func (s *Shape) Type() string {
 	panic(fmt.Errorf("type %q (%q) not found", s.Name, s.ShapeType))
 }
 
-func (s *Shape) XMLName() string {
-	for _, op := range service.Operations {
-		if op.InputRef != nil && op.InputRef.ShapeName == s.Name {
-			if op.InputRef.XMLNamespace.URI != "" {
-				return fmt.Sprintf("`xml:%q`", op.InputRef.XMLNamespace.URI+" "+op.InputRef.LocationName)
-			}
-			return fmt.Sprintf("`xml:%q`", op.InputRef.LocationName)
-		}
-	}
-	return fmt.Sprintf("`xml:%q`", s.Name)
-}
-
 // A Service is an AWS service.
 type Service struct {
 	Name          string

--- a/model/templates.go
+++ b/model/templates.go
@@ -507,7 +507,13 @@ func New(creds aws.CredentialsProvider, region string, client *http.Client) *{{ 
   body = req.{{ exportable $m.Name  }}
   {{ else }}
   contentType = "application/xml"
-  b, err := xml.Marshal(req.{{ exportable $m.Name  }})
+	{{ if ne $m.LocationName ""}}
+  req.{{ exportable $m.Name }}.XMLName = xml.Name{
+		Space: "{{ $m.XMLNamespace.URI }}",
+		Local: "{{ $m.LocationName }}",
+	}
+  {{ end }}
+  b, err := xml.Marshal(req.{{ exportable $m.Name }})
   if err != nil {
     return
   }
@@ -516,6 +522,10 @@ func New(creds aws.CredentialsProvider, region string, client *http.Client) *{{ 
   {{ end }}
   {{ else if $op.InputRef.LocationName }}
   contentType = "application/xml"
+  req.XMLName = xml.Name{
+		Space: "{{ $op.InputRef.XMLNamespace.URI }}",
+		Local: "{{ $op.InputRef.LocationName }}",
+	}
   b, err := xml.Marshal(req)
   if err != nil {
     return
@@ -586,7 +596,7 @@ func New(creds aws.CredentialsProvider, region string, client *http.Client) *{{ 
 
 // {{ exportable $name }} is undocumented.
 type {{ exportable $name }} struct {
-  XMLName xml.Name {{ $s.XMLName }}
+  XMLName xml.Name
 {{ range $name, $m := $s.Members }}
 {{ exportable $name }} {{ $m.Type }} {{ $m.XMLTag $s.ResultWrapper }}  {{ end }}
 }


### PR DESCRIPTION
The XML location name used for a given shape is not always consistent,
so we can't hard-code its value into a struct tag on XMLName. However,
we still need a way to contribute the XML namespace to elements where
the JSON schema specifies one. The solution is to rely on Go's order of
XMLName precedence.

By supplying a value to an un-tagged XMLName property, we can specify
the appropriate local name and namespace at call time just before
marshaling the request body. Since these values are logically grouped
with operations in the JSON schema, this seems a more appropriate place
to set them than via struct tags.

Resolves #35.
