### PR TITLE
query: Do not alter prefix in for-loop

### DIFF
--- a/aws/query.go
+++ b/aws/query.go
@@ -95,12 +95,13 @@ func (c *QueryClient) loadValues(v url.Values, i interface{}, prefix string) err
 		return c.loadStruct(v, value, prefix)
 	case reflect.Slice:
 		for i := 0; i < value.Len(); i++ {
-			if prefix == "" {
-				prefix = strconv.Itoa(i + 1)
+			slicePrefix := prefix
+			if slicePrefix == "" {
+				slicePrefix = strconv.Itoa(i + 1)
 			} else {
-				prefix = prefix + ".member." + strconv.Itoa(i+1)
+				slicePrefix = prefix + ".member." + strconv.Itoa(i+1)
 			}
-			if err := c.loadValues(v, value.Index(i).Interface(), prefix); err != nil {
+			if err := c.loadValues(v, value.Index(i).Interface(), slicePrefix); err != nil {
 				return err
 			}
 		}

--- a/aws/query_test.go
+++ b/aws/query_test.go
@@ -60,7 +60,10 @@ func TestQueryRequest(t *testing.T) {
 		PresentTime:        time.Date(2001, 1, 1, 2, 1, 1, 0, time.FixedZone("UTC+1", 3600)),
 		PresentSlice:       []string{"one", "two"},
 		PresentStruct:      &EmbeddedStruct{Value: aws.String("v")},
-		PresentStructSlice: []EmbeddedStruct{{Value: aws.String("p")}},
+		PresentStructSlice: []EmbeddedStruct{
+			{Value: aws.String("p")},
+			{Value: aws.String("q")},
+		},
 		PresentMap: map[string]EmbeddedStruct{
 			"aa": EmbeddedStruct{Value: aws.String("AA")},
 			"bb": EmbeddedStruct{Value: aws.String("BB")},
@@ -108,6 +111,7 @@ func TestQueryRequest(t *testing.T) {
 		"PresentSlice.member.2":             []string{"two"},
 		"PresentStruct.Value":               []string{"v"},
 		"PresentStructSlice.member.1.Value": []string{"p"},
+		"PresentStructSlice.member.2.Value": []string{"q"},
 		"PresentMap.1.Name":                 []string{"aa"},
 		"PresentMap.1.Value.Value":          []string{"AA"},
 		"PresentMap.2.Name":                 []string{"bb"},


### PR DESCRIPTION
I found this bug while I'm trying to use [SendMessageBatch in SQS](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html).
## Question

SQS still returns 400 with this fix because flattened attributes include `.member.` in its prefix.
### Expected

```
Action=SendMessageBatch
QueueUrl=<snip>
SendMessageBatchRequestEntry.1.Id=msg-0
SendMessageBatchRequestEntry.1.MessageAttributes.1.Name=ATTR1
SendMessageBatchRequestEntry.1.MessageAttributes.1.Value.DataType=String
SendMessageBatchRequestEntry.1.MessageAttributes.1.Value.StringValue=STRING%21%21
SendMessageBatchRequestEntry.1.MessageAttributes.2.Name=ATTR2
SendMessageBatchRequestEntry.1.MessageAttributes.2.Value.DataType=Number
SendMessageBatchRequestEntry.1.MessageAttributes.2.Value.StringValue=12345
SendMessageBatchRequestEntry.1.MessageBody=body1
SendMessageBatchRequestEntry.2.Id=msg-1
SendMessageBatchRequestEntry.2.MessageAttributes.1.Name=ATTR1
SendMessageBatchRequestEntry.2.MessageAttributes.1.Value.DataType=String
SendMessageBatchRequestEntry.2.MessageAttributes.1.Value.StringValue=STRING%21%21
SendMessageBatchRequestEntry.2.MessageAttributes.2.Name=ATTR2
SendMessageBatchRequestEntry.2.MessageAttributes.2.Value.DataType=Number
SendMessageBatchRequestEntry.2.MessageAttributes.2.Value.StringValue=12345
SendMessageBatchRequestEntry.2.MessageBody=body2
Version=2012-11-05
```
### Actual (with this fix)

```
Action=SendMessageBatch
QueueUrl=<snip>
SendMessageBatchRequestEntry.member.1.Id=msg-0
SendMessageBatchRequestEntry.member.1.MessageAttributes.1.Name=ATTR1
SendMessageBatchRequestEntry.member.1.MessageAttributes.1.Value.DataType=String
SendMessageBatchRequestEntry.member.1.MessageAttributes.1.Value.StringValue=STRING%21%21
SendMessageBatchRequestEntry.member.1.MessageAttributes.2.Name=ATTR2
SendMessageBatchRequestEntry.member.1.MessageAttributes.2.Value.DataType=Number
SendMessageBatchRequestEntry.member.1.MessageAttributes.2.Value.StringValue=12345
SendMessageBatchRequestEntry.member.1.MessageBody=body1
SendMessageBatchRequestEntry.member.2.Id=msg-1
SendMessageBatchRequestEntry.member.2.MessageAttributes.1.Name=ATTR1
SendMessageBatchRequestEntry.member.2.MessageAttributes.1.Value.DataType=String
SendMessageBatchRequestEntry.member.2.MessageAttributes.1.Value.StringValue=STRING%21%21
SendMessageBatchRequestEntry.member.2.MessageAttributes.2.Name=ATTR2
SendMessageBatchRequestEntry.member.2.MessageAttributes.2.Value.DataType=Number
SendMessageBatchRequestEntry.member.2.MessageAttributes.2.Value.StringValue=12345
SendMessageBatchRequestEntry.member.2.MessageBody=body2
Version=2012-11-05
```
