### PR TITLE
Add GetMetadata function

### DIFF
--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+var metadataClient = http.Client{
+	Timeout: time.Second * 1,
+}
+
+func GetMetadata(path string) (contents []byte, err error) {
+	url := "http://169.254.169.254/" + path
+
+	res, err := metadataClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		err = fmt.Errorf("Code %d returned for url %s", res.StatusCode, url)
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(body), nil
+}


### PR DESCRIPTION
Continues #182; fixes #153.

I carried @pdalinis' work, and I plan to have `aws/credentials.go` use this as well.