### PR TITLE
Add sts.STSProvider for utilising arbitrary STS credentials in AWS calls

### DIFF
--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -93,6 +93,50 @@ type Provider interface {
 	IsExpired() bool
 }
 
+// A Expiry provides shared expiration logic to be used by credentials
+// providers to implement expiry functionality.
+//
+// The best method to use this struct is as an anonymous field within the
+// provider's struct.
+//
+// Example:
+//     type EC2RoleProvider struct {
+//         Expiry
+//         ...
+//     }
+type Expiry struct {
+	// The date/time when to expire on
+	expiration time.Time
+
+	// If set will be used by IsExpired to determine the current time.
+	// Defaults to time.Now if CurrentTime is not set.  Available for testing
+	// to be able to mock out the current time.
+	CurrentTime func() time.Time
+}
+
+// SetExpiration sets the expiration IsExpired will check when called.
+//
+// If window is greater than 0 the expiration time will be reduced by the
+// window value.
+//
+// Using a window is helpful to trigger credentials to expire sooner than
+// the expiration time given to ensure no requests are made with expired
+// tokens.
+func (e *Expiry) SetExpiration(expiration time.Time, window time.Duration) {
+	e.expiration = expiration
+	if window > 0 {
+		e.expiration = e.expiration.Add(-window)
+	}
+}
+
+// IsExpired returns if the credentials are expired.
+func (e *Expiry) IsExpired() bool {
+	if e.CurrentTime == nil {
+		e.CurrentTime = time.Now
+	}
+	return e.expiration.Before(e.CurrentTime())
+}
+
 // A Credentials provides synchronous safe retrieval of AWS credentials Value.
 // Credentials will cache the credentials value until they expire. Once the value
 // expires the next Get will attempt to retrieve valid credentials.
@@ -173,6 +217,3 @@ func (c *Credentials) IsExpired() bool {
 func (c *Credentials) isExpired() bool {
 	return c.forceRefresh || c.provider.IsExpired()
 }
-
-// Provide a stub-able time.Now for unit tests so expiry can be tested.
-var currentTime = time.Now

--- a/aws/credentials/ec2_role_provider_test.go
+++ b/aws/credentials/ec2_role_provider_test.go
@@ -45,10 +45,7 @@ func TestEC2RoleProviderIsExpired(t *testing.T) {
 	defer server.Close()
 
 	p := &EC2RoleProvider{Client: http.DefaultClient, Endpoint: server.URL}
-	defer func() {
-		currentTime = time.Now
-	}()
-	currentTime = func() time.Time {
+	p.CurrentTime = func() time.Time {
 		return time.Date(2014, 12, 15, 21, 26, 0, 0, time.UTC)
 	}
 
@@ -59,7 +56,7 @@ func TestEC2RoleProviderIsExpired(t *testing.T) {
 
 	assert.False(t, p.IsExpired(), "Expect creds to not be expired after retrieve.")
 
-	currentTime = func() time.Time {
+	p.CurrentTime = func() time.Time {
 		return time.Date(3014, 12, 15, 21, 26, 0, 0, time.UTC)
 	}
 
@@ -71,10 +68,7 @@ func TestEC2RoleProviderExpiryWindowIsExpired(t *testing.T) {
 	defer server.Close()
 
 	p := &EC2RoleProvider{Client: http.DefaultClient, Endpoint: server.URL, ExpiryWindow: time.Hour * 1}
-	defer func() {
-		currentTime = time.Now
-	}()
-	currentTime = func() time.Time {
+	p.CurrentTime = func() time.Time {
 		return time.Date(2014, 12, 15, 0, 51, 37, 0, time.UTC)
 	}
 
@@ -85,7 +79,7 @@ func TestEC2RoleProviderExpiryWindowIsExpired(t *testing.T) {
 
 	assert.False(t, p.IsExpired(), "Expect creds to not be expired after retrieve.")
 
-	currentTime = func() time.Time {
+	p.CurrentTime = func() time.Time {
 		return time.Date(2014, 12, 16, 0, 55, 37, 0, time.UTC)
 	}
 

--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -1,0 +1,116 @@
+package stscreds
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"time"
+)
+
+// AssumeRoler represents the minimal subset of the STS client API used by this provider.
+type AssumeRoler interface {
+	AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
+}
+
+// AssumeRoleProvider retrieves temporary credentials from the STS service, and
+// keeps track of their expiration time. This provider must be used explicitly,
+// as it is not included in the credentials chain.
+//
+// Example how to configure a service to use this provider:
+//
+//		config := &aws.Config{
+//			Credentials: stscreds.NewCredentials(nil, "arn-of-the-role-to-assume", 10*time.Second),
+//		})
+//		// Use config for creating your AWS service.
+//
+// Example how to obtain customised credentials:
+//
+//		provider := &stscreds.Provider{
+//			// Extend the duration to 1 hour.
+//			Duration: time.Hour,
+//			// Custom role name.
+//			RoleSessionName: "custom-session-name",
+//		}
+//		creds := credentials.NewCredentials(provider)
+//
+type AssumeRoleProvider struct {
+	credentials.Expiry
+
+	// Custom STS client.
+	Client AssumeRoler
+
+	// Role to be assumed.
+	RoleARN string
+
+	// Session name, if you wish to reuse the credentials elsewhere.
+	RoleSessionName string
+
+	// Expiry duration of the STS credentials.
+	Duration time.Duration
+
+	// ExpiryWindow will allow the credentials to trigger refreshing prior to
+	// the credentials actually expiring. This is beneficial so race conditions
+	// with expiring credentials do not cause request to fail unexpectedly
+	// due to ExpiredTokenException exceptions.
+	//
+	// So a ExpiryWindow of 10s would cause calls to IsExpired() to return true
+	// 10 seconds before the credentials are actually expired.
+	//
+	// If ExpiryWindow is 0 or less it will be ignored.
+	ExpiryWindow time.Duration
+}
+
+// NewCredentials returns a pointer to a new Credentials object wrapping the
+// AssumeRoleProvider.  The credentials will expire every 15 minutes and the
+// role will be named after a nanosecond timestamp of this operation.
+//
+// The sts and roleARN parameters are used for building the "AssumeRole" call.
+// Pass nil as sts to use the default client.
+//
+// Window is the expiry window that will be subtracted from the expiry returned
+// by the role credential request. This is done so that the credentials will
+// expire sooner than their actual lifespan.
+func NewCredentials(client AssumeRoler, roleARN string, window time.Duration) *credentials.Credentials {
+	return credentials.NewCredentials(&AssumeRoleProvider{
+		Client:       client,
+		RoleARN:      roleARN,
+		ExpiryWindow: window,
+	})
+}
+
+// Retrieve generates a new set of temporary credentials using STS.
+func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
+
+	// Apply defaults where parameters are not set.
+	if p.Client == nil {
+		p.Client = sts.New(nil)
+	}
+	if p.RoleSessionName == "" {
+		// Try to work out a role name that will hopefully end up unique.
+		p.RoleSessionName = fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+	}
+	if p.Duration == 0 {
+		// Expire as often as AWS permits.
+		p.Duration = 15 * time.Minute
+	}
+
+	roleOutput, err := p.Client.AssumeRole(&sts.AssumeRoleInput{
+		DurationSeconds: aws.Long(int64(p.Duration / time.Second)),
+		RoleARN:         aws.String(p.RoleARN),
+		RoleSessionName: aws.String(p.RoleSessionName),
+	})
+
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	// We will proactively generate new credentials before they expire.
+	p.SetExpiration(*roleOutput.Credentials.Expiration, p.ExpiryWindow)
+
+	return credentials.Value{
+		AccessKeyID:     *roleOutput.Credentials.AccessKeyID,
+		SecretAccessKey: *roleOutput.Credentials.SecretAccessKey,
+		SessionToken:    *roleOutput.Credentials.SessionToken,
+	}, nil
+}

--- a/aws/credentials/stscreds/assume_role_provider_test.go
+++ b/aws/credentials/stscreds/assume_role_provider_test.go
@@ -1,0 +1,58 @@
+package stscreds
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+type stubSTS struct {
+}
+
+func (s *stubSTS) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+	expiry := time.Now().Add(60 * time.Minute)
+	return &sts.AssumeRoleOutput{
+		Credentials: &sts.Credentials{
+			// Just reflect the role arn to the provider.
+			AccessKeyID:     input.RoleARN,
+			SecretAccessKey: aws.String("assumedSecretAccessKey"),
+			SessionToken:    aws.String("assumedSessionToken"),
+			Expiration:      &expiry,
+		},
+	}, nil
+}
+
+func TestAssumeRoleProvider(t *testing.T) {
+	stub := &stubSTS{}
+	p := &AssumeRoleProvider{
+		Client:  stub,
+		RoleARN: "roleARN",
+	}
+
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "roleARN", creds.AccessKeyID, "Expect access key ID to be reflected role ARN")
+	assert.Equal(t, "assumedSecretAccessKey", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Equal(t, "assumedSessionToken", creds.SessionToken, "Expect session token to match")
+}
+
+func BenchmarkAssumeRoleProvider(b *testing.B) {
+	stub := &stubSTS{}
+	p := &AssumeRoleProvider{
+		Client:  stub,
+		RoleARN: "roleARN",
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := p.Retrieve()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR is incomplete (lacks tests) but I was hoping I could get some feedback on how to best implement this. I had to put it in the "sts" package - I tried "credentials" but that caused import loops. 

It seems ugly that the ExpiryWindow feature is copy-pasted from the EC2RoleProvider, but I wasn't sure how to approach this. Would creating a common "TemporaryProvider" which would implement the ExpiryWindow functionality be appropriate?

Ah yes, and here is a [gist of our actual use-case](https://gist.github.com/mateusz/631e50a46ee94a288595), which we are currently accomplishing by hacking about. 

Thanks for help.