### PR TITLE
Simplify struct, map, array and slice literals

### DIFF
--- a/aws/awsutil/path_value_test.go
+++ b/aws/awsutil/path_value_test.go
@@ -16,8 +16,8 @@ type Struct struct {
 }
 
 var data = Struct{
-	A: []Struct{Struct{C: "value1"}, Struct{C: "value2"}, Struct{C: "value3"}},
-	z: []Struct{Struct{C: "value1"}, Struct{C: "value2"}, Struct{C: "value3"}},
+	A: []Struct{{C: "value1"}, {C: "value2"}, {C: "value3"}},
+	z: []Struct{{C: "value1"}, {C: "value2"}, {C: "value3"}},
 	B: &Struct{B: &Struct{C: "terminal"}, D: &Struct{C: "terminal2"}},
 	C: "initial",
 }

--- a/aws/param_validator_test.go
+++ b/aws/param_validator_test.go
@@ -41,8 +41,8 @@ func TestNoErrors(t *testing.T) {
 	input := &StructShape{
 		RequiredList: []*ConditionalStructShape{},
 		RequiredMap: map[string]*ConditionalStructShape{
-			"key1": &ConditionalStructShape{Name: aws.String("Name")},
-			"key2": &ConditionalStructShape{Name: aws.String("Name")},
+			"key1": {Name: aws.String("Name")},
+			"key2": {Name: aws.String("Name")},
 		},
 		RequiredBool:   aws.Boolean(true),
 		OptionalStruct: &ConditionalStructShape{Name: aws.String("Name")},
@@ -65,10 +65,10 @@ func TestMissingRequiredParameters(t *testing.T) {
 
 func TestNestedMissingRequiredParameters(t *testing.T) {
 	input := &StructShape{
-		RequiredList: []*ConditionalStructShape{&ConditionalStructShape{}},
+		RequiredList: []*ConditionalStructShape{{}},
 		RequiredMap: map[string]*ConditionalStructShape{
-			"key1": &ConditionalStructShape{Name: aws.String("Name")},
-			"key2": &ConditionalStructShape{},
+			"key1": {Name: aws.String("Name")},
+			"key2": {},
 		},
 		RequiredBool:   aws.Boolean(true),
 		OptionalStruct: &ConditionalStructShape{},

--- a/aws/request_pagination_test.go
+++ b/aws/request_pagination_test.go
@@ -19,9 +19,9 @@ func TestPagination(t *testing.T) {
 
 	reqNum := 0
 	resps := []*dynamodb.ListTablesOutput{
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table1"), aws.String("Table2")}, LastEvaluatedTableName: aws.String("Table2")},
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table3"), aws.String("Table4")}, LastEvaluatedTableName: aws.String("Table4")},
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table5")}},
+		{TableNames: []*string{aws.String("Table1"), aws.String("Table2")}, LastEvaluatedTableName: aws.String("Table2")},
+		{TableNames: []*string{aws.String("Table3"), aws.String("Table4")}, LastEvaluatedTableName: aws.String("Table4")},
+		{TableNames: []*string{aws.String("Table5")}},
 	}
 
 	db.Handlers.Send.Clear() // mock sending
@@ -71,9 +71,9 @@ func TestPaginationEachPage(t *testing.T) {
 
 	reqNum := 0
 	resps := []*dynamodb.ListTablesOutput{
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table1"), aws.String("Table2")}, LastEvaluatedTableName: aws.String("Table2")},
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table3"), aws.String("Table4")}, LastEvaluatedTableName: aws.String("Table4")},
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table5")}},
+		{TableNames: []*string{aws.String("Table1"), aws.String("Table2")}, LastEvaluatedTableName: aws.String("Table2")},
+		{TableNames: []*string{aws.String("Table3"), aws.String("Table4")}, LastEvaluatedTableName: aws.String("Table4")},
+		{TableNames: []*string{aws.String("Table5")}},
 	}
 
 	db.Handlers.Send.Clear() // mock sending
@@ -124,9 +124,9 @@ func TestPaginationEarlyExit(t *testing.T) {
 
 	reqNum := 0
 	resps := []*dynamodb.ListTablesOutput{
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table1"), aws.String("Table2")}, LastEvaluatedTableName: aws.String("Table2")},
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table3"), aws.String("Table4")}, LastEvaluatedTableName: aws.String("Table4")},
-		&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("Table5")}},
+		{TableNames: []*string{aws.String("Table1"), aws.String("Table2")}, LastEvaluatedTableName: aws.String("Table2")},
+		{TableNames: []*string{aws.String("Table3"), aws.String("Table4")}, LastEvaluatedTableName: aws.String("Table4")},
+		{TableNames: []*string{aws.String("Table5")}},
 	}
 
 	db.Handlers.Send.Clear() // mock sending
@@ -189,10 +189,10 @@ func TestPaginationTruncation(t *testing.T) {
 
 	reqNum := &count
 	resps := []*s3.ListObjectsOutput{
-		&s3.ListObjectsOutput{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{&s3.Object{Key: aws.String("Key1")}}},
-		&s3.ListObjectsOutput{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{&s3.Object{Key: aws.String("Key2")}}},
-		&s3.ListObjectsOutput{IsTruncated: aws.Boolean(false), Contents: []*s3.Object{&s3.Object{Key: aws.String("Key3")}}},
-		&s3.ListObjectsOutput{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{&s3.Object{Key: aws.String("Key4")}}},
+		{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{{Key: aws.String("Key1")}}},
+		{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{{Key: aws.String("Key2")}}},
+		{IsTruncated: aws.Boolean(false), Contents: []*s3.Object{{Key: aws.String("Key3")}}},
+		{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{{Key: aws.String("Key4")}}},
 	}
 
 	client.Handlers.Send.Clear() // mock sending
@@ -232,20 +232,20 @@ func TestPaginationTruncation(t *testing.T) {
 
 // Benchmarks
 var benchResps = []*dynamodb.ListTablesOutput{
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
-	&dynamodb.ListTablesOutput{TableNames: []*string{aws.String("TABLE")}},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE"), aws.String("NXT")}, LastEvaluatedTableName: aws.String("NXT")},
+	{TableNames: []*string{aws.String("TABLE")}},
 }
 
 var benchDb = func() *dynamodb.DynamoDB {

--- a/aws/request_test.go
+++ b/aws/request_test.go
@@ -68,9 +68,9 @@ type jsonErrorResponse struct {
 func TestRequestRecoverRetry5xx(t *testing.T) {
 	reqNum := 0
 	reqs := []http.Response{
-		http.Response{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
-		http.Response{StatusCode: 501, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
-		http.Response{StatusCode: 200, Body: body(`{"data":"valid"}`)},
+		{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
+		{StatusCode: 501, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
+		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
 	s := NewService(&Config{MaxRetries: 10})
@@ -94,9 +94,9 @@ func TestRequestRecoverRetry5xx(t *testing.T) {
 func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 	reqNum := 0
 	reqs := []http.Response{
-		http.Response{StatusCode: 400, Body: body(`{"__type":"Throttling","message":"Rate exceeded."}`)},
-		http.Response{StatusCode: 429, Body: body(`{"__type":"ProvisionedThroughputExceededException","message":"Rate exceeded."}`)},
-		http.Response{StatusCode: 200, Body: body(`{"data":"valid"}`)},
+		{StatusCode: 400, Body: body(`{"__type":"Throttling","message":"Rate exceeded."}`)},
+		{StatusCode: 429, Body: body(`{"__type":"ProvisionedThroughputExceededException","message":"Rate exceeded."}`)},
+		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
 	s := NewService(&Config{MaxRetries: 10})
@@ -148,10 +148,10 @@ func TestRequestExhaustRetries(t *testing.T) {
 
 	reqNum := 0
 	reqs := []http.Response{
-		http.Response{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
-		http.Response{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
-		http.Response{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
-		http.Response{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
+		{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
+		{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
+		{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
+		{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
 	}
 
 	s := NewService(&Config{MaxRetries: -1})
@@ -181,8 +181,8 @@ func TestRequestExhaustRetries(t *testing.T) {
 func TestRequestRecoverExpiredCreds(t *testing.T) {
 	reqNum := 0
 	reqs := []http.Response{
-		http.Response{StatusCode: 400, Body: body(`{"__type":"ExpiredTokenException","message":"expired token"}`)},
-		http.Response{StatusCode: 200, Body: body(`{"data":"valid"}`)},
+		{StatusCode: 400, Body: body(`{"__type":"ExpiredTokenException","message":"expired token"}`)},
+		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
 	s := NewService(&Config{MaxRetries: 10, Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "")})

--- a/aws/service.go
+++ b/aws/service.go
@@ -136,18 +136,18 @@ func retryRules(r *Request) time.Duration {
 // retryableCodes is a collection of service response codes which are retry-able
 // without any further action.
 var retryableCodes = map[string]struct{}{
-	"RequestError":                           struct{}{},
-	"ProvisionedThroughputExceededException": struct{}{},
-	"Throttling":                             struct{}{},
+	"RequestError":                           {},
+	"ProvisionedThroughputExceededException": {},
+	"Throttling":                             {},
 }
 
 // credsExpiredCodes is a collection of error codes which signify the credentials
 // need to be refreshed. Expired tokens require refreshing of credentials, and
 // resigning before the request can be retried.
 var credsExpiredCodes = map[string]struct{}{
-	"ExpiredToken":          struct{}{},
-	"ExpiredTokenException": struct{}{},
-	"RequestExpired":        struct{}{}, // EC2 Only
+	"ExpiredToken":          {},
+	"ExpiredTokenException": {},
+	"RequestExpired":        {}, // EC2 Only
 }
 
 func isCodeRetryable(code string) bool {

--- a/internal/protocol/xml/xmlutil/unmarshal.go
+++ b/internal/protocol/xml/xmlutil/unmarshal.go
@@ -114,7 +114,7 @@ func parseStruct(r reflect.Value, node *XMLNode, tag reflect.StructTag) error {
 			for _, a := range node.Attr {
 				if name == a.Name.Local {
 					// turn this into a text node for de-serializing
-					elems = []*XMLNode{&XMLNode{Text: a.Value}}
+					elems = []*XMLNode{{Text: a.Value}}
 				}
 			}
 		}

--- a/sdk.go
+++ b/sdk.go
@@ -5,4 +5,3 @@
 //
 // https://github.com/aws/aws-sdk-go/wiki
 package sdk
-

--- a/service/s3/customizations_test.go
+++ b/service/s3/customizations_test.go
@@ -30,7 +30,7 @@ func TestMD5InPutBucketCORS(t *testing.T) {
 		Bucket: aws.String("bucketname"),
 		CORSConfiguration: &s3.CORSConfiguration{
 			CORSRules: []*s3.CORSRule{
-				&s3.CORSRule{AllowedMethods: []*string{aws.String("GET")}},
+				{AllowedMethods: []*string{aws.String("GET")}},
 			},
 		},
 	})
@@ -43,7 +43,7 @@ func TestMD5InPutBucketLifecycle(t *testing.T) {
 		Bucket: aws.String("bucketname"),
 		LifecycleConfiguration: &s3.LifecycleConfiguration{
 			Rules: []*s3.LifecycleRule{
-				&s3.LifecycleRule{
+				{
 					ID:     aws.String("ID"),
 					Prefix: aws.String("Prefix"),
 					Status: aws.String("Enabled"),
@@ -69,7 +69,7 @@ func TestMD5InPutBucketTagging(t *testing.T) {
 		Bucket: aws.String("bucketname"),
 		Tagging: &s3.Tagging{
 			TagSet: []*s3.Tag{
-				&s3.Tag{Key: aws.String("KEY"), Value: aws.String("VALUE")},
+				{Key: aws.String("KEY"), Value: aws.String("VALUE")},
 			},
 		},
 	})
@@ -82,7 +82,7 @@ func TestMD5InDeleteObjects(t *testing.T) {
 		Bucket: aws.String("bucketname"),
 		Delete: &s3.Delete{
 			Objects: []*s3.ObjectIdentifier{
-				&s3.ObjectIdentifier{Key: aws.String("key")},
+				{Key: aws.String("key")},
 			},
 		},
 	})

--- a/service/sqs/api_test.go
+++ b/service/sqs/api_test.go
@@ -15,7 +15,7 @@ func TestFlattenedTraits(t *testing.T) {
 	_, err := s.DeleteMessageBatch(&sqs.DeleteMessageBatchInput{
 		QueueURL: aws.String("QUEUE"),
 		Entries: []*sqs.DeleteMessageBatchRequestEntry{
-			&sqs.DeleteMessageBatchRequestEntry{
+			{
 				ID:            aws.String("TEST"),
 				ReceiptHandle: aws.String("RECEIPT"),
 			},

--- a/service/sqs/checksums_test.go
+++ b/service/sqs/checksums_test.go
@@ -118,10 +118,10 @@ func TestRecieveMessageChecksum(t *testing.T) {
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.ReceiveMessageOutput{
 			Messages: []*sqs.Message{
-				&sqs.Message{Body: aws.String("test"), MD5OfBody: &md5},
-				&sqs.Message{Body: aws.String("test"), MD5OfBody: &md5},
-				&sqs.Message{Body: aws.String("test"), MD5OfBody: &md5},
-				&sqs.Message{Body: aws.String("test"), MD5OfBody: &md5},
+				{Body: aws.String("test"), MD5OfBody: &md5},
+				{Body: aws.String("test"), MD5OfBody: &md5},
+				{Body: aws.String("test"), MD5OfBody: &md5},
+				{Body: aws.String("test"), MD5OfBody: &md5},
 			},
 		}
 	})
@@ -137,10 +137,10 @@ func TestRecieveMessageChecksumInvalid(t *testing.T) {
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.ReceiveMessageOutput{
 			Messages: []*sqs.Message{
-				&sqs.Message{Body: aws.String("test"), MD5OfBody: &md5},
-				&sqs.Message{Body: aws.String("test"), MD5OfBody: aws.String("000"), MessageID: aws.String("123")},
-				&sqs.Message{Body: aws.String("test"), MD5OfBody: aws.String("000"), MessageID: aws.String("456")},
-				&sqs.Message{Body: aws.String("test"), MD5OfBody: &md5},
+				{Body: aws.String("test"), MD5OfBody: &md5},
+				{Body: aws.String("test"), MD5OfBody: aws.String("000"), MessageID: aws.String("123")},
+				{Body: aws.String("test"), MD5OfBody: aws.String("000"), MessageID: aws.String("456")},
+				{Body: aws.String("test"), MD5OfBody: &md5},
 			},
 		}
 	})
@@ -154,10 +154,10 @@ func TestRecieveMessageChecksumInvalid(t *testing.T) {
 func TestSendMessageBatchChecksum(t *testing.T) {
 	req, _ := svc.SendMessageBatchRequest(&sqs.SendMessageBatchInput{
 		Entries: []*sqs.SendMessageBatchRequestEntry{
-			&sqs.SendMessageBatchRequestEntry{ID: aws.String("1"), MessageBody: aws.String("test")},
-			&sqs.SendMessageBatchRequestEntry{ID: aws.String("2"), MessageBody: aws.String("test")},
-			&sqs.SendMessageBatchRequestEntry{ID: aws.String("3"), MessageBody: aws.String("test")},
-			&sqs.SendMessageBatchRequestEntry{ID: aws.String("4"), MessageBody: aws.String("test")},
+			{ID: aws.String("1"), MessageBody: aws.String("test")},
+			{ID: aws.String("2"), MessageBody: aws.String("test")},
+			{ID: aws.String("3"), MessageBody: aws.String("test")},
+			{ID: aws.String("4"), MessageBody: aws.String("test")},
 		},
 	})
 	req.Handlers.Send.PushBack(func(r *aws.Request) {
@@ -166,10 +166,10 @@ func TestSendMessageBatchChecksum(t *testing.T) {
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageBatchOutput{
 			Successful: []*sqs.SendMessageBatchResultEntry{
-				&sqs.SendMessageBatchResultEntry{MD5OfMessageBody: &md5, MessageID: aws.String("123"), ID: aws.String("1")},
-				&sqs.SendMessageBatchResultEntry{MD5OfMessageBody: &md5, MessageID: aws.String("456"), ID: aws.String("2")},
-				&sqs.SendMessageBatchResultEntry{MD5OfMessageBody: &md5, MessageID: aws.String("789"), ID: aws.String("3")},
-				&sqs.SendMessageBatchResultEntry{MD5OfMessageBody: &md5, MessageID: aws.String("012"), ID: aws.String("4")},
+				{MD5OfMessageBody: &md5, MessageID: aws.String("123"), ID: aws.String("1")},
+				{MD5OfMessageBody: &md5, MessageID: aws.String("456"), ID: aws.String("2")},
+				{MD5OfMessageBody: &md5, MessageID: aws.String("789"), ID: aws.String("3")},
+				{MD5OfMessageBody: &md5, MessageID: aws.String("012"), ID: aws.String("4")},
 			},
 		}
 	})
@@ -180,10 +180,10 @@ func TestSendMessageBatchChecksum(t *testing.T) {
 func TestSendMessageBatchChecksumInvalid(t *testing.T) {
 	req, _ := svc.SendMessageBatchRequest(&sqs.SendMessageBatchInput{
 		Entries: []*sqs.SendMessageBatchRequestEntry{
-			&sqs.SendMessageBatchRequestEntry{ID: aws.String("1"), MessageBody: aws.String("test")},
-			&sqs.SendMessageBatchRequestEntry{ID: aws.String("2"), MessageBody: aws.String("test")},
-			&sqs.SendMessageBatchRequestEntry{ID: aws.String("3"), MessageBody: aws.String("test")},
-			&sqs.SendMessageBatchRequestEntry{ID: aws.String("4"), MessageBody: aws.String("test")},
+			{ID: aws.String("1"), MessageBody: aws.String("test")},
+			{ID: aws.String("2"), MessageBody: aws.String("test")},
+			{ID: aws.String("3"), MessageBody: aws.String("test")},
+			{ID: aws.String("4"), MessageBody: aws.String("test")},
 		},
 	})
 	req.Handlers.Send.PushBack(func(r *aws.Request) {
@@ -192,10 +192,10 @@ func TestSendMessageBatchChecksumInvalid(t *testing.T) {
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageBatchOutput{
 			Successful: []*sqs.SendMessageBatchResultEntry{
-				&sqs.SendMessageBatchResultEntry{MD5OfMessageBody: &md5, MessageID: aws.String("123"), ID: aws.String("1")},
-				&sqs.SendMessageBatchResultEntry{MD5OfMessageBody: aws.String("000"), MessageID: aws.String("456"), ID: aws.String("2")},
-				&sqs.SendMessageBatchResultEntry{MD5OfMessageBody: aws.String("000"), MessageID: aws.String("789"), ID: aws.String("3")},
-				&sqs.SendMessageBatchResultEntry{MD5OfMessageBody: &md5, MessageID: aws.String("012"), ID: aws.String("4")},
+				{MD5OfMessageBody: &md5, MessageID: aws.String("123"), ID: aws.String("1")},
+				{MD5OfMessageBody: aws.String("000"), MessageID: aws.String("456"), ID: aws.String("2")},
+				{MD5OfMessageBody: aws.String("000"), MessageID: aws.String("789"), ID: aws.String("3")},
+				{MD5OfMessageBody: &md5, MessageID: aws.String("012"), ID: aws.String("4")},
 			},
 		}
 	})


### PR DESCRIPTION
Such a simplified formatting helps to improve code readability.