### PR TITLE
Handle resigning requests cleanly

### DIFF
--- a/aws/handler_functions.go
+++ b/aws/handler_functions.go
@@ -114,8 +114,6 @@ func AfterRetryHandler(r *Request) {
 			if err, ok := r.Error.(awserr.Error); ok {
 				if isCodeExpiredCreds(err.Code()) {
 					r.Config.Credentials.Expire()
-					// The credentials will need to be resigned with new credentials
-					r.signed = false
 				}
 			}
 		}

--- a/aws/request.go
+++ b/aws/request.go
@@ -32,8 +32,7 @@ type Request struct {
 	Retryable    SettableBool
 	RetryDelay   time.Duration
 
-	built  bool
-	signed bool
+	built bool
 }
 
 // An Operation is the service API operation to be made.
@@ -164,17 +163,12 @@ func (r *Request) Build() error {
 // Send will build the request prior to signing. All Sign Handlers will
 // be executed in the order they were set.
 func (r *Request) Sign() error {
-	if r.signed {
-		return r.Error
-	}
-
 	r.Build()
 	if r.Error != nil {
 		return r.Error
 	}
 
 	r.Handlers.Sign.Run(r)
-	r.signed = r.Error != nil
 	return r.Error
 }
 

--- a/internal/signer/v4/v4.go
+++ b/internal/signer/v4/v4.go
@@ -34,18 +34,17 @@ var ignoredHeaders = map[string]bool{
 }
 
 type signer struct {
-	Request         *http.Request
-	Time            time.Time
-	ExpireTime      time.Duration
-	ServiceName     string
-	Region          string
-	AccessKeyID     string
-	SecretAccessKey string
-	SessionToken    string
-	Query           url.Values
-	Body            io.ReadSeeker
-	Debug           uint
-	Logger          io.Writer
+	Request     *http.Request
+	Time        time.Time
+	ExpireTime  time.Duration
+	ServiceName string
+	Region      string
+	CredValues  credentials.Value
+	Credentials *credentials.Credentials
+	Query       url.Values
+	Body        io.ReadSeeker
+	Debug       uint
+	Logger      io.Writer
 
 	isPresign          bool
 	formattedTime      string
@@ -71,11 +70,6 @@ func Sign(req *aws.Request) {
 	if req.Service.Config.Credentials == credentials.AnonymousCredentials {
 		return
 	}
-	creds, err := req.Service.Config.Credentials.Get()
-	if err != nil {
-		req.Error = err
-		return
-	}
 
 	region := req.Service.SigningRegion
 	if region == "" {
@@ -88,56 +82,81 @@ func Sign(req *aws.Request) {
 	}
 
 	s := signer{
-		Request:         req.HTTPRequest,
-		Time:            req.Time,
-		ExpireTime:      req.ExpireTime,
-		Query:           req.HTTPRequest.URL.Query(),
-		Body:            req.Body,
-		ServiceName:     name,
-		Region:          region,
-		AccessKeyID:     creds.AccessKeyID,
-		SecretAccessKey: creds.SecretAccessKey,
-		SessionToken:    creds.SessionToken,
-		Debug:           req.Service.Config.LogLevel,
-		Logger:          req.Service.Config.Logger,
+		Request:     req.HTTPRequest,
+		Time:        req.Time,
+		ExpireTime:  req.ExpireTime,
+		Query:       req.HTTPRequest.URL.Query(),
+		Body:        req.Body,
+		ServiceName: name,
+		Region:      region,
+		Credentials: req.Service.Config.Credentials,
+		Debug:       req.Service.Config.LogLevel,
+		Logger:      req.Service.Config.Logger,
 	}
-	s.sign()
-	return
+
+	req.Error = s.sign()
 }
 
-func (v4 *signer) sign() {
+func (v4 *signer) sign() error {
 	if v4.ExpireTime != 0 {
 		v4.isPresign = true
 	}
 
+	if v4.isRequestSigned() {
+		if !v4.Credentials.IsExpired() {
+			// If the request is already signed, and the credentials have not
+			// expired yet ignore the signing request.
+			return nil
+		}
+
+		// The credentials have expired for this request. The current signing
+		// is invalid, and needs to be request because the request will fail.
+		if v4.isPresign {
+			v4.removePresign()
+		}
+	}
+
+	var err error
+	v4.CredValues, err = v4.Credentials.Get()
+	if err != nil {
+		return err
+	}
+
 	if v4.isPresign {
 		v4.Query.Set("X-Amz-Algorithm", authHeaderPrefix)
-		if v4.SessionToken != "" {
-			v4.Query.Set("X-Amz-Security-Token", v4.SessionToken)
+		if v4.CredValues.SessionToken != "" {
+			v4.Query.Set("X-Amz-Security-Token", v4.CredValues.SessionToken)
 		} else {
 			v4.Query.Del("X-Amz-Security-Token")
 		}
-	} else if v4.SessionToken != "" {
-		v4.Request.Header.Set("X-Amz-Security-Token", v4.SessionToken)
+	} else if v4.CredValues.SessionToken != "" {
+		v4.Request.Header.Set("X-Amz-Security-Token", v4.CredValues.SessionToken)
 	}
 
 	v4.build()
 
 	if v4.Debug > 0 {
-		out := v4.Logger
-		fmt.Fprintf(out, "---[ CANONICAL STRING  ]-----------------------------\n")
-		fmt.Fprintln(out, v4.canonicalString)
-		fmt.Fprintf(out, "---[ STRING TO SIGN ]--------------------------------\n")
-		fmt.Fprintln(out, v4.stringToSign)
-		if v4.isPresign {
-			fmt.Fprintf(out, "---[ SIGNED URL ]--------------------------------\n")
-			fmt.Fprintln(out, v4.Request.URL)
-		}
-		fmt.Fprintf(out, "-----------------------------------------------------\n")
+		v4.logSigningInfo()
 	}
+
+	return nil
+}
+
+func (v4 *signer) logSigningInfo() {
+	out := v4.Logger
+	fmt.Fprintf(out, "---[ CANONICAL STRING  ]-----------------------------\n")
+	fmt.Fprintln(out, v4.canonicalString)
+	fmt.Fprintf(out, "---[ STRING TO SIGN ]--------------------------------\n")
+	fmt.Fprintln(out, v4.stringToSign)
+	if v4.isPresign {
+		fmt.Fprintf(out, "---[ SIGNED URL ]--------------------------------\n")
+		fmt.Fprintln(out, v4.Request.URL)
+	}
+	fmt.Fprintf(out, "-----------------------------------------------------\n")
 }
 
 func (v4 *signer) build() {
+
 	v4.buildTime()             // no depends
 	v4.buildCredentialString() // no depends
 	if v4.isPresign {
@@ -152,7 +171,7 @@ func (v4 *signer) build() {
 		v4.Request.URL.RawQuery += "&X-Amz-Signature=" + v4.signature
 	} else {
 		parts := []string{
-			authHeaderPrefix + " Credential=" + v4.AccessKeyID + "/" + v4.credentialString,
+			authHeaderPrefix + " Credential=" + v4.CredValues.AccessKeyID + "/" + v4.credentialString,
 			"SignedHeaders=" + v4.signedHeaders,
 			"Signature=" + v4.signature,
 		}
@@ -182,7 +201,7 @@ func (v4 *signer) buildCredentialString() {
 	}, "/")
 
 	if v4.isPresign {
-		v4.Query.Set("X-Amz-Credential", v4.AccessKeyID+"/"+v4.credentialString)
+		v4.Query.Set("X-Amz-Credential", v4.CredValues.AccessKeyID+"/"+v4.credentialString)
 	}
 }
 
@@ -269,7 +288,7 @@ func (v4 *signer) buildStringToSign() {
 }
 
 func (v4 *signer) buildSignature() {
-	secret := v4.SecretAccessKey
+	secret := v4.CredValues.SecretAccessKey
 	date := makeHmac([]byte("AWS4"+secret), []byte(v4.formattedShortTime))
 	region := makeHmac(date, []byte(v4.Region))
 	service := makeHmac(region, []byte(v4.ServiceName))
@@ -291,6 +310,27 @@ func (v4 *signer) bodyDigest() string {
 		v4.Request.Header.Add("X-Amz-Content-Sha256", hash)
 	}
 	return hash
+}
+
+// isRequestSigned returns if the request is currently signed or presigned
+func (v4 *signer) isRequestSigned() bool {
+	if v4.Request.Header.Get("Authorization") != "" ||
+		v4.Query.Get("X-Amz-Signature") != "" {
+		return true
+	}
+
+	return false
+}
+
+// unsign removes signing flags for both signed and presigned requests.
+func (v4 *signer) removePresign() {
+	v4.Query.Del("X-Amz-Algorithm")
+	v4.Query.Del("X-Amz-Signature")
+	v4.Query.Del("X-Amz-Security-Token")
+	v4.Query.Del("X-Amz-Date")
+	v4.Query.Del("X-Amz-Expires")
+	v4.Query.Del("X-Amz-Credential")
+	v4.Query.Del("X-Amz-SignedHeaders")
 }
 
 func makeHmac(key []byte, data []byte) []byte {

--- a/internal/signer/v4/v4.go
+++ b/internal/signer/v4/v4.go
@@ -113,6 +113,9 @@ func (v4 *signer) sign() error {
 		// is invalid, and needs to be request because the request will fail.
 		if v4.isPresign {
 			v4.removePresign()
+			// Update the request's query string to ensure the values stays in
+			// sync in the case retrieving the new credentials fails.
+			v4.Request.URL.RawQuery = v4.Query.Encode()
 		}
 	}
 

--- a/internal/signer/v4/v4.go
+++ b/internal/signer/v4/v4.go
@@ -317,8 +317,10 @@ func (v4 *signer) bodyDigest() string {
 
 // isRequestSigned returns if the request is currently signed or presigned
 func (v4 *signer) isRequestSigned() bool {
-	if v4.Request.Header.Get("Authorization") != "" ||
-		v4.Query.Get("X-Amz-Signature") != "" {
+	if v4.isPresign && v4.Query.Get("X-Amz-Signature") != "" {
+		return true
+	}
+	if v4.Request.Header.Get("Authorization") != "" {
 		return true
 	}
 


### PR DESCRIPTION
Simplified aws.Request to not need logic to handle request resigning.
Updated the v4 signer to resign the request if the request was already
signed and the credentials have expired. This occurs when a request fails
due to expired tokens or network errors.