### PR TITLE
aws/credentials: Add Expiry struct for Provider expiration shared logic

### DIFF
--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -93,6 +93,50 @@ type Provider interface {
 	IsExpired() bool
 }
 
+// A Expiry provides shared expiration logic to be used by credentials
+// providers to implement expiry functionality.
+//
+// The best method to use this struct is as an anonymous field within the
+// provider's struct.
+//
+// Example:
+//     type EC2RoleProvider struct {
+//         Expiry
+//         ...
+//     }
+type Expiry struct {
+	// The date/time when to expire on
+	expiration time.Time
+
+	// If set will be used by IsExpired to determine the current time.
+	// Defaults to time.Now if CurrentTime is not set.  Available for testing
+	// to be able to mock out the current time.
+	CurrentTime func() time.Time
+}
+
+// SetExpiration sets the expiration IsExpired will check when called.
+//
+// If window is greater than 0 the expiration time will be reduced by the
+// window value.
+//
+// Using a window is helpful to trigger credentials to expire sooner than
+// the expiration time given to ensure no requests are made with expired
+// tokens.
+func (e *Expiry) SetExpiration(expiration time.Time, window time.Duration) {
+	e.expiration = expiration
+	if window > 0 {
+		e.expiration = e.expiration.Add(-window)
+	}
+}
+
+// IsExpired returns if the credentials are expired.
+func (e *Expiry) IsExpired() bool {
+	if e.CurrentTime == nil {
+		e.CurrentTime = time.Now
+	}
+	return e.expiration.Before(e.CurrentTime())
+}
+
 // A Credentials provides synchronous safe retrieval of AWS credentials Value.
 // Credentials will cache the credentials value until they expire. Once the value
 // expires the next Get will attempt to retrieve valid credentials.
@@ -173,6 +217,3 @@ func (c *Credentials) IsExpired() bool {
 func (c *Credentials) isExpired() bool {
 	return c.forceRefresh || c.provider.IsExpired()
 }
-
-// Provide a stub-able time.Now for unit tests so expiry can be tested.
-var currentTime = time.Now

--- a/aws/credentials/ec2_role_provider_test.go
+++ b/aws/credentials/ec2_role_provider_test.go
@@ -45,10 +45,7 @@ func TestEC2RoleProviderIsExpired(t *testing.T) {
 	defer server.Close()
 
 	p := &EC2RoleProvider{Client: http.DefaultClient, Endpoint: server.URL}
-	defer func() {
-		currentTime = time.Now
-	}()
-	currentTime = func() time.Time {
+	p.CurrentTime = func() time.Time {
 		return time.Date(2014, 12, 15, 21, 26, 0, 0, time.UTC)
 	}
 
@@ -59,7 +56,7 @@ func TestEC2RoleProviderIsExpired(t *testing.T) {
 
 	assert.False(t, p.IsExpired(), "Expect creds to not be expired after retrieve.")
 
-	currentTime = func() time.Time {
+	p.CurrentTime = func() time.Time {
 		return time.Date(3014, 12, 15, 21, 26, 0, 0, time.UTC)
 	}
 
@@ -71,10 +68,7 @@ func TestEC2RoleProviderExpiryWindowIsExpired(t *testing.T) {
 	defer server.Close()
 
 	p := &EC2RoleProvider{Client: http.DefaultClient, Endpoint: server.URL, ExpiryWindow: time.Hour * 1}
-	defer func() {
-		currentTime = time.Now
-	}()
-	currentTime = func() time.Time {
+	p.CurrentTime = func() time.Time {
 		return time.Date(2014, 12, 15, 0, 51, 37, 0, time.UTC)
 	}
 
@@ -85,7 +79,7 @@ func TestEC2RoleProviderExpiryWindowIsExpired(t *testing.T) {
 
 	assert.False(t, p.IsExpired(), "Expect creds to not be expired after retrieve.")
 
-	currentTime = func() time.Time {
+	p.CurrentTime = func() time.Time {
 		return time.Date(2014, 12, 16, 0, 55, 37, 0, time.UTC)
 	}
 


### PR DESCRIPTION
Moves the expiry shared logic out of EC2RoleProvider and into the new shared struct.
This allows other providers which need expiration, to use shared logic.

Adds Expiry struct for PR #267