### PR TITLE
handler_functions: avoid panic on nil HTTPResponse

### DIFF
--- a/aws/handler_functions.go
+++ b/aws/handler_functions.go
@@ -88,7 +88,7 @@ func SendHandler(r *Request) {
 
 // ValidateResponseHandler is a request handler to validate service response.
 func ValidateResponseHandler(r *Request) {
-	if r.HTTPResponse.StatusCode == 0 || r.HTTPResponse.StatusCode >= 300 {
+	if r.HTTPResponse == nil || r.HTTPResponse.StatusCode == 0 || r.HTTPResponse.StatusCode >= 300 {
 		// this may be replaced by an UnmarshalError handler
 		r.Error = apierr.New("UnknownError", "unknown error", nil)
 	}

--- a/aws/handler_functions_test.go
+++ b/aws/handler_functions_test.go
@@ -35,6 +35,12 @@ func TestValidateEndpointHandlerErrorRegion(t *testing.T) {
 	assert.Equal(t, ErrMissingRegion, err)
 }
 
+func TestValidateResponseHandlerNilResponse(t *testing.T) {
+	req := &Request{}
+	ValidateResponseHandler(req)
+	assert.Equal(t, "UnknownError: unknown error", req.Error.Error())
+}
+
 type mockCredsProvider struct {
 	expired        bool
 	retreiveCalled bool


### PR DESCRIPTION
Guards against a panic we had reported over in:
https://github.com/hashicorp/terraform/issues/2202