### PR TITLE
aws/awserr: Error constructors exposed

### DIFF
--- a/aws/awserr/error.go
+++ b/aws/awserr/error.go
@@ -42,6 +42,17 @@ type Error interface {
 	OrigErr() error
 }
 
+// New returns an Error object described by the code, message, and origErr.
+//
+// If origErr satisfies the Error interface it will not be wrapped within a new
+// Error object and will instead be returned.
+func New(code, message string, origErr error) Error {
+	if e, ok := origErr.(Error); ok && e != nil {
+		return e
+	}
+	return newBaseError(code, message, origErr)
+}
+
 // A RequestFailure is an interface to extract request failure information from
 // an Error such as the request ID of the failed request returned by a service.
 // RequestFailures may not always have a requestID value if the request failed
@@ -85,4 +96,10 @@ type RequestFailure interface {
 	// be empty if no request ID is available such as the request failed due
 	// to a connection error.
 	RequestID() string
+}
+
+// NewRequestFailure returns a new request error wrapper for the given Error
+// provided.
+func NewRequestFailure(err Error, statusCode int, reqID string) RequestFailure {
+	return newRequestError(err, statusCode, reqID)
 }

--- a/aws/awserr/types.go
+++ b/aws/awserr/types.go
@@ -1,14 +1,28 @@
-// Package apierr represents API error types.
-package apierr
+package awserr
 
 import "fmt"
 
-// A BaseError wraps the code and message which defines an error. It also
+// SprintError returns a string of the formatted error code.
+//
+// Both extra and origErr are optional.  If they are included their lines
+// will be added, but if they are not included their lines will be ignored.
+func SprintError(code, message, extra string, origErr error) string {
+	msg := fmt.Sprintf("%s: %s", code, message)
+	if extra != "" {
+		msg = fmt.Sprintf("%s\n\t%s", msg, extra)
+	}
+	if origErr != nil {
+		msg = fmt.Sprintf("%s\ncaused by: %s", msg, origErr.Error())
+	}
+	return msg
+}
+
+// A baseError wraps the code and message which defines an error. It also
 // can be used to wrap an original error object.
 //
 // Should be used as the root for errors satisfying the awserr.Error. Also
 // for any error which does not fit into a specific error wrapper type.
-type BaseError struct {
+type baseError struct {
 	// Classification of error
 	code string
 
@@ -20,7 +34,7 @@ type BaseError struct {
 	origErr error
 }
 
-// New returns an error object for the code, message, and err.
+// newBaseError returns an error object for the code, message, and err.
 //
 // code is a short no whitespace phrase depicting the classification of
 // the error that is being created.
@@ -28,8 +42,8 @@ type BaseError struct {
 // message is the free flow string containing detailed information about the error.
 //
 // origErr is the error object which will be nested under the new error to be returned.
-func New(code, message string, origErr error) *BaseError {
-	return &BaseError{
+func newBaseError(code, message string, origErr error) *baseError {
+	return &baseError{
 		code:    code,
 		message: message,
 		origErr: origErr,
@@ -41,75 +55,56 @@ func New(code, message string, origErr error) *BaseError {
 // See ErrorWithExtra for formatting.
 //
 // Satisfies the error interface.
-func (b *BaseError) Error() string {
-	return b.ErrorWithExtra("")
+func (b baseError) Error() string {
+	return SprintError(b.code, b.message, "", b.origErr)
 }
 
 // String returns the string representation of the error.
 // Alias for Error to satisfy the stringer interface.
-func (b *BaseError) String() string {
+func (b baseError) String() string {
 	return b.Error()
 }
 
 // Code returns the short phrase depicting the classification of the error.
-func (b *BaseError) Code() string {
+func (b baseError) Code() string {
 	return b.code
 }
 
 // Message returns the error details message.
-func (b *BaseError) Message() string {
+func (b baseError) Message() string {
 	return b.message
 }
 
 // OrigErr returns the original error if one was set. Nil is returned if no error
 // was set.
-func (b *BaseError) OrigErr() error {
+func (b baseError) OrigErr() error {
 	return b.origErr
 }
 
-// ErrorWithExtra is a helper method to add an extra string to the stratified
-// error message. The extra message will be added on the next line below the
-// error message like the following:
-//
-//     <error code>: <error message>
-//         <extra message>
-//
-// If there is a original error the error will be included on a new line.
-//
-//     <error code>: <error message>
-//         <extra message>
-//     caused by: <original error>
-func (b *BaseError) ErrorWithExtra(extra string) string {
-	msg := fmt.Sprintf("%s: %s", b.code, b.message)
-	if extra != "" {
-		msg = fmt.Sprintf("%s\n\t%s", msg, extra)
-	}
-	if b.origErr != nil {
-		msg = fmt.Sprintf("%s\ncaused by: %s", msg, b.origErr.Error())
-	}
-	return msg
-}
+// So that the Error interface type can be included as an anonymous field
+// in the requestError struct and not conflict with the error.Error() method.
+type awsError Error
 
-// A RequestError wraps a request or service error.
+// A requestError wraps a request or service error.
 //
-// Composed of BaseError for code, message, and original error.
-type RequestError struct {
-	*BaseError
+// Composed of baseError for code, message, and original error.
+type requestError struct {
+	awsError
 	statusCode int
 	requestID  string
 }
 
-// NewRequestError returns a wrapped error with additional information for request
+// newRequestError returns a wrapped error with additional information for request
 // status code, and service requestID.
 //
 // Should be used to wrap all request which involve service requests. Even if
 // the request failed without a service response, but had an HTTP status code
 // that may be meaningful.
 //
-// Also wraps original errors via the BaseError.
-func NewRequestError(base *BaseError, statusCode int, requestID string) *RequestError {
-	return &RequestError{
-		BaseError:  base,
+// Also wraps original errors via the baseError.
+func newRequestError(err Error, statusCode int, requestID string) *requestError {
+	return &requestError{
+		awsError:   err,
 		statusCode: statusCode,
 		requestID:  requestID,
 	}
@@ -117,23 +112,24 @@ func NewRequestError(base *BaseError, statusCode int, requestID string) *Request
 
 // Error returns the string representation of the error.
 // Satisfies the error interface.
-func (r *RequestError) Error() string {
-	return r.ErrorWithExtra(fmt.Sprintf("status code: %d, request id: [%s]",
-		r.statusCode, r.requestID))
+func (r requestError) Error() string {
+	extra := fmt.Sprintf("status code: %d, request id: [%s]",
+		r.statusCode, r.requestID)
+	return SprintError(r.Code(), r.Message(), extra, r.OrigErr())
 }
 
 // String returns the string representation of the error.
 // Alias for Error to satisfy the stringer interface.
-func (r *RequestError) String() string {
+func (r requestError) String() string {
 	return r.Error()
 }
 
 // StatusCode returns the wrapped status code for the error
-func (r *RequestError) StatusCode() int {
+func (r requestError) StatusCode() int {
 	return r.statusCode
 }
 
 // RequestID returns the wrapped requestID
-func (r *RequestError) RequestID() string {
+func (r requestError) RequestID() string {
 	return r.requestID
 }

--- a/aws/credentials/chain_provider.go
+++ b/aws/credentials/chain_provider.go
@@ -1,13 +1,13 @@
 package credentials
 
 import (
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 var (
 	// ErrNoValidProvidersFoundInChain Is returned when there are no valid
 	// providers in the ChainProvider.
-	ErrNoValidProvidersFoundInChain = apierr.New("NoCredentialProviders", "no valid providers in chain", nil)
+	ErrNoValidProvidersFoundInChain = awserr.New("NoCredentialProviders", "no valid providers in chain", nil)
 )
 
 // A ChainProvider will search for a provider which returns credentials

--- a/aws/credentials/chain_provider_test.go
+++ b/aws/credentials/chain_provider_test.go
@@ -3,15 +3,15 @@ package credentials
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestChainProviderGet(t *testing.T) {
 	p := &ChainProvider{
 		Providers: []Provider{
-			&stubProvider{err: apierr.New("FirstError", "first provider error", nil)},
-			&stubProvider{err: apierr.New("SecondError", "second provider error", nil)},
+			&stubProvider{err: awserr.New("FirstError", "first provider error", nil)},
+			&stubProvider{err: awserr.New("SecondError", "second provider error", nil)},
 			&stubProvider{
 				creds: Value{
 					AccessKeyID:     "AKID",
@@ -62,8 +62,8 @@ func TestChainProviderWithNoProvider(t *testing.T) {
 func TestChainProviderWithNoValidProvider(t *testing.T) {
 	p := &ChainProvider{
 		Providers: []Provider{
-			&stubProvider{err: apierr.New("FirstError", "first provider error", nil)},
-			&stubProvider{err: apierr.New("SecondError", "second provider error", nil)},
+			&stubProvider{err: awserr.New("FirstError", "first provider error", nil)},
+			&stubProvider{err: awserr.New("SecondError", "second provider error", nil)},
 		},
 	}
 

--- a/aws/credentials/credentials_test.go
+++ b/aws/credentials/credentials_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/internal/apierr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,7 +39,7 @@ func TestCredentialsGet(t *testing.T) {
 }
 
 func TestCredentialsGetWithError(t *testing.T) {
-	c := NewCredentials(&stubProvider{err: apierr.New("provider error", "", nil), expired: true})
+	c := NewCredentials(&stubProvider{err: awserr.New("provider error", "", nil), expired: true})
 
 	_, err := c.Get()
 	assert.Equal(t, "provider error", err.(awserr.Error).Code(), "Expected provider error")

--- a/aws/credentials/ec2_role_provider.go
+++ b/aws/credentials/ec2_role_provider.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 const metadataCredentialsEndpoint = "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
@@ -90,7 +90,7 @@ func (m *EC2RoleProvider) Retrieve() (Value, error) {
 	}
 
 	if len(credsList) == 0 {
-		return Value{}, apierr.New("EmptyEC2RoleList", "empty EC2 Role list", nil)
+		return Value{}, awserr.New("EmptyEC2RoleList", "empty EC2 Role list", nil)
 	}
 	credsName := credsList[0]
 
@@ -122,7 +122,7 @@ type ec2RoleCredRespBody struct {
 func requestCredList(client *http.Client, endpoint string) ([]string, error) {
 	resp, err := client.Get(endpoint)
 	if err != nil {
-		return nil, apierr.New("ListEC2Role", "failed to list EC2 Roles", err)
+		return nil, awserr.New("ListEC2Role", "failed to list EC2 Roles", err)
 	}
 	defer resp.Body.Close()
 
@@ -133,7 +133,7 @@ func requestCredList(client *http.Client, endpoint string) ([]string, error) {
 	}
 
 	if err := s.Err(); err != nil {
-		return nil, apierr.New("ReadEC2Role", "failed to read list of EC2 Roles", err)
+		return nil, awserr.New("ReadEC2Role", "failed to read list of EC2 Roles", err)
 	}
 
 	return credsList, nil
@@ -146,7 +146,7 @@ func requestCredList(client *http.Client, endpoint string) ([]string, error) {
 func requestCred(client *http.Client, endpoint, credsName string) (*ec2RoleCredRespBody, error) {
 	resp, err := client.Get(endpoint + credsName)
 	if err != nil {
-		return nil, apierr.New("GetEC2RoleCredentials",
+		return nil, awserr.New("GetEC2RoleCredentials",
 			fmt.Sprintf("failed to get %s EC2 Role credentials", credsName),
 			err)
 	}
@@ -154,7 +154,7 @@ func requestCred(client *http.Client, endpoint, credsName string) (*ec2RoleCredR
 
 	respCreds := &ec2RoleCredRespBody{}
 	if err := json.NewDecoder(resp.Body).Decode(respCreds); err != nil {
-		return nil, apierr.New("DecodeEC2RoleCredentials",
+		return nil, awserr.New("DecodeEC2RoleCredentials",
 			fmt.Sprintf("failed to decode %s EC2 Role credentials", credsName),
 			err)
 	}

--- a/aws/credentials/env_provider.go
+++ b/aws/credentials/env_provider.go
@@ -3,16 +3,16 @@ package credentials
 import (
 	"os"
 
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 var (
 	// ErrAccessKeyIDNotFound is returned when the AWS Access Key ID can't be
 	// found in the process's environment.
-	ErrAccessKeyIDNotFound = apierr.New("EnvAccessKeyNotFound", "AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY not found in environment", nil)
+	ErrAccessKeyIDNotFound = awserr.New("EnvAccessKeyNotFound", "AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY not found in environment", nil)
 	// ErrSecretAccessKeyNotFound is returned when the AWS Secret Access Key
 	// can't be found in the process's environment.
-	ErrSecretAccessKeyNotFound = apierr.New("EnvSecretNotFound", "AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY not found in environment", nil)
+	ErrSecretAccessKeyNotFound = awserr.New("EnvSecretNotFound", "AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY not found in environment", nil)
 )
 
 // A EnvProvider retrieves credentials from the environment variables of the

--- a/aws/credentials/shared_credentials_provider.go
+++ b/aws/credentials/shared_credentials_provider.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/vaughan0/go-ini"
 
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 var (
 	// ErrSharedCredentialsHomeNotFound is emitted when the user directory cannot be found.
-	ErrSharedCredentialsHomeNotFound = apierr.New("UserHomeNotFound", "user home directory not found.", nil)
+	ErrSharedCredentialsHomeNotFound = awserr.New("UserHomeNotFound", "user home directory not found.", nil)
 )
 
 // A SharedCredentialsProvider retrieves credentials from the current user's home
@@ -72,20 +72,20 @@ func (p *SharedCredentialsProvider) IsExpired() bool {
 func loadProfile(filename, profile string) (Value, error) {
 	config, err := ini.LoadFile(filename)
 	if err != nil {
-		return Value{}, apierr.New("SharedCredsLoad", "failed to load shared credentials file", err)
+		return Value{}, awserr.New("SharedCredsLoad", "failed to load shared credentials file", err)
 	}
 	iniProfile := config.Section(profile)
 
 	id, ok := iniProfile["aws_access_key_id"]
 	if !ok {
-		return Value{}, apierr.New("SharedCredsAccessKey",
+		return Value{}, awserr.New("SharedCredsAccessKey",
 			fmt.Sprintf("shared credentials %s in %s did not contain aws_access_key_id", profile, filename),
 			nil)
 	}
 
 	secret, ok := iniProfile["aws_secret_access_key"]
 	if !ok {
-		return Value{}, apierr.New("SharedCredsSecret",
+		return Value{}, awserr.New("SharedCredsSecret",
 			fmt.Sprintf("shared credentials %s in %s did not contain aws_secret_access_key", profile, filename),
 			nil)
 	}

--- a/aws/credentials/static_provider.go
+++ b/aws/credentials/static_provider.go
@@ -1,12 +1,12 @@
 package credentials
 
 import (
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 var (
 	// ErrStaticCredentialsEmpty is emitted when static credentials are empty.
-	ErrStaticCredentialsEmpty = apierr.New("EmptyStaticCreds", "static credentials are empty", nil)
+	ErrStaticCredentialsEmpty = awserr.New("EmptyStaticCreds", "static credentials are empty", nil)
 )
 
 // A StaticProvider is a set of credentials which are set pragmatically,

--- a/aws/handler_functions.go
+++ b/aws/handler_functions.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/internal/apierr"
 )
 
 var sleepDelay = func(delay time.Duration) {
@@ -90,7 +89,7 @@ func SendHandler(r *Request) {
 			}
 		}
 		// Catch all other request errors.
-		r.Error = apierr.New("RequestError", "send request failed", err)
+		r.Error = awserr.New("RequestError", "send request failed", err)
 		r.Retryable.Set(true) // network errors are retryable
 	}
 }
@@ -99,7 +98,7 @@ func SendHandler(r *Request) {
 func ValidateResponseHandler(r *Request) {
 	if r.HTTPResponse.StatusCode == 0 || r.HTTPResponse.StatusCode >= 300 {
 		// this may be replaced by an UnmarshalError handler
-		r.Error = apierr.New("UnknownError", "unknown error", nil)
+		r.Error = awserr.New("UnknownError", "unknown error", nil)
 	}
 }
 
@@ -135,11 +134,11 @@ func AfterRetryHandler(r *Request) {
 var (
 	// ErrMissingRegion is an error that is returned if region configuration is
 	// not found.
-	ErrMissingRegion error = apierr.New("MissingRegion", "could not find region configuration", nil)
+	ErrMissingRegion error = awserr.New("MissingRegion", "could not find region configuration", nil)
 
 	// ErrMissingEndpoint is an error that is returned if an endpoint cannot be
 	// resolved for a service.
-	ErrMissingEndpoint error = apierr.New("MissingEndpoint", "'Endpoint' configuration is required for this service", nil)
+	ErrMissingEndpoint error = awserr.New("MissingEndpoint", "'Endpoint' configuration is required for this service", nil)
 )
 
 // ValidateEndpointHandler is a request handler to validate a request had the

--- a/aws/handler_functions_test.go
+++ b/aws/handler_functions_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/internal/apierr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,11 +56,11 @@ func TestAfterRetryRefreshCreds(t *testing.T) {
 
 	svc.Handlers.Clear()
 	svc.Handlers.ValidateResponse.PushBack(func(r *Request) {
-		r.Error = apierr.New("UnknownError", "", nil)
+		r.Error = awserr.New("UnknownError", "", nil)
 		r.HTTPResponse = &http.Response{StatusCode: 400}
 	})
 	svc.Handlers.UnmarshalError.PushBack(func(r *Request) {
-		r.Error = apierr.New("ExpiredTokenException", "", nil)
+		r.Error = awserr.New("ExpiredTokenException", "", nil)
 	})
 	svc.Handlers.AfterRetry.PushBack(func(r *Request) {
 		AfterRetryHandler(r)

--- a/aws/param_validator.go
+++ b/aws/param_validator.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 // ValidateParameters is a request handler to validate the input parameters.
@@ -18,7 +18,7 @@ func ValidateParameters(r *Request) {
 		if count := len(v.errors); count > 0 {
 			format := "%d validation errors:\n- %s"
 			msg := fmt.Sprintf(format, count, strings.Join(v.errors, "\n- "))
-			r.Error = apierr.New("InvalidParameter", msg, nil)
+			r.Error = awserr.New("InvalidParameter", msg, nil)
 		}
 	}
 }

--- a/aws/request_test.go
+++ b/aws/request_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/internal/apierr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,12 +35,12 @@ func unmarshal(req *Request) {
 func unmarshalError(req *Request) {
 	bodyBytes, err := ioutil.ReadAll(req.HTTPResponse.Body)
 	if err != nil {
-		req.Error = apierr.New("UnmarshaleError", req.HTTPResponse.Status, err)
+		req.Error = awserr.New("UnmarshaleError", req.HTTPResponse.Status, err)
 		return
 	}
 	if len(bodyBytes) == 0 {
-		req.Error = apierr.NewRequestError(
-			apierr.New("UnmarshaleError", req.HTTPResponse.Status, fmt.Errorf("empty body")),
+		req.Error = awserr.NewRequestFailure(
+			awserr.New("UnmarshaleError", req.HTTPResponse.Status, fmt.Errorf("empty body")),
 			req.HTTPResponse.StatusCode,
 			"",
 		)
@@ -49,11 +48,11 @@ func unmarshalError(req *Request) {
 	}
 	var jsonErr jsonErrorResponse
 	if err := json.Unmarshal(bodyBytes, &jsonErr); err != nil {
-		req.Error = apierr.New("UnmarshaleError", "JSON unmarshal", err)
+		req.Error = awserr.New("UnmarshaleError", "JSON unmarshal", err)
 		return
 	}
-	req.Error = apierr.NewRequestError(
-		apierr.New(jsonErr.Code, jsonErr.Message, nil),
+	req.Error = awserr.NewRequestFailure(
+		awserr.New(jsonErr.Code, jsonErr.Message, nil),
 		req.HTTPResponse.StatusCode,
 		"",
 	)

--- a/internal/protocol/ec2query/build.go
+++ b/internal/protocol/ec2query/build.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/internal/protocol/query/queryutil"
 )
 
@@ -18,7 +18,7 @@ func Build(r *aws.Request) {
 		"Version": {r.Service.APIVersion},
 	}
 	if err := queryutil.Parse(body, r.Params, true); err != nil {
-		r.Error = apierr.New("SerializationError", "failed encoding EC2 Query request", err)
+		r.Error = awserr.New("SerializationError", "failed encoding EC2 Query request", err)
 	}
 
 	if r.ExpireTime == 0 {

--- a/internal/protocol/ec2query/unmarshal.go
+++ b/internal/protocol/ec2query/unmarshal.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 )
 
@@ -18,7 +18,7 @@ func Unmarshal(r *aws.Request) {
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
 		err := xmlutil.UnmarshalXML(r.Data, decoder, "")
 		if err != nil {
-			r.Error = apierr.New("SerializationError", "failed decoding EC2 Query response", err)
+			r.Error = awserr.New("SerializationError", "failed decoding EC2 Query response", err)
 			return
 		}
 	}
@@ -43,10 +43,10 @@ func UnmarshalError(r *aws.Request) {
 	resp := &xmlErrorResponse{}
 	err := xml.NewDecoder(r.HTTPResponse.Body).Decode(resp)
 	if err != nil && err != io.EOF {
-		r.Error = apierr.New("SerializationError", "failed decoding EC2 Query error response", err)
+		r.Error = awserr.New("SerializationError", "failed decoding EC2 Query error response", err)
 	} else {
-		r.Error = apierr.NewRequestError(
-			apierr.New(resp.Code, resp.Message, nil),
+		r.Error = awserr.NewRequestFailure(
+			awserr.New(resp.Code, resp.Message, nil),
 			r.HTTPResponse.StatusCode,
 			resp.RequestID,
 		)

--- a/internal/protocol/query/build.go
+++ b/internal/protocol/query/build.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/internal/protocol/query/queryutil"
 )
 
@@ -18,7 +18,7 @@ func Build(r *aws.Request) {
 		"Version": {r.Service.APIVersion},
 	}
 	if err := queryutil.Parse(body, r.Params, false); err != nil {
-		r.Error = apierr.New("SerializationError", "failed encoding Query request", err)
+		r.Error = awserr.New("SerializationError", "failed encoding Query request", err)
 		return
 	}
 

--- a/internal/protocol/query/unmarshal.go
+++ b/internal/protocol/query/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 )
 
@@ -17,7 +17,7 @@ func Unmarshal(r *aws.Request) {
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
 		err := xmlutil.UnmarshalXML(r.Data, decoder, r.Operation.Name+"Result")
 		if err != nil {
-			r.Error = apierr.New("SerializationError", "failed decoding Query response", err)
+			r.Error = awserr.New("SerializationError", "failed decoding Query response", err)
 			return
 		}
 	}

--- a/internal/protocol/query/unmarshal_error.go
+++ b/internal/protocol/query/unmarshal_error.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 type xmlErrorResponse struct {
@@ -22,10 +22,10 @@ func UnmarshalError(r *aws.Request) {
 	resp := &xmlErrorResponse{}
 	err := xml.NewDecoder(r.HTTPResponse.Body).Decode(resp)
 	if err != nil && err != io.EOF {
-		r.Error = apierr.New("SerializationError", "failed to decode query XML error response", err)
+		r.Error = awserr.New("SerializationError", "failed to decode query XML error response", err)
 	} else {
-		r.Error = apierr.NewRequestError(
-			apierr.New(resp.Code, resp.Message, nil),
+		r.Error = awserr.NewRequestFailure(
+			awserr.New(resp.Code, resp.Message, nil),
 			r.HTTPResponse.StatusCode,
 			resp.RequestID,
 		)

--- a/internal/protocol/rest/build.go
+++ b/internal/protocol/rest/build.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 // RFC822 returns an RFC822 formatted timestamp for AWS protocols
@@ -102,7 +102,7 @@ func buildBody(r *aws.Request, v reflect.Value) {
 					case string:
 						r.SetStringBody(reader)
 					default:
-						r.Error = apierr.New("SerializationError",
+						r.Error = awserr.New("SerializationError",
 							"failed to encode REST request",
 							fmt.Errorf("unknown payload type %s", payload.Type()))
 					}
@@ -115,7 +115,7 @@ func buildBody(r *aws.Request, v reflect.Value) {
 func buildHeader(r *aws.Request, v reflect.Value, name string) {
 	str, err := convertType(v)
 	if err != nil {
-		r.Error = apierr.New("SerializationError", "failed to encode REST request", err)
+		r.Error = awserr.New("SerializationError", "failed to encode REST request", err)
 	} else if str != nil {
 		r.HTTPRequest.Header.Add(name, *str)
 	}
@@ -125,7 +125,7 @@ func buildHeaderMap(r *aws.Request, v reflect.Value, prefix string) {
 	for _, key := range v.MapKeys() {
 		str, err := convertType(v.MapIndex(key))
 		if err != nil {
-			r.Error = apierr.New("SerializationError", "failed to encode REST request", err)
+			r.Error = awserr.New("SerializationError", "failed to encode REST request", err)
 		} else if str != nil {
 			r.HTTPRequest.Header.Add(prefix+key.String(), *str)
 		}
@@ -135,7 +135,7 @@ func buildHeaderMap(r *aws.Request, v reflect.Value, prefix string) {
 func buildURI(r *aws.Request, v reflect.Value, name string) {
 	value, err := convertType(v)
 	if err != nil {
-		r.Error = apierr.New("SerializationError", "failed to encode REST request", err)
+		r.Error = awserr.New("SerializationError", "failed to encode REST request", err)
 	} else if value != nil {
 		uri := r.HTTPRequest.URL.Path
 		uri = strings.Replace(uri, "{"+name+"}", EscapePath(*value, true), -1)
@@ -147,7 +147,7 @@ func buildURI(r *aws.Request, v reflect.Value, name string) {
 func buildQueryString(r *aws.Request, v reflect.Value, name string, query url.Values) {
 	str, err := convertType(v)
 	if err != nil {
-		r.Error = apierr.New("SerializationError", "failed to encode REST request", err)
+		r.Error = awserr.New("SerializationError", "failed to encode REST request", err)
 	} else if str != nil {
 		query.Set(name, *str)
 	}

--- a/internal/protocol/rest/unmarshal.go
+++ b/internal/protocol/rest/unmarshal.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 // Unmarshal unmarshals the REST component of a response in a REST service.
@@ -34,14 +34,14 @@ func unmarshalBody(r *aws.Request, v reflect.Value) {
 					case []byte:
 						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
-							r.Error = apierr.New("SerializationError", "failed to decode REST response", err)
+							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 						} else {
 							payload.Set(reflect.ValueOf(b))
 						}
 					case *string:
 						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
-							r.Error = apierr.New("SerializationError", "failed to decode REST response", err)
+							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 						} else {
 							str := string(b)
 							payload.Set(reflect.ValueOf(&str))
@@ -53,7 +53,7 @@ func unmarshalBody(r *aws.Request, v reflect.Value) {
 						case "aws.ReadSeekCloser", "io.ReadCloser":
 							payload.Set(reflect.ValueOf(r.HTTPResponse.Body))
 						default:
-							r.Error = apierr.New("SerializationError",
+							r.Error = awserr.New("SerializationError",
 								"failed to decode REST response",
 								fmt.Errorf("unknown payload type %s", payload.Type()))
 						}
@@ -83,14 +83,14 @@ func unmarshalLocationElements(r *aws.Request, v reflect.Value) {
 			case "header":
 				err := unmarshalHeader(m, r.HTTPResponse.Header.Get(name))
 				if err != nil {
-					r.Error = apierr.New("SerializationError", "failed to decode REST response", err)
+					r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 					break
 				}
 			case "headers":
 				prefix := field.Tag.Get("locationName")
 				err := unmarshalHeaderMap(m, r.HTTPResponse.Header, prefix)
 				if err != nil {
-					r.Error = apierr.New("SerializationError", "failed to decode REST response", err)
+					r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 					break
 				}
 			}

--- a/internal/protocol/restxml/restxml.go
+++ b/internal/protocol/restxml/restxml.go
@@ -10,7 +10,7 @@ import (
 	"encoding/xml"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/protocol/rest"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
@@ -24,7 +24,7 @@ func Build(r *aws.Request) {
 		var buf bytes.Buffer
 		err := xmlutil.BuildXML(r.Params, xml.NewEncoder(&buf))
 		if err != nil {
-			r.Error = apierr.New("SerializationError", "failed to enode rest XML request", err)
+			r.Error = awserr.New("SerializationError", "failed to enode rest XML request", err)
 			return
 		}
 		r.SetBufferBody(buf.Bytes())
@@ -38,7 +38,7 @@ func Unmarshal(r *aws.Request) {
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
 		err := xmlutil.UnmarshalXML(r.Data, decoder, "")
 		if err != nil {
-			r.Error = apierr.New("SerializationError", "failed to decode REST XML response", err)
+			r.Error = awserr.New("SerializationError", "failed to decode REST XML response", err)
 			return
 		}
 	}

--- a/service/dynamodb/customizations.go
+++ b/service/dynamodb/customizations.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 func init() {
@@ -76,6 +76,6 @@ func validateCRC32(r *aws.Request) {
 	if crc != uint32(expected) {
 		// CRC does not match, set a retryable error
 		r.Retryable.Set(true)
-		r.Error = apierr.New("CRC32CheckFailed", "CRC32 integrity check failed", nil)
+		r.Error = awserr.New("CRC32CheckFailed", "CRC32 integrity check failed", nil)
 	}
 }

--- a/service/s3/bucket_location.go
+++ b/service/s3/bucket_location.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/internal/apierr"
 )
 
 var reBucketLocation = regexp.MustCompile(`>([^<>]+)<\/Location`)
@@ -16,7 +16,7 @@ func buildGetBucketLocation(r *aws.Request) {
 		out := r.Data.(*GetBucketLocationOutput)
 		b, err := ioutil.ReadAll(r.HTTPResponse.Body)
 		if err != nil {
-			r.Error = apierr.New("SerializationError", "failed reading response body", err)
+			r.Error = awserr.New("SerializationError", "failed reading response body", err)
 			return
 		}
 

--- a/service/s3/content_md5.go
+++ b/service/s3/content_md5.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 // contentMD5 computes and sets the HTTP Content-MD5 header for requests that
@@ -19,12 +19,12 @@ func contentMD5(r *aws.Request) {
 	// body.
 	_, err := io.Copy(h, r.Body)
 	if err != nil {
-		r.Error = apierr.New("ContentMD5", "failed to read body", err)
+		r.Error = awserr.New("ContentMD5", "failed to read body", err)
 		return
 	}
 	_, err = r.Body.Seek(0, 0)
 	if err != nil {
-		r.Error = apierr.New("ContentMD5", "failed to seek body", err)
+		r.Error = awserr.New("ContentMD5", "failed to seek body", err)
 		return
 	}
 

--- a/service/s3/sse.go
+++ b/service/s3/sse.go
@@ -5,11 +5,11 @@ import (
 	"encoding/base64"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/internal/apierr"
 )
 
-var errSSERequiresSSL = apierr.New("ConfigError", "cannot send SSE keys over HTTP.", nil)
+var errSSERequiresSSL = awserr.New("ConfigError", "cannot send SSE keys over HTTP.", nil)
 
 func validateSSERequiresSSL(r *aws.Request) {
 	if r.HTTPRequest.URL.Scheme != "https" {

--- a/service/s3/unmarshal_error.go
+++ b/service/s3/unmarshal_error.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 type xmlErrorResponse struct {
@@ -20,8 +20,8 @@ func unmarshalError(r *aws.Request) {
 
 	if r.HTTPResponse.ContentLength == int64(0) {
 		// No body, use status code to generate an awserr.Error
-		r.Error = apierr.NewRequestError(
-			apierr.New(strings.Replace(r.HTTPResponse.Status, " ", "", -1), r.HTTPResponse.Status, nil),
+		r.Error = awserr.NewRequestFailure(
+			awserr.New(strings.Replace(r.HTTPResponse.Status, " ", "", -1), r.HTTPResponse.Status, nil),
 			r.HTTPResponse.StatusCode,
 			"",
 		)
@@ -31,10 +31,10 @@ func unmarshalError(r *aws.Request) {
 	resp := &xmlErrorResponse{}
 	err := xml.NewDecoder(r.HTTPResponse.Body).Decode(resp)
 	if err != nil && err != io.EOF {
-		r.Error = apierr.New("SerializationError", "failed to decode S3 XML error response", nil)
+		r.Error = awserr.New("SerializationError", "failed to decode S3 XML error response", nil)
 	} else {
-		r.Error = apierr.NewRequestError(
-			apierr.New(resp.Code, resp.Message, nil),
+		r.Error = awserr.NewRequestFailure(
+			awserr.New(resp.Code, resp.Message, nil),
 			r.HTTPResponse.StatusCode,
 			"",
 		)

--- a/service/sqs/checksums.go
+++ b/service/sqs/checksums.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/internal/apierr"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 var (
@@ -100,5 +100,5 @@ func checksumsMatch(body, expectedMD5 *string) error {
 
 func setChecksumError(r *aws.Request, format string, args ...interface{}) {
 	r.Retryable.Set(true)
-	r.Error = apierr.New("InvalidChecksum", fmt.Sprintf(format, args...), nil)
+	r.Error = awserr.New("InvalidChecksum", fmt.Sprintf(format, args...), nil)
 }


### PR DESCRIPTION
Adds two new constructors for the awserr Error types. Can also be used for building awserr.Error for testing.

- awserr.New() returns an Error object described by code, message, and origErr. If origErr satisfies the Error interface it will not be wrapped within a new Error object, and will instead be returned.

- awserr.NewRequestFailure() returns a new request error wrapper for the given Error provided.

Fixes: #254