### PR TITLE
Change dynamodbattribute package name.

### DIFF
--- a/service/dynamodb/dynamodbattribute/converter.go
+++ b/service/dynamodb/dynamodbattribute/converter.go
@@ -1,4 +1,4 @@
-package dynamodb
+package dynamodbattribute
 
 import (
 	"bytes"

--- a/service/dynamodb/dynamodbattribute/converter_test.go
+++ b/service/dynamodb/dynamodbattribute/converter_test.go
@@ -1,4 +1,4 @@
-package dynamodb
+package dynamodbattribute
 
 import (
 	"math"
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 

--- a/service/dynamodb/dynamodbattribute/converter_test.go
+++ b/service/dynamodb/dynamodbattribute/converter_test.go
@@ -460,7 +460,7 @@ func TestConvertFromListError(t *testing.T) {
 
 	// Test that we get an error using ConvertFromList to convert to a struct.
 	var actual2 myComplexStruct
-	expected = awserr.New("SerializationError", `v must be a non-nil pointer to an array or slice, got *dynamodb.myComplexStruct`, nil).Error()
+	expected = awserr.New("SerializationError", `v must be a non-nil pointer to an array or slice, got *dynamodbattribute.myComplexStruct`, nil).Error()
 	if err := ConvertFromList(nil, &actual2); err == nil {
 		t.Errorf("ConvertFromList with input %#v returned no error, expected error `%s`", nil, expected)
 	} else if err.Error() != expected {


### PR DESCRIPTION
Make the package name match the import path.

Having mismatched package/imports is confusing and only makes things
harder to understand. Additional confusion is added when the package
called "dynamodb" imports another package called "dynamodb."

Also, goimports didn't like your alphabetizing :P