### PR TITLE
Add String() and GoString() to service structs

### DIFF
--- a/internal/fixtures/protocol/generate.go
+++ b/internal/fixtures/protocol/generate.go
@@ -256,6 +256,7 @@ func generateTestSuite(filename string) string {
 
 		suite.API.NoInflections = true // don't require inflections
 		suite.API.NoInitMethods = true // don't generate init methods
+		suite.API.NoStringerMethods = true // don't generate stringer methods
 		suite.API.Setup()
 		suite.API.Metadata.EndpointPrefix = suite.API.PackageName()
 

--- a/internal/model/api/api.go
+++ b/internal/model/api/api.go
@@ -28,6 +28,9 @@ type API struct {
 	// Set to true to ignore service/request init methods (for testing)
 	NoInitMethods bool
 
+	// Set to true to ignore String() and GoString methods (for generated tests)
+	NoStringerMethods bool
+
 	initialized       bool
 	imports           map[string]bool
 	name              string
@@ -197,6 +200,7 @@ var tplAPI = template.Must(template.New("api").Parse(`
 // APIGoCode renders the API in Go code. Returning it as a string
 func (a *API) APIGoCode() string {
 	a.resetImports()
+	a.imports["github.com/aws/aws-sdk-go/aws/awsutil"] = true
 	var buf bytes.Buffer
 	err := tplAPI.Execute(&buf, a)
 	if err != nil {

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAttachInstances = "AttachInstances"
@@ -1655,6 +1656,16 @@ type metadataActivity struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Activity) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Activity) GoString() string {
+	return s.String()
+}
+
 // Describes a policy adjustment type.
 //
 // For more information, see Dynamic Scaling (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html)
@@ -1669,6 +1680,16 @@ type AdjustmentType struct {
 
 type metadataAdjustmentType struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AdjustmentType) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AdjustmentType) GoString() string {
+	return s.String()
 }
 
 // Describes an alarm.
@@ -1686,6 +1707,16 @@ type metadataAlarm struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Alarm) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Alarm) GoString() string {
+	return s.String()
+}
+
 type AttachInstancesInput struct {
 	// The name of the group.
 	AutoScalingGroupName *string `type:"string" required:"true"`
@@ -1700,12 +1731,32 @@ type metadataAttachInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachInstancesInput) GoString() string {
+	return s.String()
+}
+
 type AttachInstancesOutput struct {
 	metadataAttachInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type AttachLoadBalancersInput struct {
@@ -1722,12 +1773,32 @@ type metadataAttachLoadBalancersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachLoadBalancersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachLoadBalancersInput) GoString() string {
+	return s.String()
+}
+
 type AttachLoadBalancersOutput struct {
 	metadataAttachLoadBalancersOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachLoadBalancersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachLoadBalancersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachLoadBalancersOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a block device mapping.
@@ -1755,6 +1826,16 @@ type metadataBlockDeviceMapping struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BlockDeviceMapping) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BlockDeviceMapping) GoString() string {
+	return s.String()
+}
+
 type CompleteLifecycleActionInput struct {
 	// The name of the group for the lifecycle hook.
 	AutoScalingGroupName *string `type:"string" required:"true"`
@@ -1778,12 +1859,32 @@ type metadataCompleteLifecycleActionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CompleteLifecycleActionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompleteLifecycleActionInput) GoString() string {
+	return s.String()
+}
+
 type CompleteLifecycleActionOutput struct {
 	metadataCompleteLifecycleActionOutput `json:"-" xml:"-"`
 }
 
 type metadataCompleteLifecycleActionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CompleteLifecycleActionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompleteLifecycleActionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateAutoScalingGroupInput struct {
@@ -1897,12 +1998,32 @@ type metadataCreateAutoScalingGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAutoScalingGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAutoScalingGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateAutoScalingGroupOutput struct {
 	metadataCreateAutoScalingGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAutoScalingGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAutoScalingGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAutoScalingGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateLaunchConfigurationInput struct {
@@ -2056,12 +2177,32 @@ type metadataCreateLaunchConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLaunchConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLaunchConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type CreateLaunchConfigurationOutput struct {
 	metadataCreateLaunchConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLaunchConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLaunchConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLaunchConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 type CreateOrUpdateTagsInput struct {
@@ -2075,12 +2216,32 @@ type metadataCreateOrUpdateTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateOrUpdateTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateOrUpdateTagsInput) GoString() string {
+	return s.String()
+}
+
 type CreateOrUpdateTagsOutput struct {
 	metadataCreateOrUpdateTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateOrUpdateTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateOrUpdateTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateOrUpdateTagsOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteAutoScalingGroupInput struct {
@@ -2099,12 +2260,32 @@ type metadataDeleteAutoScalingGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAutoScalingGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAutoScalingGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteAutoScalingGroupOutput struct {
 	metadataDeleteAutoScalingGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAutoScalingGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAutoScalingGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAutoScalingGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteLaunchConfigurationInput struct {
@@ -2118,12 +2299,32 @@ type metadataDeleteLaunchConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLaunchConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLaunchConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLaunchConfigurationOutput struct {
 	metadataDeleteLaunchConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLaunchConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLaunchConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLaunchConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteLifecycleHookInput struct {
@@ -2140,12 +2341,32 @@ type metadataDeleteLifecycleHookInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLifecycleHookInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLifecycleHookInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLifecycleHookOutput struct {
 	metadataDeleteLifecycleHookOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLifecycleHookOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLifecycleHookOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLifecycleHookOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteNotificationConfigurationInput struct {
@@ -2163,12 +2384,32 @@ type metadataDeleteNotificationConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteNotificationConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteNotificationConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type DeleteNotificationConfigurationOutput struct {
 	metadataDeleteNotificationConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNotificationConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteNotificationConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteNotificationConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 type DeletePolicyInput struct {
@@ -2185,12 +2426,32 @@ type metadataDeletePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeletePolicyOutput struct {
 	metadataDeletePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteScheduledActionInput struct {
@@ -2207,12 +2468,32 @@ type metadataDeleteScheduledActionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteScheduledActionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteScheduledActionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteScheduledActionOutput struct {
 	metadataDeleteScheduledActionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteScheduledActionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteScheduledActionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteScheduledActionOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteTagsInput struct {
@@ -2229,6 +2510,16 @@ type metadataDeleteTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteTagsOutput struct {
 	metadataDeleteTagsOutput `json:"-" xml:"-"`
 }
@@ -2237,12 +2528,32 @@ type metadataDeleteTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeAccountLimitsInput struct {
 	metadataDescribeAccountLimitsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAccountLimitsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAccountLimitsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountLimitsInput) GoString() string {
+	return s.String()
 }
 
 type DescribeAccountLimitsOutput struct {
@@ -2261,12 +2572,32 @@ type metadataDescribeAccountLimitsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAccountLimitsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountLimitsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeAdjustmentTypesInput struct {
 	metadataDescribeAdjustmentTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAdjustmentTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAdjustmentTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAdjustmentTypesInput) GoString() string {
+	return s.String()
 }
 
 type DescribeAdjustmentTypesOutput struct {
@@ -2278,6 +2609,16 @@ type DescribeAdjustmentTypesOutput struct {
 
 type metadataDescribeAdjustmentTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAdjustmentTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAdjustmentTypesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAutoScalingGroupsInput struct {
@@ -2298,6 +2639,16 @@ type metadataDescribeAutoScalingGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAutoScalingGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAutoScalingGroupsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeAutoScalingGroupsOutput struct {
 	// The groups.
 	AutoScalingGroups []*Group `type:"list" required:"true"`
@@ -2311,6 +2662,16 @@ type DescribeAutoScalingGroupsOutput struct {
 
 type metadataDescribeAutoScalingGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAutoScalingGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAutoScalingGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAutoScalingInstancesInput struct {
@@ -2333,6 +2694,16 @@ type metadataDescribeAutoScalingInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAutoScalingInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAutoScalingInstancesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeAutoScalingInstancesOutput struct {
 	// The instances.
 	AutoScalingInstances []*InstanceDetails `type:"list"`
@@ -2348,12 +2719,32 @@ type metadataDescribeAutoScalingInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAutoScalingInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAutoScalingInstancesOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeAutoScalingNotificationTypesInput struct {
 	metadataDescribeAutoScalingNotificationTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAutoScalingNotificationTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAutoScalingNotificationTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAutoScalingNotificationTypesInput) GoString() string {
+	return s.String()
 }
 
 type DescribeAutoScalingNotificationTypesOutput struct {
@@ -2377,6 +2768,16 @@ type metadataDescribeAutoScalingNotificationTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAutoScalingNotificationTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAutoScalingNotificationTypesOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeLaunchConfigurationsInput struct {
 	// The launch configuration names.
 	LaunchConfigurationNames []*string `type:"list"`
@@ -2395,6 +2796,16 @@ type metadataDescribeLaunchConfigurationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLaunchConfigurationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLaunchConfigurationsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLaunchConfigurationsOutput struct {
 	// The launch configurations.
 	LaunchConfigurations []*LaunchConfiguration `type:"list" required:"true"`
@@ -2410,12 +2821,32 @@ type metadataDescribeLaunchConfigurationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLaunchConfigurationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLaunchConfigurationsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeLifecycleHookTypesInput struct {
 	metadataDescribeLifecycleHookTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLifecycleHookTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLifecycleHookTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLifecycleHookTypesInput) GoString() string {
+	return s.String()
 }
 
 type DescribeLifecycleHookTypesOutput struct {
@@ -2433,6 +2864,16 @@ type metadataDescribeLifecycleHookTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLifecycleHookTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLifecycleHookTypesOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeLifecycleHooksInput struct {
 	// The name of the group.
 	AutoScalingGroupName *string `type:"string" required:"true"`
@@ -2447,6 +2888,16 @@ type metadataDescribeLifecycleHooksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLifecycleHooksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLifecycleHooksInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLifecycleHooksOutput struct {
 	// The lifecycle hooks for the specified group.
 	LifecycleHooks []*LifecycleHook `type:"list"`
@@ -2456,6 +2907,16 @@ type DescribeLifecycleHooksOutput struct {
 
 type metadataDescribeLifecycleHooksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLifecycleHooksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLifecycleHooksOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeLoadBalancersInput struct {
@@ -2476,6 +2937,16 @@ type metadataDescribeLoadBalancersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLoadBalancersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancersInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLoadBalancersOutput struct {
 	// The load balancers.
 	LoadBalancers []*LoadBalancerState `type:"list"`
@@ -2491,12 +2962,32 @@ type metadataDescribeLoadBalancersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLoadBalancersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancersOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeMetricCollectionTypesInput struct {
 	metadataDescribeMetricCollectionTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMetricCollectionTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMetricCollectionTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMetricCollectionTypesInput) GoString() string {
+	return s.String()
 }
 
 type DescribeMetricCollectionTypesOutput struct {
@@ -2511,6 +3002,16 @@ type DescribeMetricCollectionTypesOutput struct {
 
 type metadataDescribeMetricCollectionTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMetricCollectionTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMetricCollectionTypesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeNotificationConfigurationsInput struct {
@@ -2531,6 +3032,16 @@ type metadataDescribeNotificationConfigurationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeNotificationConfigurationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeNotificationConfigurationsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeNotificationConfigurationsOutput struct {
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
@@ -2544,6 +3055,16 @@ type DescribeNotificationConfigurationsOutput struct {
 
 type metadataDescribeNotificationConfigurationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeNotificationConfigurationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeNotificationConfigurationsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribePoliciesInput struct {
@@ -2570,6 +3091,16 @@ type metadataDescribePoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribePoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePoliciesInput) GoString() string {
+	return s.String()
+}
+
 type DescribePoliciesOutput struct {
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
@@ -2583,6 +3114,16 @@ type DescribePoliciesOutput struct {
 
 type metadataDescribePoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribePoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeScalingActivitiesInput struct {
@@ -2610,6 +3151,16 @@ type metadataDescribeScalingActivitiesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeScalingActivitiesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeScalingActivitiesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeScalingActivitiesOutput struct {
 	// The scaling activities.
 	Activities []*Activity `type:"list" required:"true"`
@@ -2625,12 +3176,32 @@ type metadataDescribeScalingActivitiesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeScalingActivitiesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeScalingActivitiesOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeScalingProcessTypesInput struct {
 	metadataDescribeScalingProcessTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeScalingProcessTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeScalingProcessTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeScalingProcessTypesInput) GoString() string {
+	return s.String()
 }
 
 type DescribeScalingProcessTypesOutput struct {
@@ -2642,6 +3213,16 @@ type DescribeScalingProcessTypesOutput struct {
 
 type metadataDescribeScalingProcessTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeScalingProcessTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeScalingProcessTypesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeScheduledActionsInput struct {
@@ -2679,6 +3260,16 @@ type metadataDescribeScheduledActionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeScheduledActionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeScheduledActionsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeScheduledActionsOutput struct {
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
@@ -2692,6 +3283,16 @@ type DescribeScheduledActionsOutput struct {
 
 type metadataDescribeScheduledActionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeScheduledActionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeScheduledActionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeTagsInput struct {
@@ -2712,6 +3313,16 @@ type metadataDescribeTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeTagsOutput struct {
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
@@ -2727,12 +3338,32 @@ type metadataDescribeTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeTerminationPolicyTypesInput struct {
 	metadataDescribeTerminationPolicyTypesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeTerminationPolicyTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTerminationPolicyTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTerminationPolicyTypesInput) GoString() string {
+	return s.String()
 }
 
 type DescribeTerminationPolicyTypesOutput struct {
@@ -2745,6 +3376,16 @@ type DescribeTerminationPolicyTypesOutput struct {
 
 type metadataDescribeTerminationPolicyTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTerminationPolicyTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTerminationPolicyTypesOutput) GoString() string {
+	return s.String()
 }
 
 type DetachInstancesInput struct {
@@ -2765,6 +3406,16 @@ type metadataDetachInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachInstancesInput) GoString() string {
+	return s.String()
+}
+
 type DetachInstancesOutput struct {
 	// The activities related to detaching the instances from the Auto Scaling group.
 	Activities []*Activity `type:"list"`
@@ -2774,6 +3425,16 @@ type DetachInstancesOutput struct {
 
 type metadataDetachInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type DetachLoadBalancersInput struct {
@@ -2790,12 +3451,32 @@ type metadataDetachLoadBalancersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachLoadBalancersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachLoadBalancersInput) GoString() string {
+	return s.String()
+}
+
 type DetachLoadBalancersOutput struct {
 	metadataDetachLoadBalancersOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachLoadBalancersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachLoadBalancersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachLoadBalancersOutput) GoString() string {
+	return s.String()
 }
 
 type DisableMetricsCollectionInput struct {
@@ -2828,12 +3509,32 @@ type metadataDisableMetricsCollectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableMetricsCollectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableMetricsCollectionInput) GoString() string {
+	return s.String()
+}
+
 type DisableMetricsCollectionOutput struct {
 	metadataDisableMetricsCollectionOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableMetricsCollectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableMetricsCollectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableMetricsCollectionOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an Amazon EBS volume.
@@ -2880,6 +3581,16 @@ type metadataEBS struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EBS) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EBS) GoString() string {
+	return s.String()
+}
+
 type EnableMetricsCollectionInput struct {
 	// The name or ARN of the Auto Scaling group.
 	AutoScalingGroupName *string `type:"string" required:"true"`
@@ -2917,12 +3628,32 @@ type metadataEnableMetricsCollectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableMetricsCollectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableMetricsCollectionInput) GoString() string {
+	return s.String()
+}
+
 type EnableMetricsCollectionOutput struct {
 	metadataEnableMetricsCollectionOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableMetricsCollectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableMetricsCollectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableMetricsCollectionOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an enabled metric.
@@ -2956,6 +3687,16 @@ type metadataEnabledMetric struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnabledMetric) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnabledMetric) GoString() string {
+	return s.String()
+}
+
 type EnterStandbyInput struct {
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `type:"string" required:"true"`
@@ -2977,6 +3718,16 @@ type metadataEnterStandbyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnterStandbyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnterStandbyInput) GoString() string {
+	return s.String()
+}
+
 type EnterStandbyOutput struct {
 	// The activities related to moving instances into Standby mode.
 	Activities []*Activity `type:"list"`
@@ -2986,6 +3737,16 @@ type EnterStandbyOutput struct {
 
 type metadataEnterStandbyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnterStandbyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnterStandbyOutput) GoString() string {
+	return s.String()
 }
 
 type ExecutePolicyInput struct {
@@ -3013,12 +3774,32 @@ type metadataExecutePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ExecutePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExecutePolicyInput) GoString() string {
+	return s.String()
+}
+
 type ExecutePolicyOutput struct {
 	metadataExecutePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataExecutePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ExecutePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExecutePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type ExitStandbyInput struct {
@@ -3035,6 +3816,16 @@ type metadataExitStandbyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ExitStandbyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExitStandbyInput) GoString() string {
+	return s.String()
+}
+
 type ExitStandbyOutput struct {
 	// The activities related to moving instances out of Standby mode.
 	Activities []*Activity `type:"list"`
@@ -3044,6 +3835,16 @@ type ExitStandbyOutput struct {
 
 type metadataExitStandbyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ExitStandbyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExitStandbyOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a filter.
@@ -3060,6 +3861,16 @@ type Filter struct {
 
 type metadataFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Filter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Filter) GoString() string {
+	return s.String()
 }
 
 // Describes an Auto Scaling group.
@@ -3138,6 +3949,16 @@ type metadataGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Group) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Group) GoString() string {
+	return s.String()
+}
+
 // Describes an EC2 instance.
 type Instance struct {
 	// The Availability Zone in which the instance is running.
@@ -3161,6 +3982,16 @@ type Instance struct {
 
 type metadataInstance struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Instance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Instance) GoString() string {
+	return s.String()
 }
 
 // Describes an EC2 instance associated with an Auto Scaling group.
@@ -3194,6 +4025,16 @@ type metadataInstanceDetails struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceDetails) GoString() string {
+	return s.String()
+}
+
 // Describes whether instance monitoring is enabled.
 type InstanceMonitoring struct {
 	// If True, instance monitoring is enabled.
@@ -3204,6 +4045,16 @@ type InstanceMonitoring struct {
 
 type metadataInstanceMonitoring struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceMonitoring) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceMonitoring) GoString() string {
+	return s.String()
 }
 
 // Describes a launch configuration.
@@ -3282,6 +4133,16 @@ type metadataLaunchConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LaunchConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LaunchConfiguration) GoString() string {
+	return s.String()
+}
+
 // Describes a lifecycle hook, which tells Auto Scaling that you want to perform
 // an action when an instance launches or terminates. When you have a lifecycle
 // hook in place, the Auto Scaling group will either:
@@ -3341,6 +4202,16 @@ type metadataLifecycleHook struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LifecycleHook) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LifecycleHook) GoString() string {
+	return s.String()
+}
+
 // Describes the state of a load balancer.
 type LoadBalancerState struct {
 	// The name of the load balancer.
@@ -3365,6 +4236,16 @@ type LoadBalancerState struct {
 
 type metadataLoadBalancerState struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LoadBalancerState) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerState) GoString() string {
+	return s.String()
 }
 
 // Describes a metric.
@@ -3395,6 +4276,16 @@ type metadataMetricCollectionType struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MetricCollectionType) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MetricCollectionType) GoString() string {
+	return s.String()
+}
+
 // Describes a granularity of a metric.
 type MetricGranularityType struct {
 	// The granularity. The only valid value is 1Minute.
@@ -3405,6 +4296,16 @@ type MetricGranularityType struct {
 
 type metadataMetricGranularityType struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MetricGranularityType) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MetricGranularityType) GoString() string {
+	return s.String()
 }
 
 // Describes a notification.
@@ -3436,6 +4337,16 @@ type metadataNotificationConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NotificationConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NotificationConfiguration) GoString() string {
+	return s.String()
+}
+
 // Describes a process type.
 //
 // For more information, see Auto Scaling Processes (http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/US_SuspendResume.html#process-types)
@@ -3465,6 +4376,16 @@ type ProcessType struct {
 
 type metadataProcessType struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ProcessType) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ProcessType) GoString() string {
+	return s.String()
 }
 
 type PutLifecycleHookInput struct {
@@ -3534,12 +4455,32 @@ type metadataPutLifecycleHookInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutLifecycleHookInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutLifecycleHookInput) GoString() string {
+	return s.String()
+}
+
 type PutLifecycleHookOutput struct {
 	metadataPutLifecycleHookOutput `json:"-" xml:"-"`
 }
 
 type metadataPutLifecycleHookOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutLifecycleHookOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutLifecycleHookOutput) GoString() string {
+	return s.String()
 }
 
 type PutNotificationConfigurationInput struct {
@@ -3561,12 +4502,32 @@ type metadataPutNotificationConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutNotificationConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutNotificationConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type PutNotificationConfigurationOutput struct {
 	metadataPutNotificationConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataPutNotificationConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutNotificationConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutNotificationConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 type PutScalingPolicyInput struct {
@@ -3612,6 +4573,16 @@ type metadataPutScalingPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutScalingPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutScalingPolicyInput) GoString() string {
+	return s.String()
+}
+
 type PutScalingPolicyOutput struct {
 	// The Amazon Resource Name (ARN) of the policy.
 	PolicyARN *string `type:"string"`
@@ -3621,6 +4592,16 @@ type PutScalingPolicyOutput struct {
 
 type metadataPutScalingPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutScalingPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutScalingPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type PutScheduledUpdateGroupActionInput struct {
@@ -3673,12 +4654,32 @@ type metadataPutScheduledUpdateGroupActionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutScheduledUpdateGroupActionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutScheduledUpdateGroupActionInput) GoString() string {
+	return s.String()
+}
+
 type PutScheduledUpdateGroupActionOutput struct {
 	metadataPutScheduledUpdateGroupActionOutput `json:"-" xml:"-"`
 }
 
 type metadataPutScheduledUpdateGroupActionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutScheduledUpdateGroupActionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutScheduledUpdateGroupActionOutput) GoString() string {
+	return s.String()
 }
 
 type RecordLifecycleActionHeartbeatInput struct {
@@ -3700,6 +4701,16 @@ type metadataRecordLifecycleActionHeartbeatInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecordLifecycleActionHeartbeatInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecordLifecycleActionHeartbeatInput) GoString() string {
+	return s.String()
+}
+
 type RecordLifecycleActionHeartbeatOutput struct {
 	metadataRecordLifecycleActionHeartbeatOutput `json:"-" xml:"-"`
 }
@@ -3708,12 +4719,32 @@ type metadataRecordLifecycleActionHeartbeatOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecordLifecycleActionHeartbeatOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecordLifecycleActionHeartbeatOutput) GoString() string {
+	return s.String()
+}
+
 type ResumeProcessesOutput struct {
 	metadataResumeProcessesOutput `json:"-" xml:"-"`
 }
 
 type metadataResumeProcessesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResumeProcessesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResumeProcessesOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a scaling policy.
@@ -3755,6 +4786,16 @@ type metadataScalingPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ScalingPolicy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScalingPolicy) GoString() string {
+	return s.String()
+}
+
 type ScalingProcessQuery struct {
 	// The name or Amazon Resource Name (ARN) of the Auto Scaling group.
 	AutoScalingGroupName *string `type:"string" required:"true"`
@@ -3783,6 +4824,16 @@ type ScalingProcessQuery struct {
 
 type metadataScalingProcessQuery struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ScalingProcessQuery) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScalingProcessQuery) GoString() string {
+	return s.String()
 }
 
 // Describes a scheduled update to an Auto Scaling group.
@@ -3829,6 +4880,16 @@ type metadataScheduledUpdateGroupAction struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ScheduledUpdateGroupAction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScheduledUpdateGroupAction) GoString() string {
+	return s.String()
+}
+
 type SetDesiredCapacityInput struct {
 	// The name of the Auto Scaling group.
 	AutoScalingGroupName *string `type:"string" required:"true"`
@@ -3849,12 +4910,32 @@ type metadataSetDesiredCapacityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetDesiredCapacityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetDesiredCapacityInput) GoString() string {
+	return s.String()
+}
+
 type SetDesiredCapacityOutput struct {
 	metadataSetDesiredCapacityOutput `json:"-" xml:"-"`
 }
 
 type metadataSetDesiredCapacityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetDesiredCapacityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetDesiredCapacityOutput) GoString() string {
+	return s.String()
 }
 
 type SetInstanceHealthInput struct {
@@ -3882,6 +4963,16 @@ type metadataSetInstanceHealthInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetInstanceHealthInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetInstanceHealthInput) GoString() string {
+	return s.String()
+}
+
 type SetInstanceHealthOutput struct {
 	metadataSetInstanceHealthOutput `json:"-" xml:"-"`
 }
@@ -3890,12 +4981,32 @@ type metadataSetInstanceHealthOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetInstanceHealthOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetInstanceHealthOutput) GoString() string {
+	return s.String()
+}
+
 type SuspendProcessesOutput struct {
 	metadataSuspendProcessesOutput `json:"-" xml:"-"`
 }
 
 type metadataSuspendProcessesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SuspendProcessesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SuspendProcessesOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an Auto Scaling process that has been suspended. For more information,
@@ -3912,6 +5023,16 @@ type SuspendedProcess struct {
 
 type metadataSuspendedProcess struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SuspendedProcess) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SuspendedProcess) GoString() string {
+	return s.String()
 }
 
 // Describes a tag for an Auto Scaling group.
@@ -3939,6 +5060,16 @@ type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
 // Describes a tag for an Auto Scaling group.
 type TagDescription struct {
 	// The tag key.
@@ -3964,6 +5095,16 @@ type metadataTagDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TagDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TagDescription) GoString() string {
+	return s.String()
+}
+
 type TerminateInstanceInAutoScalingGroupInput struct {
 	// The ID of the EC2 instance.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
@@ -3979,6 +5120,16 @@ type metadataTerminateInstanceInAutoScalingGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TerminateInstanceInAutoScalingGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateInstanceInAutoScalingGroupInput) GoString() string {
+	return s.String()
+}
+
 type TerminateInstanceInAutoScalingGroupOutput struct {
 	// A scaling activity.
 	Activity *Activity `type:"structure"`
@@ -3988,6 +5139,16 @@ type TerminateInstanceInAutoScalingGroupOutput struct {
 
 type metadataTerminateInstanceInAutoScalingGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TerminateInstanceInAutoScalingGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateInstanceInAutoScalingGroupOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateAutoScalingGroupInput struct {
@@ -4058,10 +5219,30 @@ type metadataUpdateAutoScalingGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateAutoScalingGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAutoScalingGroupInput) GoString() string {
+	return s.String()
+}
+
 type UpdateAutoScalingGroupOutput struct {
 	metadataUpdateAutoScalingGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAutoScalingGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateAutoScalingGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAutoScalingGroupOutput) GoString() string {
+	return s.String()
 }

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCancelUpdateStack = "CancelUpdateStack"
@@ -605,12 +606,32 @@ type metadataCancelUpdateStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelUpdateStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelUpdateStackInput) GoString() string {
+	return s.String()
+}
+
 type CancelUpdateStackOutput struct {
 	metadataCancelUpdateStackOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelUpdateStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelUpdateStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelUpdateStackOutput) GoString() string {
+	return s.String()
 }
 
 // The input for CreateStack action.
@@ -709,6 +730,16 @@ type metadataCreateStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStackInput) GoString() string {
+	return s.String()
+}
+
 // The output for a CreateStack action.
 type CreateStackOutput struct {
 	// Unique identifier of the stack.
@@ -719,6 +750,16 @@ type CreateStackOutput struct {
 
 type metadataCreateStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStackOutput) GoString() string {
+	return s.String()
 }
 
 // The input for DeleteStack action.
@@ -733,12 +774,32 @@ type metadataDeleteStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteStackInput) GoString() string {
+	return s.String()
+}
+
 type DeleteStackOutput struct {
 	metadataDeleteStackOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteStackOutput) GoString() string {
+	return s.String()
 }
 
 // The input for DescribeStackEvents action.
@@ -764,6 +825,16 @@ type metadataDescribeStackEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStackEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackEventsInput) GoString() string {
+	return s.String()
+}
+
 // The output for a DescribeStackEvents action.
 type DescribeStackEventsOutput struct {
 	// String that identifies the start of the next list of events, if there is
@@ -778,6 +849,16 @@ type DescribeStackEventsOutput struct {
 
 type metadataDescribeStackEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStackEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackEventsOutput) GoString() string {
+	return s.String()
 }
 
 // The input for DescribeStackResource action.
@@ -802,6 +883,16 @@ type metadataDescribeStackResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStackResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackResourceInput) GoString() string {
+	return s.String()
+}
+
 // The output for a DescribeStackResource action.
 type DescribeStackResourceOutput struct {
 	// A StackResourceDetail structure containing the description of the specified
@@ -813,6 +904,16 @@ type DescribeStackResourceOutput struct {
 
 type metadataDescribeStackResourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStackResourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackResourceOutput) GoString() string {
+	return s.String()
 }
 
 // The input for DescribeStackResources action.
@@ -854,6 +955,16 @@ type metadataDescribeStackResourcesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStackResourcesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackResourcesInput) GoString() string {
+	return s.String()
+}
+
 // The output for a DescribeStackResources action.
 type DescribeStackResourcesOutput struct {
 	// A list of StackResource structures.
@@ -864,6 +975,16 @@ type DescribeStackResourcesOutput struct {
 
 type metadataDescribeStackResourcesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStackResourcesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackResourcesOutput) GoString() string {
+	return s.String()
 }
 
 // The input for DescribeStacks action.
@@ -887,6 +1008,16 @@ type metadataDescribeStacksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStacksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStacksInput) GoString() string {
+	return s.String()
+}
+
 // The output for a DescribeStacks action.
 type DescribeStacksOutput struct {
 	// String that identifies the start of the next list of stacks, if there is
@@ -901,6 +1032,16 @@ type DescribeStacksOutput struct {
 
 type metadataDescribeStacksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStacksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStacksOutput) GoString() string {
+	return s.String()
 }
 
 type EstimateTemplateCostInput struct {
@@ -932,6 +1073,16 @@ type metadataEstimateTemplateCostInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EstimateTemplateCostInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EstimateTemplateCostInput) GoString() string {
+	return s.String()
+}
+
 // The output for a EstimateTemplateCost action.
 type EstimateTemplateCostOutput struct {
 	// An AWS Simple Monthly Calculator URL with a query string that describes the
@@ -943,6 +1094,16 @@ type EstimateTemplateCostOutput struct {
 
 type metadataEstimateTemplateCostOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EstimateTemplateCostOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EstimateTemplateCostOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the GetStackPolicy action.
@@ -958,6 +1119,16 @@ type metadataGetStackPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetStackPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetStackPolicyInput) GoString() string {
+	return s.String()
+}
+
 // The output for the GetStackPolicy action.
 type GetStackPolicyOutput struct {
 	// Structure containing the stack policy body. (For more information, go to
@@ -970,6 +1141,16 @@ type GetStackPolicyOutput struct {
 
 type metadataGetStackPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetStackPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetStackPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // The input for a GetTemplate action.
@@ -989,6 +1170,16 @@ type metadataGetTemplateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetTemplateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetTemplateInput) GoString() string {
+	return s.String()
+}
+
 // The output for GetTemplate action.
 type GetTemplateOutput struct {
 	// Structure containing the template body. (For more information, go to Template
@@ -1001,6 +1192,16 @@ type GetTemplateOutput struct {
 
 type metadataGetTemplateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetTemplateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetTemplateOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the GetTemplateSummary action.
@@ -1039,6 +1240,16 @@ type metadataGetTemplateSummaryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetTemplateSummaryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetTemplateSummaryInput) GoString() string {
+	return s.String()
+}
+
 // The output for the GetTemplateSummary action.
 type GetTemplateSummaryOutput struct {
 	// The capabilities found within the template. Currently, AWS CloudFormation
@@ -1073,6 +1284,16 @@ type metadataGetTemplateSummaryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetTemplateSummaryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetTemplateSummaryOutput) GoString() string {
+	return s.String()
+}
+
 // The input for the ListStackResource action.
 type ListStackResourcesInput struct {
 	// String that identifies the start of the next list of stack resource summaries,
@@ -1096,6 +1317,16 @@ type metadataListStackResourcesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListStackResourcesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStackResourcesInput) GoString() string {
+	return s.String()
+}
+
 // The output for a ListStackResources action.
 type ListStackResourcesOutput struct {
 	// String that identifies the start of the next list of stack resources, if
@@ -1110,6 +1341,16 @@ type ListStackResourcesOutput struct {
 
 type metadataListStackResourcesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListStackResourcesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStackResourcesOutput) GoString() string {
+	return s.String()
 }
 
 // The input for ListStacks action.
@@ -1132,6 +1373,16 @@ type metadataListStacksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListStacksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStacksInput) GoString() string {
+	return s.String()
+}
+
 // The output for ListStacks action.
 type ListStacksOutput struct {
 	// String that identifies the start of the next list of stacks, if there is
@@ -1147,6 +1398,16 @@ type ListStacksOutput struct {
 
 type metadataListStacksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListStacksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStacksOutput) GoString() string {
+	return s.String()
 }
 
 // The Output data type.
@@ -1165,6 +1426,16 @@ type Output struct {
 
 type metadataOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Output) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Output) GoString() string {
+	return s.String()
 }
 
 // The Parameter data type.
@@ -1189,6 +1460,16 @@ type metadataParameter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Parameter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Parameter) GoString() string {
+	return s.String()
+}
+
 // A set of criteria that AWS CloudFormation uses to validate parameter values.
 // Although other constraints might be defined in the stack template, AWS CloudFormation
 // returns only the AllowedValues property.
@@ -1201,6 +1482,16 @@ type ParameterConstraints struct {
 
 type metadataParameterConstraints struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ParameterConstraints) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ParameterConstraints) GoString() string {
+	return s.String()
 }
 
 // The ParameterDeclaration data type.
@@ -1231,6 +1522,16 @@ type metadataParameterDeclaration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ParameterDeclaration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ParameterDeclaration) GoString() string {
+	return s.String()
+}
+
 // The input for the SetStackPolicy action.
 type SetStackPolicyInput struct {
 	// The name or unique stack ID that you want to associate a policy with.
@@ -1255,12 +1556,32 @@ type metadataSetStackPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetStackPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetStackPolicyInput) GoString() string {
+	return s.String()
+}
+
 type SetStackPolicyOutput struct {
 	metadataSetStackPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataSetStackPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetStackPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetStackPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the SignalResource action.
@@ -1290,12 +1611,32 @@ type metadataSignalResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SignalResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SignalResourceInput) GoString() string {
+	return s.String()
+}
+
 type SignalResourceOutput struct {
 	metadataSignalResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataSignalResourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SignalResourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SignalResourceOutput) GoString() string {
+	return s.String()
 }
 
 // The Stack data type.
@@ -1352,6 +1693,16 @@ type metadataStack struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Stack) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Stack) GoString() string {
+	return s.String()
+}
+
 // The StackEvent data type.
 type StackEvent struct {
 	// The unique ID of this event.
@@ -1394,6 +1745,16 @@ type metadataStackEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StackEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StackEvent) GoString() string {
+	return s.String()
+}
+
 // The StackResource data type.
 type StackResource struct {
 	// User defined description associated with the resource.
@@ -1431,6 +1792,16 @@ type StackResource struct {
 
 type metadataStackResource struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StackResource) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StackResource) GoString() string {
+	return s.String()
 }
 
 // Contains detailed information about the specified stack resource.
@@ -1477,6 +1848,16 @@ type metadataStackResourceDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StackResourceDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StackResourceDetail) GoString() string {
+	return s.String()
+}
+
 // Contains high-level information about the specified stack resource.
 type StackResourceSummary struct {
 	// Time the status was updated.
@@ -1505,6 +1886,16 @@ type StackResourceSummary struct {
 
 type metadataStackResourceSummary struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StackResourceSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StackResourceSummary) GoString() string {
+	return s.String()
 }
 
 // The StackSummary Data Type
@@ -1541,6 +1932,16 @@ type metadataStackSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StackSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StackSummary) GoString() string {
+	return s.String()
+}
+
 // The Tag type is used by CreateStack in the Tags parameter. It allows you
 // to specify a key/value pair that can be used to store information related
 // to cost allocation for an AWS CloudFormation stack.
@@ -1559,6 +1960,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // The TemplateParameter data type.
@@ -1581,6 +1992,16 @@ type TemplateParameter struct {
 
 type metadataTemplateParameter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TemplateParameter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TemplateParameter) GoString() string {
+	return s.String()
 }
 
 // The input for UpdateStack action.
@@ -1679,6 +2100,16 @@ type metadataUpdateStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateStackInput) GoString() string {
+	return s.String()
+}
+
 // The output for a UpdateStack action.
 type UpdateStackOutput struct {
 	// Unique identifier of the stack.
@@ -1689,6 +2120,16 @@ type UpdateStackOutput struct {
 
 type metadataUpdateStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateStackOutput) GoString() string {
+	return s.String()
 }
 
 // The input for ValidateTemplate action.
@@ -1718,6 +2159,16 @@ type metadataValidateTemplateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ValidateTemplateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidateTemplateInput) GoString() string {
+	return s.String()
+}
+
 // The output for ValidateTemplate action.
 type ValidateTemplateOutput struct {
 	// The capabilities found within the template. Currently, AWS CloudFormation
@@ -1742,4 +2193,14 @@ type ValidateTemplateOutput struct {
 
 type metadataValidateTemplateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ValidateTemplateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidateTemplateOutput) GoString() string {
+	return s.String()
 }

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIdentity2015_04_17"
@@ -653,6 +654,16 @@ type metadataActiveTrustedSigners struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActiveTrustedSigners) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActiveTrustedSigners) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains information about CNAMEs (alternate domain names),
 // if any, for this distribution.
 type Aliases struct {
@@ -668,6 +679,16 @@ type Aliases struct {
 
 type metadataAliases struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Aliases) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Aliases) GoString() string {
+	return s.String()
 }
 
 // A complex type that controls which HTTP methods CloudFront processes and
@@ -701,6 +722,16 @@ type AllowedMethods struct {
 
 type metadataAllowedMethods struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AllowedMethods) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AllowedMethods) GoString() string {
+	return s.String()
 }
 
 // A complex type that describes how CloudFront processes requests. You can
@@ -804,6 +835,16 @@ type metadataCacheBehavior struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CacheBehavior) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheBehavior) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains zero or more CacheBehavior elements.
 type CacheBehaviors struct {
 	// Optional: A complex type that contains cache behaviors for this distribution.
@@ -818,6 +859,16 @@ type CacheBehaviors struct {
 
 type metadataCacheBehaviors struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CacheBehaviors) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheBehaviors) GoString() string {
+	return s.String()
 }
 
 // A complex type that controls whether CloudFront caches the response to requests
@@ -843,6 +894,16 @@ type metadataCachedMethods struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CachedMethods) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CachedMethods) GoString() string {
+	return s.String()
+}
+
 // A complex type that specifies the whitelisted cookies, if any, that you want
 // CloudFront to forward to your origin that is associated with this cache behavior.
 type CookieNames struct {
@@ -858,6 +919,16 @@ type CookieNames struct {
 
 type metadataCookieNames struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CookieNames) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CookieNames) GoString() string {
+	return s.String()
 }
 
 // A complex type that specifies the cookie preferences associated with this
@@ -880,6 +951,16 @@ type metadataCookiePreference struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CookiePreference) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CookiePreference) GoString() string {
+	return s.String()
+}
+
 // The request to create a new origin access identity.
 type CreateCloudFrontOriginAccessIdentityInput struct {
 	// The origin access identity's configuration information.
@@ -890,6 +971,16 @@ type CreateCloudFrontOriginAccessIdentityInput struct {
 
 type metadataCreateCloudFrontOriginAccessIdentityInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
+}
+
+// String returns the string representation
+func (s CreateCloudFrontOriginAccessIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCloudFrontOriginAccessIdentityInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -911,6 +1002,16 @@ type metadataCreateCloudFrontOriginAccessIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
 }
 
+// String returns the string representation
+func (s CreateCloudFrontOriginAccessIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCloudFrontOriginAccessIdentityOutput) GoString() string {
+	return s.String()
+}
+
 // The request to create a new distribution.
 type CreateDistributionInput struct {
 	// The distribution's configuration information.
@@ -921,6 +1022,16 @@ type CreateDistributionInput struct {
 
 type metadataCreateDistributionInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"DistributionConfig"`
+}
+
+// String returns the string representation
+func (s CreateDistributionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDistributionInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -942,6 +1053,16 @@ type metadataCreateDistributionOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Distribution"`
 }
 
+// String returns the string representation
+func (s CreateDistributionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDistributionOutput) GoString() string {
+	return s.String()
+}
+
 // The request to create an invalidation.
 type CreateInvalidationInput struct {
 	// The distribution's id.
@@ -955,6 +1076,16 @@ type CreateInvalidationInput struct {
 
 type metadataCreateInvalidationInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"InvalidationBatch"`
+}
+
+// String returns the string representation
+func (s CreateInvalidationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInvalidationInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -973,6 +1104,16 @@ type metadataCreateInvalidationOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Invalidation"`
 }
 
+// String returns the string representation
+func (s CreateInvalidationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInvalidationOutput) GoString() string {
+	return s.String()
+}
+
 // The request to create a new streaming distribution.
 type CreateStreamingDistributionInput struct {
 	// The streaming distribution's configuration information.
@@ -983,6 +1124,16 @@ type CreateStreamingDistributionInput struct {
 
 type metadataCreateStreamingDistributionInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"StreamingDistributionConfig"`
+}
+
+// String returns the string representation
+func (s CreateStreamingDistributionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStreamingDistributionInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -1002,6 +1153,16 @@ type CreateStreamingDistributionOutput struct {
 
 type metadataCreateStreamingDistributionOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"StreamingDistribution"`
+}
+
+// String returns the string representation
+func (s CreateStreamingDistributionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStreamingDistributionOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that describes how you'd prefer CloudFront to respond to requests
@@ -1045,6 +1206,16 @@ type metadataCustomErrorResponse struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CustomErrorResponse) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CustomErrorResponse) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains zero or more CustomErrorResponse elements.
 type CustomErrorResponses struct {
 	// Optional: A complex type that contains custom error responses for this distribution.
@@ -1059,6 +1230,16 @@ type CustomErrorResponses struct {
 
 type metadataCustomErrorResponses struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CustomErrorResponses) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CustomErrorResponses) GoString() string {
+	return s.String()
 }
 
 // A customer origin.
@@ -1077,6 +1258,16 @@ type CustomOriginConfig struct {
 
 type metadataCustomOriginConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CustomOriginConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CustomOriginConfig) GoString() string {
+	return s.String()
 }
 
 // A complex type that describes the default cache behavior if you do not specify
@@ -1160,6 +1351,16 @@ type metadataDefaultCacheBehavior struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DefaultCacheBehavior) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefaultCacheBehavior) GoString() string {
+	return s.String()
+}
+
 // The request to delete a origin access identity.
 type DeleteCloudFrontOriginAccessIdentityInput struct {
 	// The origin access identity's id.
@@ -1176,12 +1377,32 @@ type metadataDeleteCloudFrontOriginAccessIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteCloudFrontOriginAccessIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCloudFrontOriginAccessIdentityInput) GoString() string {
+	return s.String()
+}
+
 type DeleteCloudFrontOriginAccessIdentityOutput struct {
 	metadataDeleteCloudFrontOriginAccessIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCloudFrontOriginAccessIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteCloudFrontOriginAccessIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCloudFrontOriginAccessIdentityOutput) GoString() string {
+	return s.String()
 }
 
 // The request to delete a distribution.
@@ -1200,12 +1421,32 @@ type metadataDeleteDistributionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDistributionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDistributionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDistributionOutput struct {
 	metadataDeleteDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDistributionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDistributionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDistributionOutput) GoString() string {
+	return s.String()
 }
 
 // The request to delete a streaming distribution.
@@ -1224,12 +1465,32 @@ type metadataDeleteStreamingDistributionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteStreamingDistributionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteStreamingDistributionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteStreamingDistributionOutput struct {
 	metadataDeleteStreamingDistributionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStreamingDistributionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteStreamingDistributionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteStreamingDistributionOutput) GoString() string {
+	return s.String()
 }
 
 // A distribution.
@@ -1269,6 +1530,16 @@ type Distribution struct {
 
 type metadataDistribution struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Distribution) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Distribution) GoString() string {
+	return s.String()
 }
 
 // A distribution Configuration.
@@ -1340,6 +1611,16 @@ type metadataDistributionConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DistributionConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DistributionConfig) GoString() string {
+	return s.String()
+}
+
 // A distribution list.
 type DistributionList struct {
 	// A flag that indicates whether more distributions remain to be listed. If
@@ -1371,6 +1652,16 @@ type DistributionList struct {
 
 type metadataDistributionList struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DistributionList) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DistributionList) GoString() string {
+	return s.String()
 }
 
 // A summary of the information for an Amazon CloudFront distribution.
@@ -1430,6 +1721,16 @@ type metadataDistributionSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DistributionSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DistributionSummary) GoString() string {
+	return s.String()
+}
+
 // A complex type that specifies how CloudFront handles query strings, cookies
 // and headers.
 type ForwardedValues struct {
@@ -1450,6 +1751,16 @@ type ForwardedValues struct {
 
 type metadataForwardedValues struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ForwardedValues) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ForwardedValues) GoString() string {
+	return s.String()
 }
 
 // A complex type that controls the countries in which your content is distributed.
@@ -1490,6 +1801,16 @@ type metadataGeoRestriction struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GeoRestriction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GeoRestriction) GoString() string {
+	return s.String()
+}
+
 // The request to get an origin access identity's configuration.
 type GetCloudFrontOriginAccessIdentityConfigInput struct {
 	// The identity's id.
@@ -1500,6 +1821,16 @@ type GetCloudFrontOriginAccessIdentityConfigInput struct {
 
 type metadataGetCloudFrontOriginAccessIdentityConfigInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCloudFrontOriginAccessIdentityConfigInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCloudFrontOriginAccessIdentityConfigInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -1517,6 +1848,16 @@ type metadataGetCloudFrontOriginAccessIdentityConfigOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 }
 
+// String returns the string representation
+func (s GetCloudFrontOriginAccessIdentityConfigOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCloudFrontOriginAccessIdentityConfigOutput) GoString() string {
+	return s.String()
+}
+
 // The request to get an origin access identity's information.
 type GetCloudFrontOriginAccessIdentityInput struct {
 	// The identity's id.
@@ -1527,6 +1868,16 @@ type GetCloudFrontOriginAccessIdentityInput struct {
 
 type metadataGetCloudFrontOriginAccessIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCloudFrontOriginAccessIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCloudFrontOriginAccessIdentityInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -1545,6 +1896,16 @@ type metadataGetCloudFrontOriginAccessIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
 }
 
+// String returns the string representation
+func (s GetCloudFrontOriginAccessIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCloudFrontOriginAccessIdentityOutput) GoString() string {
+	return s.String()
+}
+
 // The request to get a distribution configuration.
 type GetDistributionConfigInput struct {
 	// The distribution's id.
@@ -1555,6 +1916,16 @@ type GetDistributionConfigInput struct {
 
 type metadataGetDistributionConfigInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDistributionConfigInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDistributionConfigInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -1572,6 +1943,16 @@ type metadataGetDistributionConfigOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"DistributionConfig"`
 }
 
+// String returns the string representation
+func (s GetDistributionConfigOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDistributionConfigOutput) GoString() string {
+	return s.String()
+}
+
 // The request to get a distribution's information.
 type GetDistributionInput struct {
 	// The distribution's id.
@@ -1582,6 +1963,16 @@ type GetDistributionInput struct {
 
 type metadataGetDistributionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDistributionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDistributionInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -1599,6 +1990,16 @@ type metadataGetDistributionOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Distribution"`
 }
 
+// String returns the string representation
+func (s GetDistributionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDistributionOutput) GoString() string {
+	return s.String()
+}
+
 // The request to get an invalidation's information.
 type GetInvalidationInput struct {
 	// The distribution's id.
@@ -1614,6 +2015,16 @@ type metadataGetInvalidationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetInvalidationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetInvalidationInput) GoString() string {
+	return s.String()
+}
+
 // The returned result of the corresponding request.
 type GetInvalidationOutput struct {
 	// The invalidation's information.
@@ -1626,6 +2037,16 @@ type metadataGetInvalidationOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Invalidation"`
 }
 
+// String returns the string representation
+func (s GetInvalidationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetInvalidationOutput) GoString() string {
+	return s.String()
+}
+
 // To request to get a streaming distribution configuration.
 type GetStreamingDistributionConfigInput struct {
 	// The streaming distribution's id.
@@ -1636,6 +2057,16 @@ type GetStreamingDistributionConfigInput struct {
 
 type metadataGetStreamingDistributionConfigInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetStreamingDistributionConfigInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetStreamingDistributionConfigInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -1653,6 +2084,16 @@ type metadataGetStreamingDistributionConfigOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"StreamingDistributionConfig"`
 }
 
+// String returns the string representation
+func (s GetStreamingDistributionConfigOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetStreamingDistributionConfigOutput) GoString() string {
+	return s.String()
+}
+
 // The request to get a streaming distribution's information.
 type GetStreamingDistributionInput struct {
 	// The streaming distribution's id.
@@ -1663,6 +2104,16 @@ type GetStreamingDistributionInput struct {
 
 type metadataGetStreamingDistributionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetStreamingDistributionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetStreamingDistributionInput) GoString() string {
+	return s.String()
 }
 
 // The returned result of the corresponding request.
@@ -1679,6 +2130,16 @@ type GetStreamingDistributionOutput struct {
 
 type metadataGetStreamingDistributionOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"StreamingDistribution"`
+}
+
+// String returns the string representation
+func (s GetStreamingDistributionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetStreamingDistributionOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that specifies the headers that you want CloudFront to forward
@@ -1711,6 +2172,16 @@ type metadataHeaders struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Headers) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Headers) GoString() string {
+	return s.String()
+}
+
 // An invalidation.
 type Invalidation struct {
 	// The date and time the invalidation request was first made.
@@ -1731,6 +2202,16 @@ type Invalidation struct {
 
 type metadataInvalidation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Invalidation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Invalidation) GoString() string {
+	return s.String()
 }
 
 // An invalidation batch.
@@ -1759,6 +2240,16 @@ type InvalidationBatch struct {
 
 type metadataInvalidationBatch struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InvalidationBatch) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InvalidationBatch) GoString() string {
+	return s.String()
 }
 
 // An invalidation list.
@@ -1794,6 +2285,16 @@ type metadataInvalidationList struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InvalidationList) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InvalidationList) GoString() string {
+	return s.String()
+}
+
 // Summary of an invalidation request.
 type InvalidationSummary struct {
 	CreateTime *time.Time `type:"timestamp" timestampFormat:"iso8601" required:"true"`
@@ -1811,6 +2312,16 @@ type metadataInvalidationSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InvalidationSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InvalidationSummary) GoString() string {
+	return s.String()
+}
+
 // A complex type that lists the active CloudFront key pairs, if any, that are
 // associated with AwsAccountNumber.
 type KeyPairIDs struct {
@@ -1826,6 +2337,16 @@ type KeyPairIDs struct {
 
 type metadataKeyPairIDs struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s KeyPairIDs) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s KeyPairIDs) GoString() string {
+	return s.String()
 }
 
 // The request to list origin access identities.
@@ -1847,6 +2368,16 @@ type metadataListCloudFrontOriginAccessIdentitiesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListCloudFrontOriginAccessIdentitiesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListCloudFrontOriginAccessIdentitiesInput) GoString() string {
+	return s.String()
+}
+
 // The returned result of the corresponding request.
 type ListCloudFrontOriginAccessIdentitiesOutput struct {
 	// The CloudFrontOriginAccessIdentityList type.
@@ -1857,6 +2388,16 @@ type ListCloudFrontOriginAccessIdentitiesOutput struct {
 
 type metadataListCloudFrontOriginAccessIdentitiesOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentityList"`
+}
+
+// String returns the string representation
+func (s ListCloudFrontOriginAccessIdentitiesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListCloudFrontOriginAccessIdentitiesOutput) GoString() string {
+	return s.String()
 }
 
 // The request to list your distributions.
@@ -1878,6 +2419,16 @@ type metadataListDistributionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDistributionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDistributionsInput) GoString() string {
+	return s.String()
+}
+
 // The returned result of the corresponding request.
 type ListDistributionsOutput struct {
 	// The DistributionList type.
@@ -1888,6 +2439,16 @@ type ListDistributionsOutput struct {
 
 type metadataListDistributionsOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"DistributionList"`
+}
+
+// String returns the string representation
+func (s ListDistributionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDistributionsOutput) GoString() string {
+	return s.String()
 }
 
 // The request to list invalidations.
@@ -1914,6 +2475,16 @@ type metadataListInvalidationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListInvalidationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInvalidationsInput) GoString() string {
+	return s.String()
+}
+
 // The returned result of the corresponding request.
 type ListInvalidationsOutput struct {
 	// Information about invalidation batches.
@@ -1924,6 +2495,16 @@ type ListInvalidationsOutput struct {
 
 type metadataListInvalidationsOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"InvalidationList"`
+}
+
+// String returns the string representation
+func (s ListInvalidationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInvalidationsOutput) GoString() string {
+	return s.String()
 }
 
 // The request to list your streaming distributions.
@@ -1945,6 +2526,16 @@ type metadataListStreamingDistributionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListStreamingDistributionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStreamingDistributionsInput) GoString() string {
+	return s.String()
+}
+
 // The returned result of the corresponding request.
 type ListStreamingDistributionsOutput struct {
 	// The StreamingDistributionList type.
@@ -1955,6 +2546,16 @@ type ListStreamingDistributionsOutput struct {
 
 type metadataListStreamingDistributionsOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"StreamingDistributionList"`
+}
+
+// String returns the string representation
+func (s ListStreamingDistributionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStreamingDistributionsOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that controls whether access logs are written for the distribution.
@@ -1989,6 +2590,16 @@ type LoggingConfig struct {
 
 type metadataLoggingConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LoggingConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoggingConfig) GoString() string {
+	return s.String()
 }
 
 // A complex type that describes the Amazon S3 bucket or the HTTP server (for
@@ -2028,6 +2639,16 @@ type metadataOrigin struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Origin) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Origin) GoString() string {
+	return s.String()
+}
+
 // CloudFront origin access identity.
 type OriginAccessIdentity struct {
 	// The current configuration information for the identity.
@@ -2046,6 +2667,16 @@ type OriginAccessIdentity struct {
 
 type metadataOriginAccessIdentity struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OriginAccessIdentity) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OriginAccessIdentity) GoString() string {
+	return s.String()
 }
 
 // Origin access identity configuration.
@@ -2071,6 +2702,16 @@ type OriginAccessIdentityConfig struct {
 
 type metadataOriginAccessIdentityConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OriginAccessIdentityConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OriginAccessIdentityConfig) GoString() string {
+	return s.String()
 }
 
 // The CloudFrontOriginAccessIdentityList type.
@@ -2107,6 +2748,16 @@ type metadataOriginAccessIdentityList struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s OriginAccessIdentityList) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OriginAccessIdentityList) GoString() string {
+	return s.String()
+}
+
 // Summary of the information about a CloudFront origin access identity.
 type OriginAccessIdentitySummary struct {
 	// The comment for this origin access identity, as originally specified when
@@ -2128,6 +2779,16 @@ type metadataOriginAccessIdentitySummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s OriginAccessIdentitySummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OriginAccessIdentitySummary) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains information about origins for this distribution.
 type Origins struct {
 	// A complex type that contains origins for this distribution.
@@ -2141,6 +2802,16 @@ type Origins struct {
 
 type metadataOrigins struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Origins) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Origins) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the objects that you want
@@ -2157,6 +2828,16 @@ type Paths struct {
 
 type metadataPaths struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Paths) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Paths) GoString() string {
+	return s.String()
 }
 
 // A complex type that identifies ways in which you want to restrict distribution
@@ -2177,6 +2858,16 @@ type metadataRestrictions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Restrictions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Restrictions) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains information about the Amazon S3 bucket from
 // which you want CloudFront to get your media files for distribution.
 type S3Origin struct {
@@ -2191,6 +2882,16 @@ type S3Origin struct {
 
 type metadataS3Origin struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s S3Origin) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s S3Origin) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the Amazon S3 origin. If the
@@ -2216,6 +2917,16 @@ type metadataS3OriginConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s S3OriginConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s S3OriginConfig) GoString() string {
+	return s.String()
+}
+
 // A complex type that lists the AWS accounts that were included in the TrustedSigners
 // complex type, as well as their active CloudFront key pair IDs, if any.
 type Signer struct {
@@ -2234,6 +2945,16 @@ type Signer struct {
 
 type metadataSigner struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Signer) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Signer) GoString() string {
+	return s.String()
 }
 
 // A streaming distribution.
@@ -2271,6 +2992,16 @@ type StreamingDistribution struct {
 
 type metadataStreamingDistribution struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StreamingDistribution) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StreamingDistribution) GoString() string {
+	return s.String()
 }
 
 // The configuration for the streaming distribution.
@@ -2330,6 +3061,16 @@ type metadataStreamingDistributionConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StreamingDistributionConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StreamingDistributionConfig) GoString() string {
+	return s.String()
+}
+
 // A streaming distribution list.
 type StreamingDistributionList struct {
 	// A flag that indicates whether more streaming distributions remain to be listed.
@@ -2362,6 +3103,16 @@ type StreamingDistributionList struct {
 
 type metadataStreamingDistributionList struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StreamingDistributionList) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StreamingDistributionList) GoString() string {
+	return s.String()
 }
 
 // A summary of the information for an Amazon CloudFront streaming distribution.
@@ -2416,6 +3167,16 @@ type metadataStreamingDistributionSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StreamingDistributionSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StreamingDistributionSummary) GoString() string {
+	return s.String()
+}
+
 // A complex type that controls whether access logs are written for this streaming
 // distribution.
 type StreamingLoggingConfig struct {
@@ -2441,6 +3202,16 @@ type StreamingLoggingConfig struct {
 
 type metadataStreamingLoggingConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StreamingLoggingConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StreamingLoggingConfig) GoString() string {
+	return s.String()
 }
 
 // A complex type that specifies the AWS accounts, if any, that you want to
@@ -2473,6 +3244,16 @@ type metadataTrustedSigners struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TrustedSigners) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedSigners) GoString() string {
+	return s.String()
+}
+
 // The request to update an origin access identity.
 type UpdateCloudFrontOriginAccessIdentityInput struct {
 	// The identity's configuration information.
@@ -2492,6 +3273,16 @@ type metadataUpdateCloudFrontOriginAccessIdentityInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentityConfig"`
 }
 
+// String returns the string representation
+func (s UpdateCloudFrontOriginAccessIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateCloudFrontOriginAccessIdentityInput) GoString() string {
+	return s.String()
+}
+
 // The returned result of the corresponding request.
 type UpdateCloudFrontOriginAccessIdentityOutput struct {
 	// The origin access identity's information.
@@ -2505,6 +3296,16 @@ type UpdateCloudFrontOriginAccessIdentityOutput struct {
 
 type metadataUpdateCloudFrontOriginAccessIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CloudFrontOriginAccessIdentity"`
+}
+
+// String returns the string representation
+func (s UpdateCloudFrontOriginAccessIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateCloudFrontOriginAccessIdentityOutput) GoString() string {
+	return s.String()
 }
 
 // The request to update a distribution.
@@ -2526,6 +3327,16 @@ type metadataUpdateDistributionInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"DistributionConfig"`
 }
 
+// String returns the string representation
+func (s UpdateDistributionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDistributionInput) GoString() string {
+	return s.String()
+}
+
 // The returned result of the corresponding request.
 type UpdateDistributionOutput struct {
 	// The distribution's information.
@@ -2539,6 +3350,16 @@ type UpdateDistributionOutput struct {
 
 type metadataUpdateDistributionOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Distribution"`
+}
+
+// String returns the string representation
+func (s UpdateDistributionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDistributionOutput) GoString() string {
+	return s.String()
 }
 
 // The request to update a streaming distribution.
@@ -2560,6 +3381,16 @@ type metadataUpdateStreamingDistributionInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"StreamingDistributionConfig"`
 }
 
+// String returns the string representation
+func (s UpdateStreamingDistributionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateStreamingDistributionInput) GoString() string {
+	return s.String()
+}
+
 // The returned result of the corresponding request.
 type UpdateStreamingDistributionOutput struct {
 	// The current version of the configuration. For example: E2QWRUHAPOMQZL.
@@ -2573,6 +3404,16 @@ type UpdateStreamingDistributionOutput struct {
 
 type metadataUpdateStreamingDistributionOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"StreamingDistribution"`
+}
+
+// String returns the string representation
+func (s UpdateStreamingDistributionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateStreamingDistributionOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about viewer certificates for this
@@ -2619,4 +3460,14 @@ type ViewerCertificate struct {
 
 type metadataViewerCertificate struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ViewerCertificate) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ViewerCertificate) GoString() string {
+	return s.String()
 }

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -5,6 +5,7 @@ package cloudhsm
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateHAPG = "CreateHapg"
@@ -502,6 +503,16 @@ type metadataCreateHAPGInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateHAPGInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHAPGInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of the CreateHAPartitionGroup action.
 type CreateHAPGOutput struct {
 	// The ARN of the high-availability partition group.
@@ -512,6 +523,16 @@ type CreateHAPGOutput struct {
 
 type metadataCreateHAPGOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateHAPGOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHAPGOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the CreateHsm action.
@@ -549,6 +570,16 @@ type metadataCreateHSMInput struct {
 	SDKShapeTraits bool `locationName:"CreateHsmRequest" type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateHSMInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHSMInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of the CreateHsm action.
 type CreateHSMOutput struct {
 	// The ARN of the HSM.
@@ -559,6 +590,16 @@ type CreateHSMOutput struct {
 
 type metadataCreateHSMOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateHSMOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHSMOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the CreateLunaClient action.
@@ -577,6 +618,16 @@ type metadataCreateLunaClientInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLunaClientInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLunaClientInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of the CreateLunaClient action.
 type CreateLunaClientOutput struct {
 	// The ARN of the client.
@@ -587,6 +638,16 @@ type CreateLunaClientOutput struct {
 
 type metadataCreateLunaClientOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLunaClientOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLunaClientOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DeleteHapg action.
@@ -601,6 +662,16 @@ type metadataDeleteHAPGInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteHAPGInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHAPGInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of the DeleteHapg action.
 type DeleteHAPGOutput struct {
 	// The status of the action.
@@ -611,6 +682,16 @@ type DeleteHAPGOutput struct {
 
 type metadataDeleteHAPGOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteHAPGOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHAPGOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DeleteHsm action.
@@ -625,6 +706,16 @@ type metadataDeleteHSMInput struct {
 	SDKShapeTraits bool `locationName:"DeleteHsmRequest" type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteHSMInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHSMInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of the DeleteHsm action.
 type DeleteHSMOutput struct {
 	// The status of the action.
@@ -635,6 +726,16 @@ type DeleteHSMOutput struct {
 
 type metadataDeleteHSMOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteHSMOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHSMOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteLunaClientInput struct {
@@ -648,6 +749,16 @@ type metadataDeleteLunaClientInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLunaClientInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLunaClientInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLunaClientOutput struct {
 	// The status of the action.
 	Status *string `type:"string" required:"true"`
@@ -657,6 +768,16 @@ type DeleteLunaClientOutput struct {
 
 type metadataDeleteLunaClientOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLunaClientOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLunaClientOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DescribeHapg action.
@@ -669,6 +790,16 @@ type DescribeHAPGInput struct {
 
 type metadataDescribeHAPGInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeHAPGInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeHAPGInput) GoString() string {
+	return s.String()
 }
 
 // Contains the output of the DescribeHapg action.
@@ -708,6 +839,16 @@ type metadataDescribeHAPGOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeHAPGOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeHAPGOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the DescribeHsm action.
 type DescribeHSMInput struct {
 	// The ARN of the HSM. Either the HsmArn or the SerialNumber parameter must
@@ -723,6 +864,16 @@ type DescribeHSMInput struct {
 
 type metadataDescribeHSMInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeHSMInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeHSMInput) GoString() string {
+	return s.String()
 }
 
 // Contains the output of the DescribeHsm action.
@@ -797,6 +948,16 @@ type metadataDescribeHSMOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeHSMOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeHSMOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeLunaClientInput struct {
 	// The certificate fingerprint.
 	CertificateFingerprint *string `type:"string"`
@@ -809,6 +970,16 @@ type DescribeLunaClientInput struct {
 
 type metadataDescribeLunaClientInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLunaClientInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLunaClientInput) GoString() string {
+	return s.String()
 }
 
 type DescribeLunaClientOutput struct {
@@ -834,6 +1005,16 @@ type metadataDescribeLunaClientOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLunaClientOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLunaClientOutput) GoString() string {
+	return s.String()
+}
+
 type GetConfigInput struct {
 	// The ARN of the client.
 	ClientARN *string `locationName:"ClientArn" type:"string" required:"true"`
@@ -850,6 +1031,16 @@ type GetConfigInput struct {
 
 type metadataGetConfigInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetConfigInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetConfigInput) GoString() string {
+	return s.String()
 }
 
 type GetConfigOutput struct {
@@ -869,6 +1060,16 @@ type metadataGetConfigOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetConfigOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetConfigOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the ListAvailableZones action.
 type ListAvailableZonesInput struct {
 	metadataListAvailableZonesInput `json:"-" xml:"-"`
@@ -876,6 +1077,16 @@ type ListAvailableZonesInput struct {
 
 type metadataListAvailableZonesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAvailableZonesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAvailableZonesInput) GoString() string {
+	return s.String()
 }
 
 type ListAvailableZonesOutput struct {
@@ -889,6 +1100,16 @@ type metadataListAvailableZonesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListAvailableZonesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAvailableZonesOutput) GoString() string {
+	return s.String()
+}
+
 type ListHSMsInput struct {
 	// The NextToken value from a previous call to ListHsms. Pass null if this is
 	// the first call.
@@ -899,6 +1120,16 @@ type ListHSMsInput struct {
 
 type metadataListHSMsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListHSMsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHSMsInput) GoString() string {
+	return s.String()
 }
 
 // Contains the output of the ListHsms action.
@@ -917,6 +1148,16 @@ type metadataListHSMsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListHSMsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHSMsOutput) GoString() string {
+	return s.String()
+}
+
 type ListHapgsInput struct {
 	// The NextToken value from a previous call to ListHapgs. Pass null if this
 	// is the first call.
@@ -927,6 +1168,16 @@ type ListHapgsInput struct {
 
 type metadataListHapgsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListHapgsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHapgsInput) GoString() string {
+	return s.String()
 }
 
 type ListHapgsOutput struct {
@@ -944,6 +1195,16 @@ type metadataListHapgsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListHapgsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHapgsOutput) GoString() string {
+	return s.String()
+}
+
 type ListLunaClientsInput struct {
 	// The NextToken value from a previous call to ListLunaClients. Pass null if
 	// this is the first call.
@@ -954,6 +1215,16 @@ type ListLunaClientsInput struct {
 
 type metadataListLunaClientsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListLunaClientsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListLunaClientsInput) GoString() string {
+	return s.String()
 }
 
 type ListLunaClientsOutput struct {
@@ -969,6 +1240,16 @@ type ListLunaClientsOutput struct {
 
 type metadataListLunaClientsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListLunaClientsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListLunaClientsOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyHAPGInput struct {
@@ -989,6 +1270,16 @@ type metadataModifyHAPGInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyHAPGInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyHAPGInput) GoString() string {
+	return s.String()
+}
+
 type ModifyHAPGOutput struct {
 	// The ARN of the high-availability partition group.
 	HAPGARN *string `locationName:"HapgArn" type:"string"`
@@ -998,6 +1289,16 @@ type ModifyHAPGOutput struct {
 
 type metadataModifyHAPGOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyHAPGOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyHAPGOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the ModifyHsm action.
@@ -1027,6 +1328,16 @@ type metadataModifyHSMInput struct {
 	SDKShapeTraits bool `locationName:"ModifyHsmRequest" type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyHSMInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyHSMInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of the ModifyHsm action.
 type ModifyHSMOutput struct {
 	// The ARN of the HSM.
@@ -1037,6 +1348,16 @@ type ModifyHSMOutput struct {
 
 type metadataModifyHSMOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyHSMOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyHSMOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyLunaClientInput struct {
@@ -1053,6 +1374,16 @@ type metadataModifyLunaClientInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyLunaClientInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyLunaClientInput) GoString() string {
+	return s.String()
+}
+
 type ModifyLunaClientOutput struct {
 	// The ARN of the client.
 	ClientARN *string `locationName:"ClientArn" type:"string"`
@@ -1062,4 +1393,14 @@ type ModifyLunaClientOutput struct {
 
 type metadataModifyLunaClientOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyLunaClientOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyLunaClientOutput) GoString() string {
+	return s.String()
 }

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opBuildSuggesters = "BuildSuggesters"
@@ -765,6 +766,16 @@ type metadataAccessPoliciesStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AccessPoliciesStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccessPoliciesStatus) GoString() string {
+	return s.String()
+}
+
 // Synonyms, stopwords, and stemming options for an analysis scheme. Includes
 // tokenization dictionary for Japanese.
 type AnalysisOptions struct {
@@ -811,6 +822,16 @@ type metadataAnalysisOptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AnalysisOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AnalysisOptions) GoString() string {
+	return s.String()
+}
+
 // Configuration information for an analysis scheme. Each analysis scheme has
 // a unique name and specifies the language of the text to be processed. The
 // following options can be configured for an analysis scheme: Synonyms, Stopwords,
@@ -835,6 +856,16 @@ type metadataAnalysisScheme struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AnalysisScheme) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AnalysisScheme) GoString() string {
+	return s.String()
+}
+
 // The status and configuration of an AnalysisScheme.
 type AnalysisSchemeStatus struct {
 	// Configuration information for an analysis scheme. Each analysis scheme has
@@ -853,6 +884,16 @@ type metadataAnalysisSchemeStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AnalysisSchemeStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AnalysisSchemeStatus) GoString() string {
+	return s.String()
+}
+
 // The status and configuration of the domain's availability options.
 type AvailabilityOptionsStatus struct {
 	// The availability options configured for the domain.
@@ -866,6 +907,16 @@ type AvailabilityOptionsStatus struct {
 
 type metadataAvailabilityOptionsStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AvailabilityOptionsStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AvailabilityOptionsStatus) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the BuildSuggester operation. Specifies the
@@ -884,6 +935,16 @@ type metadataBuildSuggestersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BuildSuggestersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BuildSuggestersInput) GoString() string {
+	return s.String()
+}
+
 // The result of a BuildSuggester request. Contains a list of the fields used
 // for suggestions.
 type BuildSuggestersOutput struct {
@@ -895,6 +956,16 @@ type BuildSuggestersOutput struct {
 
 type metadataBuildSuggestersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BuildSuggestersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BuildSuggestersOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the CreateDomain operation. Specifies a name
@@ -912,6 +983,16 @@ type metadataCreateDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDomainInput) GoString() string {
+	return s.String()
+}
+
 // The result of a CreateDomainRequest. Contains the status of a newly created
 // domain.
 type CreateDomainOutput struct {
@@ -923,6 +1004,16 @@ type CreateDomainOutput struct {
 
 type metadataCreateDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDomainOutput) GoString() string {
+	return s.String()
 }
 
 // Options for a field that contains an array of dates. Present if IndexFieldType
@@ -948,6 +1039,16 @@ type DateArrayOptions struct {
 
 type metadataDateArrayOptions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DateArrayOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DateArrayOptions) GoString() string {
+	return s.String()
 }
 
 // Options for a date field. Dates and times are specified in UTC (Coordinated
@@ -993,6 +1094,16 @@ type metadataDateOptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DateOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DateOptions) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the DefineAnalysisScheme operation. Specifies
 // the name of the domain you want to update and the analysis scheme configuration.
 type DefineAnalysisSchemeInput struct {
@@ -1015,6 +1126,16 @@ type metadataDefineAnalysisSchemeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DefineAnalysisSchemeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefineAnalysisSchemeInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DefineAnalysisScheme request. Contains the status of the
 // newly-configured analysis scheme.
 type DefineAnalysisSchemeOutput struct {
@@ -1026,6 +1147,16 @@ type DefineAnalysisSchemeOutput struct {
 
 type metadataDefineAnalysisSchemeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DefineAnalysisSchemeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefineAnalysisSchemeOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DefineExpression operation. Specifies
@@ -1050,6 +1181,16 @@ type metadataDefineExpressionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DefineExpressionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefineExpressionInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DefineExpression request. Contains the status of the newly-configured
 // expression.
 type DefineExpressionOutput struct {
@@ -1061,6 +1202,16 @@ type DefineExpressionOutput struct {
 
 type metadataDefineExpressionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DefineExpressionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefineExpressionOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DefineIndexField operation. Specifies
@@ -1082,6 +1233,16 @@ type metadataDefineIndexFieldInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DefineIndexFieldInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefineIndexFieldInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DefineIndexField request. Contains the status of the newly-configured
 // index field.
 type DefineIndexFieldOutput struct {
@@ -1093,6 +1254,16 @@ type DefineIndexFieldOutput struct {
 
 type metadataDefineIndexFieldOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DefineIndexFieldOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefineIndexFieldOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DefineSuggester operation. Specifies
@@ -1116,6 +1287,16 @@ type metadataDefineSuggesterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DefineSuggesterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefineSuggesterInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DefineSuggester request. Contains the status of the newly-configured
 // suggester.
 type DefineSuggesterOutput struct {
@@ -1127,6 +1308,16 @@ type DefineSuggesterOutput struct {
 
 type metadataDefineSuggesterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DefineSuggesterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefineSuggesterOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DeleteAnalysisScheme operation. Specifies
@@ -1149,6 +1340,16 @@ type metadataDeleteAnalysisSchemeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAnalysisSchemeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAnalysisSchemeInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DeleteAnalysisScheme request. Contains the status of the
 // deleted analysis scheme.
 type DeleteAnalysisSchemeOutput struct {
@@ -1160,6 +1361,16 @@ type DeleteAnalysisSchemeOutput struct {
 
 type metadataDeleteAnalysisSchemeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAnalysisSchemeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAnalysisSchemeOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DeleteDomain operation. Specifies the
@@ -1175,6 +1386,16 @@ type metadataDeleteDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDomainInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DeleteDomain request. Contains the status of a newly deleted
 // domain, or no status if the domain has already been completely deleted.
 type DeleteDomainOutput struct {
@@ -1186,6 +1407,16 @@ type DeleteDomainOutput struct {
 
 type metadataDeleteDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDomainOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DeleteExpression operation. Specifies
@@ -1208,6 +1439,16 @@ type metadataDeleteExpressionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteExpressionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteExpressionInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DeleteExpression request. Specifies the expression being
 // deleted.
 type DeleteExpressionOutput struct {
@@ -1219,6 +1460,16 @@ type DeleteExpressionOutput struct {
 
 type metadataDeleteExpressionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteExpressionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteExpressionOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DeleteIndexField operation. Specifies
@@ -1242,6 +1493,16 @@ type metadataDeleteIndexFieldInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteIndexFieldInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteIndexFieldInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DeleteIndexField request.
 type DeleteIndexFieldOutput struct {
 	// The status of the index field being deleted.
@@ -1252,6 +1513,16 @@ type DeleteIndexFieldOutput struct {
 
 type metadataDeleteIndexFieldOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteIndexFieldOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteIndexFieldOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DeleteSuggester operation. Specifies
@@ -1274,6 +1545,16 @@ type metadataDeleteSuggesterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSuggesterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSuggesterInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DeleteSuggester request. Contains the status of the deleted
 // suggester.
 type DeleteSuggesterOutput struct {
@@ -1285,6 +1566,16 @@ type DeleteSuggesterOutput struct {
 
 type metadataDeleteSuggesterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSuggesterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSuggesterOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeAnalysisSchemes operation. Specifies
@@ -1310,6 +1601,16 @@ type metadataDescribeAnalysisSchemesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAnalysisSchemesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAnalysisSchemesInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DescribeAnalysisSchemes request. Contains the analysis schemes
 // configured for the domain specified in the request.
 type DescribeAnalysisSchemesOutput struct {
@@ -1321,6 +1622,16 @@ type DescribeAnalysisSchemesOutput struct {
 
 type metadataDescribeAnalysisSchemesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAnalysisSchemesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAnalysisSchemesOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeAvailabilityOptions operation.
@@ -1342,6 +1653,16 @@ type metadataDescribeAvailabilityOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAvailabilityOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAvailabilityOptionsInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DescribeAvailabilityOptions request. Indicates whether or
 // not the Multi-AZ option is enabled for the domain specified in the request.
 type DescribeAvailabilityOptionsOutput struct {
@@ -1354,6 +1675,16 @@ type DescribeAvailabilityOptionsOutput struct {
 
 type metadataDescribeAvailabilityOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAvailabilityOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAvailabilityOptionsOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeDomains operation. By default
@@ -1370,6 +1701,16 @@ type metadataDescribeDomainsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDomainsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDomainsInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DescribeDomains request. Contains the status of the domains
 // specified in the request or all domains owned by the account.
 type DescribeDomainsOutput struct {
@@ -1381,6 +1722,16 @@ type DescribeDomainsOutput struct {
 
 type metadataDescribeDomainsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDomainsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDomainsOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeDomains operation. Specifies
@@ -1407,6 +1758,16 @@ type metadataDescribeExpressionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeExpressionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeExpressionsInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DescribeExpressions request. Contains the expressions configured
 // for the domain specified in the request.
 type DescribeExpressionsOutput struct {
@@ -1418,6 +1779,16 @@ type DescribeExpressionsOutput struct {
 
 type metadataDescribeExpressionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeExpressionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeExpressionsOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeIndexFields operation. Specifies
@@ -1444,6 +1815,16 @@ type metadataDescribeIndexFieldsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeIndexFieldsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIndexFieldsInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DescribeIndexFields request. Contains the index fields configured
 // for the domain specified in the request.
 type DescribeIndexFieldsOutput struct {
@@ -1455,6 +1836,16 @@ type DescribeIndexFieldsOutput struct {
 
 type metadataDescribeIndexFieldsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeIndexFieldsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIndexFieldsOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeScalingParameters operation.
@@ -1473,6 +1864,16 @@ type metadataDescribeScalingParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeScalingParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeScalingParametersInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DescribeScalingParameters request. Contains the scaling parameters
 // configured for the domain specified in the request.
 type DescribeScalingParametersOutput struct {
@@ -1484,6 +1885,16 @@ type DescribeScalingParametersOutput struct {
 
 type metadataDescribeScalingParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeScalingParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeScalingParametersOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeServiceAccessPolicies operation.
@@ -1505,6 +1916,16 @@ type metadataDescribeServiceAccessPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeServiceAccessPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeServiceAccessPoliciesInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DescribeServiceAccessPolicies request.
 type DescribeServiceAccessPoliciesOutput struct {
 	// The access rules configured for the domain specified in the request.
@@ -1515,6 +1936,16 @@ type DescribeServiceAccessPoliciesOutput struct {
 
 type metadataDescribeServiceAccessPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeServiceAccessPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeServiceAccessPoliciesOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeSuggester operation. Specifies
@@ -1540,6 +1971,16 @@ type metadataDescribeSuggestersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSuggestersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSuggestersInput) GoString() string {
+	return s.String()
+}
+
 // The result of a DescribeSuggesters request.
 type DescribeSuggestersOutput struct {
 	// The suggesters configured for the domain specified in the request.
@@ -1550,6 +1991,16 @@ type DescribeSuggestersOutput struct {
 
 type metadataDescribeSuggestersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSuggestersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSuggestersOutput) GoString() string {
+	return s.String()
 }
 
 // Options for a search suggester.
@@ -1578,6 +2029,16 @@ type DocumentSuggesterOptions struct {
 
 type metadataDocumentSuggesterOptions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DocumentSuggesterOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DocumentSuggesterOptions) GoString() string {
+	return s.String()
 }
 
 // The current status of the search domain.
@@ -1639,6 +2100,16 @@ type metadataDomainStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DomainStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DomainStatus) GoString() string {
+	return s.String()
+}
+
 // Options for a field that contains an array of double-precision 64-bit floating
 // point values. Present if IndexFieldType specifies the field is of type double-array.
 // All options are enabled by default.
@@ -1663,6 +2134,16 @@ type DoubleArrayOptions struct {
 
 type metadataDoubleArrayOptions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DoubleArrayOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DoubleArrayOptions) GoString() string {
+	return s.String()
 }
 
 // Options for a double-precision 64-bit floating point field. Present if IndexFieldType
@@ -1695,6 +2176,16 @@ type metadataDoubleOptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DoubleOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DoubleOptions) GoString() string {
+	return s.String()
+}
+
 // A named expression that can be evaluated at search time. Can be used to sort
 // the search results, define other expressions, or return computed information
 // in the search results.
@@ -1716,6 +2207,16 @@ type metadataExpression struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Expression) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Expression) GoString() string {
+	return s.String()
+}
+
 // The value of an Expression and its current status.
 type ExpressionStatus struct {
 	// The expression that is evaluated for sorting while processing a search request.
@@ -1729,6 +2230,16 @@ type ExpressionStatus struct {
 
 type metadataExpressionStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ExpressionStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExpressionStatus) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the IndexDocuments operation. Specifies the
@@ -1747,6 +2258,16 @@ type metadataIndexDocumentsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s IndexDocumentsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IndexDocumentsInput) GoString() string {
+	return s.String()
+}
+
 // The result of an IndexDocuments request. Contains the status of the indexing
 // operation, including the fields being indexed.
 type IndexDocumentsOutput struct {
@@ -1758,6 +2279,16 @@ type IndexDocumentsOutput struct {
 
 type metadataIndexDocumentsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IndexDocumentsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IndexDocumentsOutput) GoString() string {
+	return s.String()
 }
 
 // Configuration information for a field in the index, including its name, type,
@@ -1844,6 +2375,16 @@ type metadataIndexField struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s IndexField) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IndexField) GoString() string {
+	return s.String()
+}
+
 // The value of an IndexField and its current status.
 type IndexFieldStatus struct {
 	// Configuration information for a field in the index, including its name, type,
@@ -1858,6 +2399,16 @@ type IndexFieldStatus struct {
 
 type metadataIndexFieldStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IndexFieldStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IndexFieldStatus) GoString() string {
+	return s.String()
 }
 
 // Options for a field that contains an array of 64-bit signed integers. Present
@@ -1884,6 +2435,16 @@ type IntArrayOptions struct {
 
 type metadataIntArrayOptions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IntArrayOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IntArrayOptions) GoString() string {
+	return s.String()
 }
 
 // Options for a 64-bit signed integer field. Present if IndexFieldType specifies
@@ -1914,6 +2475,16 @@ type IntOptions struct {
 
 type metadataIntOptions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IntOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IntOptions) GoString() string {
+	return s.String()
 }
 
 // Options for a latlon field. A latlon field contains a location stored as
@@ -1958,6 +2529,16 @@ type metadataLatLonOptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LatLonOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LatLonOptions) GoString() string {
+	return s.String()
+}
+
 type Limits struct {
 	MaximumPartitionCount *int64 `type:"integer" required:"true"`
 
@@ -1970,12 +2551,32 @@ type metadataLimits struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Limits) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Limits) GoString() string {
+	return s.String()
+}
+
 type ListDomainNamesInput struct {
 	metadataListDomainNamesInput `json:"-" xml:"-"`
 }
 
 type metadataListDomainNamesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDomainNamesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDomainNamesInput) GoString() string {
+	return s.String()
 }
 
 // The result of a ListDomainNames request. Contains a list of the domains owned
@@ -1989,6 +2590,16 @@ type ListDomainNamesOutput struct {
 
 type metadataListDomainNamesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDomainNamesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDomainNamesOutput) GoString() string {
+	return s.String()
 }
 
 // Options for a field that contains an array of literal strings. Present if
@@ -2015,6 +2626,16 @@ type LiteralArrayOptions struct {
 
 type metadataLiteralArrayOptions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LiteralArrayOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LiteralArrayOptions) GoString() string {
+	return s.String()
 }
 
 // Options for literal field. Present if IndexFieldType specifies the field
@@ -2058,6 +2679,16 @@ type metadataLiteralOptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LiteralOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LiteralOptions) GoString() string {
+	return s.String()
+}
+
 // The status of domain configuration option.
 type OptionStatus struct {
 	// A timestamp for when this option was created.
@@ -2090,6 +2721,16 @@ type metadataOptionStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s OptionStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionStatus) GoString() string {
+	return s.String()
+}
+
 // The desired instance type and desired number of replicas of each index partition.
 type ScalingParameters struct {
 	// The instance type that you want to preconfigure for your domain. For example,
@@ -2110,6 +2751,16 @@ type metadataScalingParameters struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ScalingParameters) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScalingParameters) GoString() string {
+	return s.String()
+}
+
 // The status and configuration of a search domain's scaling parameters.
 type ScalingParametersStatus struct {
 	// The desired instance type and desired number of replicas of each index partition.
@@ -2125,6 +2776,16 @@ type metadataScalingParametersStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ScalingParametersStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScalingParametersStatus) GoString() string {
+	return s.String()
+}
+
 // The endpoint to which service requests can be submitted.
 type ServiceEndpoint struct {
 	// The endpoint to which service requests can be submitted. For example, search-imdb-movies-oopcnjfn6ugofer3zx5iadxxca.eu-west-1.cloudsearch.amazonaws.com
@@ -2136,6 +2797,16 @@ type ServiceEndpoint struct {
 
 type metadataServiceEndpoint struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ServiceEndpoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ServiceEndpoint) GoString() string {
+	return s.String()
 }
 
 // Configuration information for a search suggester. Each suggester has a unique
@@ -2156,6 +2827,16 @@ type metadataSuggester struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Suggester) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Suggester) GoString() string {
+	return s.String()
+}
+
 // The value of a Suggester and its current status.
 type SuggesterStatus struct {
 	// Configuration information for a search suggester. Each suggester has a unique
@@ -2171,6 +2852,16 @@ type SuggesterStatus struct {
 
 type metadataSuggesterStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SuggesterStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SuggesterStatus) GoString() string {
+	return s.String()
 }
 
 // Options for a field that contains an array of text strings. Present if IndexFieldType
@@ -2197,6 +2888,16 @@ type TextArrayOptions struct {
 
 type metadataTextArrayOptions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TextArrayOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TextArrayOptions) GoString() string {
+	return s.String()
 }
 
 // Options for text field. Present if IndexFieldType specifies the field is
@@ -2241,6 +2942,16 @@ type metadataTextOptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TextOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TextOptions) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the UpdateAvailabilityOptions operation.
 // Specifies the name of the domain you want to update and the Multi-AZ availability
 // option.
@@ -2264,6 +2975,16 @@ type metadataUpdateAvailabilityOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateAvailabilityOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAvailabilityOptionsInput) GoString() string {
+	return s.String()
+}
+
 // The result of a UpdateAvailabilityOptions request. Contains the status of
 // the domain's availability options.
 type UpdateAvailabilityOptionsOutput struct {
@@ -2276,6 +2997,16 @@ type UpdateAvailabilityOptionsOutput struct {
 
 type metadataUpdateAvailabilityOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateAvailabilityOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAvailabilityOptionsOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the UpdateScalingParameters operation. Specifies
@@ -2298,6 +3029,16 @@ type metadataUpdateScalingParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateScalingParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateScalingParametersInput) GoString() string {
+	return s.String()
+}
+
 // The result of a UpdateScalingParameters request. Contains the status of the
 // newly-configured scaling parameters.
 type UpdateScalingParametersOutput struct {
@@ -2309,6 +3050,16 @@ type UpdateScalingParametersOutput struct {
 
 type metadataUpdateScalingParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateScalingParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateScalingParametersOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the UpdateServiceAccessPolicies operation.
@@ -2332,6 +3083,16 @@ type metadataUpdateServiceAccessPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateServiceAccessPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateServiceAccessPoliciesInput) GoString() string {
+	return s.String()
+}
+
 // The result of an UpdateServiceAccessPolicies request. Contains the new access
 // policies.
 type UpdateServiceAccessPoliciesOutput struct {
@@ -2343,4 +3104,14 @@ type UpdateServiceAccessPoliciesOutput struct {
 
 type metadataUpdateServiceAccessPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateServiceAccessPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateServiceAccessPoliciesOutput) GoString() string {
+	return s.String()
 }

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opSearch = "Search"
@@ -160,6 +161,16 @@ type metadataBucket struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Bucket) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Bucket) GoString() string {
+	return s.String()
+}
+
 // A container for the calculated facet values and counts.
 type BucketInfo struct {
 	// A list of the calculated facet values and counts.
@@ -170,6 +181,16 @@ type BucketInfo struct {
 
 type metadataBucketInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BucketInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BucketInfo) GoString() string {
+	return s.String()
 }
 
 // A warning returned by the document service when an issue is discovered while
@@ -183,6 +204,16 @@ type DocumentServiceWarning struct {
 
 type metadataDocumentServiceWarning struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DocumentServiceWarning) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DocumentServiceWarning) GoString() string {
+	return s.String()
 }
 
 // Information about a document that matches the search request.
@@ -206,6 +237,16 @@ type metadataHit struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Hit) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Hit) GoString() string {
+	return s.String()
+}
+
 // The collection of documents that match the search request.
 type Hits struct {
 	// A cursor that can be used to retrieve the next set of matching documents
@@ -226,6 +267,16 @@ type Hits struct {
 
 type metadataHits struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Hits) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Hits) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the Search request.
@@ -514,6 +565,16 @@ type metadataSearchInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SearchInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SearchInput) GoString() string {
+	return s.String()
+}
+
 // The result of a Search request. Contains the documents that match the specified
 // search criteria and any requested fields, highlights, and facet information.
 type SearchOutput struct {
@@ -533,6 +594,16 @@ type metadataSearchOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SearchOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SearchOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SearchStatus struct {
@@ -547,6 +618,16 @@ type SearchStatus struct {
 
 type metadataSearchStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SearchStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SearchStatus) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the Suggest request.
@@ -567,6 +648,16 @@ type metadataSuggestInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SuggestInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SuggestInput) GoString() string {
+	return s.String()
+}
+
 // Container for the suggestion information returned in a SuggestResponse.
 type SuggestModel struct {
 	// The number of documents that were found to match the query string.
@@ -585,6 +676,16 @@ type metadataSuggestModel struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SuggestModel) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SuggestModel) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a Suggest request.
 type SuggestOutput struct {
 	// The status of a SuggestRequest. Contains the resource ID (rid) and how long
@@ -601,6 +702,16 @@ type metadataSuggestOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SuggestOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SuggestOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the resource id (rid) and the time it took to process the request
 // (timems).
 type SuggestStatus struct {
@@ -615,6 +726,16 @@ type SuggestStatus struct {
 
 type metadataSuggestStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SuggestStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SuggestStatus) GoString() string {
+	return s.String()
 }
 
 // An autocomplete suggestion that matches the query string specified in a SuggestRequest.
@@ -635,6 +756,16 @@ type metadataSuggestionMatch struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SuggestionMatch) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SuggestionMatch) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the UploadDocuments request.
 type UploadDocumentsInput struct {
 	// The format of the batch you are uploading. Amazon CloudSearch supports two
@@ -651,6 +782,16 @@ type UploadDocumentsInput struct {
 
 type metadataUploadDocumentsInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Documents"`
+}
+
+// String returns the string representation
+func (s UploadDocumentsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadDocumentsInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to an UploadDocuments request.
@@ -672,4 +813,14 @@ type UploadDocumentsOutput struct {
 
 type metadataUploadDocumentsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UploadDocumentsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadDocumentsOutput) GoString() string {
+	return s.String()
 }

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateTrail = "CreateTrail"
@@ -289,6 +290,16 @@ type metadataCreateTrailInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTrailInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTrailInput) GoString() string {
+	return s.String()
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type CreateTrailOutput struct {
@@ -326,6 +337,16 @@ type metadataCreateTrailOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTrailOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTrailOutput) GoString() string {
+	return s.String()
+}
+
 // The request that specifies the name of a trail to delete.
 type DeleteTrailInput struct {
 	// The name of a trail to be deleted.
@@ -338,6 +359,16 @@ type metadataDeleteTrailInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTrailInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTrailInput) GoString() string {
+	return s.String()
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type DeleteTrailOutput struct {
@@ -346,6 +377,16 @@ type DeleteTrailOutput struct {
 
 type metadataDeleteTrailOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTrailOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTrailOutput) GoString() string {
+	return s.String()
 }
 
 // Returns information about the trail.
@@ -360,6 +401,16 @@ type metadataDescribeTrailsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTrailsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrailsInput) GoString() string {
+	return s.String()
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type DescribeTrailsOutput struct {
@@ -371,6 +422,16 @@ type DescribeTrailsOutput struct {
 
 type metadataDescribeTrailsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTrailsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrailsOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information about an event that was returned by a lookup request.
@@ -402,6 +463,16 @@ type metadataEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Event) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Event) GoString() string {
+	return s.String()
+}
+
 // The name of a trail about which you want the current status.
 type GetTrailStatusInput struct {
 	// The name of the trail for which you are requesting the current status.
@@ -412,6 +483,16 @@ type GetTrailStatusInput struct {
 
 type metadataGetTrailStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetTrailStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetTrailStatusInput) GoString() string {
+	return s.String()
 }
 
 // Returns the objects or data listed below if successful. Otherwise, returns
@@ -462,6 +543,16 @@ type metadataGetTrailStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetTrailStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetTrailStatusOutput) GoString() string {
+	return s.String()
+}
+
 // Specifies an attribute and value that filter the events returned.
 type LookupAttribute struct {
 	// Specifies an attribute on which to filter the events returned.
@@ -475,6 +566,16 @@ type LookupAttribute struct {
 
 type metadataLookupAttribute struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LookupAttribute) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LookupAttribute) GoString() string {
+	return s.String()
 }
 
 // Contains a request for LookupEvents.
@@ -511,6 +612,16 @@ type metadataLookupEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LookupEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LookupEventsInput) GoString() string {
+	return s.String()
+}
+
 // Contains a response to a LookupEvents action.
 type LookupEventsOutput struct {
 	// A list of events returned based on the lookup attributes specified and the
@@ -530,6 +641,16 @@ type LookupEventsOutput struct {
 
 type metadataLookupEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LookupEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LookupEventsOutput) GoString() string {
+	return s.String()
 }
 
 // Specifies the type and name of a resource referenced by an event.
@@ -554,6 +675,16 @@ type metadataResource struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Resource) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Resource) GoString() string {
+	return s.String()
+}
+
 // The request to CloudTrail to start logging AWS API calls for an account.
 type StartLoggingInput struct {
 	// The name of the trail for which CloudTrail logs AWS API calls.
@@ -566,6 +697,16 @@ type metadataStartLoggingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartLoggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartLoggingInput) GoString() string {
+	return s.String()
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type StartLoggingOutput struct {
@@ -574,6 +715,16 @@ type StartLoggingOutput struct {
 
 type metadataStartLoggingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartLoggingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartLoggingOutput) GoString() string {
+	return s.String()
 }
 
 // Passes the request to CloudTrail to stop logging AWS API calls for the specified
@@ -590,6 +741,16 @@ type metadataStopLoggingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StopLoggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopLoggingInput) GoString() string {
+	return s.String()
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type StopLoggingOutput struct {
@@ -598,6 +759,16 @@ type StopLoggingOutput struct {
 
 type metadataStopLoggingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopLoggingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopLoggingOutput) GoString() string {
+	return s.String()
 }
 
 // The settings for a trail.
@@ -632,6 +803,16 @@ type Trail struct {
 
 type metadataTrail struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Trail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Trail) GoString() string {
+	return s.String()
 }
 
 // Specifies settings to update for the trail.
@@ -671,6 +852,16 @@ type metadataUpdateTrailInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateTrailInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTrailInput) GoString() string {
+	return s.String()
+}
+
 // Returns the objects or data listed below if successful. Otherwise, returns
 // an error.
 type UpdateTrailOutput struct {
@@ -706,4 +897,14 @@ type UpdateTrailOutput struct {
 
 type metadataUpdateTrailOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateTrailOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTrailOutput) GoString() string {
+	return s.String()
 }

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opDeleteAlarms = "DeleteAlarms"
@@ -430,6 +431,16 @@ type metadataAlarmHistoryItem struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AlarmHistoryItem) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AlarmHistoryItem) GoString() string {
+	return s.String()
+}
+
 // The Datapoint data type encapsulates the statistical data that Amazon CloudWatch
 // computes from metric data.
 type Datapoint struct {
@@ -466,6 +477,16 @@ type metadataDatapoint struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Datapoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Datapoint) GoString() string {
+	return s.String()
+}
+
 type DeleteAlarmsInput struct {
 	// A list of alarms to be deleted.
 	AlarmNames []*string `type:"list" required:"true"`
@@ -477,12 +498,32 @@ type metadataDeleteAlarmsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAlarmsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAlarmsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteAlarmsOutput struct {
 	metadataDeleteAlarmsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAlarmsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAlarmsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAlarmsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAlarmHistoryInput struct {
@@ -512,6 +553,16 @@ type metadataDescribeAlarmHistoryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAlarmHistoryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAlarmHistoryInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DescribeAlarmHistory action.
 type DescribeAlarmHistoryOutput struct {
 	// A list of alarm histories in JSON format.
@@ -525,6 +576,16 @@ type DescribeAlarmHistoryOutput struct {
 
 type metadataDescribeAlarmHistoryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAlarmHistoryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAlarmHistoryOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAlarmsForMetricInput struct {
@@ -553,6 +614,16 @@ type metadataDescribeAlarmsForMetricInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAlarmsForMetricInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAlarmsForMetricInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DescribeAlarmsForMetric action.
 type DescribeAlarmsForMetricOutput struct {
 	// A list of information for each alarm with the specified metric.
@@ -563,6 +634,16 @@ type DescribeAlarmsForMetricOutput struct {
 
 type metadataDescribeAlarmsForMetricOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAlarmsForMetricOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAlarmsForMetricOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAlarmsInput struct {
@@ -593,6 +674,16 @@ type metadataDescribeAlarmsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAlarmsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAlarmsInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DescribeAlarms action.
 type DescribeAlarmsOutput struct {
 	// A list of information for the specified alarms.
@@ -606,6 +697,16 @@ type DescribeAlarmsOutput struct {
 
 type metadataDescribeAlarmsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAlarmsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAlarmsOutput) GoString() string {
+	return s.String()
 }
 
 // The Dimension data type further expands on the identity of a metric using
@@ -626,6 +727,16 @@ type metadataDimension struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Dimension) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Dimension) GoString() string {
+	return s.String()
+}
+
 // The DimensionFilter data type is used to filter ListMetrics results.
 type DimensionFilter struct {
 	// The dimension name to be matched.
@@ -641,6 +752,16 @@ type metadataDimensionFilter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DimensionFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DimensionFilter) GoString() string {
+	return s.String()
+}
+
 type DisableAlarmActionsInput struct {
 	// The names of the alarms to disable actions for.
 	AlarmNames []*string `type:"list" required:"true"`
@@ -652,12 +773,32 @@ type metadataDisableAlarmActionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableAlarmActionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableAlarmActionsInput) GoString() string {
+	return s.String()
+}
+
 type DisableAlarmActionsOutput struct {
 	metadataDisableAlarmActionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableAlarmActionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableAlarmActionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableAlarmActionsOutput) GoString() string {
+	return s.String()
 }
 
 type EnableAlarmActionsInput struct {
@@ -671,12 +812,32 @@ type metadataEnableAlarmActionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableAlarmActionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableAlarmActionsInput) GoString() string {
+	return s.String()
+}
+
 type EnableAlarmActionsOutput struct {
 	metadataEnableAlarmActionsOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableAlarmActionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableAlarmActionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableAlarmActionsOutput) GoString() string {
+	return s.String()
 }
 
 type GetMetricStatisticsInput struct {
@@ -720,6 +881,16 @@ type metadataGetMetricStatisticsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetMetricStatisticsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetMetricStatisticsInput) GoString() string {
+	return s.String()
+}
+
 // The output for the GetMetricStatistics action.
 type GetMetricStatisticsOutput struct {
 	// The datapoints for the specified metric.
@@ -733,6 +904,16 @@ type GetMetricStatisticsOutput struct {
 
 type metadataGetMetricStatisticsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetMetricStatisticsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetMetricStatisticsOutput) GoString() string {
+	return s.String()
 }
 
 type ListMetricsInput struct {
@@ -756,6 +937,16 @@ type metadataListMetricsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListMetricsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListMetricsInput) GoString() string {
+	return s.String()
+}
+
 // The output for the ListMetrics action.
 type ListMetricsOutput struct {
 	// A list of metrics used to generate statistics for an AWS account.
@@ -769,6 +960,16 @@ type ListMetricsOutput struct {
 
 type metadataListMetricsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListMetricsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListMetricsOutput) GoString() string {
+	return s.String()
 }
 
 // The Metric data type contains information about a specific metric. If you
@@ -793,6 +994,16 @@ type Metric struct {
 
 type metadataMetric struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Metric) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Metric) GoString() string {
+	return s.String()
 }
 
 // The MetricAlarm data type represents an alarm. You can use PutMetricAlarm
@@ -889,6 +1100,16 @@ type metadataMetricAlarm struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MetricAlarm) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MetricAlarm) GoString() string {
+	return s.String()
+}
+
 // The MetricDatum data type encapsulates the information sent with PutMetricData
 // to either create a new metric or add new values to be aggregated into an
 // existing metric.
@@ -927,6 +1148,16 @@ type MetricDatum struct {
 
 type metadataMetricDatum struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MetricDatum) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MetricDatum) GoString() string {
+	return s.String()
 }
 
 type PutMetricAlarmInput struct {
@@ -994,12 +1225,32 @@ type metadataPutMetricAlarmInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutMetricAlarmInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutMetricAlarmInput) GoString() string {
+	return s.String()
+}
+
 type PutMetricAlarmOutput struct {
 	metadataPutMetricAlarmOutput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricAlarmOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutMetricAlarmOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutMetricAlarmOutput) GoString() string {
+	return s.String()
 }
 
 type PutMetricDataInput struct {
@@ -1016,12 +1267,32 @@ type metadataPutMetricDataInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutMetricDataInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutMetricDataInput) GoString() string {
+	return s.String()
+}
+
 type PutMetricDataOutput struct {
 	metadataPutMetricDataOutput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricDataOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutMetricDataOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutMetricDataOutput) GoString() string {
+	return s.String()
 }
 
 type SetAlarmStateInput struct {
@@ -1047,12 +1318,32 @@ type metadataSetAlarmStateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetAlarmStateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetAlarmStateInput) GoString() string {
+	return s.String()
+}
+
 type SetAlarmStateOutput struct {
 	metadataSetAlarmStateOutput `json:"-" xml:"-"`
 }
 
 type metadataSetAlarmStateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetAlarmStateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetAlarmStateOutput) GoString() string {
+	return s.String()
 }
 
 // The StatisticSet data type describes the StatisticValues component of MetricDatum,
@@ -1075,4 +1366,14 @@ type StatisticSet struct {
 
 type metadataStatisticSet struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StatisticSet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StatisticSet) GoString() string {
+	return s.String()
 }

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -5,6 +5,7 @@ package cloudwatchlogs
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateLogGroup = "CreateLogGroup"
@@ -649,12 +650,32 @@ type metadataCreateLogGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLogGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLogGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateLogGroupOutput struct {
 	metadataCreateLogGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLogGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLogGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLogGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateLogStreamInput struct {
@@ -671,12 +692,32 @@ type metadataCreateLogStreamInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLogStreamInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLogStreamInput) GoString() string {
+	return s.String()
+}
+
 type CreateLogStreamOutput struct {
 	metadataCreateLogStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLogStreamOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLogStreamOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLogStreamOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteLogGroupInput struct {
@@ -690,12 +731,32 @@ type metadataDeleteLogGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLogGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLogGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLogGroupOutput struct {
 	metadataDeleteLogGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLogGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLogGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLogGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteLogStreamInput struct {
@@ -712,12 +773,32 @@ type metadataDeleteLogStreamInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLogStreamInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLogStreamInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLogStreamOutput struct {
 	metadataDeleteLogStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLogStreamOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLogStreamOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLogStreamOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteMetricFilterInput struct {
@@ -734,12 +815,32 @@ type metadataDeleteMetricFilterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteMetricFilterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMetricFilterInput) GoString() string {
+	return s.String()
+}
+
 type DeleteMetricFilterOutput struct {
 	metadataDeleteMetricFilterOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMetricFilterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteMetricFilterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMetricFilterOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteRetentionPolicyInput struct {
@@ -754,12 +855,32 @@ type metadataDeleteRetentionPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteRetentionPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRetentionPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteRetentionPolicyOutput struct {
 	metadataDeleteRetentionPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRetentionPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRetentionPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRetentionPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteSubscriptionFilterInput struct {
@@ -777,12 +898,32 @@ type metadataDeleteSubscriptionFilterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSubscriptionFilterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSubscriptionFilterInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSubscriptionFilterOutput struct {
 	metadataDeleteSubscriptionFilterOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSubscriptionFilterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSubscriptionFilterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSubscriptionFilterOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeLogGroupsInput struct {
@@ -806,6 +947,16 @@ type metadataDescribeLogGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLogGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLogGroupsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLogGroupsOutput struct {
 	// A list of log groups.
 	LogGroups []*LogGroup `locationName:"logGroups" type:"list"`
@@ -820,6 +971,16 @@ type DescribeLogGroupsOutput struct {
 
 type metadataDescribeLogGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLogGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLogGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeLogStreamsInput struct {
@@ -856,6 +1017,16 @@ type metadataDescribeLogStreamsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLogStreamsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLogStreamsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLogStreamsOutput struct {
 	// A list of log streams.
 	LogStreams []*LogStream `locationName:"logStreams" type:"list"`
@@ -870,6 +1041,16 @@ type DescribeLogStreamsOutput struct {
 
 type metadataDescribeLogStreamsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLogStreamsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLogStreamsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeMetricFiltersInput struct {
@@ -896,6 +1077,16 @@ type metadataDescribeMetricFiltersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeMetricFiltersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMetricFiltersInput) GoString() string {
+	return s.String()
+}
+
 type DescribeMetricFiltersOutput struct {
 	MetricFilters []*MetricFilter `locationName:"metricFilters" type:"list"`
 
@@ -909,6 +1100,16 @@ type DescribeMetricFiltersOutput struct {
 
 type metadataDescribeMetricFiltersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMetricFiltersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMetricFiltersOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeSubscriptionFiltersInput struct {
@@ -934,6 +1135,16 @@ type metadataDescribeSubscriptionFiltersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSubscriptionFiltersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSubscriptionFiltersInput) GoString() string {
+	return s.String()
+}
+
 type DescribeSubscriptionFiltersOutput struct {
 	// A string token used for pagination that points to the next page of results.
 	// It must be a value obtained from the response of the previous request. The
@@ -947,6 +1158,16 @@ type DescribeSubscriptionFiltersOutput struct {
 
 type metadataDescribeSubscriptionFiltersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSubscriptionFiltersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSubscriptionFiltersOutput) GoString() string {
+	return s.String()
 }
 
 type FilterLogEventsInput struct {
@@ -990,6 +1211,16 @@ type metadataFilterLogEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FilterLogEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FilterLogEventsInput) GoString() string {
+	return s.String()
+}
+
 type FilterLogEventsOutput struct {
 	// A list of FilteredLogEvent objects representing the matched events from the
 	// request.
@@ -1009,6 +1240,16 @@ type FilterLogEventsOutput struct {
 
 type metadataFilterLogEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s FilterLogEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FilterLogEventsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a matched event from a FilterLogEvents request.
@@ -1035,6 +1276,16 @@ type FilteredLogEvent struct {
 
 type metadataFilteredLogEvent struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s FilteredLogEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FilteredLogEvent) GoString() string {
+	return s.String()
 }
 
 type GetLogEventsInput struct {
@@ -1073,6 +1324,16 @@ type metadataGetLogEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetLogEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetLogEventsInput) GoString() string {
+	return s.String()
+}
+
 type GetLogEventsOutput struct {
 	Events []*OutputLogEvent `locationName:"events" type:"list"`
 
@@ -1093,6 +1354,16 @@ type metadataGetLogEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetLogEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetLogEventsOutput) GoString() string {
+	return s.String()
+}
+
 // A log event is a record of some activity that was recorded by the application
 // or resource being monitored. The log event record that Amazon CloudWatch
 // Logs understands contains two properties: the timestamp of when the event
@@ -1109,6 +1380,16 @@ type InputLogEvent struct {
 
 type metadataInputLogEvent struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InputLogEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InputLogEvent) GoString() string {
+	return s.String()
 }
 
 type LogGroup struct {
@@ -1135,6 +1416,16 @@ type LogGroup struct {
 
 type metadataLogGroup struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LogGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LogGroup) GoString() string {
+	return s.String()
 }
 
 // A log stream is sequence of log events from a single emitter of logs.
@@ -1173,6 +1464,16 @@ type metadataLogStream struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LogStream) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LogStream) GoString() string {
+	return s.String()
+}
+
 // Metric filters can be used to express how Amazon CloudWatch Logs would extract
 // metric observations from ingested log events and transform them to metric
 // data in a CloudWatch metric.
@@ -1199,6 +1500,16 @@ type metadataMetricFilter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MetricFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MetricFilter) GoString() string {
+	return s.String()
+}
+
 type MetricFilterMatchRecord struct {
 	EventMessage *string `locationName:"eventMessage" type:"string"`
 
@@ -1211,6 +1522,16 @@ type MetricFilterMatchRecord struct {
 
 type metadataMetricFilterMatchRecord struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MetricFilterMatchRecord) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MetricFilterMatchRecord) GoString() string {
+	return s.String()
 }
 
 type MetricTransformation struct {
@@ -1234,6 +1555,16 @@ type metadataMetricTransformation struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MetricTransformation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MetricTransformation) GoString() string {
+	return s.String()
+}
+
 type OutputLogEvent struct {
 	// A point in time expressed as the number of milliseconds since Jan 1, 1970
 	// 00:00:00 UTC.
@@ -1250,6 +1581,16 @@ type OutputLogEvent struct {
 
 type metadataOutputLogEvent struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OutputLogEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OutputLogEvent) GoString() string {
+	return s.String()
 }
 
 type PutLogEventsInput struct {
@@ -1273,6 +1614,16 @@ type metadataPutLogEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutLogEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutLogEventsInput) GoString() string {
+	return s.String()
+}
+
 type PutLogEventsOutput struct {
 	// A string token used for making PutLogEvents requests. A sequenceToken can
 	// only be used once, and PutLogEvents requests must include the sequenceToken
@@ -1286,6 +1637,16 @@ type PutLogEventsOutput struct {
 
 type metadataPutLogEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutLogEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutLogEventsOutput) GoString() string {
+	return s.String()
 }
 
 type PutMetricFilterInput struct {
@@ -1309,12 +1670,32 @@ type metadataPutMetricFilterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutMetricFilterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutMetricFilterInput) GoString() string {
+	return s.String()
+}
+
 type PutMetricFilterOutput struct {
 	metadataPutMetricFilterOutput `json:"-" xml:"-"`
 }
 
 type metadataPutMetricFilterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutMetricFilterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutMetricFilterOutput) GoString() string {
+	return s.String()
 }
 
 type PutRetentionPolicyInput struct {
@@ -1333,12 +1714,32 @@ type metadataPutRetentionPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutRetentionPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRetentionPolicyInput) GoString() string {
+	return s.String()
+}
+
 type PutRetentionPolicyOutput struct {
 	metadataPutRetentionPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutRetentionPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutRetentionPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRetentionPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type PutSubscriptionFilterInput struct {
@@ -1366,12 +1767,32 @@ type metadataPutSubscriptionFilterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutSubscriptionFilterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutSubscriptionFilterInput) GoString() string {
+	return s.String()
+}
+
 type PutSubscriptionFilterOutput struct {
 	metadataPutSubscriptionFilterOutput `json:"-" xml:"-"`
 }
 
 type metadataPutSubscriptionFilterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutSubscriptionFilterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutSubscriptionFilterOutput) GoString() string {
+	return s.String()
 }
 
 type RejectedLogEventsInfo struct {
@@ -1386,6 +1807,16 @@ type RejectedLogEventsInfo struct {
 
 type metadataRejectedLogEventsInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RejectedLogEventsInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RejectedLogEventsInfo) GoString() string {
+	return s.String()
 }
 
 // An object indicating the search status of a log stream in a FilterLogEvents
@@ -1403,6 +1834,16 @@ type SearchedLogStream struct {
 
 type metadataSearchedLogStream struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SearchedLogStream) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SearchedLogStream) GoString() string {
+	return s.String()
 }
 
 type SubscriptionFilter struct {
@@ -1432,6 +1873,16 @@ type metadataSubscriptionFilter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SubscriptionFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubscriptionFilter) GoString() string {
+	return s.String()
+}
+
 type TestMetricFilterInput struct {
 	// A symbolic description of how Amazon CloudWatch Logs should interpret the
 	// data in each log event. For example, a log event may contain timestamps,
@@ -1449,6 +1900,16 @@ type metadataTestMetricFilterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TestMetricFilterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TestMetricFilterInput) GoString() string {
+	return s.String()
+}
+
 type TestMetricFilterOutput struct {
 	Matches []*MetricFilterMatchRecord `locationName:"matches" type:"list"`
 
@@ -1457,4 +1918,14 @@ type TestMetricFilterOutput struct {
 
 type metadataTestMetricFilterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TestMetricFilterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TestMetricFilterOutput) GoString() string {
+	return s.String()
 }

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddTagsToOnPremisesInstances = "AddTagsToOnPremisesInstances"
@@ -979,12 +980,32 @@ type metadataAddTagsToOnPremisesInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddTagsToOnPremisesInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToOnPremisesInstancesInput) GoString() string {
+	return s.String()
+}
+
 type AddTagsToOnPremisesInstancesOutput struct {
 	metadataAddTagsToOnPremisesInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToOnPremisesInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddTagsToOnPremisesInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToOnPremisesInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Information about an application.
@@ -1009,6 +1030,16 @@ type metadataApplicationInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ApplicationInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplicationInfo) GoString() string {
+	return s.String()
+}
+
 // Information about an Auto Scaling group.
 type AutoScalingGroup struct {
 	// An Auto Scaling lifecycle event hook name.
@@ -1024,6 +1055,16 @@ type metadataAutoScalingGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AutoScalingGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingGroup) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a batch get applications operation.
 type BatchGetApplicationsInput struct {
 	// A list of application names, with multiple application names separated by
@@ -1035,6 +1076,16 @@ type BatchGetApplicationsInput struct {
 
 type metadataBatchGetApplicationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BatchGetApplicationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetApplicationsInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a batch get applications operation.
@@ -1049,6 +1100,16 @@ type metadataBatchGetApplicationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BatchGetApplicationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetApplicationsOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a batch get deployments operation.
 type BatchGetDeploymentsInput struct {
 	// A list of deployment IDs, with multiple deployment IDs separated by spaces.
@@ -1059,6 +1120,16 @@ type BatchGetDeploymentsInput struct {
 
 type metadataBatchGetDeploymentsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BatchGetDeploymentsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetDeploymentsInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a batch get deployments operation.
@@ -1073,6 +1144,16 @@ type metadataBatchGetDeploymentsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BatchGetDeploymentsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetDeploymentsOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a batch get on-premises instances operation.
 type BatchGetOnPremisesInstancesInput struct {
 	// The names of the on-premises instances to get information about.
@@ -1085,6 +1166,16 @@ type metadataBatchGetOnPremisesInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BatchGetOnPremisesInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetOnPremisesInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a batch get on-premises instances operation.
 type BatchGetOnPremisesInstancesOutput struct {
 	// Information about the on-premises instances.
@@ -1095,6 +1186,16 @@ type BatchGetOnPremisesInstancesOutput struct {
 
 type metadataBatchGetOnPremisesInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BatchGetOnPremisesInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetOnPremisesInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a create application operation.
@@ -1110,6 +1211,16 @@ type metadataCreateApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateApplicationInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a create application operation.
 type CreateApplicationOutput struct {
 	// A unique application ID.
@@ -1120,6 +1231,16 @@ type CreateApplicationOutput struct {
 
 type metadataCreateApplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateApplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateApplicationOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a create deployment configuration operation.
@@ -1152,6 +1273,16 @@ type metadataCreateDeploymentConfigInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDeploymentConfigInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDeploymentConfigInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a create deployment configuration operation.
 type CreateDeploymentConfigOutput struct {
 	// A unique deployment configuration ID.
@@ -1162,6 +1293,16 @@ type CreateDeploymentConfigOutput struct {
 
 type metadataCreateDeploymentConfigOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDeploymentConfigOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDeploymentConfigOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a create deployment group operation.
@@ -1224,6 +1365,16 @@ type metadataCreateDeploymentGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDeploymentGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDeploymentGroupInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a create deployment group operation.
 type CreateDeploymentGroupOutput struct {
 	// A unique deployment group ID.
@@ -1234,6 +1385,16 @@ type CreateDeploymentGroupOutput struct {
 
 type metadataCreateDeploymentGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDeploymentGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDeploymentGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a create deployment operation.
@@ -1278,6 +1439,16 @@ type metadataCreateDeploymentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDeploymentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDeploymentInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a create deployment operation.
 type CreateDeploymentOutput struct {
 	// A unique deployment ID.
@@ -1288,6 +1459,16 @@ type CreateDeploymentOutput struct {
 
 type metadataCreateDeploymentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDeploymentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDeploymentOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a delete application operation.
@@ -1303,12 +1484,32 @@ type metadataDeleteApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteApplicationInput) GoString() string {
+	return s.String()
+}
+
 type DeleteApplicationOutput struct {
 	metadataDeleteApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteApplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteApplicationOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a delete deployment configuration operation.
@@ -1324,12 +1525,32 @@ type metadataDeleteDeploymentConfigInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDeploymentConfigInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDeploymentConfigInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDeploymentConfigOutput struct {
 	metadataDeleteDeploymentConfigOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDeploymentConfigOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDeploymentConfigOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDeploymentConfigOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a delete deployment group operation.
@@ -1348,6 +1569,16 @@ type metadataDeleteDeploymentGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDeploymentGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDeploymentGroupInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a delete deployment group operation.
 type DeleteDeploymentGroupOutput struct {
 	// If the output contains no data, and the corresponding deployment group contained
@@ -1363,6 +1594,16 @@ type DeleteDeploymentGroupOutput struct {
 
 type metadataDeleteDeploymentGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDeploymentGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDeploymentGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Information about a deployment configuration.
@@ -1384,6 +1625,16 @@ type DeploymentConfigInfo struct {
 
 type metadataDeploymentConfigInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeploymentConfigInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeploymentConfigInfo) GoString() string {
+	return s.String()
 }
 
 // Information about a deployment group.
@@ -1421,6 +1672,16 @@ type DeploymentGroupInfo struct {
 
 type metadataDeploymentGroupInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeploymentGroupInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeploymentGroupInfo) GoString() string {
+	return s.String()
 }
 
 // Information about a deployment.
@@ -1491,6 +1752,16 @@ type metadataDeploymentInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeploymentInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeploymentInfo) GoString() string {
+	return s.String()
+}
+
 // Information about the deployment status of the instances in the deployment.
 type DeploymentOverview struct {
 	// The number of instances that have failed in the deployment.
@@ -1515,6 +1786,16 @@ type metadataDeploymentOverview struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeploymentOverview) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeploymentOverview) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a deregister on-premises instance operation.
 type DeregisterOnPremisesInstanceInput struct {
 	// The name of the on-premises instance to deregister.
@@ -1527,12 +1808,32 @@ type metadataDeregisterOnPremisesInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterOnPremisesInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterOnPremisesInstanceInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterOnPremisesInstanceOutput struct {
 	metadataDeregisterOnPremisesInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterOnPremisesInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterOnPremisesInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterOnPremisesInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // Diagnostic information about executable scripts that are part of a deployment.
@@ -1563,6 +1864,16 @@ type metadataDiagnostics struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Diagnostics) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Diagnostics) GoString() string {
+	return s.String()
+}
+
 // Information about a tag filter.
 type EC2TagFilter struct {
 	// The tag filter key.
@@ -1581,6 +1892,16 @@ type EC2TagFilter struct {
 
 type metadataEC2TagFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EC2TagFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EC2TagFilter) GoString() string {
+	return s.String()
 }
 
 // Information about a deployment error.
@@ -1618,6 +1939,16 @@ type metadataErrorInformation struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ErrorInformation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ErrorInformation) GoString() string {
+	return s.String()
+}
+
 // Information about an application revision.
 type GenericRevisionInfo struct {
 	// A list of deployment groups that use this revision.
@@ -1642,6 +1973,16 @@ type metadataGenericRevisionInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GenericRevisionInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenericRevisionInfo) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a get application operation.
 type GetApplicationInput struct {
 	// The name of an existing AWS CodeDeploy application associated with the applicable
@@ -1655,6 +1996,16 @@ type metadataGetApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetApplicationInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a get application operation.
 type GetApplicationOutput struct {
 	// Information about the application.
@@ -1665,6 +2016,16 @@ type GetApplicationOutput struct {
 
 type metadataGetApplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetApplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetApplicationOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a get application revision operation.
@@ -1681,6 +2042,16 @@ type GetApplicationRevisionInput struct {
 
 type metadataGetApplicationRevisionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetApplicationRevisionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetApplicationRevisionInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a get application revision operation.
@@ -1702,6 +2073,16 @@ type metadataGetApplicationRevisionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetApplicationRevisionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetApplicationRevisionOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a get deployment configuration operation.
 type GetDeploymentConfigInput struct {
 	// The name of an existing deployment configuration associated with the applicable
@@ -1715,6 +2096,16 @@ type metadataGetDeploymentConfigInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetDeploymentConfigInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDeploymentConfigInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a get deployment configuration operation.
 type GetDeploymentConfigOutput struct {
 	// Information about the deployment configuration.
@@ -1725,6 +2116,16 @@ type GetDeploymentConfigOutput struct {
 
 type metadataGetDeploymentConfigOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDeploymentConfigOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDeploymentConfigOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a get deployment group operation.
@@ -1743,6 +2144,16 @@ type metadataGetDeploymentGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetDeploymentGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDeploymentGroupInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a get deployment group operation.
 type GetDeploymentGroupOutput struct {
 	// Information about the deployment group.
@@ -1753,6 +2164,16 @@ type GetDeploymentGroupOutput struct {
 
 type metadataGetDeploymentGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDeploymentGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDeploymentGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a get deployment operation.
@@ -1766,6 +2187,16 @@ type GetDeploymentInput struct {
 
 type metadataGetDeploymentInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDeploymentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDeploymentInput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a get deployment instance operation.
@@ -1783,6 +2214,16 @@ type metadataGetDeploymentInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetDeploymentInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDeploymentInstanceInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a get deployment instance operation.
 type GetDeploymentInstanceOutput struct {
 	// Information about the instance.
@@ -1793,6 +2234,16 @@ type GetDeploymentInstanceOutput struct {
 
 type metadataGetDeploymentInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDeploymentInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDeploymentInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a get deployment operation.
@@ -1807,6 +2258,16 @@ type metadataGetDeploymentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetDeploymentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDeploymentOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a get on-premises instance operation.
 type GetOnPremisesInstanceInput struct {
 	// The name of the on-premises instance to get information about
@@ -1819,6 +2280,16 @@ type metadataGetOnPremisesInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetOnPremisesInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOnPremisesInstanceInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a get on-premises instance operation.
 type GetOnPremisesInstanceOutput struct {
 	// Information about the on-premises instance.
@@ -1829,6 +2300,16 @@ type GetOnPremisesInstanceOutput struct {
 
 type metadataGetOnPremisesInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetOnPremisesInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOnPremisesInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // Information about the location of application artifacts that are stored in
@@ -1849,6 +2330,16 @@ type GitHubLocation struct {
 
 type metadataGitHubLocation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GitHubLocation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GitHubLocation) GoString() string {
+	return s.String()
 }
 
 // Information about an on-premises instance.
@@ -1877,6 +2368,16 @@ type InstanceInfo struct {
 
 type metadataInstanceInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceInfo) GoString() string {
+	return s.String()
 }
 
 // Information about an instance in a deployment.
@@ -1909,6 +2410,16 @@ type metadataInstanceSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceSummary) GoString() string {
+	return s.String()
+}
+
 // Information about a deployment lifecycle event.
 type LifecycleEvent struct {
 	// Diagnostic information about the deployment lifecycle event.
@@ -1938,6 +2449,16 @@ type LifecycleEvent struct {
 
 type metadataLifecycleEvent struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LifecycleEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LifecycleEvent) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a list application revisions operation.
@@ -1993,6 +2514,16 @@ type metadataListApplicationRevisionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListApplicationRevisionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListApplicationRevisionsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a list application revisions operation.
 type ListApplicationRevisionsOutput struct {
 	// If the amount of information that is returned is significantly large, an
@@ -2011,6 +2542,16 @@ type metadataListApplicationRevisionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListApplicationRevisionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListApplicationRevisionsOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a list applications operation.
 type ListApplicationsInput struct {
 	// An identifier that was returned from the previous list applications call,
@@ -2022,6 +2563,16 @@ type ListApplicationsInput struct {
 
 type metadataListApplicationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListApplicationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListApplicationsInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a list applications operation.
@@ -2041,6 +2592,16 @@ type metadataListApplicationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListApplicationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListApplicationsOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a list deployment configurations operation.
 type ListDeploymentConfigsInput struct {
 	// An identifier that was returned from the previous list deployment configurations
@@ -2053,6 +2614,16 @@ type ListDeploymentConfigsInput struct {
 
 type metadataListDeploymentConfigsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDeploymentConfigsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeploymentConfigsInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a list deployment configurations operation.
@@ -2074,6 +2645,16 @@ type metadataListDeploymentConfigsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDeploymentConfigsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeploymentConfigsOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a list deployment groups operation.
 type ListDeploymentGroupsInput struct {
 	// The name of an existing AWS CodeDeploy application associated with the applicable
@@ -2090,6 +2671,16 @@ type ListDeploymentGroupsInput struct {
 
 type metadataListDeploymentGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDeploymentGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeploymentGroupsInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a list deployment groups operation.
@@ -2111,6 +2702,16 @@ type ListDeploymentGroupsOutput struct {
 
 type metadataListDeploymentGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDeploymentGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeploymentGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a list deployment instances operation.
@@ -2141,6 +2742,16 @@ type metadataListDeploymentInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDeploymentInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeploymentInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a list deployment instances operation.
 type ListDeploymentInstancesOutput struct {
 	// A list of instances IDs.
@@ -2157,6 +2768,16 @@ type ListDeploymentInstancesOutput struct {
 
 type metadataListDeploymentInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDeploymentInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeploymentInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a list deployments operation.
@@ -2192,6 +2813,16 @@ type metadataListDeploymentsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDeploymentsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeploymentsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a list deployments operation.
 type ListDeploymentsOutput struct {
 	// A list of deployment IDs.
@@ -2207,6 +2838,16 @@ type ListDeploymentsOutput struct {
 
 type metadataListDeploymentsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDeploymentsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeploymentsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a list on-premises instances operation.
@@ -2235,6 +2876,16 @@ type metadataListOnPremisesInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListOnPremisesInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListOnPremisesInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of list on-premises instances operation.
 type ListOnPremisesInstancesOutput struct {
 	// The list of matching on-premises instance names.
@@ -2251,6 +2902,16 @@ type ListOnPremisesInstancesOutput struct {
 
 type metadataListOnPremisesInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListOnPremisesInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListOnPremisesInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Information about minimum healthy instances.
@@ -2282,6 +2943,16 @@ type metadataMinimumHealthyHosts struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MinimumHealthyHosts) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MinimumHealthyHosts) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a register application revision operation.
 type RegisterApplicationRevisionInput struct {
 	// The name of an existing AWS CodeDeploy application associated with the applicable
@@ -2302,12 +2973,32 @@ type metadataRegisterApplicationRevisionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterApplicationRevisionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterApplicationRevisionInput) GoString() string {
+	return s.String()
+}
+
 type RegisterApplicationRevisionOutput struct {
 	metadataRegisterApplicationRevisionOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterApplicationRevisionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterApplicationRevisionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterApplicationRevisionOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of register on-premises instance operation.
@@ -2325,12 +3016,32 @@ type metadataRegisterOnPremisesInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterOnPremisesInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterOnPremisesInstanceInput) GoString() string {
+	return s.String()
+}
+
 type RegisterOnPremisesInstanceOutput struct {
 	metadataRegisterOnPremisesInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterOnPremisesInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterOnPremisesInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterOnPremisesInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a remove tags from on-premises instances operation.
@@ -2348,12 +3059,32 @@ type metadataRemoveTagsFromOnPremisesInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveTagsFromOnPremisesInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromOnPremisesInstancesInput) GoString() string {
+	return s.String()
+}
+
 type RemoveTagsFromOnPremisesInstancesOutput struct {
 	metadataRemoveTagsFromOnPremisesInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromOnPremisesInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveTagsFromOnPremisesInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromOnPremisesInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Information about an application revision's location.
@@ -2377,6 +3108,16 @@ type RevisionLocation struct {
 
 type metadataRevisionLocation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RevisionLocation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevisionLocation) GoString() string {
+	return s.String()
 }
 
 // Information about the location of application artifacts that are stored in
@@ -2416,6 +3157,16 @@ type metadataS3Location struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s S3Location) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s S3Location) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a stop deployment operation.
 type StopDeploymentInput struct {
 	// The unique ID of a deployment.
@@ -2426,6 +3177,16 @@ type StopDeploymentInput struct {
 
 type metadataStopDeploymentInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopDeploymentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopDeploymentInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a stop deployment operation.
@@ -2445,6 +3206,16 @@ type metadataStopDeploymentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StopDeploymentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopDeploymentOutput) GoString() string {
+	return s.String()
+}
+
 // Information about a tag.
 type Tag struct {
 	// The tag's key.
@@ -2458,6 +3229,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // Information about an on-premises instance tag filter.
@@ -2480,6 +3261,16 @@ type metadataTagFilter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TagFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TagFilter) GoString() string {
+	return s.String()
+}
+
 // Information about a time range.
 type TimeRange struct {
 	// The time range's end time.
@@ -2499,6 +3290,16 @@ type metadataTimeRange struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TimeRange) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TimeRange) GoString() string {
+	return s.String()
+}
+
 // Represents the input of an update application operation.
 type UpdateApplicationInput struct {
 	// The current name of the application that you want to change.
@@ -2514,12 +3315,32 @@ type metadataUpdateApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateApplicationInput) GoString() string {
+	return s.String()
+}
+
 type UpdateApplicationOutput struct {
 	metadataUpdateApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateApplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateApplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateApplicationOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of an update deployment group operation.
@@ -2559,6 +3380,16 @@ type metadataUpdateDeploymentGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateDeploymentGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDeploymentGroupInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of an update deployment group operation.
 type UpdateDeploymentGroupOutput struct {
 	// If the output contains no data, and the corresponding deployment group contained
@@ -2573,4 +3404,14 @@ type UpdateDeploymentGroupOutput struct {
 
 type metadataUpdateDeploymentGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateDeploymentGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDeploymentGroupOutput) GoString() string {
+	return s.String()
 }

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateIdentityPool = "CreateIdentityPool"
@@ -607,6 +608,16 @@ type metadataCreateIdentityPoolInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateIdentityPoolInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateIdentityPoolInput) GoString() string {
+	return s.String()
+}
+
 // Credentials for the the provided identity ID.
 type Credentials struct {
 	// The Access Key portion of the credentials.
@@ -628,6 +639,16 @@ type metadataCredentials struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Credentials) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Credentials) GoString() string {
+	return s.String()
+}
+
 // Input to the DeleteIdentities action.
 type DeleteIdentitiesInput struct {
 	// A list of 1-60 identities that you want to delete.
@@ -638,6 +659,16 @@ type DeleteIdentitiesInput struct {
 
 type metadataDeleteIdentitiesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteIdentitiesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteIdentitiesInput) GoString() string {
+	return s.String()
 }
 
 // Returned in response to a successful DeleteIdentities operation.
@@ -653,6 +684,16 @@ type metadataDeleteIdentitiesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteIdentitiesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteIdentitiesOutput) GoString() string {
+	return s.String()
+}
+
 // Input to the DeleteIdentityPool action.
 type DeleteIdentityPoolInput struct {
 	// An identity pool ID in the format REGION:GUID.
@@ -665,12 +706,32 @@ type metadataDeleteIdentityPoolInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteIdentityPoolInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteIdentityPoolInput) GoString() string {
+	return s.String()
+}
+
 type DeleteIdentityPoolOutput struct {
 	metadataDeleteIdentityPoolOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteIdentityPoolOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteIdentityPoolOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteIdentityPoolOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the DescribeIdentity action.
@@ -685,6 +746,16 @@ type metadataDescribeIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIdentityInput) GoString() string {
+	return s.String()
+}
+
 // Input to the DescribeIdentityPool action.
 type DescribeIdentityPoolInput struct {
 	// An identity pool ID in the format REGION:GUID.
@@ -695,6 +766,16 @@ type DescribeIdentityPoolInput struct {
 
 type metadataDescribeIdentityPoolInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeIdentityPoolInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIdentityPoolInput) GoString() string {
+	return s.String()
 }
 
 // Input to the GetCredentialsForIdentity action.
@@ -712,6 +793,16 @@ type metadataGetCredentialsForIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetCredentialsForIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCredentialsForIdentityInput) GoString() string {
+	return s.String()
+}
+
 // Returned in response to a successful GetCredentialsForIdentity operation.
 type GetCredentialsForIdentityOutput struct {
 	// Credentials for the the provided identity ID.
@@ -725,6 +816,16 @@ type GetCredentialsForIdentityOutput struct {
 
 type metadataGetCredentialsForIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCredentialsForIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCredentialsForIdentityOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the GetId action.
@@ -749,6 +850,16 @@ type metadataGetIDInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetIDInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIDInput) GoString() string {
+	return s.String()
+}
+
 // Returned in response to a GetId request.
 type GetIDOutput struct {
 	// A unique identifier in the format REGION:GUID.
@@ -761,6 +872,16 @@ type metadataGetIDOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetIDOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIDOutput) GoString() string {
+	return s.String()
+}
+
 // Input to the GetIdentityPoolRoles action.
 type GetIdentityPoolRolesInput struct {
 	// An identity pool ID in the format REGION:GUID.
@@ -771,6 +892,16 @@ type GetIdentityPoolRolesInput struct {
 
 type metadataGetIdentityPoolRolesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetIdentityPoolRolesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityPoolRolesInput) GoString() string {
+	return s.String()
 }
 
 // Returned in response to a successful GetIdentityPoolRoles operation.
@@ -787,6 +918,16 @@ type GetIdentityPoolRolesOutput struct {
 
 type metadataGetIdentityPoolRolesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetIdentityPoolRolesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityPoolRolesOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the GetOpenIdTokenForDeveloperIdentity action.
@@ -825,6 +966,16 @@ type metadataGetOpenIDTokenForDeveloperIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetOpenIDTokenForDeveloperIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOpenIDTokenForDeveloperIdentityInput) GoString() string {
+	return s.String()
+}
+
 // Returned in response to a successful GetOpenIdTokenForDeveloperIdentity request.
 type GetOpenIDTokenForDeveloperIdentityOutput struct {
 	// A unique identifier in the format REGION:GUID.
@@ -838,6 +989,16 @@ type GetOpenIDTokenForDeveloperIdentityOutput struct {
 
 type metadataGetOpenIDTokenForDeveloperIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetOpenIDTokenForDeveloperIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOpenIDTokenForDeveloperIdentityOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the GetOpenIdToken action.
@@ -858,6 +1019,16 @@ type metadataGetOpenIDTokenInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetOpenIDTokenInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOpenIDTokenInput) GoString() string {
+	return s.String()
+}
+
 // Returned in response to a successful GetOpenIdToken request.
 type GetOpenIDTokenOutput struct {
 	// A unique identifier in the format REGION:GUID. Note that the IdentityId returned
@@ -872,6 +1043,16 @@ type GetOpenIDTokenOutput struct {
 
 type metadataGetOpenIDTokenOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetOpenIDTokenOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOpenIDTokenOutput) GoString() string {
+	return s.String()
 }
 
 // A description of the identity.
@@ -893,6 +1074,16 @@ type IdentityDescription struct {
 
 type metadataIdentityDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IdentityDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IdentityDescription) GoString() string {
+	return s.String()
 }
 
 // An object representing a Cognito identity pool.
@@ -922,6 +1113,16 @@ type metadataIdentityPool struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s IdentityPool) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IdentityPool) GoString() string {
+	return s.String()
+}
+
 // A description of the identity pool.
 type IdentityPoolShortDescription struct {
 	// An identity pool ID in the format REGION:GUID.
@@ -935,6 +1136,16 @@ type IdentityPoolShortDescription struct {
 
 type metadataIdentityPoolShortDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IdentityPoolShortDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IdentityPoolShortDescription) GoString() string {
+	return s.String()
 }
 
 // Input to the ListIdentities action.
@@ -960,6 +1171,16 @@ type metadataListIdentitiesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListIdentitiesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListIdentitiesInput) GoString() string {
+	return s.String()
+}
+
 // The response to a ListIdentities request.
 type ListIdentitiesOutput struct {
 	// An object containing a set of identities and associated mappings.
@@ -978,6 +1199,16 @@ type metadataListIdentitiesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListIdentitiesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListIdentitiesOutput) GoString() string {
+	return s.String()
+}
+
 // Input to the ListIdentityPools action.
 type ListIdentityPoolsInput struct {
 	// The maximum number of identities to return.
@@ -993,6 +1224,16 @@ type metadataListIdentityPoolsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListIdentityPoolsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListIdentityPoolsInput) GoString() string {
+	return s.String()
+}
+
 // The result of a successful ListIdentityPools action.
 type ListIdentityPoolsOutput struct {
 	// The identity pools returned by the ListIdentityPools action.
@@ -1006,6 +1247,16 @@ type ListIdentityPoolsOutput struct {
 
 type metadataListIdentityPoolsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListIdentityPoolsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListIdentityPoolsOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the LookupDeveloperIdentityInput action.
@@ -1039,6 +1290,16 @@ type metadataLookupDeveloperIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LookupDeveloperIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LookupDeveloperIdentityInput) GoString() string {
+	return s.String()
+}
+
 // Returned in response to a successful LookupDeveloperIdentity action.
 type LookupDeveloperIdentityOutput struct {
 	// This is the list of developer user identifiers associated with an identity
@@ -1062,6 +1323,16 @@ type LookupDeveloperIdentityOutput struct {
 
 type metadataLookupDeveloperIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LookupDeveloperIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LookupDeveloperIdentityOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the MergeDeveloperIdentities action.
@@ -1089,6 +1360,16 @@ type metadataMergeDeveloperIdentitiesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MergeDeveloperIdentitiesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MergeDeveloperIdentitiesInput) GoString() string {
+	return s.String()
+}
+
 // Returned in response to a successful MergeDeveloperIdentities action.
 type MergeDeveloperIdentitiesOutput struct {
 	// A unique identifier in the format REGION:GUID.
@@ -1099,6 +1380,16 @@ type MergeDeveloperIdentitiesOutput struct {
 
 type metadataMergeDeveloperIdentitiesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MergeDeveloperIdentitiesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MergeDeveloperIdentitiesOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the SetIdentityPoolRoles action.
@@ -1118,12 +1409,32 @@ type metadataSetIdentityPoolRolesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetIdentityPoolRolesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityPoolRolesInput) GoString() string {
+	return s.String()
+}
+
 type SetIdentityPoolRolesOutput struct {
 	metadataSetIdentityPoolRolesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetIdentityPoolRolesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetIdentityPoolRolesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityPoolRolesOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the UnlinkDeveloperIdentity action.
@@ -1147,12 +1458,32 @@ type metadataUnlinkDeveloperIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnlinkDeveloperIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnlinkDeveloperIdentityInput) GoString() string {
+	return s.String()
+}
+
 type UnlinkDeveloperIdentityOutput struct {
 	metadataUnlinkDeveloperIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataUnlinkDeveloperIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnlinkDeveloperIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnlinkDeveloperIdentityOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the UnlinkIdentity action.
@@ -1173,12 +1504,32 @@ type metadataUnlinkIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnlinkIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnlinkIdentityInput) GoString() string {
+	return s.String()
+}
+
 type UnlinkIdentityOutput struct {
 	metadataUnlinkIdentityOutput `json:"-" xml:"-"`
 }
 
 type metadataUnlinkIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnlinkIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnlinkIdentityOutput) GoString() string {
+	return s.String()
 }
 
 // An array of UnprocessedIdentityId objects, each of which contains an ErrorCode
@@ -1195,4 +1546,14 @@ type UnprocessedIdentityID struct {
 
 type metadataUnprocessedIdentityID struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnprocessedIdentityID) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnprocessedIdentityID) GoString() string {
+	return s.String()
 }

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opBulkPublish = "BulkPublish"
@@ -569,6 +570,16 @@ type metadataBulkPublishInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BulkPublishInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BulkPublishInput) GoString() string {
+	return s.String()
+}
+
 // The output for the BulkPublish operation.
 type BulkPublishOutput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
@@ -580,6 +591,16 @@ type BulkPublishOutput struct {
 
 type metadataBulkPublishOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BulkPublishOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BulkPublishOutput) GoString() string {
+	return s.String()
 }
 
 // Configuration options for configure Cognito streams.
@@ -605,6 +626,16 @@ type CognitoStreams struct {
 
 type metadataCognitoStreams struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CognitoStreams) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CognitoStreams) GoString() string {
+	return s.String()
 }
 
 // A collection of data for an identity pool. An identity pool can have multiple
@@ -643,6 +674,16 @@ type metadataDataset struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Dataset) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Dataset) GoString() string {
+	return s.String()
+}
+
 // A request to delete the specific dataset.
 type DeleteDatasetInput struct {
 	// A string of up to 128 characters. Allowed characters are a-z, A-Z, 0-9, '_'
@@ -664,6 +705,16 @@ type metadataDeleteDatasetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDatasetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDatasetInput) GoString() string {
+	return s.String()
+}
+
 // Response to a successful DeleteDataset request.
 type DeleteDatasetOutput struct {
 	// A collection of data for an identity pool. An identity pool can have multiple
@@ -678,6 +729,16 @@ type DeleteDatasetOutput struct {
 
 type metadataDeleteDatasetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDatasetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDatasetOutput) GoString() string {
+	return s.String()
 }
 
 // A request for meta data about a dataset (creation date, number of records,
@@ -702,6 +763,16 @@ type metadataDescribeDatasetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDatasetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDatasetInput) GoString() string {
+	return s.String()
+}
+
 // Response to a successful DescribeDataset request.
 type DescribeDatasetOutput struct {
 	// Meta data for a collection of data for an identity. An identity can have
@@ -718,6 +789,16 @@ type metadataDescribeDatasetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDatasetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDatasetOutput) GoString() string {
+	return s.String()
+}
+
 // A request for usage information about the identity pool.
 type DescribeIdentityPoolUsageInput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
@@ -731,6 +812,16 @@ type metadataDescribeIdentityPoolUsageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeIdentityPoolUsageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIdentityPoolUsageInput) GoString() string {
+	return s.String()
+}
+
 // Response to a successful DescribeIdentityPoolUsage request.
 type DescribeIdentityPoolUsageOutput struct {
 	// Information about the usage of the identity pool.
@@ -741,6 +832,16 @@ type DescribeIdentityPoolUsageOutput struct {
 
 type metadataDescribeIdentityPoolUsageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeIdentityPoolUsageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIdentityPoolUsageOutput) GoString() string {
+	return s.String()
 }
 
 // A request for information about the usage of an identity pool.
@@ -760,6 +861,16 @@ type metadataDescribeIdentityUsageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeIdentityUsageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIdentityUsageInput) GoString() string {
+	return s.String()
+}
+
 // The response to a successful DescribeIdentityUsage request.
 type DescribeIdentityUsageOutput struct {
 	// Usage information for the identity.
@@ -770,6 +881,16 @@ type DescribeIdentityUsageOutput struct {
 
 type metadataDescribeIdentityUsageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeIdentityUsageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeIdentityUsageOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the GetBulkPublishDetails operation.
@@ -783,6 +904,16 @@ type GetBulkPublishDetailsInput struct {
 
 type metadataGetBulkPublishDetailsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBulkPublishDetailsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBulkPublishDetailsInput) GoString() string {
+	return s.String()
 }
 
 // The output for the GetBulkPublishDetails operation.
@@ -821,6 +952,16 @@ type metadataGetBulkPublishDetailsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBulkPublishDetailsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBulkPublishDetailsOutput) GoString() string {
+	return s.String()
+}
+
 // A request for a list of the configured Cognito Events
 type GetCognitoEventsInput struct {
 	// The Cognito Identity Pool ID for the request
@@ -831,6 +972,16 @@ type GetCognitoEventsInput struct {
 
 type metadataGetCognitoEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCognitoEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCognitoEventsInput) GoString() string {
+	return s.String()
 }
 
 // The response from the GetCognitoEvents request
@@ -845,6 +996,16 @@ type metadataGetCognitoEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetCognitoEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCognitoEventsOutput) GoString() string {
+	return s.String()
+}
+
 // The input for the GetIdentityPoolConfiguration operation.
 type GetIdentityPoolConfigurationInput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
@@ -857,6 +1018,16 @@ type GetIdentityPoolConfigurationInput struct {
 
 type metadataGetIdentityPoolConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetIdentityPoolConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityPoolConfigurationInput) GoString() string {
+	return s.String()
 }
 
 // The output for the GetIdentityPoolConfiguration operation.
@@ -876,6 +1047,16 @@ type GetIdentityPoolConfigurationOutput struct {
 
 type metadataGetIdentityPoolConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetIdentityPoolConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityPoolConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 // Usage information for the identity pool.
@@ -898,6 +1079,16 @@ type IdentityPoolUsage struct {
 
 type metadataIdentityPoolUsage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IdentityPoolUsage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IdentityPoolUsage) GoString() string {
+	return s.String()
 }
 
 // Usage information for the identity.
@@ -926,6 +1117,16 @@ type metadataIdentityUsage struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s IdentityUsage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IdentityUsage) GoString() string {
+	return s.String()
+}
+
 // Request for a list of datasets for an identity.
 type ListDatasetsInput struct {
 	// A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE)
@@ -949,6 +1150,16 @@ type metadataListDatasetsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDatasetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDatasetsInput) GoString() string {
+	return s.String()
+}
+
 // Returned for a successful ListDatasets request.
 type ListDatasetsOutput struct {
 	// Number of datasets returned.
@@ -967,6 +1178,16 @@ type metadataListDatasetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDatasetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDatasetsOutput) GoString() string {
+	return s.String()
+}
+
 // A request for usage information on an identity pool.
 type ListIdentityPoolUsageInput struct {
 	// The maximum number of results to be returned.
@@ -980,6 +1201,16 @@ type ListIdentityPoolUsageInput struct {
 
 type metadataListIdentityPoolUsageInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListIdentityPoolUsageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListIdentityPoolUsageInput) GoString() string {
+	return s.String()
 }
 
 // Returned for a successful ListIdentityPoolUsage request.
@@ -1001,6 +1232,16 @@ type ListIdentityPoolUsageOutput struct {
 
 type metadataListIdentityPoolUsageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListIdentityPoolUsageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListIdentityPoolUsageOutput) GoString() string {
+	return s.String()
 }
 
 // A request for a list of records.
@@ -1034,6 +1275,16 @@ type ListRecordsInput struct {
 
 type metadataListRecordsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListRecordsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListRecordsInput) GoString() string {
+	return s.String()
 }
 
 // Returned for a successful ListRecordsRequest.
@@ -1072,6 +1323,16 @@ type metadataListRecordsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListRecordsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListRecordsOutput) GoString() string {
+	return s.String()
+}
+
 // Configuration options to be applied to the identity pool.
 type PushSync struct {
 	// List of SNS platform application ARNs that could be used by clients.
@@ -1085,6 +1346,16 @@ type PushSync struct {
 
 type metadataPushSync struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PushSync) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PushSync) GoString() string {
+	return s.String()
 }
 
 // The basic data structure of a dataset.
@@ -1114,6 +1385,16 @@ type metadataRecord struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Record) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Record) GoString() string {
+	return s.String()
+}
+
 // An update operation for a record.
 type RecordPatch struct {
 	// The last modified date of the client device.
@@ -1136,6 +1417,16 @@ type RecordPatch struct {
 
 type metadataRecordPatch struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RecordPatch) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecordPatch) GoString() string {
+	return s.String()
 }
 
 // A request to RegisterDevice.
@@ -1161,6 +1452,16 @@ type metadataRegisterDeviceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterDeviceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterDeviceInput) GoString() string {
+	return s.String()
+}
+
 // Response to a RegisterDevice request.
 type RegisterDeviceOutput struct {
 	// The unique ID generated for this device by Cognito.
@@ -1171,6 +1472,16 @@ type RegisterDeviceOutput struct {
 
 type metadataRegisterDeviceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterDeviceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterDeviceOutput) GoString() string {
+	return s.String()
 }
 
 // A request to configure Cognito Events"
@@ -1190,12 +1501,32 @@ type metadataSetCognitoEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetCognitoEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetCognitoEventsInput) GoString() string {
+	return s.String()
+}
+
 type SetCognitoEventsOutput struct {
 	metadataSetCognitoEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataSetCognitoEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetCognitoEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetCognitoEventsOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the SetIdentityPoolConfiguration operation.
@@ -1217,6 +1548,16 @@ type metadataSetIdentityPoolConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetIdentityPoolConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityPoolConfigurationInput) GoString() string {
+	return s.String()
+}
+
 // The output for the SetIdentityPoolConfiguration operation
 type SetIdentityPoolConfigurationOutput struct {
 	// Options to apply to this identity pool for Amazon Cognito streams.
@@ -1234,6 +1575,16 @@ type SetIdentityPoolConfigurationOutput struct {
 
 type metadataSetIdentityPoolConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetIdentityPoolConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityPoolConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 // A request to SubscribeToDatasetRequest.
@@ -1258,6 +1609,16 @@ type metadataSubscribeToDatasetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SubscribeToDatasetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubscribeToDatasetInput) GoString() string {
+	return s.String()
+}
+
 // Response to a SubscribeToDataset request.
 type SubscribeToDatasetOutput struct {
 	metadataSubscribeToDatasetOutput `json:"-" xml:"-"`
@@ -1265,6 +1626,16 @@ type SubscribeToDatasetOutput struct {
 
 type metadataSubscribeToDatasetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SubscribeToDatasetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubscribeToDatasetOutput) GoString() string {
+	return s.String()
 }
 
 // A request to UnsubscribeFromDataset.
@@ -1289,6 +1660,16 @@ type metadataUnsubscribeFromDatasetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnsubscribeFromDatasetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnsubscribeFromDatasetInput) GoString() string {
+	return s.String()
+}
+
 // Response to an UnsubscribeFromDataset request.
 type UnsubscribeFromDatasetOutput struct {
 	metadataUnsubscribeFromDatasetOutput `json:"-" xml:"-"`
@@ -1296,6 +1677,16 @@ type UnsubscribeFromDatasetOutput struct {
 
 type metadataUnsubscribeFromDatasetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnsubscribeFromDatasetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnsubscribeFromDatasetOutput) GoString() string {
+	return s.String()
 }
 
 // A request to post updates to records or add and delete records for a dataset
@@ -1334,6 +1725,16 @@ type metadataUpdateRecordsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateRecordsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRecordsInput) GoString() string {
+	return s.String()
+}
+
 // Returned for a successful UpdateRecordsRequest.
 type UpdateRecordsOutput struct {
 	// A list of records that have been updated.
@@ -1344,4 +1745,14 @@ type UpdateRecordsOutput struct {
 
 type metadataUpdateRecordsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateRecordsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRecordsOutput) GoString() string {
+	return s.String()
 }

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opDeleteDeliveryChannel = "DeleteDeliveryChannel"
@@ -403,6 +404,16 @@ type metadataConfigExportDeliveryInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfigExportDeliveryInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigExportDeliveryInfo) GoString() string {
+	return s.String()
+}
+
 // A list that contains the status of the delivery of the configuration stream
 // notification to the Amazon SNS topic.
 type ConfigStreamDeliveryInfo struct {
@@ -427,6 +438,16 @@ type ConfigStreamDeliveryInfo struct {
 
 type metadataConfigStreamDeliveryInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfigStreamDeliveryInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigStreamDeliveryInfo) GoString() string {
+	return s.String()
 }
 
 // A list that contains detailed configurations of a specified resource.
@@ -497,6 +518,16 @@ type metadataConfigurationItem struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfigurationItem) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigurationItem) GoString() string {
+	return s.String()
+}
+
 // An object that represents the recording of configuration changes of an AWS
 // resource.
 type ConfigurationRecorder struct {
@@ -519,6 +550,16 @@ type ConfigurationRecorder struct {
 
 type metadataConfigurationRecorder struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfigurationRecorder) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigurationRecorder) GoString() string {
+	return s.String()
 }
 
 // The current status of the configuration recorder.
@@ -554,6 +595,16 @@ type metadataConfigurationRecorderStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfigurationRecorderStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigurationRecorderStatus) GoString() string {
+	return s.String()
+}
+
 // The input for the DeleteDeliveryChannel action. The action accepts the following
 // data in JSON format.
 type DeleteDeliveryChannelInput struct {
@@ -567,12 +618,32 @@ type metadataDeleteDeliveryChannelInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDeliveryChannelInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDeliveryChannelInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDeliveryChannelOutput struct {
 	metadataDeleteDeliveryChannelOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDeliveryChannelOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDeliveryChannelOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDeliveryChannelOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the DeliverConfigSnapshot action.
@@ -587,6 +658,16 @@ type metadataDeliverConfigSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeliverConfigSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeliverConfigSnapshotInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DeliverConfigSnapshot action in JSON format.
 type DeliverConfigSnapshotOutput struct {
 	// The ID of the snapshot that is being created.
@@ -597,6 +678,16 @@ type DeliverConfigSnapshotOutput struct {
 
 type metadataDeliverConfigSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeliverConfigSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeliverConfigSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // A logical container used for storing the configuration changes of an AWS
@@ -625,6 +716,16 @@ type metadataDeliveryChannel struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeliveryChannel) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeliveryChannel) GoString() string {
+	return s.String()
+}
+
 // The status of a specified delivery channel.
 //
 // Valid values: Success | Failure
@@ -651,6 +752,16 @@ type metadataDeliveryChannelStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeliveryChannelStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeliveryChannelStatus) GoString() string {
+	return s.String()
+}
+
 // The input for the DescribeConfigurationRecorderStatus action.
 type DescribeConfigurationRecorderStatusInput struct {
 	// The name(s) of the configuration recorder. If the name is not specified,
@@ -665,6 +776,16 @@ type metadataDescribeConfigurationRecorderStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeConfigurationRecorderStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConfigurationRecorderStatusInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DescribeConfigurationRecorderStatus action in JSON format.
 type DescribeConfigurationRecorderStatusOutput struct {
 	// A list that contains status of the specified recorders.
@@ -675,6 +796,16 @@ type DescribeConfigurationRecorderStatusOutput struct {
 
 type metadataDescribeConfigurationRecorderStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeConfigurationRecorderStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConfigurationRecorderStatusOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the DescribeConfigurationRecorders action.
@@ -689,6 +820,16 @@ type metadataDescribeConfigurationRecordersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeConfigurationRecordersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConfigurationRecordersInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DescribeConfigurationRecorders action.
 type DescribeConfigurationRecordersOutput struct {
 	// A list that contains the descriptions of the specified configuration recorders.
@@ -699,6 +840,16 @@ type DescribeConfigurationRecordersOutput struct {
 
 type metadataDescribeConfigurationRecordersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeConfigurationRecordersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConfigurationRecordersOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the DeliveryChannelStatus action.
@@ -713,6 +864,16 @@ type metadataDescribeDeliveryChannelStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDeliveryChannelStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDeliveryChannelStatusInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DescribeDeliveryChannelStatus action.
 type DescribeDeliveryChannelStatusOutput struct {
 	// A list that contains the status of a specified delivery channel.
@@ -723,6 +884,16 @@ type DescribeDeliveryChannelStatusOutput struct {
 
 type metadataDescribeDeliveryChannelStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDeliveryChannelStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDeliveryChannelStatusOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the DescribeDeliveryChannels action.
@@ -737,6 +908,16 @@ type metadataDescribeDeliveryChannelsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDeliveryChannelsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDeliveryChannelsInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DescribeDeliveryChannels action.
 type DescribeDeliveryChannelsOutput struct {
 	// A list that contains the descriptions of the specified delivery channel.
@@ -747,6 +928,16 @@ type DescribeDeliveryChannelsOutput struct {
 
 type metadataDescribeDeliveryChannelsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDeliveryChannelsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDeliveryChannelsOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the GetResourceConfigHistory action.
@@ -784,6 +975,16 @@ type metadataGetResourceConfigHistoryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetResourceConfigHistoryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetResourceConfigHistoryInput) GoString() string {
+	return s.String()
+}
+
 // The output for the GetResourceConfigHistory action.
 type GetResourceConfigHistoryOutput struct {
 	// A list that contains the configuration history of one or more resources.
@@ -799,6 +1000,16 @@ type metadataGetResourceConfigHistoryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetResourceConfigHistoryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetResourceConfigHistoryOutput) GoString() string {
+	return s.String()
+}
+
 // The input for the PutConfigurationRecorder action.
 type PutConfigurationRecorderInput struct {
 	// The configuration recorder object that records each configuration change
@@ -812,12 +1023,32 @@ type metadataPutConfigurationRecorderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutConfigurationRecorderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutConfigurationRecorderInput) GoString() string {
+	return s.String()
+}
+
 type PutConfigurationRecorderOutput struct {
 	metadataPutConfigurationRecorderOutput `json:"-" xml:"-"`
 }
 
 type metadataPutConfigurationRecorderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutConfigurationRecorderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutConfigurationRecorderOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the PutDeliveryChannel action.
@@ -833,12 +1064,32 @@ type metadataPutDeliveryChannelInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutDeliveryChannelInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutDeliveryChannelInput) GoString() string {
+	return s.String()
+}
+
 type PutDeliveryChannelOutput struct {
 	metadataPutDeliveryChannelOutput `json:"-" xml:"-"`
 }
 
 type metadataPutDeliveryChannelOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutDeliveryChannelOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutDeliveryChannelOutput) GoString() string {
+	return s.String()
 }
 
 // The group of AWS resource types that AWS Config records when starting the
@@ -866,6 +1117,16 @@ type metadataRecordingGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecordingGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecordingGroup) GoString() string {
+	return s.String()
+}
+
 // The relationship of the related resource to the main resource.
 type Relationship struct {
 	// The name of the related resource.
@@ -884,6 +1145,16 @@ type metadataRelationship struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Relationship) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Relationship) GoString() string {
+	return s.String()
+}
+
 // The input for the StartConfigurationRecorder action.
 type StartConfigurationRecorderInput struct {
 	// The name of the recorder object that records each configuration change made
@@ -897,12 +1168,32 @@ type metadataStartConfigurationRecorderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartConfigurationRecorderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartConfigurationRecorderInput) GoString() string {
+	return s.String()
+}
+
 type StartConfigurationRecorderOutput struct {
 	metadataStartConfigurationRecorderOutput `json:"-" xml:"-"`
 }
 
 type metadataStartConfigurationRecorderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartConfigurationRecorderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartConfigurationRecorderOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the StopConfigurationRecorder action.
@@ -918,10 +1209,30 @@ type metadataStopConfigurationRecorderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StopConfigurationRecorderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopConfigurationRecorderInput) GoString() string {
+	return s.String()
+}
+
 type StopConfigurationRecorderOutput struct {
 	metadataStopConfigurationRecorderOutput `json:"-" xml:"-"`
 }
 
 type metadataStopConfigurationRecorderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopConfigurationRecorderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopConfigurationRecorderOutput) GoString() string {
+	return s.String()
 }

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opActivatePipeline = "ActivatePipeline"
@@ -663,6 +664,16 @@ type metadataActivatePipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActivatePipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivatePipelineInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of ActivatePipeline.
 type ActivatePipelineOutput struct {
 	metadataActivatePipelineOutput `json:"-" xml:"-"`
@@ -670,6 +681,16 @@ type ActivatePipelineOutput struct {
 
 type metadataActivatePipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ActivatePipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivatePipelineOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for AddTags.
@@ -687,6 +708,16 @@ type metadataAddTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of AddTags.
 type AddTagsOutput struct {
 	metadataAddTagsOutput `json:"-" xml:"-"`
@@ -694,6 +725,16 @@ type AddTagsOutput struct {
 
 type metadataAddTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for CreatePipeline.
@@ -732,6 +773,16 @@ type metadataCreatePipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePipelineInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of CreatePipeline.
 type CreatePipelineOutput struct {
 	// The ID that AWS Data Pipeline assigns the newly created pipeline. For example,
@@ -743,6 +794,16 @@ type CreatePipelineOutput struct {
 
 type metadataCreatePipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreatePipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePipelineOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for DeactivatePipeline.
@@ -762,6 +823,16 @@ type metadataDeactivatePipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeactivatePipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeactivatePipelineInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DeactivatePipeline.
 type DeactivatePipelineOutput struct {
 	metadataDeactivatePipelineOutput `json:"-" xml:"-"`
@@ -769,6 +840,16 @@ type DeactivatePipelineOutput struct {
 
 type metadataDeactivatePipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeactivatePipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeactivatePipelineOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for DeletePipeline.
@@ -783,12 +864,32 @@ type metadataDeletePipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletePipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePipelineInput) GoString() string {
+	return s.String()
+}
+
 type DeletePipelineOutput struct {
 	metadataDeletePipelineOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePipelineOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for DescribeObjects.
@@ -817,6 +918,16 @@ type metadataDescribeObjectsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeObjectsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeObjectsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DescribeObjects.
 type DescribeObjectsOutput struct {
 	// Indicates whether there are more results to return.
@@ -837,6 +948,16 @@ type metadataDescribeObjectsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeObjectsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeObjectsOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for DescribePipelines.
 type DescribePipelinesInput struct {
 	// The IDs of the pipelines to describe. You can pass as many as 25 identifiers
@@ -850,6 +971,16 @@ type metadataDescribePipelinesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribePipelinesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePipelinesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DescribePipelines.
 type DescribePipelinesOutput struct {
 	// An array of descriptions for the specified pipelines.
@@ -860,6 +991,16 @@ type DescribePipelinesOutput struct {
 
 type metadataDescribePipelinesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribePipelinesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePipelinesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for EvaluateExpression.
@@ -880,6 +1021,16 @@ type metadataEvaluateExpressionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EvaluateExpressionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EvaluateExpressionInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of EvaluateExpression.
 type EvaluateExpressionOutput struct {
 	// The evaluated expression.
@@ -890,6 +1041,16 @@ type EvaluateExpressionOutput struct {
 
 type metadataEvaluateExpressionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EvaluateExpressionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EvaluateExpressionOutput) GoString() string {
+	return s.String()
 }
 
 // A key-value pair that describes a property of a pipeline object. The value
@@ -912,6 +1073,16 @@ type metadataField struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Field) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Field) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for GetPipelineDefinition.
 type GetPipelineDefinitionInput struct {
 	// The ID of the pipeline.
@@ -927,6 +1098,16 @@ type GetPipelineDefinitionInput struct {
 
 type metadataGetPipelineDefinitionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetPipelineDefinitionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPipelineDefinitionInput) GoString() string {
+	return s.String()
 }
 
 // Contains the output of GetPipelineDefinition.
@@ -945,6 +1126,16 @@ type GetPipelineDefinitionOutput struct {
 
 type metadataGetPipelineDefinitionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetPipelineDefinitionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPipelineDefinitionOutput) GoString() string {
+	return s.String()
 }
 
 // Identity information for the EC2 instance that is hosting the task runner.
@@ -970,6 +1161,16 @@ type metadataInstanceIdentity struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceIdentity) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceIdentity) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for ListPipelines.
 type ListPipelinesInput struct {
 	// The starting point for the results to be returned. For the first call, this
@@ -983,6 +1184,16 @@ type ListPipelinesInput struct {
 
 type metadataListPipelinesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListPipelinesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPipelinesInput) GoString() string {
+	return s.String()
 }
 
 // Contains the output of ListPipelines.
@@ -1005,6 +1216,16 @@ type ListPipelinesOutput struct {
 
 type metadataListPipelinesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListPipelinesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPipelinesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains a logical operation for comparing the value of a field with a specified
@@ -1040,6 +1261,16 @@ type metadataOperator struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Operator) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Operator) GoString() string {
+	return s.String()
+}
+
 // The attributes allowed or specified with a parameter object.
 type ParameterAttribute struct {
 	// The field identifier.
@@ -1053,6 +1284,16 @@ type ParameterAttribute struct {
 
 type metadataParameterAttribute struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ParameterAttribute) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ParameterAttribute) GoString() string {
+	return s.String()
 }
 
 // Contains information about a parameter object.
@@ -1070,6 +1311,16 @@ type metadataParameterObject struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ParameterObject) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ParameterObject) GoString() string {
+	return s.String()
+}
+
 // A value or list of parameter values.
 type ParameterValue struct {
 	// The ID of the parameter value.
@@ -1083,6 +1334,16 @@ type ParameterValue struct {
 
 type metadataParameterValue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ParameterValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ParameterValue) GoString() string {
+	return s.String()
 }
 
 // Contains pipeline metadata.
@@ -1114,6 +1375,16 @@ type metadataPipelineDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PipelineDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PipelineDescription) GoString() string {
+	return s.String()
+}
+
 // Contains the name and identifier of a pipeline.
 type PipelineIDName struct {
 	// The ID of the pipeline that was assigned by AWS Data Pipeline. This is a
@@ -1128,6 +1399,16 @@ type PipelineIDName struct {
 
 type metadataPipelineIDName struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PipelineIDName) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PipelineIDName) GoString() string {
+	return s.String()
 }
 
 // Contains information about a pipeline object. This can be a logical, physical,
@@ -1148,6 +1429,16 @@ type PipelineObject struct {
 
 type metadataPipelineObject struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PipelineObject) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PipelineObject) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for PollForTask.
@@ -1177,6 +1468,16 @@ type metadataPollForTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PollForTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PollForTaskInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of PollForTask.
 type PollForTaskOutput struct {
 	// The information needed to complete the task that is being assigned to the
@@ -1190,6 +1491,16 @@ type PollForTaskOutput struct {
 
 type metadataPollForTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PollForTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PollForTaskOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for PutPipelineDefinition.
@@ -1214,6 +1525,16 @@ type metadataPutPipelineDefinitionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutPipelineDefinitionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutPipelineDefinitionInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of PutPipelineDefinition.
 type PutPipelineDefinitionOutput struct {
 	// Indicates whether there were validation errors, and the pipeline definition
@@ -1234,6 +1555,16 @@ type metadataPutPipelineDefinitionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutPipelineDefinitionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutPipelineDefinitionOutput) GoString() string {
+	return s.String()
+}
+
 // Defines the query to run against an object.
 type Query struct {
 	// List of selectors that define the query. An object must satisfy all of the
@@ -1245,6 +1576,16 @@ type Query struct {
 
 type metadataQuery struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Query) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Query) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for QueryObjects.
@@ -1279,6 +1620,16 @@ type metadataQueryObjectsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s QueryObjectsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s QueryObjectsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of QueryObjects.
 type QueryObjectsOutput struct {
 	// Indicates whether there are more results that can be obtained by a subsequent
@@ -1300,6 +1651,16 @@ type metadataQueryObjectsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s QueryObjectsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s QueryObjectsOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for RemoveTags.
 type RemoveTagsInput struct {
 	// The ID of the pipeline.
@@ -1315,6 +1676,16 @@ type metadataRemoveTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of RemoveTags.
 type RemoveTagsOutput struct {
 	metadataRemoveTagsOutput `json:"-" xml:"-"`
@@ -1322,6 +1693,16 @@ type RemoveTagsOutput struct {
 
 type metadataRemoveTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for ReportTaskProgress.
@@ -1341,6 +1722,16 @@ type metadataReportTaskProgressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReportTaskProgressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReportTaskProgressInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of ReportTaskProgress.
 type ReportTaskProgressOutput struct {
 	// If true, the calling task runner should cancel processing of the task. The
@@ -1352,6 +1743,16 @@ type ReportTaskProgressOutput struct {
 
 type metadataReportTaskProgressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReportTaskProgressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReportTaskProgressOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for ReportTaskRunnerHeartbeat.
@@ -1380,6 +1781,16 @@ type metadataReportTaskRunnerHeartbeatInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReportTaskRunnerHeartbeatInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReportTaskRunnerHeartbeatInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of ReportTaskRunnerHeartbeat.
 type ReportTaskRunnerHeartbeatOutput struct {
 	// Indicates whether the calling task runner should terminate.
@@ -1390,6 +1801,16 @@ type ReportTaskRunnerHeartbeatOutput struct {
 
 type metadataReportTaskRunnerHeartbeatOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReportTaskRunnerHeartbeatOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReportTaskRunnerHeartbeatOutput) GoString() string {
+	return s.String()
 }
 
 // A comparision that is used to determine whether a query should return this
@@ -1412,6 +1833,16 @@ type metadataSelector struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Selector) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Selector) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for SetStatus.
 type SetStatusInput struct {
 	// The IDs of the objects. The corresponding objects can be either physical
@@ -1432,12 +1863,32 @@ type metadataSetStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetStatusInput) GoString() string {
+	return s.String()
+}
+
 type SetStatusOutput struct {
 	metadataSetStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataSetStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetStatusOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for SetTaskStatus.
@@ -1475,6 +1926,16 @@ type metadataSetTaskStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetTaskStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetTaskStatusInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of SetTaskStatus.
 type SetTaskStatusOutput struct {
 	metadataSetTaskStatusOutput `json:"-" xml:"-"`
@@ -1482,6 +1943,16 @@ type SetTaskStatusOutput struct {
 
 type metadataSetTaskStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetTaskStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetTaskStatusOutput) GoString() string {
+	return s.String()
 }
 
 // Tags are key/value pairs defined by a user and associated with a pipeline
@@ -1505,6 +1976,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // Contains information about a pipeline task that is assigned to a task runner.
@@ -1531,6 +2012,16 @@ type metadataTaskObject struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TaskObject) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TaskObject) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for ValidatePipelineDefinition.
 type ValidatePipelineDefinitionInput struct {
 	// The parameter objects used with the pipeline.
@@ -1552,6 +2043,16 @@ type metadataValidatePipelineDefinitionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ValidatePipelineDefinitionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidatePipelineDefinitionInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of ValidatePipelineDefinition.
 type ValidatePipelineDefinitionOutput struct {
 	// Indicates whether there were validation errors.
@@ -1568,6 +2069,16 @@ type ValidatePipelineDefinitionOutput struct {
 
 type metadataValidatePipelineDefinitionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ValidatePipelineDefinitionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidatePipelineDefinitionOutput) GoString() string {
+	return s.String()
 }
 
 // Defines a validation error. Validation errors prevent pipeline activation.
@@ -1587,6 +2098,16 @@ type metadataValidationError struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ValidationError) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidationError) GoString() string {
+	return s.String()
+}
+
 // Defines a validation warning. Validation warnings do not prevent pipeline
 // activation. The set of validation warnings that can be returned are defined
 // by AWS Data Pipeline.
@@ -1602,4 +2123,14 @@ type ValidationWarning struct {
 
 type metadataValidationWarning struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ValidationWarning) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidationWarning) GoString() string {
+	return s.String()
 }

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -5,6 +5,7 @@ package directconnect
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAllocateConnectionOnInterconnect = "AllocateConnectionOnInterconnect"
@@ -651,6 +652,16 @@ type metadataAllocateConnectionOnInterconnectInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AllocateConnectionOnInterconnectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AllocateConnectionOnInterconnectInput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the AllocatePrivateVirtualInterface operation.
 type AllocatePrivateVirtualInterfaceInput struct {
 	// The connection ID on which the private virtual interface is provisioned.
@@ -673,6 +684,16 @@ type AllocatePrivateVirtualInterfaceInput struct {
 
 type metadataAllocatePrivateVirtualInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AllocatePrivateVirtualInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AllocatePrivateVirtualInterfaceInput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the AllocatePublicVirtualInterface operation.
@@ -699,6 +720,16 @@ type metadataAllocatePublicVirtualInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AllocatePublicVirtualInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AllocatePublicVirtualInterfaceInput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the ConfirmConnection operation.
 type ConfirmConnectionInput struct {
 	// ID of the connection.
@@ -713,6 +744,16 @@ type ConfirmConnectionInput struct {
 
 type metadataConfirmConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfirmConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmConnectionInput) GoString() string {
+	return s.String()
 }
 
 // The response received when ConfirmConnection is called.
@@ -734,6 +775,16 @@ type ConfirmConnectionOutput struct {
 
 type metadataConfirmConnectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfirmConnectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmConnectionOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the ConfirmPrivateVirtualInterface operation.
@@ -759,6 +810,16 @@ type ConfirmPrivateVirtualInterfaceInput struct {
 
 type metadataConfirmPrivateVirtualInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfirmPrivateVirtualInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmPrivateVirtualInterfaceInput) GoString() string {
+	return s.String()
 }
 
 // The response received when ConfirmPrivateVirtualInterface is called.
@@ -788,6 +849,16 @@ type metadataConfirmPrivateVirtualInterfaceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfirmPrivateVirtualInterfaceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmPrivateVirtualInterfaceOutput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the ConfirmPublicVirtualInterface operation.
 type ConfirmPublicVirtualInterfaceInput struct {
 	// ID of the virtual interface.
@@ -802,6 +873,16 @@ type ConfirmPublicVirtualInterfaceInput struct {
 
 type metadataConfirmPublicVirtualInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfirmPublicVirtualInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmPublicVirtualInterfaceInput) GoString() string {
+	return s.String()
 }
 
 // The response received when ConfirmPublicVirtualInterface is called.
@@ -829,6 +910,16 @@ type ConfirmPublicVirtualInterfaceOutput struct {
 
 type metadataConfirmPublicVirtualInterfaceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfirmPublicVirtualInterfaceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmPublicVirtualInterfaceOutput) GoString() string {
+	return s.String()
 }
 
 // A connection represents the physical network connection between the AWS Direct
@@ -897,6 +988,16 @@ type metadataConnection struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Connection) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Connection) GoString() string {
+	return s.String()
+}
+
 // A structure containing a list of connections.
 type Connections struct {
 	// A list of connections.
@@ -907,6 +1008,16 @@ type Connections struct {
 
 type metadataConnections struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Connections) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Connections) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the CreateConnection operation.
@@ -937,6 +1048,16 @@ type CreateConnectionInput struct {
 
 type metadataCreateConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateConnectionInput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the CreateInterconnect operation.
@@ -971,6 +1092,16 @@ type metadataCreateInterconnectInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateInterconnectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInterconnectInput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the CreatePrivateVirtualInterface operation.
 type CreatePrivateVirtualInterfaceInput struct {
 	// ID of the connection.
@@ -990,6 +1121,16 @@ type CreatePrivateVirtualInterfaceInput struct {
 
 type metadataCreatePrivateVirtualInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreatePrivateVirtualInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePrivateVirtualInterfaceInput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the CreatePublicVirtualInterface operation.
@@ -1013,6 +1154,16 @@ type metadataCreatePublicVirtualInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePublicVirtualInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePublicVirtualInterfaceInput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the DeleteConnection operation.
 type DeleteConnectionInput struct {
 	// ID of the connection.
@@ -1029,6 +1180,16 @@ type metadataDeleteConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteConnectionInput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the DeleteInterconnect operation.
 type DeleteInterconnectInput struct {
 	// The ID of the interconnect.
@@ -1041,6 +1202,16 @@ type DeleteInterconnectInput struct {
 
 type metadataDeleteInterconnectInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteInterconnectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteInterconnectInput) GoString() string {
+	return s.String()
 }
 
 // The response received when DeleteInterconnect is called.
@@ -1060,6 +1231,16 @@ type metadataDeleteInterconnectOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteInterconnectOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteInterconnectOutput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the DeleteVirtualInterface operation.
 type DeleteVirtualInterfaceInput struct {
 	// ID of the virtual interface.
@@ -1074,6 +1255,16 @@ type DeleteVirtualInterfaceInput struct {
 
 type metadataDeleteVirtualInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVirtualInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVirtualInterfaceInput) GoString() string {
+	return s.String()
 }
 
 // The response received when DeleteVirtualInterface is called.
@@ -1103,6 +1294,16 @@ type metadataDeleteVirtualInterfaceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVirtualInterfaceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVirtualInterfaceOutput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the DescribeConnections operation.
 type DescribeConnectionsInput struct {
 	// ID of the connection.
@@ -1117,6 +1318,16 @@ type DescribeConnectionsInput struct {
 
 type metadataDescribeConnectionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeConnectionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConnectionsInput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeConnectionsOnInterconnect operation.
@@ -1135,6 +1346,16 @@ type metadataDescribeConnectionsOnInterconnectInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeConnectionsOnInterconnectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConnectionsOnInterconnectInput) GoString() string {
+	return s.String()
+}
+
 // Container for the parameters to the DescribeInterconnects operation.
 type DescribeInterconnectsInput struct {
 	// The ID of the interconnect.
@@ -1149,6 +1370,16 @@ type metadataDescribeInterconnectsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeInterconnectsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInterconnectsInput) GoString() string {
+	return s.String()
+}
+
 // A structure containing a list of interconnects.
 type DescribeInterconnectsOutput struct {
 	// A list of interconnects.
@@ -1161,12 +1392,32 @@ type metadataDescribeInterconnectsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeInterconnectsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInterconnectsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeLocationsInput struct {
 	metadataDescribeLocationsInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeLocationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLocationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocationsInput) GoString() string {
+	return s.String()
 }
 
 type DescribeLocationsOutput struct {
@@ -1179,12 +1430,32 @@ type metadataDescribeLocationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLocationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLocationsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeVirtualGatewaysInput struct {
 	metadataDescribeVirtualGatewaysInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeVirtualGatewaysInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVirtualGatewaysInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVirtualGatewaysInput) GoString() string {
+	return s.String()
 }
 
 // A structure containing a list of virtual private gateways.
@@ -1197,6 +1468,16 @@ type DescribeVirtualGatewaysOutput struct {
 
 type metadataDescribeVirtualGatewaysOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVirtualGatewaysOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVirtualGatewaysOutput) GoString() string {
+	return s.String()
 }
 
 // Container for the parameters to the DescribeVirtualInterfaces operation.
@@ -1222,6 +1503,16 @@ type metadataDescribeVirtualInterfacesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVirtualInterfacesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVirtualInterfacesInput) GoString() string {
+	return s.String()
+}
+
 // A structure containing a list of virtual interfaces.
 type DescribeVirtualInterfacesOutput struct {
 	// A list of virtual interfaces.
@@ -1232,6 +1523,16 @@ type DescribeVirtualInterfacesOutput struct {
 
 type metadataDescribeVirtualInterfacesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVirtualInterfacesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVirtualInterfacesOutput) GoString() string {
+	return s.String()
 }
 
 // An interconnect is a connection that can host other connections.
@@ -1293,6 +1594,16 @@ type metadataInterconnect struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Interconnect) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Interconnect) GoString() string {
+	return s.String()
+}
+
 // An AWS Direct Connect location where connections and interconnects can be
 // requested.
 type Location struct {
@@ -1308,6 +1619,16 @@ type Location struct {
 
 type metadataLocation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Location) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Location) GoString() string {
+	return s.String()
 }
 
 // A structure containing information about a new private virtual interface.
@@ -1355,6 +1676,16 @@ type metadataNewPrivateVirtualInterface struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NewPrivateVirtualInterface) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NewPrivateVirtualInterface) GoString() string {
+	return s.String()
+}
+
 // A structure containing information about a private virtual interface that
 // will be provisioned on a connection.
 type NewPrivateVirtualInterfaceAllocation struct {
@@ -1393,6 +1724,16 @@ type NewPrivateVirtualInterfaceAllocation struct {
 
 type metadataNewPrivateVirtualInterfaceAllocation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NewPrivateVirtualInterfaceAllocation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NewPrivateVirtualInterfaceAllocation) GoString() string {
+	return s.String()
 }
 
 // A structure containing information about a new public virtual interface.
@@ -1436,6 +1777,16 @@ type NewPublicVirtualInterface struct {
 
 type metadataNewPublicVirtualInterface struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NewPublicVirtualInterface) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NewPublicVirtualInterface) GoString() string {
+	return s.String()
 }
 
 // A structure containing information about a public virtual interface that
@@ -1482,6 +1833,16 @@ type metadataNewPublicVirtualInterfaceAllocation struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NewPublicVirtualInterfaceAllocation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NewPublicVirtualInterfaceAllocation) GoString() string {
+	return s.String()
+}
+
 // A route filter prefix that the customer can advertise through Border Gateway
 // Protocol (BGP) over a public virtual interface.
 type RouteFilterPrefix struct {
@@ -1496,6 +1857,16 @@ type RouteFilterPrefix struct {
 
 type metadataRouteFilterPrefix struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RouteFilterPrefix) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RouteFilterPrefix) GoString() string {
+	return s.String()
 }
 
 // You can create one or more AWS Direct Connect private virtual interfaces
@@ -1522,6 +1893,16 @@ type VirtualGateway struct {
 
 type metadataVirtualGateway struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VirtualGateway) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VirtualGateway) GoString() string {
+	return s.String()
 }
 
 // A virtual interface (VLAN) transmits the traffic between the AWS Direct Connect
@@ -1622,4 +2003,14 @@ type VirtualInterface struct {
 
 type metadataVirtualInterface struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VirtualInterface) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VirtualInterface) GoString() string {
+	return s.String()
 }

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opConnectDirectory = "ConnectDirectory"
@@ -520,6 +521,16 @@ type metadataAttribute struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Attribute) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Attribute) GoString() string {
+	return s.String()
+}
+
 // Contains information about a computer account in a directory.
 type Computer struct {
 	// An array of Attribute objects that contain the LDAP attributes that belong
@@ -537,6 +548,16 @@ type Computer struct {
 
 type metadataComputer struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Computer) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Computer) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the ConnectDirectory operation.
@@ -567,6 +588,16 @@ type metadataConnectDirectoryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConnectDirectoryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConnectDirectoryInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the ConnectDirectory operation.
 type ConnectDirectoryOutput struct {
 	// The identifier of the new directory.
@@ -577,6 +608,16 @@ type ConnectDirectoryOutput struct {
 
 type metadataConnectDirectoryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConnectDirectoryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConnectDirectoryOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the CreateAlias operation.
@@ -597,6 +638,16 @@ type metadataCreateAliasInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAliasInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAliasInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the CreateAlias operation.
 type CreateAliasOutput struct {
 	// The alias for the directory.
@@ -610,6 +661,16 @@ type CreateAliasOutput struct {
 
 type metadataCreateAliasOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAliasOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAliasOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the CreateComputer operation.
@@ -639,6 +700,16 @@ type metadataCreateComputerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateComputerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateComputerInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results for the CreateComputer operation.
 type CreateComputerOutput struct {
 	// A Computer object the represents the computer account.
@@ -649,6 +720,16 @@ type CreateComputerOutput struct {
 
 type metadataCreateComputerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateComputerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateComputerOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the CreateDirectory operation.
@@ -681,6 +762,16 @@ type metadataCreateDirectoryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDirectoryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDirectoryInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the CreateDirectory operation.
 type CreateDirectoryOutput struct {
 	// The identifier of the directory that was created.
@@ -691,6 +782,16 @@ type CreateDirectoryOutput struct {
 
 type metadataCreateDirectoryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDirectoryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDirectoryOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the CreateSnapshot operation.
@@ -708,6 +809,16 @@ type metadataCreateSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the CreateSnapshot operation.
 type CreateSnapshotOutput struct {
 	// The identifier of the snapshot that was created.
@@ -718,6 +829,16 @@ type CreateSnapshotOutput struct {
 
 type metadataCreateSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DeleteDirectory operation.
@@ -732,6 +853,16 @@ type metadataDeleteDirectoryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDirectoryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDirectoryInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the DeleteDirectory operation.
 type DeleteDirectoryOutput struct {
 	// The directory identifier.
@@ -742,6 +873,16 @@ type DeleteDirectoryOutput struct {
 
 type metadataDeleteDirectoryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDirectoryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDirectoryOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DeleteSnapshot operation.
@@ -756,6 +897,16 @@ type metadataDeleteSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the DeleteSnapshot operation.
 type DeleteSnapshotOutput struct {
 	// The identifier of the directory snapshot that was deleted.
@@ -766,6 +917,16 @@ type DeleteSnapshotOutput struct {
 
 type metadataDeleteSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DescribeDirectories operation.
@@ -792,6 +953,16 @@ type metadataDescribeDirectoriesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDirectoriesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDirectoriesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the DescribeDirectories operation.
 type DescribeDirectoriesOutput struct {
 	// The list of DirectoryDescription objects that were retrieved.
@@ -812,6 +983,16 @@ type DescribeDirectoriesOutput struct {
 
 type metadataDescribeDirectoriesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDirectoriesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDirectoriesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DescribeSnapshots operation.
@@ -838,6 +1019,16 @@ type metadataDescribeSnapshotsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSnapshotsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the DescribeSnapshots operation.
 type DescribeSnapshotsOutput struct {
 	// If not null, more results are available. Pass this value in the NextToken
@@ -857,6 +1048,16 @@ type DescribeSnapshotsOutput struct {
 
 type metadataDescribeSnapshotsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSnapshotsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotsOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information for the ConnectDirectory operation when an AD Connector
@@ -886,6 +1087,16 @@ type metadataDirectoryConnectSettings struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DirectoryConnectSettings) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DirectoryConnectSettings) GoString() string {
+	return s.String()
+}
+
 // Contains information about an AD Connector directory.
 type DirectoryConnectSettingsDescription struct {
 	// A list of the Availability Zones that the directory is in.
@@ -911,6 +1122,16 @@ type DirectoryConnectSettingsDescription struct {
 
 type metadataDirectoryConnectSettingsDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DirectoryConnectSettingsDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DirectoryConnectSettingsDescription) GoString() string {
+	return s.String()
 }
 
 // Contains information about an AWS Directory Service directory.
@@ -986,6 +1207,16 @@ type metadataDirectoryDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DirectoryDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DirectoryDescription) GoString() string {
+	return s.String()
+}
+
 // Contains directory limit information for a region.
 type DirectoryLimits struct {
 	// The current number of cloud directories in the region.
@@ -1013,6 +1244,16 @@ type metadataDirectoryLimits struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DirectoryLimits) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DirectoryLimits) GoString() string {
+	return s.String()
+}
+
 // Contains information for the CreateDirectory operation when a Simple AD directory
 // is being created.
 type DirectoryVPCSettings struct {
@@ -1029,6 +1270,16 @@ type DirectoryVPCSettings struct {
 
 type metadataDirectoryVPCSettings struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DirectoryVPCSettings) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DirectoryVPCSettings) GoString() string {
+	return s.String()
 }
 
 // Contains information about a Simple AD directory.
@@ -1052,6 +1303,16 @@ type metadataDirectoryVPCSettingsDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DirectoryVPCSettingsDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DirectoryVPCSettingsDescription) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the DisableRadius operation.
 type DisableRadiusInput struct {
 	// The identifier of the directory to disable MFA for.
@@ -1064,6 +1325,16 @@ type metadataDisableRadiusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableRadiusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableRadiusInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the DisableRadius operation.
 type DisableRadiusOutput struct {
 	metadataDisableRadiusOutput `json:"-" xml:"-"`
@@ -1071,6 +1342,16 @@ type DisableRadiusOutput struct {
 
 type metadataDisableRadiusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableRadiusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableRadiusOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DisableSso operation.
@@ -1101,6 +1382,16 @@ type metadataDisableSSOInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableSSOInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableSSOInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the DisableSso operation.
 type DisableSSOOutput struct {
 	metadataDisableSSOOutput `json:"-" xml:"-"`
@@ -1108,6 +1399,16 @@ type DisableSSOOutput struct {
 
 type metadataDisableSSOOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableSSOOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableSSOOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the EnableRadius operation.
@@ -1125,6 +1426,16 @@ type metadataEnableRadiusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableRadiusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableRadiusInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the EnableRadius operation.
 type EnableRadiusOutput struct {
 	metadataEnableRadiusOutput `json:"-" xml:"-"`
@@ -1132,6 +1443,16 @@ type EnableRadiusOutput struct {
 
 type metadataEnableRadiusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableRadiusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableRadiusOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the EnableSso operation.
@@ -1162,6 +1483,16 @@ type metadataEnableSSOInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableSSOInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableSSOInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the EnableSso operation.
 type EnableSSOOutput struct {
 	metadataEnableSSOOutput `json:"-" xml:"-"`
@@ -1171,6 +1502,16 @@ type metadataEnableSSOOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableSSOOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableSSOOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the GetDirectoryLimits operation.
 type GetDirectoryLimitsInput struct {
 	metadataGetDirectoryLimitsInput `json:"-" xml:"-"`
@@ -1178,6 +1519,16 @@ type GetDirectoryLimitsInput struct {
 
 type metadataGetDirectoryLimitsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDirectoryLimitsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDirectoryLimitsInput) GoString() string {
+	return s.String()
 }
 
 // Contains the results of the GetDirectoryLimits operation.
@@ -1193,6 +1544,16 @@ type metadataGetDirectoryLimitsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetDirectoryLimitsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDirectoryLimitsOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the GetSnapshotLimits operation.
 type GetSnapshotLimitsInput struct {
 	// Contains the identifier of the directory to obtain the limits for.
@@ -1203,6 +1564,16 @@ type GetSnapshotLimitsInput struct {
 
 type metadataGetSnapshotLimitsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetSnapshotLimitsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSnapshotLimitsInput) GoString() string {
+	return s.String()
 }
 
 // Contains the results of the GetSnapshotLimits operation.
@@ -1216,6 +1587,16 @@ type GetSnapshotLimitsOutput struct {
 
 type metadataGetSnapshotLimitsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetSnapshotLimitsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSnapshotLimitsOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information about a Remote Authentication Dial In User Service (RADIUS)
@@ -1257,6 +1638,16 @@ type metadataRadiusSettings struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RadiusSettings) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RadiusSettings) GoString() string {
+	return s.String()
+}
+
 // An object representing the inputs for the RestoreFromSnapshot operation.
 type RestoreFromSnapshotInput struct {
 	// The identifier of the snapshot to restore from.
@@ -1269,6 +1660,16 @@ type metadataRestoreFromSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RestoreFromSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreFromSnapshotInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the RestoreFromSnapshot operation.
 type RestoreFromSnapshotOutput struct {
 	metadataRestoreFromSnapshotOutput `json:"-" xml:"-"`
@@ -1276,6 +1677,16 @@ type RestoreFromSnapshotOutput struct {
 
 type metadataRestoreFromSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RestoreFromSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreFromSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a directory snapshot.
@@ -1305,6 +1716,16 @@ type metadataSnapshot struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Snapshot) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Snapshot) GoString() string {
+	return s.String()
+}
+
 // Contains manual snapshot limit information for a directory.
 type SnapshotLimits struct {
 	// The current number of manual snapshots of the directory.
@@ -1323,6 +1744,16 @@ type metadataSnapshotLimits struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SnapshotLimits) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SnapshotLimits) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the UpdateRadius operation.
 type UpdateRadiusInput struct {
 	// The identifier of the directory to update the RADIUS server information for.
@@ -1338,6 +1769,16 @@ type metadataUpdateRadiusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateRadiusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRadiusInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the UpdateRadius operation.
 type UpdateRadiusOutput struct {
 	metadataUpdateRadiusOutput `json:"-" xml:"-"`
@@ -1345,4 +1786,14 @@ type UpdateRadiusOutput struct {
 
 type metadataUpdateRadiusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateRadiusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRadiusOutput) GoString() string {
+	return s.String()
 }

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opBatchGetItem = "BatchGetItem"
@@ -687,6 +688,16 @@ type metadataAttributeDefinition struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttributeDefinition) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttributeDefinition) GoString() string {
+	return s.String()
+}
+
 // Represents the data for an attribute. You can set one, and only one, of the
 // elements.
 //
@@ -730,6 +741,16 @@ type AttributeValue struct {
 
 type metadataAttributeValue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttributeValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttributeValue) GoString() string {
+	return s.String()
 }
 
 // For the UpdateItem operation, represents the attributes to be modified, the
@@ -821,6 +842,16 @@ type AttributeValueUpdate struct {
 
 type metadataAttributeValueUpdate struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttributeValueUpdate) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttributeValueUpdate) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a BatchGetItem operation.
@@ -920,6 +951,16 @@ type metadataBatchGetItemInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BatchGetItemInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetItemInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a BatchGetItem operation.
 type BatchGetItemOutput struct {
 	// The read capacity units consumed by the operation.
@@ -963,6 +1004,16 @@ type BatchGetItemOutput struct {
 
 type metadataBatchGetItemOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BatchGetItemOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchGetItemOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a BatchWriteItem operation.
@@ -1011,6 +1062,16 @@ type BatchWriteItemInput struct {
 
 type metadataBatchWriteItemInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BatchWriteItemInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchWriteItemInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a BatchWriteItem operation.
@@ -1083,6 +1144,16 @@ type metadataBatchWriteItemOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BatchWriteItemOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchWriteItemOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the amount of provisioned throughput capacity consumed on a table
 // or an index.
 type Capacity struct {
@@ -1094,6 +1165,16 @@ type Capacity struct {
 
 type metadataCapacity struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Capacity) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Capacity) GoString() string {
+	return s.String()
 }
 
 // Represents the selection criteria for a Query or Scan operation:
@@ -1264,6 +1345,16 @@ type metadataCondition struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Condition) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Condition) GoString() string {
+	return s.String()
+}
+
 // The capacity units consumed by an operation. The data returned includes the
 // total provisioned throughput consumed, along with statistics for the table
 // and any indexes involved in the operation. ConsumedCapacity is only returned
@@ -1293,6 +1384,16 @@ type metadataConsumedCapacity struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConsumedCapacity) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConsumedCapacity) GoString() string {
+	return s.String()
+}
+
 // Represents a new global secondary index to be added to an existing table.
 type CreateGlobalSecondaryIndexAction struct {
 	// The name of the global secondary index to be created.
@@ -1319,6 +1420,16 @@ type CreateGlobalSecondaryIndexAction struct {
 
 type metadataCreateGlobalSecondaryIndexAction struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateGlobalSecondaryIndexAction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateGlobalSecondaryIndexAction) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a CreateTable operation.
@@ -1432,6 +1543,16 @@ type metadataCreateTableInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTableInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTableInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a CreateTable operation.
 type CreateTableOutput struct {
 	// Represents the properties of a table.
@@ -1444,6 +1565,16 @@ type metadataCreateTableOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTableOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTableOutput) GoString() string {
+	return s.String()
+}
+
 // Represents a global secondary index to be deleted from an existing table.
 type DeleteGlobalSecondaryIndexAction struct {
 	// The name of the global secondary index to be deleted.
@@ -1454,6 +1585,16 @@ type DeleteGlobalSecondaryIndexAction struct {
 
 type metadataDeleteGlobalSecondaryIndexAction struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteGlobalSecondaryIndexAction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteGlobalSecondaryIndexAction) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DeleteItem operation.
@@ -1792,6 +1933,16 @@ type metadataDeleteItemInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteItemInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteItemInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DeleteItem operation.
 type DeleteItemOutput struct {
 	// A map of attribute names to AttributeValue objects, representing the item
@@ -1835,6 +1986,16 @@ type metadataDeleteItemOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteItemOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteItemOutput) GoString() string {
+	return s.String()
+}
+
 // Represents a request to perform a DeleteItem operation on an item.
 type DeleteRequest struct {
 	// A map of attribute name to attribute values, representing the primary key
@@ -1849,6 +2010,16 @@ type metadataDeleteRequest struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRequest) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a DeleteTable operation.
 type DeleteTableInput struct {
 	// The name of the table to delete.
@@ -1859,6 +2030,16 @@ type DeleteTableInput struct {
 
 type metadataDeleteTableInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTableInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTableInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a DeleteTable operation.
@@ -1873,6 +2054,16 @@ type metadataDeleteTableOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTableOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTableOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a DescribeTable operation.
 type DescribeTableInput struct {
 	// The name of the table to describe.
@@ -1885,6 +2076,16 @@ type metadataDescribeTableInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTableInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTableInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeTable operation.
 type DescribeTableOutput struct {
 	// Represents the properties of a table.
@@ -1895,6 +2096,16 @@ type DescribeTableOutput struct {
 
 type metadataDescribeTableOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTableOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTableOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a condition to be compared with an attribute value. This condition
@@ -2104,6 +2315,16 @@ type metadataExpectedAttributeValue struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ExpectedAttributeValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExpectedAttributeValue) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a GetItem operation.
 type GetItemInput struct {
 	// This is a legacy parameter, for backward compatibility. New applications
@@ -2202,6 +2423,16 @@ type metadataGetItemInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetItemInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetItemInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a GetItem operation.
 type GetItemOutput struct {
 	// The capacity units consumed by an operation. The data returned includes the
@@ -2220,6 +2451,16 @@ type GetItemOutput struct {
 
 type metadataGetItemOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetItemOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetItemOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the properties of a global secondary index.
@@ -2250,6 +2491,16 @@ type GlobalSecondaryIndex struct {
 
 type metadataGlobalSecondaryIndex struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GlobalSecondaryIndex) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GlobalSecondaryIndex) GoString() string {
+	return s.String()
 }
 
 // Represents the properties of a global secondary index.
@@ -2308,6 +2559,16 @@ type metadataGlobalSecondaryIndexDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GlobalSecondaryIndexDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GlobalSecondaryIndexDescription) GoString() string {
+	return s.String()
+}
+
 // Represents one of the following:
 //
 //  A new global secondary index to be added to an existing table.
@@ -2344,6 +2605,16 @@ type metadataGlobalSecondaryIndexUpdate struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GlobalSecondaryIndexUpdate) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GlobalSecondaryIndexUpdate) GoString() string {
+	return s.String()
+}
+
 // Information about item collections, if any, that were affected by the operation.
 // ItemCollectionMetrics is only returned if the request asked for it. If the
 // table does not have any local secondary indexes, this information is not
@@ -2371,6 +2642,16 @@ type metadataItemCollectionMetrics struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ItemCollectionMetrics) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ItemCollectionMetrics) GoString() string {
+	return s.String()
+}
+
 // Represents a single element of a key schema. A key schema specifies the attributes
 // that make up the primary key of a table, or the key attributes of an index.
 //
@@ -2390,6 +2671,16 @@ type KeySchemaElement struct {
 
 type metadataKeySchemaElement struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s KeySchemaElement) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s KeySchemaElement) GoString() string {
+	return s.String()
 }
 
 // Represents a set of primary keys and, for each key, the attributes to retrieve
@@ -2470,6 +2761,16 @@ type metadataKeysAndAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s KeysAndAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s KeysAndAttributes) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a ListTables operation.
 type ListTablesInput struct {
 	// The first table name that this operation will evaluate. Use the value that
@@ -2486,6 +2787,16 @@ type ListTablesInput struct {
 
 type metadataListTablesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTablesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTablesInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a ListTables operation.
@@ -2513,6 +2824,16 @@ type metadataListTablesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListTablesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTablesOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the properties of a local secondary index.
 type LocalSecondaryIndex struct {
 	// The name of the local secondary index. The name must be unique among all
@@ -2533,6 +2854,16 @@ type LocalSecondaryIndex struct {
 
 type metadataLocalSecondaryIndex struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LocalSecondaryIndex) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LocalSecondaryIndex) GoString() string {
+	return s.String()
 }
 
 // Represents the properties of a local secondary index.
@@ -2565,6 +2896,16 @@ type metadataLocalSecondaryIndexDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LocalSecondaryIndexDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LocalSecondaryIndexDescription) GoString() string {
+	return s.String()
+}
+
 // Represents attributes that are copied (projected) from the table into an
 // index. These are in addition to the primary key attributes and index key
 // attributes, which are automatically projected.
@@ -2594,6 +2935,16 @@ type metadataProjection struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Projection) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Projection) GoString() string {
+	return s.String()
+}
+
 // Represents the provisioned throughput settings for a specified table or index.
 // The settings can be modified using the UpdateTable operation.
 //
@@ -2618,6 +2969,16 @@ type ProvisionedThroughput struct {
 
 type metadataProvisionedThroughput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ProvisionedThroughput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ProvisionedThroughput) GoString() string {
+	return s.String()
 }
 
 // Represents the provisioned throughput settings for the table, consisting
@@ -2650,6 +3011,16 @@ type ProvisionedThroughputDescription struct {
 
 type metadataProvisionedThroughputDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ProvisionedThroughputDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ProvisionedThroughputDescription) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a PutItem operation.
@@ -3000,6 +3371,16 @@ type metadataPutItemInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutItemInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutItemInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a PutItem operation.
 type PutItemOutput struct {
 	// The attribute values as they appeared before the PutItem operation, but only
@@ -3043,6 +3424,16 @@ type metadataPutItemOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutItemOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutItemOutput) GoString() string {
+	return s.String()
+}
+
 // Represents a request to perform a PutItem operation on an item.
 type PutRequest struct {
 	// A map of attribute name to attribute values, representing the primary key
@@ -3057,6 +3448,16 @@ type PutRequest struct {
 
 type metadataPutRequest struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRequest) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a Query operation.
@@ -3527,6 +3928,16 @@ type metadataQueryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s QueryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s QueryInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a Query operation.
 type QueryOutput struct {
 	// The capacity units consumed by an operation. The data returned includes the
@@ -3577,6 +3988,16 @@ type QueryOutput struct {
 
 type metadataQueryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s QueryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s QueryOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a Scan operation.
@@ -3845,6 +4266,16 @@ type metadataScanInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ScanInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScanInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a Scan operation.
 type ScanOutput struct {
 	// The capacity units consumed by an operation. The data returned includes the
@@ -3894,6 +4325,16 @@ type ScanOutput struct {
 
 type metadataScanOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ScanOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScanOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the properties of a table.
@@ -4061,6 +4502,16 @@ type metadataTableDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TableDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TableDescription) GoString() string {
+	return s.String()
+}
+
 // Represents the new provisioned throughput settings to be applied to a global
 // secondary index.
 type UpdateGlobalSecondaryIndexAction struct {
@@ -4080,6 +4531,16 @@ type UpdateGlobalSecondaryIndexAction struct {
 
 type metadataUpdateGlobalSecondaryIndexAction struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateGlobalSecondaryIndexAction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGlobalSecondaryIndexAction) GoString() string {
+	return s.String()
 }
 
 // Represents the input of an UpdateItem operation.
@@ -4590,6 +5051,16 @@ type metadataUpdateItemInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateItemInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateItemInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of an UpdateItem operation.
 type UpdateItemOutput struct {
 	// A map of attribute values as they appeared before the UpdateItem operation.
@@ -4616,6 +5087,16 @@ type UpdateItemOutput struct {
 
 type metadataUpdateItemOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateItemOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateItemOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of an UpdateTable operation.
@@ -4654,6 +5135,16 @@ type metadataUpdateTableInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateTableInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTableInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of an UpdateTable operation.
 type UpdateTableOutput struct {
 	// Represents the properties of a table.
@@ -4664,6 +5155,16 @@ type UpdateTableOutput struct {
 
 type metadataUpdateTableOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateTableOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTableOutput) GoString() string {
+	return s.String()
 }
 
 // Represents an operation to perform - either DeleteItem or PutItem. You can
@@ -4682,4 +5183,14 @@ type WriteRequest struct {
 
 type metadataWriteRequest struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WriteRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WriteRequest) GoString() string {
+	return s.String()
 }

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAcceptVPCPeeringConnection = "AcceptVpcPeeringConnection"
@@ -6268,6 +6269,16 @@ type metadataAcceptVPCPeeringConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AcceptVPCPeeringConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AcceptVPCPeeringConnectionInput) GoString() string {
+	return s.String()
+}
+
 type AcceptVPCPeeringConnectionOutput struct {
 	// Information about the VPC peering connection.
 	VPCPeeringConnection *VPCPeeringConnection `locationName:"vpcPeeringConnection" type:"structure"`
@@ -6277,6 +6288,16 @@ type AcceptVPCPeeringConnectionOutput struct {
 
 type metadataAcceptVPCPeeringConnectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AcceptVPCPeeringConnectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AcceptVPCPeeringConnectionOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an account attribute.
@@ -6294,6 +6315,16 @@ type metadataAccountAttribute struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AccountAttribute) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccountAttribute) GoString() string {
+	return s.String()
+}
+
 // Describes a value of an account attribute.
 type AccountAttributeValue struct {
 	// The value of the attribute.
@@ -6304,6 +6335,16 @@ type AccountAttributeValue struct {
 
 type metadataAccountAttributeValue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AccountAttributeValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccountAttributeValue) GoString() string {
+	return s.String()
 }
 
 // Describes a running instance in a Spot fleet.
@@ -6322,6 +6363,16 @@ type ActiveInstance struct {
 
 type metadataActiveInstance struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ActiveInstance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActiveInstance) GoString() string {
+	return s.String()
 }
 
 // Describes an Elastic IP address.
@@ -6359,6 +6410,16 @@ type metadataAddress struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Address) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Address) GoString() string {
+	return s.String()
+}
+
 type AllocateAddressInput struct {
 	// Set to vpc to allocate the address for use with instances in a VPC.
 	//
@@ -6378,6 +6439,16 @@ type metadataAllocateAddressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AllocateAddressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AllocateAddressInput) GoString() string {
+	return s.String()
+}
+
 type AllocateAddressOutput struct {
 	// [EC2-VPC] The ID that AWS assigns to represent the allocation of the Elastic
 	// IP address for use with instances in a VPC.
@@ -6395,6 +6466,16 @@ type AllocateAddressOutput struct {
 
 type metadataAllocateAddressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AllocateAddressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AllocateAddressOutput) GoString() string {
+	return s.String()
 }
 
 type AssignPrivateIPAddressesInput struct {
@@ -6424,12 +6505,32 @@ type metadataAssignPrivateIPAddressesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssignPrivateIPAddressesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssignPrivateIPAddressesInput) GoString() string {
+	return s.String()
+}
+
 type AssignPrivateIPAddressesOutput struct {
 	metadataAssignPrivateIPAddressesOutput `json:"-" xml:"-"`
 }
 
 type metadataAssignPrivateIPAddressesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssignPrivateIPAddressesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssignPrivateIPAddressesOutput) GoString() string {
+	return s.String()
 }
 
 type AssociateAddressInput struct {
@@ -6474,6 +6575,16 @@ type metadataAssociateAddressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssociateAddressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateAddressInput) GoString() string {
+	return s.String()
+}
+
 type AssociateAddressOutput struct {
 	// [EC2-VPC] The ID that represents the association of the Elastic IP address
 	// with an instance.
@@ -6484,6 +6595,16 @@ type AssociateAddressOutput struct {
 
 type metadataAssociateAddressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociateAddressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateAddressOutput) GoString() string {
+	return s.String()
 }
 
 type AssociateDHCPOptionsInput struct {
@@ -6507,12 +6628,32 @@ type metadataAssociateDHCPOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssociateDHCPOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateDHCPOptionsInput) GoString() string {
+	return s.String()
+}
+
 type AssociateDHCPOptionsOutput struct {
 	metadataAssociateDHCPOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataAssociateDHCPOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociateDHCPOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateDHCPOptionsOutput) GoString() string {
+	return s.String()
 }
 
 type AssociateRouteTableInput struct {
@@ -6535,6 +6676,16 @@ type metadataAssociateRouteTableInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssociateRouteTableInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateRouteTableInput) GoString() string {
+	return s.String()
+}
+
 type AssociateRouteTableOutput struct {
 	// The route table association ID (needed to disassociate the route table).
 	AssociationID *string `locationName:"associationId" type:"string"`
@@ -6544,6 +6695,16 @@ type AssociateRouteTableOutput struct {
 
 type metadataAssociateRouteTableOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociateRouteTableOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateRouteTableOutput) GoString() string {
+	return s.String()
 }
 
 type AttachClassicLinkVPCInput struct {
@@ -6570,6 +6731,16 @@ type metadataAttachClassicLinkVPCInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachClassicLinkVPCInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachClassicLinkVPCInput) GoString() string {
+	return s.String()
+}
+
 type AttachClassicLinkVPCOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
@@ -6579,6 +6750,16 @@ type AttachClassicLinkVPCOutput struct {
 
 type metadataAttachClassicLinkVPCOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachClassicLinkVPCOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachClassicLinkVPCOutput) GoString() string {
+	return s.String()
 }
 
 type AttachInternetGatewayInput struct {
@@ -6601,12 +6782,32 @@ type metadataAttachInternetGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachInternetGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachInternetGatewayInput) GoString() string {
+	return s.String()
+}
+
 type AttachInternetGatewayOutput struct {
 	metadataAttachInternetGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachInternetGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachInternetGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachInternetGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type AttachNetworkInterfaceInput struct {
@@ -6632,6 +6833,16 @@ type metadataAttachNetworkInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachNetworkInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachNetworkInterfaceInput) GoString() string {
+	return s.String()
+}
+
 type AttachNetworkInterfaceOutput struct {
 	// The ID of the network interface attachment.
 	AttachmentID *string `locationName:"attachmentId" type:"string"`
@@ -6641,6 +6852,16 @@ type AttachNetworkInterfaceOutput struct {
 
 type metadataAttachNetworkInterfaceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachNetworkInterfaceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachNetworkInterfaceOutput) GoString() string {
+	return s.String()
 }
 
 type AttachVPNGatewayInput struct {
@@ -6663,6 +6884,16 @@ type metadataAttachVPNGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachVPNGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachVPNGatewayInput) GoString() string {
+	return s.String()
+}
+
 type AttachVPNGatewayOutput struct {
 	// Information about the attachment.
 	VPCAttachment *VPCAttachment `locationName:"attachment" type:"structure"`
@@ -6672,6 +6903,16 @@ type AttachVPNGatewayOutput struct {
 
 type metadataAttachVPNGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachVPNGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachVPNGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type AttachVolumeInput struct {
@@ -6698,6 +6939,16 @@ type metadataAttachVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachVolumeInput) GoString() string {
+	return s.String()
+}
+
 // The value to use when a resource attribute accepts a Boolean value.
 type AttributeBooleanValue struct {
 	// Valid values are true or false.
@@ -6710,6 +6961,16 @@ type metadataAttributeBooleanValue struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttributeBooleanValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttributeBooleanValue) GoString() string {
+	return s.String()
+}
+
 // The value to use for a resource attribute.
 type AttributeValue struct {
 	// Valid values are case-sensitive and vary by action.
@@ -6720,6 +6981,16 @@ type AttributeValue struct {
 
 type metadataAttributeValue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttributeValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttributeValue) GoString() string {
+	return s.String()
 }
 
 type AuthorizeSecurityGroupEgressInput struct {
@@ -6767,12 +7038,32 @@ type metadataAuthorizeSecurityGroupEgressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AuthorizeSecurityGroupEgressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeSecurityGroupEgressInput) GoString() string {
+	return s.String()
+}
+
 type AuthorizeSecurityGroupEgressOutput struct {
 	metadataAuthorizeSecurityGroupEgressOutput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeSecurityGroupEgressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AuthorizeSecurityGroupEgressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeSecurityGroupEgressOutput) GoString() string {
+	return s.String()
 }
 
 type AuthorizeSecurityGroupIngressInput struct {
@@ -6826,12 +7117,32 @@ type metadataAuthorizeSecurityGroupIngressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AuthorizeSecurityGroupIngressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeSecurityGroupIngressInput) GoString() string {
+	return s.String()
+}
+
 type AuthorizeSecurityGroupIngressOutput struct {
 	metadataAuthorizeSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataAuthorizeSecurityGroupIngressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AuthorizeSecurityGroupIngressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeSecurityGroupIngressOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an Availability Zone.
@@ -6855,6 +7166,16 @@ type metadataAvailabilityZone struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AvailabilityZone) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AvailabilityZone) GoString() string {
+	return s.String()
+}
+
 // Describes a message about an Availability Zone.
 type AvailabilityZoneMessage struct {
 	// The message about the Availability Zone.
@@ -6867,6 +7188,16 @@ type metadataAvailabilityZoneMessage struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AvailabilityZoneMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AvailabilityZoneMessage) GoString() string {
+	return s.String()
+}
+
 type BlobAttributeValue struct {
 	Value []byte `locationName:"value" type:"blob"`
 
@@ -6875,6 +7206,16 @@ type BlobAttributeValue struct {
 
 type metadataBlobAttributeValue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BlobAttributeValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BlobAttributeValue) GoString() string {
+	return s.String()
 }
 
 // Describes a block device mapping.
@@ -6909,6 +7250,16 @@ type metadataBlockDeviceMapping struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BlockDeviceMapping) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BlockDeviceMapping) GoString() string {
+	return s.String()
+}
+
 type BundleInstanceInput struct {
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
@@ -6937,6 +7288,16 @@ type metadataBundleInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BundleInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BundleInstanceInput) GoString() string {
+	return s.String()
+}
+
 type BundleInstanceOutput struct {
 	// Information about the bundle task.
 	BundleTask *BundleTask `locationName:"bundleInstanceTask" type:"structure"`
@@ -6946,6 +7307,16 @@ type BundleInstanceOutput struct {
 
 type metadataBundleInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BundleInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BundleInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a bundle task.
@@ -6981,6 +7352,16 @@ type metadataBundleTask struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BundleTask) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BundleTask) GoString() string {
+	return s.String()
+}
+
 // Describes an error for BundleInstance.
 type BundleTaskError struct {
 	// The error code.
@@ -6994,6 +7375,16 @@ type BundleTaskError struct {
 
 type metadataBundleTaskError struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BundleTaskError) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BundleTaskError) GoString() string {
+	return s.String()
 }
 
 type CancelBundleTaskInput struct {
@@ -7013,6 +7404,16 @@ type metadataCancelBundleTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelBundleTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelBundleTaskInput) GoString() string {
+	return s.String()
+}
+
 type CancelBundleTaskOutput struct {
 	// Information about the bundle task.
 	BundleTask *BundleTask `locationName:"bundleInstanceTask" type:"structure"`
@@ -7022,6 +7423,16 @@ type CancelBundleTaskOutput struct {
 
 type metadataCancelBundleTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelBundleTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelBundleTaskOutput) GoString() string {
+	return s.String()
 }
 
 type CancelConversionTaskInput struct {
@@ -7044,12 +7455,32 @@ type metadataCancelConversionTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelConversionTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelConversionTaskInput) GoString() string {
+	return s.String()
+}
+
 type CancelConversionTaskOutput struct {
 	metadataCancelConversionTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelConversionTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelConversionTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelConversionTaskOutput) GoString() string {
+	return s.String()
 }
 
 type CancelExportTaskInput struct {
@@ -7063,12 +7494,32 @@ type metadataCancelExportTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelExportTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelExportTaskInput) GoString() string {
+	return s.String()
+}
+
 type CancelExportTaskOutput struct {
 	metadataCancelExportTaskOutput `json:"-" xml:"-"`
 }
 
 type metadataCancelExportTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelExportTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelExportTaskOutput) GoString() string {
+	return s.String()
 }
 
 type CancelImportTaskInput struct {
@@ -7091,6 +7542,16 @@ type metadataCancelImportTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelImportTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelImportTaskInput) GoString() string {
+	return s.String()
+}
+
 type CancelImportTaskOutput struct {
 	// The ID of the task being canceled.
 	ImportTaskID *string `locationName:"importTaskId" type:"string"`
@@ -7108,6 +7569,16 @@ type metadataCancelImportTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelImportTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelImportTaskOutput) GoString() string {
+	return s.String()
+}
+
 type CancelReservedInstancesListingInput struct {
 	// The ID of the Reserved Instance listing.
 	ReservedInstancesListingID *string `locationName:"reservedInstancesListingId" type:"string" required:"true"`
@@ -7119,6 +7590,16 @@ type metadataCancelReservedInstancesListingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelReservedInstancesListingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelReservedInstancesListingInput) GoString() string {
+	return s.String()
+}
+
 type CancelReservedInstancesListingOutput struct {
 	// The Reserved Instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
@@ -7128,6 +7609,16 @@ type CancelReservedInstancesListingOutput struct {
 
 type metadataCancelReservedInstancesListingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelReservedInstancesListingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelReservedInstancesListingOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a Spot fleet error.
@@ -7145,6 +7636,16 @@ type metadataCancelSpotFleetRequestsError struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelSpotFleetRequestsError) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelSpotFleetRequestsError) GoString() string {
+	return s.String()
+}
+
 // Describes a Spot fleet request that was not successfully canceled.
 type CancelSpotFleetRequestsErrorItem struct {
 	// The error.
@@ -7158,6 +7659,16 @@ type CancelSpotFleetRequestsErrorItem struct {
 
 type metadataCancelSpotFleetRequestsErrorItem struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelSpotFleetRequestsErrorItem) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelSpotFleetRequestsErrorItem) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for CancelSpotFleetRequests.
@@ -7182,6 +7693,16 @@ type metadataCancelSpotFleetRequestsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelSpotFleetRequestsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelSpotFleetRequestsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of CancelSpotFleetRequests.
 type CancelSpotFleetRequestsOutput struct {
 	// Information about the Spot fleet requests that are successfully canceled.
@@ -7195,6 +7716,16 @@ type CancelSpotFleetRequestsOutput struct {
 
 type metadataCancelSpotFleetRequestsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelSpotFleetRequestsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelSpotFleetRequestsOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a Spot fleet request that was successfully canceled.
@@ -7215,6 +7746,16 @@ type metadataCancelSpotFleetRequestsSuccessItem struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelSpotFleetRequestsSuccessItem) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelSpotFleetRequestsSuccessItem) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for CancelSpotInstanceRequests.
 type CancelSpotInstanceRequestsInput struct {
 	// Checks whether you have the required permissions for the action, without
@@ -7233,6 +7774,16 @@ type metadataCancelSpotInstanceRequestsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelSpotInstanceRequestsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelSpotInstanceRequestsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of CancelSpotInstanceRequests.
 type CancelSpotInstanceRequestsOutput struct {
 	// One or more Spot Instance requests.
@@ -7243,6 +7794,16 @@ type CancelSpotInstanceRequestsOutput struct {
 
 type metadataCancelSpotInstanceRequestsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelSpotInstanceRequestsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelSpotInstanceRequestsOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a request to cancel a Spot Instance.
@@ -7258,6 +7819,16 @@ type CancelledSpotInstanceRequest struct {
 
 type metadataCancelledSpotInstanceRequest struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelledSpotInstanceRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelledSpotInstanceRequest) GoString() string {
+	return s.String()
 }
 
 // Describes a linked EC2-Classic instance.
@@ -7281,6 +7852,16 @@ type metadataClassicLinkInstance struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ClassicLinkInstance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClassicLinkInstance) GoString() string {
+	return s.String()
+}
+
 // Describes the client-specific data.
 type ClientData struct {
 	// A user-defined comment about the disk upload.
@@ -7300,6 +7881,16 @@ type ClientData struct {
 
 type metadataClientData struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClientData) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClientData) GoString() string {
+	return s.String()
 }
 
 type ConfirmProductInstanceInput struct {
@@ -7322,6 +7913,16 @@ type metadataConfirmProductInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfirmProductInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmProductInstanceInput) GoString() string {
+	return s.String()
+}
+
 type ConfirmProductInstanceOutput struct {
 	// The AWS account ID of the instance owner. This is only present if the product
 	// code is attached to the instance.
@@ -7332,6 +7933,16 @@ type ConfirmProductInstanceOutput struct {
 
 type metadataConfirmProductInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfirmProductInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmProductInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a conversion task.
@@ -7367,6 +7978,16 @@ type metadataConversionTask struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConversionTask) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConversionTask) GoString() string {
+	return s.String()
+}
+
 type CopyImageInput struct {
 	// Unique, case-sensitive identifier you provide to ensure idempotency of the
 	// request. For more information, see How to Ensure Idempotency (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html)
@@ -7398,6 +8019,16 @@ type metadataCopyImageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopyImageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyImageInput) GoString() string {
+	return s.String()
+}
+
 type CopyImageOutput struct {
 	// The ID of the new AMI.
 	ImageID *string `locationName:"imageId" type:"string"`
@@ -7407,6 +8038,16 @@ type CopyImageOutput struct {
 
 type metadataCopyImageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CopyImageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyImageOutput) GoString() string {
+	return s.String()
 }
 
 type CopySnapshotInput struct {
@@ -7456,6 +8097,16 @@ type metadataCopySnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopySnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopySnapshotInput) GoString() string {
+	return s.String()
+}
+
 type CopySnapshotOutput struct {
 	// The ID of the new snapshot.
 	SnapshotID *string `locationName:"snapshotId" type:"string"`
@@ -7465,6 +8116,16 @@ type CopySnapshotOutput struct {
 
 type metadataCopySnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CopySnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopySnapshotOutput) GoString() string {
+	return s.String()
 }
 
 type CreateCustomerGatewayInput struct {
@@ -7493,6 +8154,16 @@ type metadataCreateCustomerGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateCustomerGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCustomerGatewayInput) GoString() string {
+	return s.String()
+}
+
 type CreateCustomerGatewayOutput struct {
 	// Information about the customer gateway.
 	CustomerGateway *CustomerGateway `locationName:"customerGateway" type:"structure"`
@@ -7502,6 +8173,16 @@ type CreateCustomerGatewayOutput struct {
 
 type metadataCreateCustomerGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateCustomerGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCustomerGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDHCPOptionsInput struct {
@@ -7521,6 +8202,16 @@ type metadataCreateDHCPOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDHCPOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDHCPOptionsInput) GoString() string {
+	return s.String()
+}
+
 type CreateDHCPOptionsOutput struct {
 	// A set of DHCP options.
 	DHCPOptions *DHCPOptions `locationName:"dhcpOptions" type:"structure"`
@@ -7530,6 +8221,16 @@ type CreateDHCPOptionsOutput struct {
 
 type metadataCreateDHCPOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDHCPOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDHCPOptionsOutput) GoString() string {
+	return s.String()
 }
 
 type CreateFlowLogsInput struct {
@@ -7560,6 +8261,16 @@ type metadataCreateFlowLogsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateFlowLogsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateFlowLogsInput) GoString() string {
+	return s.String()
+}
+
 type CreateFlowLogsOutput struct {
 	// Unique, case-sensitive identifier you provide to ensure the idempotency of
 	// the request.
@@ -7576,6 +8287,16 @@ type CreateFlowLogsOutput struct {
 
 type metadataCreateFlowLogsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateFlowLogsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateFlowLogsOutput) GoString() string {
+	return s.String()
 }
 
 type CreateImageInput struct {
@@ -7615,6 +8336,16 @@ type metadataCreateImageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateImageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateImageInput) GoString() string {
+	return s.String()
+}
+
 type CreateImageOutput struct {
 	// The ID of the new AMI.
 	ImageID *string `locationName:"imageId" type:"string"`
@@ -7624,6 +8355,16 @@ type CreateImageOutput struct {
 
 type metadataCreateImageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateImageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateImageOutput) GoString() string {
+	return s.String()
 }
 
 type CreateInstanceExportTaskInput struct {
@@ -7647,6 +8388,16 @@ type metadataCreateInstanceExportTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateInstanceExportTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInstanceExportTaskInput) GoString() string {
+	return s.String()
+}
+
 type CreateInstanceExportTaskOutput struct {
 	// Information about the instance export task.
 	ExportTask *ExportTask `locationName:"exportTask" type:"structure"`
@@ -7656,6 +8407,16 @@ type CreateInstanceExportTaskOutput struct {
 
 type metadataCreateInstanceExportTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateInstanceExportTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInstanceExportTaskOutput) GoString() string {
+	return s.String()
 }
 
 type CreateInternetGatewayInput struct {
@@ -7672,6 +8433,16 @@ type metadataCreateInternetGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateInternetGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInternetGatewayInput) GoString() string {
+	return s.String()
+}
+
 type CreateInternetGatewayOutput struct {
 	// Information about the Internet gateway.
 	InternetGateway *InternetGateway `locationName:"internetGateway" type:"structure"`
@@ -7681,6 +8452,16 @@ type CreateInternetGatewayOutput struct {
 
 type metadataCreateInternetGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateInternetGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInternetGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type CreateKeyPairInput struct {
@@ -7702,6 +8483,16 @@ type metadataCreateKeyPairInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateKeyPairInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateKeyPairInput) GoString() string {
+	return s.String()
+}
+
 // Describes a key pair.
 type CreateKeyPairOutput struct {
 	// The SHA-1 digest of the DER encoded private key.
@@ -7718,6 +8509,16 @@ type CreateKeyPairOutput struct {
 
 type metadataCreateKeyPairOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateKeyPairOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateKeyPairOutput) GoString() string {
+	return s.String()
 }
 
 type CreateNetworkACLEntryInput struct {
@@ -7763,12 +8564,32 @@ type metadataCreateNetworkACLEntryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateNetworkACLEntryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateNetworkACLEntryInput) GoString() string {
+	return s.String()
+}
+
 type CreateNetworkACLEntryOutput struct {
 	metadataCreateNetworkACLEntryOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateNetworkACLEntryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateNetworkACLEntryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateNetworkACLEntryOutput) GoString() string {
+	return s.String()
 }
 
 type CreateNetworkACLInput struct {
@@ -7788,6 +8609,16 @@ type metadataCreateNetworkACLInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateNetworkACLInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateNetworkACLInput) GoString() string {
+	return s.String()
+}
+
 type CreateNetworkACLOutput struct {
 	// Information about the network ACL.
 	NetworkACL *NetworkACL `locationName:"networkAcl" type:"structure"`
@@ -7797,6 +8628,16 @@ type CreateNetworkACLOutput struct {
 
 type metadataCreateNetworkACLOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateNetworkACLOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateNetworkACLOutput) GoString() string {
+	return s.String()
 }
 
 type CreateNetworkInterfaceInput struct {
@@ -7842,6 +8683,16 @@ type metadataCreateNetworkInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateNetworkInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateNetworkInterfaceInput) GoString() string {
+	return s.String()
+}
+
 type CreateNetworkInterfaceOutput struct {
 	// Information about the network interface.
 	NetworkInterface *NetworkInterface `locationName:"networkInterface" type:"structure"`
@@ -7851,6 +8702,16 @@ type CreateNetworkInterfaceOutput struct {
 
 type metadataCreateNetworkInterfaceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateNetworkInterfaceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateNetworkInterfaceOutput) GoString() string {
+	return s.String()
 }
 
 type CreatePlacementGroupInput struct {
@@ -7875,12 +8736,32 @@ type metadataCreatePlacementGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePlacementGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePlacementGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreatePlacementGroupOutput struct {
 	metadataCreatePlacementGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataCreatePlacementGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreatePlacementGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePlacementGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateReservedInstancesListingInput struct {
@@ -7909,6 +8790,16 @@ type metadataCreateReservedInstancesListingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateReservedInstancesListingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateReservedInstancesListingInput) GoString() string {
+	return s.String()
+}
+
 type CreateReservedInstancesListingOutput struct {
 	// Information about the Reserved Instances listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
@@ -7918,6 +8809,16 @@ type CreateReservedInstancesListingOutput struct {
 
 type metadataCreateReservedInstancesListingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateReservedInstancesListingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateReservedInstancesListingOutput) GoString() string {
+	return s.String()
 }
 
 type CreateRouteInput struct {
@@ -7959,6 +8860,16 @@ type metadataCreateRouteInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateRouteInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateRouteInput) GoString() string {
+	return s.String()
+}
+
 type CreateRouteOutput struct {
 	// Unique, case-sensitive identifier you provide to ensure the idempotency of
 	// the request.
@@ -7972,6 +8883,16 @@ type CreateRouteOutput struct {
 
 type metadataCreateRouteOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateRouteOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateRouteOutput) GoString() string {
+	return s.String()
 }
 
 type CreateRouteTableInput struct {
@@ -7991,6 +8912,16 @@ type metadataCreateRouteTableInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateRouteTableInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateRouteTableInput) GoString() string {
+	return s.String()
+}
+
 type CreateRouteTableOutput struct {
 	// Information about the route table.
 	RouteTable *RouteTable `locationName:"routeTable" type:"structure"`
@@ -8000,6 +8931,16 @@ type CreateRouteTableOutput struct {
 
 type metadataCreateRouteTableOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateRouteTableOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateRouteTableOutput) GoString() string {
+	return s.String()
 }
 
 type CreateSecurityGroupInput struct {
@@ -8037,6 +8978,16 @@ type metadataCreateSecurityGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSecurityGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateSecurityGroupOutput struct {
 	// The ID of the security group.
 	GroupID *string `locationName:"groupId" type:"string"`
@@ -8046,6 +8997,16 @@ type CreateSecurityGroupOutput struct {
 
 type metadataCreateSecurityGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSecurityGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSecurityGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateSnapshotInput struct {
@@ -8066,6 +9027,16 @@ type CreateSnapshotInput struct {
 
 type metadataCreateSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotInput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for CreateSpotDatafeedSubscription.
@@ -8089,6 +9060,16 @@ type metadataCreateSpotDatafeedSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSpotDatafeedSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSpotDatafeedSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of CreateSpotDatafeedSubscription.
 type CreateSpotDatafeedSubscriptionOutput struct {
 	// The Spot Instance data feed subscription.
@@ -8099,6 +9080,16 @@ type CreateSpotDatafeedSubscriptionOutput struct {
 
 type metadataCreateSpotDatafeedSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSpotDatafeedSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSpotDatafeedSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateSubnetInput struct {
@@ -8126,6 +9117,16 @@ type metadataCreateSubnetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSubnetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSubnetInput) GoString() string {
+	return s.String()
+}
+
 type CreateSubnetOutput struct {
 	// Information about the subnet.
 	Subnet *Subnet `locationName:"subnet" type:"structure"`
@@ -8135,6 +9136,16 @@ type CreateSubnetOutput struct {
 
 type metadataCreateSubnetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSubnetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSubnetOutput) GoString() string {
+	return s.String()
 }
 
 type CreateTagsInput struct {
@@ -8159,12 +9170,32 @@ type metadataCreateTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTagsInput) GoString() string {
+	return s.String()
+}
+
 type CreateTagsOutput struct {
 	metadataCreateTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTagsOutput) GoString() string {
+	return s.String()
 }
 
 type CreateVPCEndpointInput struct {
@@ -8200,6 +9231,16 @@ type metadataCreateVPCEndpointInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVPCEndpointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPCEndpointInput) GoString() string {
+	return s.String()
+}
+
 type CreateVPCEndpointOutput struct {
 	// Unique, case-sensitive identifier you provide to ensure the idempotency of
 	// the request.
@@ -8213,6 +9254,16 @@ type CreateVPCEndpointOutput struct {
 
 type metadataCreateVPCEndpointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVPCEndpointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPCEndpointOutput) GoString() string {
+	return s.String()
 }
 
 type CreateVPCInput struct {
@@ -8241,6 +9292,16 @@ type metadataCreateVPCInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVPCInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPCInput) GoString() string {
+	return s.String()
+}
+
 type CreateVPCOutput struct {
 	// Information about the VPC.
 	VPC *VPC `locationName:"vpc" type:"structure"`
@@ -8250,6 +9311,16 @@ type CreateVPCOutput struct {
 
 type metadataCreateVPCOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVPCOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPCOutput) GoString() string {
+	return s.String()
 }
 
 type CreateVPCPeeringConnectionInput struct {
@@ -8277,6 +9348,16 @@ type metadataCreateVPCPeeringConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVPCPeeringConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPCPeeringConnectionInput) GoString() string {
+	return s.String()
+}
+
 type CreateVPCPeeringConnectionOutput struct {
 	// Information about the VPC peering connection.
 	VPCPeeringConnection *VPCPeeringConnection `locationName:"vpcPeeringConnection" type:"structure"`
@@ -8286,6 +9367,16 @@ type CreateVPCPeeringConnectionOutput struct {
 
 type metadataCreateVPCPeeringConnectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVPCPeeringConnectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPCPeeringConnectionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateVPNConnectionInput struct {
@@ -8318,6 +9409,16 @@ type metadataCreateVPNConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVPNConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPNConnectionInput) GoString() string {
+	return s.String()
+}
+
 type CreateVPNConnectionOutput struct {
 	// Information about the VPN connection.
 	VPNConnection *VPNConnection `locationName:"vpnConnection" type:"structure"`
@@ -8327,6 +9428,16 @@ type CreateVPNConnectionOutput struct {
 
 type metadataCreateVPNConnectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVPNConnectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPNConnectionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateVPNConnectionRouteInput struct {
@@ -8343,12 +9454,32 @@ type metadataCreateVPNConnectionRouteInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVPNConnectionRouteInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPNConnectionRouteInput) GoString() string {
+	return s.String()
+}
+
 type CreateVPNConnectionRouteOutput struct {
 	metadataCreateVPNConnectionRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateVPNConnectionRouteOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVPNConnectionRouteOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPNConnectionRouteOutput) GoString() string {
+	return s.String()
 }
 
 type CreateVPNGatewayInput struct {
@@ -8371,6 +9502,16 @@ type metadataCreateVPNGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVPNGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPNGatewayInput) GoString() string {
+	return s.String()
+}
+
 type CreateVPNGatewayOutput struct {
 	// Information about the virtual private gateway.
 	VPNGateway *VPNGateway `locationName:"vpnGateway" type:"structure"`
@@ -8380,6 +9521,16 @@ type CreateVPNGatewayOutput struct {
 
 type metadataCreateVPNGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVPNGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVPNGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type CreateVolumeInput struct {
@@ -8443,6 +9594,16 @@ type metadataCreateVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVolumeInput) GoString() string {
+	return s.String()
+}
+
 // Describes the user or group to be added or removed from the permissions for
 // a volume.
 type CreateVolumePermission struct {
@@ -8461,6 +9622,16 @@ type metadataCreateVolumePermission struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVolumePermission) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVolumePermission) GoString() string {
+	return s.String()
+}
+
 // Describes modifications to the permissions for a volume.
 type CreateVolumePermissionModifications struct {
 	// Adds a specific AWS account ID or group to a volume's list of create volume
@@ -8476,6 +9647,16 @@ type CreateVolumePermissionModifications struct {
 
 type metadataCreateVolumePermissionModifications struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVolumePermissionModifications) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVolumePermissionModifications) GoString() string {
+	return s.String()
 }
 
 // Describes a customer gateway.
@@ -8507,6 +9688,16 @@ type metadataCustomerGateway struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CustomerGateway) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CustomerGateway) GoString() string {
+	return s.String()
+}
+
 // Describes a DHCP configuration option.
 type DHCPConfiguration struct {
 	// The name of a DHCP option.
@@ -8520,6 +9711,16 @@ type DHCPConfiguration struct {
 
 type metadataDHCPConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DHCPConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DHCPConfiguration) GoString() string {
+	return s.String()
 }
 
 // Describes a set of DHCP options.
@@ -8540,6 +9741,16 @@ type metadataDHCPOptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DHCPOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DHCPOptions) GoString() string {
+	return s.String()
+}
+
 type DeleteCustomerGatewayInput struct {
 	// The ID of the customer gateway.
 	CustomerGatewayID *string `locationName:"CustomerGatewayId" type:"string" required:"true"`
@@ -8557,12 +9768,32 @@ type metadataDeleteCustomerGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteCustomerGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCustomerGatewayInput) GoString() string {
+	return s.String()
+}
+
 type DeleteCustomerGatewayOutput struct {
 	metadataDeleteCustomerGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCustomerGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteCustomerGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCustomerGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteDHCPOptionsInput struct {
@@ -8582,12 +9813,32 @@ type metadataDeleteDHCPOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDHCPOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDHCPOptionsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDHCPOptionsOutput struct {
 	metadataDeleteDHCPOptionsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDHCPOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDHCPOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDHCPOptionsOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteFlowLogsInput struct {
@@ -8601,6 +9852,16 @@ type metadataDeleteFlowLogsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteFlowLogsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteFlowLogsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteFlowLogsOutput struct {
 	// Information about the flow logs that could not be deleted successfully.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
@@ -8610,6 +9871,16 @@ type DeleteFlowLogsOutput struct {
 
 type metadataDeleteFlowLogsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteFlowLogsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteFlowLogsOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteInternetGatewayInput struct {
@@ -8629,12 +9900,32 @@ type metadataDeleteInternetGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteInternetGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteInternetGatewayInput) GoString() string {
+	return s.String()
+}
+
 type DeleteInternetGatewayOutput struct {
 	metadataDeleteInternetGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInternetGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteInternetGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteInternetGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteKeyPairInput struct {
@@ -8654,12 +9945,32 @@ type metadataDeleteKeyPairInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteKeyPairInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteKeyPairInput) GoString() string {
+	return s.String()
+}
+
 type DeleteKeyPairOutput struct {
 	metadataDeleteKeyPairOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteKeyPairOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteKeyPairOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteKeyPairOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteNetworkACLEntryInput struct {
@@ -8685,12 +9996,32 @@ type metadataDeleteNetworkACLEntryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteNetworkACLEntryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteNetworkACLEntryInput) GoString() string {
+	return s.String()
+}
+
 type DeleteNetworkACLEntryOutput struct {
 	metadataDeleteNetworkACLEntryOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkACLEntryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteNetworkACLEntryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteNetworkACLEntryOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteNetworkACLInput struct {
@@ -8710,12 +10041,32 @@ type metadataDeleteNetworkACLInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteNetworkACLInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteNetworkACLInput) GoString() string {
+	return s.String()
+}
+
 type DeleteNetworkACLOutput struct {
 	metadataDeleteNetworkACLOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkACLOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteNetworkACLOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteNetworkACLOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteNetworkInterfaceInput struct {
@@ -8735,12 +10086,32 @@ type metadataDeleteNetworkInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteNetworkInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteNetworkInterfaceInput) GoString() string {
+	return s.String()
+}
+
 type DeleteNetworkInterfaceOutput struct {
 	metadataDeleteNetworkInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteNetworkInterfaceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteNetworkInterfaceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteNetworkInterfaceOutput) GoString() string {
+	return s.String()
 }
 
 type DeletePlacementGroupInput struct {
@@ -8760,12 +10131,32 @@ type metadataDeletePlacementGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletePlacementGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePlacementGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeletePlacementGroupOutput struct {
 	metadataDeletePlacementGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePlacementGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePlacementGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePlacementGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteRouteInput struct {
@@ -8789,12 +10180,32 @@ type metadataDeleteRouteInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteRouteInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRouteInput) GoString() string {
+	return s.String()
+}
+
 type DeleteRouteOutput struct {
 	metadataDeleteRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRouteOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRouteOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRouteOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteRouteTableInput struct {
@@ -8814,12 +10225,32 @@ type metadataDeleteRouteTableInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteRouteTableInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRouteTableInput) GoString() string {
+	return s.String()
+}
+
 type DeleteRouteTableOutput struct {
 	metadataDeleteRouteTableOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRouteTableOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRouteTableOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRouteTableOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteSecurityGroupInput struct {
@@ -8843,12 +10274,32 @@ type metadataDeleteSecurityGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSecurityGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSecurityGroupOutput struct {
 	metadataDeleteSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSecurityGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSecurityGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSecurityGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteSnapshotInput struct {
@@ -8868,12 +10319,32 @@ type metadataDeleteSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSnapshotOutput struct {
 	metadataDeleteSnapshotOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for DeleteSpotDatafeedSubscription.
@@ -8891,12 +10362,32 @@ type metadataDeleteSpotDatafeedSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSpotDatafeedSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSpotDatafeedSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSpotDatafeedSubscriptionOutput struct {
 	metadataDeleteSpotDatafeedSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSpotDatafeedSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSpotDatafeedSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSpotDatafeedSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteSubnetInput struct {
@@ -8916,12 +10407,32 @@ type metadataDeleteSubnetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSubnetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSubnetInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSubnetOutput struct {
 	metadataDeleteSubnetOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSubnetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSubnetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSubnetOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteTagsInput struct {
@@ -8947,12 +10458,32 @@ type metadataDeleteTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteTagsOutput struct {
 	metadataDeleteTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteVPCEndpointsInput struct {
@@ -8972,6 +10503,16 @@ type metadataDeleteVPCEndpointsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVPCEndpointsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPCEndpointsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVPCEndpointsOutput struct {
 	// Information about the endpoints that were not successfully deleted.
 	Unsuccessful []*UnsuccessfulItem `locationName:"unsuccessful" locationNameList:"item" type:"list"`
@@ -8981,6 +10522,16 @@ type DeleteVPCEndpointsOutput struct {
 
 type metadataDeleteVPCEndpointsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVPCEndpointsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPCEndpointsOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteVPCInput struct {
@@ -9000,12 +10551,32 @@ type metadataDeleteVPCInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVPCInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPCInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVPCOutput struct {
 	metadataDeleteVPCOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPCOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVPCOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPCOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteVPCPeeringConnectionInput struct {
@@ -9025,6 +10596,16 @@ type metadataDeleteVPCPeeringConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVPCPeeringConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPCPeeringConnectionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVPCPeeringConnectionOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
@@ -9034,6 +10615,16 @@ type DeleteVPCPeeringConnectionOutput struct {
 
 type metadataDeleteVPCPeeringConnectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVPCPeeringConnectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPCPeeringConnectionOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteVPNConnectionInput struct {
@@ -9053,12 +10644,32 @@ type metadataDeleteVPNConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVPNConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPNConnectionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVPNConnectionOutput struct {
 	metadataDeleteVPNConnectionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNConnectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVPNConnectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPNConnectionOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteVPNConnectionRouteInput struct {
@@ -9075,12 +10686,32 @@ type metadataDeleteVPNConnectionRouteInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVPNConnectionRouteInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPNConnectionRouteInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVPNConnectionRouteOutput struct {
 	metadataDeleteVPNConnectionRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNConnectionRouteOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVPNConnectionRouteOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPNConnectionRouteOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteVPNGatewayInput struct {
@@ -9100,12 +10731,32 @@ type metadataDeleteVPNGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVPNGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPNGatewayInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVPNGatewayOutput struct {
 	metadataDeleteVPNGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVPNGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVPNGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVPNGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteVolumeInput struct {
@@ -9125,12 +10776,32 @@ type metadataDeleteVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVolumeInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVolumeOutput struct {
 	metadataDeleteVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVolumeOutput) GoString() string {
+	return s.String()
 }
 
 type DeregisterImageInput struct {
@@ -9150,12 +10821,32 @@ type metadataDeregisterImageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterImageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterImageInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterImageOutput struct {
 	metadataDeregisterImageOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterImageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterImageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterImageOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAccountAttributesInput struct {
@@ -9175,6 +10866,16 @@ type metadataDescribeAccountAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAccountAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountAttributesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeAccountAttributesOutput struct {
 	// Information about one or more account attributes.
 	AccountAttributes []*AccountAttribute `locationName:"accountAttributeSet" locationNameList:"item" type:"list"`
@@ -9184,6 +10885,16 @@ type DescribeAccountAttributesOutput struct {
 
 type metadataDescribeAccountAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAccountAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountAttributesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAddressesInput struct {
@@ -9233,6 +10944,16 @@ type metadataDescribeAddressesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAddressesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAddressesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeAddressesOutput struct {
 	// Information about one or more Elastic IP addresses.
 	Addresses []*Address `locationName:"addressesSet" locationNameList:"item" type:"list"`
@@ -9242,6 +10963,16 @@ type DescribeAddressesOutput struct {
 
 type metadataDescribeAddressesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAddressesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAddressesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAvailabilityZonesInput struct {
@@ -9273,6 +11004,16 @@ type metadataDescribeAvailabilityZonesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAvailabilityZonesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAvailabilityZonesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeAvailabilityZonesOutput struct {
 	// Information about one or more Availability Zones.
 	AvailabilityZones []*AvailabilityZone `locationName:"availabilityZoneInfo" locationNameList:"item" type:"list"`
@@ -9282,6 +11023,16 @@ type DescribeAvailabilityZonesOutput struct {
 
 type metadataDescribeAvailabilityZonesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAvailabilityZonesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAvailabilityZonesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeBundleTasksInput struct {
@@ -9328,6 +11079,16 @@ type metadataDescribeBundleTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeBundleTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeBundleTasksInput) GoString() string {
+	return s.String()
+}
+
 type DescribeBundleTasksOutput struct {
 	// Information about one or more bundle tasks.
 	BundleTasks []*BundleTask `locationName:"bundleInstanceTasksSet" locationNameList:"item" type:"list"`
@@ -9337,6 +11098,16 @@ type DescribeBundleTasksOutput struct {
 
 type metadataDescribeBundleTasksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeBundleTasksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeBundleTasksOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeClassicLinkInstancesInput struct {
@@ -9390,6 +11161,16 @@ type metadataDescribeClassicLinkInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClassicLinkInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClassicLinkInstancesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeClassicLinkInstancesOutput struct {
 	// Information about one or more linked EC2-Classic instances.
 	Instances []*ClassicLinkInstance `locationName:"instancesSet" locationNameList:"item" type:"list"`
@@ -9403,6 +11184,16 @@ type DescribeClassicLinkInstancesOutput struct {
 
 type metadataDescribeClassicLinkInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClassicLinkInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClassicLinkInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeConversionTasksInput struct {
@@ -9425,6 +11216,16 @@ type metadataDescribeConversionTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeConversionTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConversionTasksInput) GoString() string {
+	return s.String()
+}
+
 type DescribeConversionTasksOutput struct {
 	// Information about the conversion tasks.
 	ConversionTasks []*ConversionTask `locationName:"conversionTasks" locationNameList:"item" type:"list"`
@@ -9434,6 +11235,16 @@ type DescribeConversionTasksOutput struct {
 
 type metadataDescribeConversionTasksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeConversionTasksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConversionTasksOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeCustomerGatewaysInput struct {
@@ -9484,6 +11295,16 @@ type metadataDescribeCustomerGatewaysInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCustomerGatewaysInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCustomerGatewaysInput) GoString() string {
+	return s.String()
+}
+
 type DescribeCustomerGatewaysOutput struct {
 	// Information about one or more customer gateways.
 	CustomerGateways []*CustomerGateway `locationName:"customerGatewaySet" locationNameList:"item" type:"list"`
@@ -9493,6 +11314,16 @@ type DescribeCustomerGatewaysOutput struct {
 
 type metadataDescribeCustomerGatewaysOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCustomerGatewaysOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCustomerGatewaysOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDHCPOptionsInput struct {
@@ -9535,6 +11366,16 @@ type metadataDescribeDHCPOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDHCPOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDHCPOptionsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeDHCPOptionsOutput struct {
 	// Information about one or more DHCP options sets.
 	DHCPOptions []*DHCPOptions `locationName:"dhcpOptionsSet" locationNameList:"item" type:"list"`
@@ -9544,6 +11385,16 @@ type DescribeDHCPOptionsOutput struct {
 
 type metadataDescribeDHCPOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDHCPOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDHCPOptionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeExportTasksInput struct {
@@ -9557,6 +11408,16 @@ type metadataDescribeExportTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeExportTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeExportTasksInput) GoString() string {
+	return s.String()
+}
+
 type DescribeExportTasksOutput struct {
 	// Information about the export tasks.
 	ExportTasks []*ExportTask `locationName:"exportTaskSet" locationNameList:"item" type:"list"`
@@ -9566,6 +11427,16 @@ type DescribeExportTasksOutput struct {
 
 type metadataDescribeExportTasksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeExportTasksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeExportTasksOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeFlowLogsInput struct {
@@ -9602,6 +11473,16 @@ type metadataDescribeFlowLogsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeFlowLogsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFlowLogsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeFlowLogsOutput struct {
 	// Information about the flow logs.
 	FlowLogs []*FlowLog `locationName:"flowLogSet" locationNameList:"item" type:"list"`
@@ -9615,6 +11496,16 @@ type DescribeFlowLogsOutput struct {
 
 type metadataDescribeFlowLogsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeFlowLogsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFlowLogsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeImageAttributeInput struct {
@@ -9639,6 +11530,16 @@ type DescribeImageAttributeInput struct {
 
 type metadataDescribeImageAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeImageAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImageAttributeInput) GoString() string {
+	return s.String()
 }
 
 // Describes an image attribute.
@@ -9672,6 +11573,16 @@ type DescribeImageAttributeOutput struct {
 
 type metadataDescribeImageAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeImageAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImageAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeImagesInput struct {
@@ -9775,6 +11686,16 @@ type metadataDescribeImagesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeImagesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImagesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeImagesOutput struct {
 	// Information about one or more images.
 	Images []*Image `locationName:"imagesSet" locationNameList:"item" type:"list"`
@@ -9784,6 +11705,16 @@ type DescribeImagesOutput struct {
 
 type metadataDescribeImagesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeImagesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImagesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeImportImageTasksInput struct {
@@ -9812,6 +11743,16 @@ type metadataDescribeImportImageTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeImportImageTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImportImageTasksInput) GoString() string {
+	return s.String()
+}
+
 type DescribeImportImageTasksOutput struct {
 	// A list of zero or more import image tasks that are currently active or were
 	// completed or canceled in the previous 7 days.
@@ -9826,6 +11767,16 @@ type DescribeImportImageTasksOutput struct {
 
 type metadataDescribeImportImageTasksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeImportImageTasksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImportImageTasksOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeImportSnapshotTasksInput struct {
@@ -9854,6 +11805,16 @@ type metadataDescribeImportSnapshotTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeImportSnapshotTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImportSnapshotTasksInput) GoString() string {
+	return s.String()
+}
+
 type DescribeImportSnapshotTasksOutput struct {
 	// A list of zero or more import snapshot tasks that are currently active or
 	// were completed or canceled in the previous 7 days.
@@ -9868,6 +11829,16 @@ type DescribeImportSnapshotTasksOutput struct {
 
 type metadataDescribeImportSnapshotTasksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeImportSnapshotTasksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeImportSnapshotTasksOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeInstanceAttributeInput struct {
@@ -9888,6 +11859,16 @@ type DescribeInstanceAttributeInput struct {
 
 type metadataDescribeInstanceAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceAttributeInput) GoString() string {
+	return s.String()
 }
 
 // Describes an instance attribute.
@@ -9943,6 +11924,16 @@ type DescribeInstanceAttributeOutput struct {
 
 type metadataDescribeInstanceAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeInstanceStatusInput struct {
@@ -10020,6 +12011,16 @@ type metadataDescribeInstanceStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeInstanceStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceStatusInput) GoString() string {
+	return s.String()
+}
+
 type DescribeInstanceStatusOutput struct {
 	// One or more instance status descriptions.
 	InstanceStatuses []*InstanceStatus `locationName:"instanceStatusSet" locationNameList:"item" type:"list"`
@@ -10033,6 +12034,16 @@ type DescribeInstanceStatusOutput struct {
 
 type metadataDescribeInstanceStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceStatusOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeInstancesInput struct {
@@ -10290,6 +12301,16 @@ type metadataDescribeInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstancesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeInstancesOutput struct {
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
@@ -10303,6 +12324,16 @@ type DescribeInstancesOutput struct {
 
 type metadataDescribeInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeInternetGatewaysInput struct {
@@ -10346,6 +12377,16 @@ type metadataDescribeInternetGatewaysInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeInternetGatewaysInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInternetGatewaysInput) GoString() string {
+	return s.String()
+}
+
 type DescribeInternetGatewaysOutput struct {
 	// Information about one or more Internet gateways.
 	InternetGateways []*InternetGateway `locationName:"internetGatewaySet" locationNameList:"item" type:"list"`
@@ -10355,6 +12396,16 @@ type DescribeInternetGatewaysOutput struct {
 
 type metadataDescribeInternetGatewaysOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeInternetGatewaysOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInternetGatewaysOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeKeyPairsInput struct {
@@ -10383,6 +12434,16 @@ type metadataDescribeKeyPairsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeKeyPairsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeKeyPairsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeKeyPairsOutput struct {
 	// Information about one or more key pairs.
 	KeyPairs []*KeyPairInfo `locationName:"keySet" locationNameList:"item" type:"list"`
@@ -10392,6 +12453,16 @@ type DescribeKeyPairsOutput struct {
 
 type metadataDescribeKeyPairsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeKeyPairsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeKeyPairsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeMovingAddressesInput struct {
@@ -10427,6 +12498,16 @@ type metadataDescribeMovingAddressesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeMovingAddressesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMovingAddressesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeMovingAddressesOutput struct {
 	// The status for each Elastic IP address.
 	MovingAddressStatuses []*MovingAddressStatus `locationName:"movingAddressStatusSet" locationNameList:"item" type:"list"`
@@ -10440,6 +12521,16 @@ type DescribeMovingAddressesOutput struct {
 
 type metadataDescribeMovingAddressesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMovingAddressesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMovingAddressesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeNetworkACLsInput struct {
@@ -10510,6 +12601,16 @@ type metadataDescribeNetworkACLsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeNetworkACLsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeNetworkACLsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeNetworkACLsOutput struct {
 	// Information about one or more network ACLs.
 	NetworkACLs []*NetworkACL `locationName:"networkAclSet" locationNameList:"item" type:"list"`
@@ -10519,6 +12620,16 @@ type DescribeNetworkACLsOutput struct {
 
 type metadataDescribeNetworkACLsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeNetworkACLsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeNetworkACLsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeNetworkInterfaceAttributeInput struct {
@@ -10539,6 +12650,16 @@ type DescribeNetworkInterfaceAttributeInput struct {
 
 type metadataDescribeNetworkInterfaceAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeNetworkInterfaceAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeNetworkInterfaceAttributeInput) GoString() string {
+	return s.String()
 }
 
 type DescribeNetworkInterfaceAttributeOutput struct {
@@ -10562,6 +12683,16 @@ type DescribeNetworkInterfaceAttributeOutput struct {
 
 type metadataDescribeNetworkInterfaceAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeNetworkInterfaceAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeNetworkInterfaceAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeNetworkInterfacesInput struct {
@@ -10684,6 +12815,16 @@ type metadataDescribeNetworkInterfacesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeNetworkInterfacesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeNetworkInterfacesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeNetworkInterfacesOutput struct {
 	// Information about one or more network interfaces.
 	NetworkInterfaces []*NetworkInterface `locationName:"networkInterfaceSet" locationNameList:"item" type:"list"`
@@ -10693,6 +12834,16 @@ type DescribeNetworkInterfacesOutput struct {
 
 type metadataDescribeNetworkInterfacesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeNetworkInterfacesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeNetworkInterfacesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribePlacementGroupsInput struct {
@@ -10724,6 +12875,16 @@ type metadataDescribePlacementGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribePlacementGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePlacementGroupsInput) GoString() string {
+	return s.String()
+}
+
 type DescribePlacementGroupsOutput struct {
 	// One or more placement groups.
 	PlacementGroups []*PlacementGroup `locationName:"placementGroupSet" locationNameList:"item" type:"list"`
@@ -10733,6 +12894,16 @@ type DescribePlacementGroupsOutput struct {
 
 type metadataDescribePlacementGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribePlacementGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePlacementGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribePrefixListsInput struct {
@@ -10771,6 +12942,16 @@ type metadataDescribePrefixListsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribePrefixListsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePrefixListsInput) GoString() string {
+	return s.String()
+}
+
 type DescribePrefixListsOutput struct {
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
@@ -10784,6 +12965,16 @@ type DescribePrefixListsOutput struct {
 
 type metadataDescribePrefixListsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribePrefixListsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePrefixListsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeRegionsInput struct {
@@ -10810,6 +13001,16 @@ type metadataDescribeRegionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeRegionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRegionsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeRegionsOutput struct {
 	// Information about one or more regions.
 	Regions []*Region `locationName:"regionInfo" locationNameList:"item" type:"list"`
@@ -10819,6 +13020,16 @@ type DescribeRegionsOutput struct {
 
 type metadataDescribeRegionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeRegionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRegionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeReservedInstancesInput struct {
@@ -10895,6 +13106,16 @@ type metadataDescribeReservedInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedInstancesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeReservedInstancesListingsInput struct {
 	// One or more filters.
 	//
@@ -10921,6 +13142,16 @@ type metadataDescribeReservedInstancesListingsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedInstancesListingsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedInstancesListingsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeReservedInstancesListingsOutput struct {
 	// Information about the Reserved Instance listing.
 	ReservedInstancesListings []*ReservedInstancesListing `locationName:"reservedInstancesListingsSet" locationNameList:"item" type:"list"`
@@ -10930,6 +13161,16 @@ type DescribeReservedInstancesListingsOutput struct {
 
 type metadataDescribeReservedInstancesListingsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeReservedInstancesListingsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedInstancesListingsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeReservedInstancesModificationsInput struct {
@@ -10982,6 +13223,16 @@ type metadataDescribeReservedInstancesModificationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedInstancesModificationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedInstancesModificationsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeReservedInstancesModificationsOutput struct {
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
@@ -10995,6 +13246,16 @@ type DescribeReservedInstancesModificationsOutput struct {
 
 type metadataDescribeReservedInstancesModificationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeReservedInstancesModificationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedInstancesModificationsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeReservedInstancesOfferingsInput struct {
@@ -11099,6 +13360,16 @@ type metadataDescribeReservedInstancesOfferingsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedInstancesOfferingsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedInstancesOfferingsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeReservedInstancesOfferingsOutput struct {
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
@@ -11114,6 +13385,16 @@ type metadataDescribeReservedInstancesOfferingsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedInstancesOfferingsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedInstancesOfferingsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeReservedInstancesOutput struct {
 	// A list of Reserved Instances.
 	ReservedInstances []*ReservedInstances `locationName:"reservedInstancesSet" locationNameList:"item" type:"list"`
@@ -11123,6 +13404,16 @@ type DescribeReservedInstancesOutput struct {
 
 type metadataDescribeReservedInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeReservedInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeRouteTablesInput struct {
@@ -11199,6 +13490,16 @@ type metadataDescribeRouteTablesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeRouteTablesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRouteTablesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeRouteTablesOutput struct {
 	// Information about one or more route tables.
 	RouteTables []*RouteTable `locationName:"routeTableSet" locationNameList:"item" type:"list"`
@@ -11208,6 +13509,16 @@ type DescribeRouteTablesOutput struct {
 
 type metadataDescribeRouteTablesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeRouteTablesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRouteTablesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeSecurityGroupsInput struct {
@@ -11278,6 +13589,16 @@ type metadataDescribeSecurityGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSecurityGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSecurityGroupsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeSecurityGroupsOutput struct {
 	// Information about one or more security groups.
 	SecurityGroups []*SecurityGroup `locationName:"securityGroupInfo" locationNameList:"item" type:"list"`
@@ -11287,6 +13608,16 @@ type DescribeSecurityGroupsOutput struct {
 
 type metadataDescribeSecurityGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSecurityGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSecurityGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeSnapshotAttributeInput struct {
@@ -11309,6 +13640,16 @@ type metadataDescribeSnapshotAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSnapshotAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotAttributeInput) GoString() string {
+	return s.String()
+}
+
 type DescribeSnapshotAttributeOutput struct {
 	// A list of permissions for creating volumes from the snapshot.
 	CreateVolumePermissions []*CreateVolumePermission `locationName:"createVolumePermission" locationNameList:"item" type:"list"`
@@ -11324,6 +13665,16 @@ type DescribeSnapshotAttributeOutput struct {
 
 type metadataDescribeSnapshotAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSnapshotAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeSnapshotsInput struct {
@@ -11405,6 +13756,16 @@ type metadataDescribeSnapshotsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSnapshotsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeSnapshotsOutput struct {
 	// The NextToken value to include in a future DescribeSnapshots request. When
 	// the results of a DescribeSnapshots request exceed MaxResults, this value
@@ -11422,6 +13783,16 @@ type metadataDescribeSnapshotsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSnapshotsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotsOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for DescribeSpotDatafeedSubscription.
 type DescribeSpotDatafeedSubscriptionInput struct {
 	// Checks whether you have the required permissions for the action, without
@@ -11437,6 +13808,16 @@ type metadataDescribeSpotDatafeedSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSpotDatafeedSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotDatafeedSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DescribeSpotDatafeedSubscription.
 type DescribeSpotDatafeedSubscriptionOutput struct {
 	// The Spot Instance data feed subscription.
@@ -11447,6 +13828,16 @@ type DescribeSpotDatafeedSubscriptionOutput struct {
 
 type metadataDescribeSpotDatafeedSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSpotDatafeedSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotDatafeedSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for DescribeSpotFleetInstances.
@@ -11475,6 +13866,16 @@ type metadataDescribeSpotFleetInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSpotFleetInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotFleetInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DescribeSpotFleetInstances.
 type DescribeSpotFleetInstancesOutput struct {
 	// The running instances. Note that this list is refreshed periodically and
@@ -11493,6 +13894,16 @@ type DescribeSpotFleetInstancesOutput struct {
 
 type metadataDescribeSpotFleetInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSpotFleetInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotFleetInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for DescribeSpotFleetRequestHistory.
@@ -11527,6 +13938,16 @@ type metadataDescribeSpotFleetRequestHistoryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSpotFleetRequestHistoryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotFleetRequestHistoryInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DescribeSpotFleetRequestHistory.
 type DescribeSpotFleetRequestHistoryOutput struct {
 	// Information about the events in the history of the Spot fleet request.
@@ -11555,6 +13976,16 @@ type metadataDescribeSpotFleetRequestHistoryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSpotFleetRequestHistoryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotFleetRequestHistoryOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the parameters for DescribeSpotFleetRequests.
 type DescribeSpotFleetRequestsInput struct {
 	// Checks whether you have the required permissions for the action, without
@@ -11581,6 +14012,16 @@ type metadataDescribeSpotFleetRequestsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSpotFleetRequestsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotFleetRequestsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DescribeSpotFleetRequests.
 type DescribeSpotFleetRequestsOutput struct {
 	// The token required to retrieve the next set of results. This value is null
@@ -11595,6 +14036,16 @@ type DescribeSpotFleetRequestsOutput struct {
 
 type metadataDescribeSpotFleetRequestsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSpotFleetRequestsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotFleetRequestsOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for DescribeSpotInstanceRequests.
@@ -11725,6 +14176,16 @@ type metadataDescribeSpotInstanceRequestsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSpotInstanceRequestsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotInstanceRequestsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DescribeSpotInstanceRequests.
 type DescribeSpotInstanceRequestsOutput struct {
 	// One or more Spot Instance requests.
@@ -11735,6 +14196,16 @@ type DescribeSpotInstanceRequestsOutput struct {
 
 type metadataDescribeSpotInstanceRequestsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSpotInstanceRequestsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotInstanceRequestsOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for DescribeSpotPriceHistory.
@@ -11795,6 +14266,16 @@ type metadataDescribeSpotPriceHistoryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSpotPriceHistoryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotPriceHistoryInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of DescribeSpotPriceHistory.
 type DescribeSpotPriceHistoryOutput struct {
 	// The token required to retrieve the next set of results. This value is null
@@ -11809,6 +14290,16 @@ type DescribeSpotPriceHistoryOutput struct {
 
 type metadataDescribeSpotPriceHistoryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSpotPriceHistoryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSpotPriceHistoryOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeSubnetsInput struct {
@@ -11864,6 +14355,16 @@ type metadataDescribeSubnetsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSubnetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSubnetsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeSubnetsOutput struct {
 	// Information about one or more subnets.
 	Subnets []*Subnet `locationName:"subnetSet" locationNameList:"item" type:"list"`
@@ -11873,6 +14374,16 @@ type DescribeSubnetsOutput struct {
 
 type metadataDescribeSubnetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSubnetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSubnetsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeTagsInput struct {
@@ -11913,6 +14424,16 @@ type metadataDescribeTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeTagsOutput struct {
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return..
@@ -11926,6 +14447,16 @@ type DescribeTagsOutput struct {
 
 type metadataDescribeTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVPCAttributeInput struct {
@@ -11948,6 +14479,16 @@ type metadataDescribeVPCAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVPCAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCAttributeInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVPCAttributeOutput struct {
 	// Indicates whether the instances launched in the VPC get DNS hostnames. If
 	// this attribute is true, instances in the VPC get DNS hostnames; otherwise,
@@ -11967,6 +14508,16 @@ type DescribeVPCAttributeOutput struct {
 
 type metadataDescribeVPCAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVPCAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVPCClassicLinkInput struct {
@@ -12004,6 +14555,16 @@ type metadataDescribeVPCClassicLinkInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVPCClassicLinkInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCClassicLinkInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVPCClassicLinkOutput struct {
 	// The ClassicLink status of one or more VPCs.
 	VPCs []*VPCClassicLink `locationName:"vpcSet" locationNameList:"item" type:"list"`
@@ -12013,6 +14574,16 @@ type DescribeVPCClassicLinkOutput struct {
 
 type metadataDescribeVPCClassicLinkOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVPCClassicLinkOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCClassicLinkOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVPCEndpointServicesInput struct {
@@ -12040,6 +14611,16 @@ type metadataDescribeVPCEndpointServicesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVPCEndpointServicesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCEndpointServicesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVPCEndpointServicesOutput struct {
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
@@ -12053,6 +14634,16 @@ type DescribeVPCEndpointServicesOutput struct {
 
 type metadataDescribeVPCEndpointServicesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVPCEndpointServicesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCEndpointServicesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVPCEndpointsInput struct {
@@ -12095,6 +14686,16 @@ type metadataDescribeVPCEndpointsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVPCEndpointsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCEndpointsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVPCEndpointsOutput struct {
 	// The token to use when requesting the next set of items. If there are no additional
 	// items to return, the string is empty.
@@ -12108,6 +14709,16 @@ type DescribeVPCEndpointsOutput struct {
 
 type metadataDescribeVPCEndpointsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVPCEndpointsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCEndpointsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVPCPeeringConnectionsInput struct {
@@ -12168,6 +14779,16 @@ type metadataDescribeVPCPeeringConnectionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVPCPeeringConnectionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCPeeringConnectionsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVPCPeeringConnectionsOutput struct {
 	// Information about the VPC peering connections.
 	VPCPeeringConnections []*VPCPeeringConnection `locationName:"vpcPeeringConnectionSet" locationNameList:"item" type:"list"`
@@ -12177,6 +14798,16 @@ type DescribeVPCPeeringConnectionsOutput struct {
 
 type metadataDescribeVPCPeeringConnectionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVPCPeeringConnectionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCPeeringConnectionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVPCsInput struct {
@@ -12225,6 +14856,16 @@ type metadataDescribeVPCsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVPCsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVPCsOutput struct {
 	// Information about one or more VPCs.
 	VPCs []*VPC `locationName:"vpcSet" locationNameList:"item" type:"list"`
@@ -12234,6 +14875,16 @@ type DescribeVPCsOutput struct {
 
 type metadataDescribeVPCsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVPCsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPCsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVPNConnectionsInput struct {
@@ -12297,6 +14948,16 @@ type metadataDescribeVPNConnectionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVPNConnectionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPNConnectionsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVPNConnectionsOutput struct {
 	// Information about one or more VPN connections.
 	VPNConnections []*VPNConnection `locationName:"vpnConnectionSet" locationNameList:"item" type:"list"`
@@ -12306,6 +14967,16 @@ type DescribeVPNConnectionsOutput struct {
 
 type metadataDescribeVPNConnectionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVPNConnectionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPNConnectionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVPNGatewaysInput struct {
@@ -12357,6 +15028,16 @@ type metadataDescribeVPNGatewaysInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVPNGatewaysInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPNGatewaysInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVPNGatewaysOutput struct {
 	// Information about one or more virtual private gateways.
 	VPNGateways []*VPNGateway `locationName:"vpnGatewaySet" locationNameList:"item" type:"list"`
@@ -12366,6 +15047,16 @@ type DescribeVPNGatewaysOutput struct {
 
 type metadataDescribeVPNGatewaysOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVPNGatewaysOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVPNGatewaysOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVolumeAttributeInput struct {
@@ -12388,6 +15079,16 @@ type metadataDescribeVolumeAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVolumeAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVolumeAttributeInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVolumeAttributeOutput struct {
 	// The state of autoEnableIO attribute.
 	AutoEnableIO *AttributeBooleanValue `locationName:"autoEnableIO" type:"structure"`
@@ -12403,6 +15104,16 @@ type DescribeVolumeAttributeOutput struct {
 
 type metadataDescribeVolumeAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVolumeAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVolumeAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVolumeStatusInput struct {
@@ -12473,6 +15184,16 @@ type metadataDescribeVolumeStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVolumeStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVolumeStatusInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVolumeStatusOutput struct {
 	// The token to use to retrieve the next page of results. This value is null
 	// when there are no more results to return.
@@ -12486,6 +15207,16 @@ type DescribeVolumeStatusOutput struct {
 
 type metadataDescribeVolumeStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVolumeStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVolumeStatusOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVolumesInput struct {
@@ -12570,6 +15301,16 @@ type metadataDescribeVolumesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVolumesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVolumesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeVolumesOutput struct {
 	// The NextToken value to include in a future DescribeVolumes request. When
 	// the results of a DescribeVolumes request exceed MaxResults, this value can
@@ -12585,6 +15326,16 @@ type DescribeVolumesOutput struct {
 
 type metadataDescribeVolumesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVolumesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVolumesOutput) GoString() string {
+	return s.String()
 }
 
 type DetachClassicLinkVPCInput struct {
@@ -12607,6 +15358,16 @@ type metadataDetachClassicLinkVPCInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachClassicLinkVPCInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachClassicLinkVPCInput) GoString() string {
+	return s.String()
+}
+
 type DetachClassicLinkVPCOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
@@ -12616,6 +15377,16 @@ type DetachClassicLinkVPCOutput struct {
 
 type metadataDetachClassicLinkVPCOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachClassicLinkVPCOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachClassicLinkVPCOutput) GoString() string {
+	return s.String()
 }
 
 type DetachInternetGatewayInput struct {
@@ -12638,12 +15409,32 @@ type metadataDetachInternetGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachInternetGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachInternetGatewayInput) GoString() string {
+	return s.String()
+}
+
 type DetachInternetGatewayOutput struct {
 	metadataDetachInternetGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachInternetGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachInternetGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachInternetGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type DetachNetworkInterfaceInput struct {
@@ -12666,12 +15457,32 @@ type metadataDetachNetworkInterfaceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachNetworkInterfaceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachNetworkInterfaceInput) GoString() string {
+	return s.String()
+}
+
 type DetachNetworkInterfaceOutput struct {
 	metadataDetachNetworkInterfaceOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachNetworkInterfaceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachNetworkInterfaceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachNetworkInterfaceOutput) GoString() string {
+	return s.String()
 }
 
 type DetachVPNGatewayInput struct {
@@ -12694,12 +15505,32 @@ type metadataDetachVPNGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachVPNGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachVPNGatewayInput) GoString() string {
+	return s.String()
+}
+
 type DetachVPNGatewayOutput struct {
 	metadataDetachVPNGatewayOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachVPNGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachVPNGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachVPNGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type DetachVolumeInput struct {
@@ -12734,6 +15565,16 @@ type metadataDetachVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachVolumeInput) GoString() string {
+	return s.String()
+}
+
 type DisableVGWRoutePropagationInput struct {
 	// The ID of the virtual private gateway.
 	GatewayID *string `locationName:"GatewayId" type:"string" required:"true"`
@@ -12748,12 +15589,32 @@ type metadataDisableVGWRoutePropagationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableVGWRoutePropagationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableVGWRoutePropagationInput) GoString() string {
+	return s.String()
+}
+
 type DisableVGWRoutePropagationOutput struct {
 	metadataDisableVGWRoutePropagationOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableVGWRoutePropagationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableVGWRoutePropagationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableVGWRoutePropagationOutput) GoString() string {
+	return s.String()
 }
 
 type DisableVPCClassicLinkInput struct {
@@ -12773,6 +15634,16 @@ type metadataDisableVPCClassicLinkInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableVPCClassicLinkInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableVPCClassicLinkInput) GoString() string {
+	return s.String()
+}
+
 type DisableVPCClassicLinkOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
@@ -12782,6 +15653,16 @@ type DisableVPCClassicLinkOutput struct {
 
 type metadataDisableVPCClassicLinkOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableVPCClassicLinkOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableVPCClassicLinkOutput) GoString() string {
+	return s.String()
 }
 
 type DisassociateAddressInput struct {
@@ -12804,12 +15685,32 @@ type metadataDisassociateAddressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisassociateAddressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateAddressInput) GoString() string {
+	return s.String()
+}
+
 type DisassociateAddressOutput struct {
 	metadataDisassociateAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateAddressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisassociateAddressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateAddressOutput) GoString() string {
+	return s.String()
 }
 
 type DisassociateRouteTableInput struct {
@@ -12830,12 +15731,32 @@ type metadataDisassociateRouteTableInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisassociateRouteTableInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateRouteTableInput) GoString() string {
+	return s.String()
+}
+
 type DisassociateRouteTableOutput struct {
 	metadataDisassociateRouteTableOutput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateRouteTableOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisassociateRouteTableOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateRouteTableOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a disk image.
@@ -12854,6 +15775,16 @@ type DiskImage struct {
 
 type metadataDiskImage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DiskImage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DiskImage) GoString() string {
+	return s.String()
 }
 
 // Describes a disk image.
@@ -12881,6 +15812,16 @@ type metadataDiskImageDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DiskImageDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DiskImageDescription) GoString() string {
+	return s.String()
+}
+
 // Describes a disk image.
 type DiskImageDetail struct {
 	// The size of the disk image, in GiB.
@@ -12903,6 +15844,16 @@ type metadataDiskImageDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DiskImageDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DiskImageDetail) GoString() string {
+	return s.String()
+}
+
 // Describes a disk image volume.
 type DiskImageVolumeDescription struct {
 	// The volume identifier.
@@ -12916,6 +15867,16 @@ type DiskImageVolumeDescription struct {
 
 type metadataDiskImageVolumeDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DiskImageVolumeDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DiskImageVolumeDescription) GoString() string {
+	return s.String()
 }
 
 // Describes a block device for an EBS volume.
@@ -12968,6 +15929,16 @@ type metadataEBSBlockDevice struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EBSBlockDevice) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EBSBlockDevice) GoString() string {
+	return s.String()
+}
+
 // Describes a parameter used to set up an EBS volume in a block device mapping.
 type EBSInstanceBlockDevice struct {
 	// The time stamp when the attachment initiated.
@@ -12989,6 +15960,16 @@ type metadataEBSInstanceBlockDevice struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EBSInstanceBlockDevice) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EBSInstanceBlockDevice) GoString() string {
+	return s.String()
+}
+
 type EBSInstanceBlockDeviceSpecification struct {
 	// Indicates whether the volume is deleted on instance termination.
 	DeleteOnTermination *bool `locationName:"deleteOnTermination" type:"boolean"`
@@ -13001,6 +15982,16 @@ type EBSInstanceBlockDeviceSpecification struct {
 
 type metadataEBSInstanceBlockDeviceSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EBSInstanceBlockDeviceSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EBSInstanceBlockDeviceSpecification) GoString() string {
+	return s.String()
 }
 
 type EnableVGWRoutePropagationInput struct {
@@ -13017,12 +16008,32 @@ type metadataEnableVGWRoutePropagationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableVGWRoutePropagationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableVGWRoutePropagationInput) GoString() string {
+	return s.String()
+}
+
 type EnableVGWRoutePropagationOutput struct {
 	metadataEnableVGWRoutePropagationOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableVGWRoutePropagationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableVGWRoutePropagationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableVGWRoutePropagationOutput) GoString() string {
+	return s.String()
 }
 
 type EnableVPCClassicLinkInput struct {
@@ -13042,6 +16053,16 @@ type metadataEnableVPCClassicLinkInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableVPCClassicLinkInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableVPCClassicLinkInput) GoString() string {
+	return s.String()
+}
+
 type EnableVPCClassicLinkOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
@@ -13051,6 +16072,16 @@ type EnableVPCClassicLinkOutput struct {
 
 type metadataEnableVPCClassicLinkOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableVPCClassicLinkOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableVPCClassicLinkOutput) GoString() string {
+	return s.String()
 }
 
 type EnableVolumeIOInput struct {
@@ -13070,12 +16101,32 @@ type metadataEnableVolumeIOInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableVolumeIOInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableVolumeIOInput) GoString() string {
+	return s.String()
+}
+
 type EnableVolumeIOOutput struct {
 	metadataEnableVolumeIOOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableVolumeIOOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableVolumeIOOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableVolumeIOOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a Spot fleet event.
@@ -13137,6 +16188,16 @@ type metadataEventInformation struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EventInformation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EventInformation) GoString() string {
+	return s.String()
+}
+
 // Describes an instance export task.
 type ExportTask struct {
 	// A description of the resource being exported.
@@ -13164,6 +16225,16 @@ type metadataExportTask struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ExportTask) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExportTask) GoString() string {
+	return s.String()
+}
+
 // Describes the format and location for an instance export task.
 type ExportToS3Task struct {
 	// The container format used to combine disk images with metadata (such as OVF).
@@ -13185,6 +16256,16 @@ type ExportToS3Task struct {
 
 type metadataExportToS3Task struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ExportToS3Task) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExportToS3Task) GoString() string {
+	return s.String()
 }
 
 // Describes an instance export task.
@@ -13211,6 +16292,16 @@ type metadataExportToS3TaskSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ExportToS3TaskSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExportToS3TaskSpecification) GoString() string {
+	return s.String()
+}
+
 // A filter name and value pair that is used to return a more specific list
 // of results. Filters can be used to match a set of resources by various criteria,
 // such as tags, attributes, or IDs.
@@ -13226,6 +16317,16 @@ type Filter struct {
 
 type metadataFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Filter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Filter) GoString() string {
+	return s.String()
 }
 
 // Describes a flow log.
@@ -13268,6 +16369,16 @@ type metadataFlowLog struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FlowLog) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FlowLog) GoString() string {
+	return s.String()
+}
+
 type GetConsoleOutputInput struct {
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
@@ -13283,6 +16394,16 @@ type GetConsoleOutputInput struct {
 
 type metadataGetConsoleOutputInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetConsoleOutputInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetConsoleOutputInput) GoString() string {
+	return s.String()
 }
 
 type GetConsoleOutputOutput struct {
@@ -13302,6 +16423,16 @@ type metadataGetConsoleOutputOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetConsoleOutputOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetConsoleOutputOutput) GoString() string {
+	return s.String()
+}
+
 type GetPasswordDataInput struct {
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
@@ -13317,6 +16448,16 @@ type GetPasswordDataInput struct {
 
 type metadataGetPasswordDataInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetPasswordDataInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPasswordDataInput) GoString() string {
+	return s.String()
 }
 
 type GetPasswordDataOutput struct {
@@ -13336,6 +16477,16 @@ type metadataGetPasswordDataOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetPasswordDataOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPasswordDataOutput) GoString() string {
+	return s.String()
+}
+
 // Describes a security group.
 type GroupIdentifier struct {
 	// The ID of the security group.
@@ -13349,6 +16500,16 @@ type GroupIdentifier struct {
 
 type metadataGroupIdentifier struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GroupIdentifier) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GroupIdentifier) GoString() string {
+	return s.String()
 }
 
 // Describes an event in the history of the Spot fleet request.
@@ -13376,6 +16537,16 @@ type metadataHistoryRecord struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HistoryRecord) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HistoryRecord) GoString() string {
+	return s.String()
+}
+
 // Describes an IAM instance profile.
 type IAMInstanceProfile struct {
 	// The Amazon Resource Name (ARN) of the instance profile.
@@ -13389,6 +16560,16 @@ type IAMInstanceProfile struct {
 
 type metadataIAMInstanceProfile struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IAMInstanceProfile) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IAMInstanceProfile) GoString() string {
+	return s.String()
 }
 
 // Describes an IAM instance profile.
@@ -13406,6 +16587,16 @@ type metadataIAMInstanceProfileSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s IAMInstanceProfileSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IAMInstanceProfileSpecification) GoString() string {
+	return s.String()
+}
+
 // Describes the ICMP type and code.
 type ICMPTypeCode struct {
 	// The ICMP type. A value of -1 means all types.
@@ -13419,6 +16610,16 @@ type ICMPTypeCode struct {
 
 type metadataICMPTypeCode struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ICMPTypeCode) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ICMPTypeCode) GoString() string {
+	return s.String()
 }
 
 // Describes a security group rule.
@@ -13460,6 +16661,16 @@ type metadataIPPermission struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s IPPermission) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IPPermission) GoString() string {
+	return s.String()
+}
+
 // Describes an IP range.
 type IPRange struct {
 	// The CIDR range. You can either specify a CIDR range or a source security
@@ -13471,6 +16682,16 @@ type IPRange struct {
 
 type metadataIPRange struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IPRange) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IPRange) GoString() string {
+	return s.String()
 }
 
 // Describes an image.
@@ -13558,6 +16779,16 @@ type metadataImage struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Image) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Image) GoString() string {
+	return s.String()
+}
+
 // Describes the disk container object for an import image task.
 type ImageDiskContainer struct {
 	// The description of the disk image.
@@ -13586,6 +16817,16 @@ type ImageDiskContainer struct {
 
 type metadataImageDiskContainer struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImageDiskContainer) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImageDiskContainer) GoString() string {
+	return s.String()
 }
 
 type ImportImageInput struct {
@@ -13642,6 +16883,16 @@ type metadataImportImageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ImportImageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportImageInput) GoString() string {
+	return s.String()
+}
+
 type ImportImageOutput struct {
 	// The architecture of the virtual machine.
 	Architecture *string `locationName:"architecture" type:"string"`
@@ -13681,6 +16932,16 @@ type ImportImageOutput struct {
 
 type metadataImportImageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportImageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportImageOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an import image task.
@@ -13729,6 +16990,16 @@ type metadataImportImageTask struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ImportImageTask) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportImageTask) GoString() string {
+	return s.String()
+}
+
 type ImportInstanceInput struct {
 	// A description for the instance being imported.
 	Description *string `locationName:"description" type:"string"`
@@ -13753,6 +17024,16 @@ type ImportInstanceInput struct {
 
 type metadataImportInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportInstanceInput) GoString() string {
+	return s.String()
 }
 
 // Describes the launch specification for VM import.
@@ -13800,6 +17081,16 @@ type metadataImportInstanceLaunchSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ImportInstanceLaunchSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportInstanceLaunchSpecification) GoString() string {
+	return s.String()
+}
+
 type ImportInstanceOutput struct {
 	// Information about the conversion task.
 	ConversionTask *ConversionTask `locationName:"conversionTask" type:"structure"`
@@ -13809,6 +17100,16 @@ type ImportInstanceOutput struct {
 
 type metadataImportInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an import instance task.
@@ -13830,6 +17131,16 @@ type ImportInstanceTaskDetails struct {
 
 type metadataImportInstanceTaskDetails struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportInstanceTaskDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportInstanceTaskDetails) GoString() string {
+	return s.String()
 }
 
 // Describes an import volume task.
@@ -13862,6 +17173,16 @@ type metadataImportInstanceVolumeDetailItem struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ImportInstanceVolumeDetailItem) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportInstanceVolumeDetailItem) GoString() string {
+	return s.String()
+}
+
 type ImportKeyPairInput struct {
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
@@ -13883,6 +17204,16 @@ type metadataImportKeyPairInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ImportKeyPairInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportKeyPairInput) GoString() string {
+	return s.String()
+}
+
 type ImportKeyPairOutput struct {
 	// The MD5 public key fingerprint as specified in section 4 of RFC 4716.
 	KeyFingerprint *string `locationName:"keyFingerprint" type:"string"`
@@ -13895,6 +17226,16 @@ type ImportKeyPairOutput struct {
 
 type metadataImportKeyPairOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportKeyPairOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportKeyPairOutput) GoString() string {
+	return s.String()
 }
 
 type ImportSnapshotInput struct {
@@ -13926,6 +17267,16 @@ type metadataImportSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ImportSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type ImportSnapshotOutput struct {
 	// A description of the import snapshot task.
 	Description *string `locationName:"description" type:"string"`
@@ -13941,6 +17292,16 @@ type ImportSnapshotOutput struct {
 
 type metadataImportSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an import snapshot task.
@@ -13959,6 +17320,16 @@ type ImportSnapshotTask struct {
 
 type metadataImportSnapshotTask struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportSnapshotTask) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportSnapshotTask) GoString() string {
+	return s.String()
 }
 
 type ImportVolumeInput struct {
@@ -13987,6 +17358,16 @@ type metadataImportVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ImportVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportVolumeInput) GoString() string {
+	return s.String()
+}
+
 type ImportVolumeOutput struct {
 	// Information about the conversion task.
 	ConversionTask *ConversionTask `locationName:"conversionTask" type:"structure"`
@@ -13996,6 +17377,16 @@ type ImportVolumeOutput struct {
 
 type metadataImportVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportVolumeOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an import volume task.
@@ -14020,6 +17411,16 @@ type ImportVolumeTaskDetails struct {
 
 type metadataImportVolumeTaskDetails struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ImportVolumeTaskDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ImportVolumeTaskDetails) GoString() string {
+	return s.String()
 }
 
 // Describes an instance.
@@ -14157,6 +17558,16 @@ type metadataInstance struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Instance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Instance) GoString() string {
+	return s.String()
+}
+
 // Describes a block device mapping.
 type InstanceBlockDeviceMapping struct {
 	// The device name exposed to the instance (for example, /dev/sdh or xvdh).
@@ -14171,6 +17582,16 @@ type InstanceBlockDeviceMapping struct {
 
 type metadataInstanceBlockDeviceMapping struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceBlockDeviceMapping) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceBlockDeviceMapping) GoString() string {
+	return s.String()
 }
 
 // Describes a block device mapping entry.
@@ -14195,6 +17616,16 @@ type metadataInstanceBlockDeviceMappingSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceBlockDeviceMappingSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceBlockDeviceMappingSpecification) GoString() string {
+	return s.String()
+}
+
 // Describes a Reserved Instance listing state.
 type InstanceCount struct {
 	// The number of listed Reserved Instances in the state specified by the state.
@@ -14208,6 +17639,16 @@ type InstanceCount struct {
 
 type metadataInstanceCount struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceCount) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceCount) GoString() string {
+	return s.String()
 }
 
 // Describes an instance to export.
@@ -14225,6 +17666,16 @@ type metadataInstanceExportDetails struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceExportDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceExportDetails) GoString() string {
+	return s.String()
+}
+
 // Describes the monitoring information of the instance.
 type InstanceMonitoring struct {
 	// The ID of the instance.
@@ -14238,6 +17689,16 @@ type InstanceMonitoring struct {
 
 type metadataInstanceMonitoring struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceMonitoring) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceMonitoring) GoString() string {
+	return s.String()
 }
 
 // Describes a network interface.
@@ -14292,6 +17753,16 @@ type metadataInstanceNetworkInterface struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceNetworkInterface) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceNetworkInterface) GoString() string {
+	return s.String()
+}
+
 // Describes association information for an Elastic IP address.
 type InstanceNetworkInterfaceAssociation struct {
 	// The ID of the owner of the Elastic IP address.
@@ -14308,6 +17779,16 @@ type InstanceNetworkInterfaceAssociation struct {
 
 type metadataInstanceNetworkInterfaceAssociation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceNetworkInterfaceAssociation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceNetworkInterfaceAssociation) GoString() string {
+	return s.String()
 }
 
 // Describes a network interface attachment.
@@ -14332,6 +17813,16 @@ type InstanceNetworkInterfaceAttachment struct {
 
 type metadataInstanceNetworkInterfaceAttachment struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceNetworkInterfaceAttachment) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceNetworkInterfaceAttachment) GoString() string {
+	return s.String()
 }
 
 // Describes a network interface.
@@ -14388,6 +17879,16 @@ type metadataInstanceNetworkInterfaceSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceNetworkInterfaceSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceNetworkInterfaceSpecification) GoString() string {
+	return s.String()
+}
+
 // Describes a private IP address.
 type InstancePrivateIPAddress struct {
 	// The association information for an Elastic IP address for the network interface.
@@ -14408,6 +17909,16 @@ type InstancePrivateIPAddress struct {
 
 type metadataInstancePrivateIPAddress struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstancePrivateIPAddress) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstancePrivateIPAddress) GoString() string {
+	return s.String()
 }
 
 // Describes the current state of the instance.
@@ -14438,6 +17949,16 @@ type metadataInstanceState struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceState) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceState) GoString() string {
+	return s.String()
+}
+
 // Describes an instance state change.
 type InstanceStateChange struct {
 	// The current state of the instance.
@@ -14454,6 +17975,16 @@ type InstanceStateChange struct {
 
 type metadataInstanceStateChange struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceStateChange) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStateChange) GoString() string {
+	return s.String()
 }
 
 // Describes the status of an instance.
@@ -14487,6 +18018,16 @@ type metadataInstanceStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatus) GoString() string {
+	return s.String()
+}
+
 // Describes the instance status.
 type InstanceStatusDetails struct {
 	// The time when a status check failed. For an instance that was launched and
@@ -14504,6 +18045,16 @@ type InstanceStatusDetails struct {
 
 type metadataInstanceStatusDetails struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceStatusDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatusDetails) GoString() string {
+	return s.String()
 }
 
 // Describes a scheduled event for an instance.
@@ -14531,6 +18082,16 @@ type metadataInstanceStatusEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceStatusEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatusEvent) GoString() string {
+	return s.String()
+}
+
 // Describes the status of an instance.
 type InstanceStatusSummary struct {
 	// The system instance health or application instance health.
@@ -14544,6 +18105,16 @@ type InstanceStatusSummary struct {
 
 type metadataInstanceStatusSummary struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceStatusSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatusSummary) GoString() string {
+	return s.String()
 }
 
 // Describes an Internet gateway.
@@ -14564,6 +18135,16 @@ type metadataInternetGateway struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InternetGateway) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InternetGateway) GoString() string {
+	return s.String()
+}
+
 // Describes the attachment of a VPC to an Internet gateway.
 type InternetGatewayAttachment struct {
 	// The current state of the attachment.
@@ -14577,6 +18158,16 @@ type InternetGatewayAttachment struct {
 
 type metadataInternetGatewayAttachment struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InternetGatewayAttachment) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InternetGatewayAttachment) GoString() string {
+	return s.String()
 }
 
 // Describes a key pair.
@@ -14597,6 +18188,16 @@ type metadataKeyPairInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s KeyPairInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s KeyPairInfo) GoString() string {
+	return s.String()
+}
+
 // Describes a launch permission.
 type LaunchPermission struct {
 	// The name of the group.
@@ -14610,6 +18211,16 @@ type LaunchPermission struct {
 
 type metadataLaunchPermission struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LaunchPermission) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LaunchPermission) GoString() string {
+	return s.String()
 }
 
 // Describes a launch permission modification.
@@ -14626,6 +18237,16 @@ type LaunchPermissionModifications struct {
 
 type metadataLaunchPermissionModifications struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LaunchPermissionModifications) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LaunchPermissionModifications) GoString() string {
+	return s.String()
 }
 
 // Describes the launch specification for an instance.
@@ -14691,6 +18312,16 @@ type metadataLaunchSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LaunchSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LaunchSpecification) GoString() string {
+	return s.String()
+}
+
 type ModifyImageAttributeInput struct {
 	// The name of the attribute to modify.
 	Attribute *string `type:"string"`
@@ -14736,12 +18367,32 @@ type metadataModifyImageAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyImageAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyImageAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ModifyImageAttributeOutput struct {
 	metadataModifyImageAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyImageAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyImageAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyImageAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyInstanceAttributeInput struct {
@@ -14830,12 +18481,32 @@ type metadataModifyInstanceAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyInstanceAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyInstanceAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ModifyInstanceAttributeOutput struct {
 	metadataModifyInstanceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyInstanceAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyInstanceAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyInstanceAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyNetworkInterfaceAttributeInput struct {
@@ -14875,12 +18546,32 @@ type metadataModifyNetworkInterfaceAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyNetworkInterfaceAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyNetworkInterfaceAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ModifyNetworkInterfaceAttributeOutput struct {
 	metadataModifyNetworkInterfaceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyNetworkInterfaceAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyNetworkInterfaceAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyNetworkInterfaceAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyReservedInstancesInput struct {
@@ -14901,6 +18592,16 @@ type metadataModifyReservedInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyReservedInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyReservedInstancesInput) GoString() string {
+	return s.String()
+}
+
 type ModifyReservedInstancesOutput struct {
 	// The ID for the modification.
 	ReservedInstancesModificationID *string `locationName:"reservedInstancesModificationId" type:"string"`
@@ -14910,6 +18611,16 @@ type ModifyReservedInstancesOutput struct {
 
 type metadataModifyReservedInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyReservedInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyReservedInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type ModifySnapshotAttributeInput struct {
@@ -14944,12 +18655,32 @@ type metadataModifySnapshotAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifySnapshotAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifySnapshotAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ModifySnapshotAttributeOutput struct {
 	metadataModifySnapshotAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifySnapshotAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifySnapshotAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifySnapshotAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ModifySubnetAttributeInput struct {
@@ -14967,12 +18698,32 @@ type metadataModifySubnetAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifySubnetAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifySubnetAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ModifySubnetAttributeOutput struct {
 	metadataModifySubnetAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifySubnetAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifySubnetAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifySubnetAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyVPCAttributeInput struct {
@@ -14999,12 +18750,32 @@ type metadataModifyVPCAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyVPCAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyVPCAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ModifyVPCAttributeOutput struct {
 	metadataModifyVPCAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyVPCAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyVPCAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyVPCAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyVPCEndpointInput struct {
@@ -15038,6 +18809,16 @@ type metadataModifyVPCEndpointInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyVPCEndpointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyVPCEndpointInput) GoString() string {
+	return s.String()
+}
+
 type ModifyVPCEndpointOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
@@ -15047,6 +18828,16 @@ type ModifyVPCEndpointOutput struct {
 
 type metadataModifyVPCEndpointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyVPCEndpointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyVPCEndpointOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyVolumeAttributeInput struct {
@@ -15069,12 +18860,32 @@ type metadataModifyVolumeAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyVolumeAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyVolumeAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ModifyVolumeAttributeOutput struct {
 	metadataModifyVolumeAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyVolumeAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyVolumeAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyVolumeAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type MonitorInstancesInput struct {
@@ -15094,6 +18905,16 @@ type metadataMonitorInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MonitorInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MonitorInstancesInput) GoString() string {
+	return s.String()
+}
+
 type MonitorInstancesOutput struct {
 	// Monitoring information for one or more instances.
 	InstanceMonitorings []*InstanceMonitoring `locationName:"instancesSet" locationNameList:"item" type:"list"`
@@ -15103,6 +18924,16 @@ type MonitorInstancesOutput struct {
 
 type metadataMonitorInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MonitorInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MonitorInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the monitoring for the instance.
@@ -15115,6 +18946,16 @@ type Monitoring struct {
 
 type metadataMonitoring struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Monitoring) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Monitoring) GoString() string {
+	return s.String()
 }
 
 type MoveAddressToVPCInput struct {
@@ -15134,6 +18975,16 @@ type metadataMoveAddressToVPCInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MoveAddressToVPCInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MoveAddressToVPCInput) GoString() string {
+	return s.String()
+}
+
 type MoveAddressToVPCOutput struct {
 	// The allocation ID for the Elastic IP address.
 	AllocationID *string `locationName:"allocationId" type:"string"`
@@ -15146,6 +18997,16 @@ type MoveAddressToVPCOutput struct {
 
 type metadataMoveAddressToVPCOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MoveAddressToVPCOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MoveAddressToVPCOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the status of a moving Elastic IP address.
@@ -15162,6 +19023,16 @@ type MovingAddressStatus struct {
 
 type metadataMovingAddressStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MovingAddressStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MovingAddressStatus) GoString() string {
+	return s.String()
 }
 
 // Describes a network ACL.
@@ -15191,6 +19062,16 @@ type metadataNetworkACL struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NetworkACL) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkACL) GoString() string {
+	return s.String()
+}
+
 // Describes an association between a network ACL and a subnet.
 type NetworkACLAssociation struct {
 	// The ID of the association between a network ACL and a subnet.
@@ -15207,6 +19088,16 @@ type NetworkACLAssociation struct {
 
 type metadataNetworkACLAssociation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NetworkACLAssociation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkACLAssociation) GoString() string {
+	return s.String()
 }
 
 // Describes an entry in a network ACL.
@@ -15239,6 +19130,16 @@ type NetworkACLEntry struct {
 
 type metadataNetworkACLEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NetworkACLEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkACLEntry) GoString() string {
+	return s.String()
 }
 
 // Describes a network interface.
@@ -15306,6 +19207,16 @@ type metadataNetworkInterface struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NetworkInterface) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInterface) GoString() string {
+	return s.String()
+}
+
 // Describes association information for an Elastic IP address.
 type NetworkInterfaceAssociation struct {
 	// The allocation ID.
@@ -15328,6 +19239,16 @@ type NetworkInterfaceAssociation struct {
 
 type metadataNetworkInterfaceAssociation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NetworkInterfaceAssociation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInterfaceAssociation) GoString() string {
+	return s.String()
 }
 
 // Describes a network interface attachment.
@@ -15360,6 +19281,16 @@ type metadataNetworkInterfaceAttachment struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NetworkInterfaceAttachment) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInterfaceAttachment) GoString() string {
+	return s.String()
+}
+
 // Describes an attachment change.
 type NetworkInterfaceAttachmentChanges struct {
 	// The ID of the network interface attachment.
@@ -15373,6 +19304,16 @@ type NetworkInterfaceAttachmentChanges struct {
 
 type metadataNetworkInterfaceAttachmentChanges struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NetworkInterfaceAttachmentChanges) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInterfaceAttachmentChanges) GoString() string {
+	return s.String()
 }
 
 // Describes the private IP address of a network interface.
@@ -15398,6 +19339,16 @@ type metadataNetworkInterfacePrivateIPAddress struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NetworkInterfacePrivateIPAddress) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInterfacePrivateIPAddress) GoString() string {
+	return s.String()
+}
+
 type NewDHCPConfiguration struct {
 	Key *string `locationName:"key" type:"string"`
 
@@ -15408,6 +19359,16 @@ type NewDHCPConfiguration struct {
 
 type metadataNewDHCPConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NewDHCPConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NewDHCPConfiguration) GoString() string {
+	return s.String()
 }
 
 // Describes the placement for the instance.
@@ -15429,6 +19390,16 @@ type metadataPlacement struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Placement) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Placement) GoString() string {
+	return s.String()
+}
+
 // Describes a placement group.
 type PlacementGroup struct {
 	// The name of the placement group.
@@ -15447,6 +19418,16 @@ type metadataPlacementGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PlacementGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PlacementGroup) GoString() string {
+	return s.String()
+}
+
 // Describes a range of ports.
 type PortRange struct {
 	// The first port in the range.
@@ -15460,6 +19441,16 @@ type PortRange struct {
 
 type metadataPortRange struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PortRange) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PortRange) GoString() string {
+	return s.String()
 }
 
 // Describes prefixes for AWS services.
@@ -15480,6 +19471,16 @@ type metadataPrefixList struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PrefixList) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PrefixList) GoString() string {
+	return s.String()
+}
+
 // The ID of the prefix.
 type PrefixListID struct {
 	// The ID of the prefix.
@@ -15490,6 +19491,16 @@ type PrefixListID struct {
 
 type metadataPrefixListID struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PrefixListID) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PrefixListID) GoString() string {
+	return s.String()
 }
 
 // Describes the price for a Reserved Instance.
@@ -15524,6 +19535,16 @@ type metadataPriceSchedule struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PriceSchedule) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PriceSchedule) GoString() string {
+	return s.String()
+}
+
 // Describes the price for a Reserved Instance.
 type PriceScheduleSpecification struct {
 	// The currency for transacting the Reserved Instance resale. At this time,
@@ -15544,6 +19565,16 @@ type metadataPriceScheduleSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PriceScheduleSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PriceScheduleSpecification) GoString() string {
+	return s.String()
+}
+
 // Describes a Reserved Instance offering.
 type PricingDetail struct {
 	// The number of instances available for the price.
@@ -15557,6 +19588,16 @@ type PricingDetail struct {
 
 type metadataPricingDetail struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PricingDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PricingDetail) GoString() string {
+	return s.String()
 }
 
 // Describes a secondary private IP address for a network interface.
@@ -15575,6 +19616,16 @@ type metadataPrivateIPAddressSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PrivateIPAddressSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PrivateIPAddressSpecification) GoString() string {
+	return s.String()
+}
+
 // Describes a product code.
 type ProductCode struct {
 	// The product code.
@@ -15590,6 +19641,16 @@ type metadataProductCode struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ProductCode) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ProductCode) GoString() string {
+	return s.String()
+}
+
 // Describes a virtual private gateway propagating route.
 type PropagatingVGW struct {
 	// The ID of the virtual private gateway (VGW).
@@ -15600,6 +19661,16 @@ type PropagatingVGW struct {
 
 type metadataPropagatingVGW struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PropagatingVGW) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PropagatingVGW) GoString() string {
+	return s.String()
 }
 
 type PurchaseReservedInstancesOfferingInput struct {
@@ -15627,6 +19698,16 @@ type metadataPurchaseReservedInstancesOfferingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PurchaseReservedInstancesOfferingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedInstancesOfferingInput) GoString() string {
+	return s.String()
+}
+
 type PurchaseReservedInstancesOfferingOutput struct {
 	// The IDs of the purchased Reserved Instances.
 	ReservedInstancesID *string `locationName:"reservedInstancesId" type:"string"`
@@ -15636,6 +19717,16 @@ type PurchaseReservedInstancesOfferingOutput struct {
 
 type metadataPurchaseReservedInstancesOfferingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PurchaseReservedInstancesOfferingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedInstancesOfferingOutput) GoString() string {
+	return s.String()
 }
 
 type RebootInstancesInput struct {
@@ -15655,12 +19746,32 @@ type metadataRebootInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebootInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootInstancesInput) GoString() string {
+	return s.String()
+}
+
 type RebootInstancesOutput struct {
 	metadataRebootInstancesOutput `json:"-" xml:"-"`
 }
 
 type metadataRebootInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebootInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a recurring charge.
@@ -15678,6 +19789,16 @@ type metadataRecurringCharge struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecurringCharge) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecurringCharge) GoString() string {
+	return s.String()
+}
+
 // Describes a region.
 type Region struct {
 	// The region service endpoint.
@@ -15691,6 +19812,16 @@ type Region struct {
 
 type metadataRegion struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Region) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Region) GoString() string {
+	return s.String()
 }
 
 type RegisterImageInput struct {
@@ -15752,6 +19883,16 @@ type metadataRegisterImageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterImageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterImageInput) GoString() string {
+	return s.String()
+}
+
 type RegisterImageOutput struct {
 	// The ID of the newly registered AMI.
 	ImageID *string `locationName:"imageId" type:"string"`
@@ -15761,6 +19902,16 @@ type RegisterImageOutput struct {
 
 type metadataRegisterImageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterImageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterImageOutput) GoString() string {
+	return s.String()
 }
 
 type RejectVPCPeeringConnectionInput struct {
@@ -15780,6 +19931,16 @@ type metadataRejectVPCPeeringConnectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RejectVPCPeeringConnectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RejectVPCPeeringConnectionInput) GoString() string {
+	return s.String()
+}
+
 type RejectVPCPeeringConnectionOutput struct {
 	// Returns true if the request succeeds; otherwise, it returns an error.
 	Return *bool `locationName:"return" type:"boolean"`
@@ -15789,6 +19950,16 @@ type RejectVPCPeeringConnectionOutput struct {
 
 type metadataRejectVPCPeeringConnectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RejectVPCPeeringConnectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RejectVPCPeeringConnectionOutput) GoString() string {
+	return s.String()
 }
 
 type ReleaseAddressInput struct {
@@ -15811,12 +19982,32 @@ type metadataReleaseAddressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReleaseAddressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReleaseAddressInput) GoString() string {
+	return s.String()
+}
+
 type ReleaseAddressOutput struct {
 	metadataReleaseAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataReleaseAddressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReleaseAddressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReleaseAddressOutput) GoString() string {
+	return s.String()
 }
 
 type ReplaceNetworkACLAssociationInput struct {
@@ -15840,6 +20031,16 @@ type metadataReplaceNetworkACLAssociationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReplaceNetworkACLAssociationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplaceNetworkACLAssociationInput) GoString() string {
+	return s.String()
+}
+
 type ReplaceNetworkACLAssociationOutput struct {
 	// The ID of the new association.
 	NewAssociationID *string `locationName:"newAssociationId" type:"string"`
@@ -15849,6 +20050,16 @@ type ReplaceNetworkACLAssociationOutput struct {
 
 type metadataReplaceNetworkACLAssociationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReplaceNetworkACLAssociationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplaceNetworkACLAssociationOutput) GoString() string {
+	return s.String()
 }
 
 type ReplaceNetworkACLEntryInput struct {
@@ -15893,12 +20104,32 @@ type metadataReplaceNetworkACLEntryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReplaceNetworkACLEntryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplaceNetworkACLEntryInput) GoString() string {
+	return s.String()
+}
+
 type ReplaceNetworkACLEntryOutput struct {
 	metadataReplaceNetworkACLEntryOutput `json:"-" xml:"-"`
 }
 
 type metadataReplaceNetworkACLEntryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReplaceNetworkACLEntryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplaceNetworkACLEntryOutput) GoString() string {
+	return s.String()
 }
 
 type ReplaceRouteInput struct {
@@ -15934,12 +20165,32 @@ type metadataReplaceRouteInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReplaceRouteInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplaceRouteInput) GoString() string {
+	return s.String()
+}
+
 type ReplaceRouteOutput struct {
 	metadataReplaceRouteOutput `json:"-" xml:"-"`
 }
 
 type metadataReplaceRouteOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReplaceRouteOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplaceRouteOutput) GoString() string {
+	return s.String()
 }
 
 type ReplaceRouteTableAssociationInput struct {
@@ -15962,6 +20213,16 @@ type metadataReplaceRouteTableAssociationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReplaceRouteTableAssociationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplaceRouteTableAssociationInput) GoString() string {
+	return s.String()
+}
+
 type ReplaceRouteTableAssociationOutput struct {
 	// The ID of the new association.
 	NewAssociationID *string `locationName:"newAssociationId" type:"string"`
@@ -15971,6 +20232,16 @@ type ReplaceRouteTableAssociationOutput struct {
 
 type metadataReplaceRouteTableAssociationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReplaceRouteTableAssociationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplaceRouteTableAssociationOutput) GoString() string {
+	return s.String()
 }
 
 type ReportInstanceStatusInput struct {
@@ -16026,12 +20297,32 @@ type metadataReportInstanceStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReportInstanceStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReportInstanceStatusInput) GoString() string {
+	return s.String()
+}
+
 type ReportInstanceStatusOutput struct {
 	metadataReportInstanceStatusOutput `json:"-" xml:"-"`
 }
 
 type metadataReportInstanceStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReportInstanceStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReportInstanceStatusOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for RequestSpotFleet.
@@ -16052,6 +20343,16 @@ type metadataRequestSpotFleetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RequestSpotFleetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestSpotFleetInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of RequestSpotFleet.
 type RequestSpotFleetOutput struct {
 	// The ID of the Spot fleet request.
@@ -16062,6 +20363,16 @@ type RequestSpotFleetOutput struct {
 
 type metadataRequestSpotFleetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RequestSpotFleetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestSpotFleetOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the parameters for RequestSpotInstances.
@@ -16145,6 +20456,16 @@ type metadataRequestSpotInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RequestSpotInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestSpotInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output of RequestSpotInstances.
 type RequestSpotInstancesOutput struct {
 	// One or more Spot Instance requests.
@@ -16155,6 +20476,16 @@ type RequestSpotInstancesOutput struct {
 
 type metadataRequestSpotInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RequestSpotInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestSpotInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the launch specification for an instance.
@@ -16218,6 +20549,16 @@ type metadataRequestSpotLaunchSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RequestSpotLaunchSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestSpotLaunchSpecification) GoString() string {
+	return s.String()
+}
+
 // Describes a reservation.
 type Reservation struct {
 	// One or more security groups.
@@ -16243,6 +20584,16 @@ type metadataReservation struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Reservation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Reservation) GoString() string {
+	return s.String()
+}
+
 // Describes the limit price of a Reserved Instance offering.
 type ReservedInstanceLimitPrice struct {
 	// Used for Reserved Instance Marketplace offerings. Specifies the limit price
@@ -16258,6 +20609,16 @@ type ReservedInstanceLimitPrice struct {
 
 type metadataReservedInstanceLimitPrice struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReservedInstanceLimitPrice) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedInstanceLimitPrice) GoString() string {
+	return s.String()
 }
 
 // Describes a Reserved Instance.
@@ -16318,6 +20679,16 @@ type metadataReservedInstances struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedInstances) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedInstances) GoString() string {
+	return s.String()
+}
+
 // Describes the configuration settings for the modified Reserved Instances.
 type ReservedInstancesConfiguration struct {
 	// The Availability Zone for the modified Reserved Instances.
@@ -16340,6 +20711,16 @@ type metadataReservedInstancesConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedInstancesConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedInstancesConfiguration) GoString() string {
+	return s.String()
+}
+
 // Describes the ID of a Reserved Instance.
 type ReservedInstancesID struct {
 	// The ID of the Reserved Instance.
@@ -16350,6 +20731,16 @@ type ReservedInstancesID struct {
 
 type metadataReservedInstancesID struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReservedInstancesID) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedInstancesID) GoString() string {
+	return s.String()
 }
 
 // Describes a Reserved Instance listing.
@@ -16393,6 +20784,16 @@ type metadataReservedInstancesListing struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedInstancesListing) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedInstancesListing) GoString() string {
+	return s.String()
+}
+
 // Describes a Reserved Instance modification.
 type ReservedInstancesModification struct {
 	// A unique, case-sensitive key supplied by the client to ensure that the request
@@ -16431,6 +20832,16 @@ type metadataReservedInstancesModification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedInstancesModification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedInstancesModification) GoString() string {
+	return s.String()
+}
+
 type ReservedInstancesModificationResult struct {
 	// The ID for the Reserved Instances that were created as part of the modification
 	// request. This field is only available when the modification is fulfilled.
@@ -16445,6 +20856,16 @@ type ReservedInstancesModificationResult struct {
 
 type metadataReservedInstancesModificationResult struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReservedInstancesModificationResult) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedInstancesModificationResult) GoString() string {
+	return s.String()
 }
 
 // Describes a Reserved Instance offering.
@@ -16499,6 +20920,16 @@ type metadataReservedInstancesOffering struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedInstancesOffering) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedInstancesOffering) GoString() string {
+	return s.String()
+}
+
 type ResetImageAttributeInput struct {
 	// The attribute to reset (currently you can only reset the launch permission
 	// attribute).
@@ -16520,12 +20951,32 @@ type metadataResetImageAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResetImageAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetImageAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ResetImageAttributeOutput struct {
 	metadataResetImageAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataResetImageAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResetImageAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetImageAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ResetInstanceAttributeInput struct {
@@ -16548,12 +20999,32 @@ type metadataResetInstanceAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResetInstanceAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetInstanceAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ResetInstanceAttributeOutput struct {
 	metadataResetInstanceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataResetInstanceAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResetInstanceAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetInstanceAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ResetNetworkInterfaceAttributeInput struct {
@@ -16576,12 +21047,32 @@ type metadataResetNetworkInterfaceAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResetNetworkInterfaceAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetNetworkInterfaceAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ResetNetworkInterfaceAttributeOutput struct {
 	metadataResetNetworkInterfaceAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataResetNetworkInterfaceAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResetNetworkInterfaceAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetNetworkInterfaceAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type ResetSnapshotAttributeInput struct {
@@ -16605,12 +21096,32 @@ type metadataResetSnapshotAttributeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResetSnapshotAttributeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetSnapshotAttributeInput) GoString() string {
+	return s.String()
+}
+
 type ResetSnapshotAttributeOutput struct {
 	metadataResetSnapshotAttributeOutput `json:"-" xml:"-"`
 }
 
 type metadataResetSnapshotAttributeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResetSnapshotAttributeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetSnapshotAttributeOutput) GoString() string {
+	return s.String()
 }
 
 type RestoreAddressToClassicInput struct {
@@ -16630,6 +21141,16 @@ type metadataRestoreAddressToClassicInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RestoreAddressToClassicInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreAddressToClassicInput) GoString() string {
+	return s.String()
+}
+
 type RestoreAddressToClassicOutput struct {
 	// The Elastic IP address.
 	PublicIP *string `locationName:"publicIp" type:"string"`
@@ -16642,6 +21163,16 @@ type RestoreAddressToClassicOutput struct {
 
 type metadataRestoreAddressToClassicOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RestoreAddressToClassicOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreAddressToClassicOutput) GoString() string {
+	return s.String()
 }
 
 type RevokeSecurityGroupEgressInput struct {
@@ -16689,12 +21220,32 @@ type metadataRevokeSecurityGroupEgressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RevokeSecurityGroupEgressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeSecurityGroupEgressInput) GoString() string {
+	return s.String()
+}
+
 type RevokeSecurityGroupEgressOutput struct {
 	metadataRevokeSecurityGroupEgressOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeSecurityGroupEgressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RevokeSecurityGroupEgressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeSecurityGroupEgressOutput) GoString() string {
+	return s.String()
 }
 
 type RevokeSecurityGroupIngressInput struct {
@@ -16748,12 +21299,32 @@ type metadataRevokeSecurityGroupIngressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RevokeSecurityGroupIngressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeSecurityGroupIngressInput) GoString() string {
+	return s.String()
+}
+
 type RevokeSecurityGroupIngressOutput struct {
 	metadataRevokeSecurityGroupIngressOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeSecurityGroupIngressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RevokeSecurityGroupIngressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeSecurityGroupIngressOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a route in a route table.
@@ -16799,6 +21370,16 @@ type metadataRoute struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Route) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Route) GoString() string {
+	return s.String()
+}
+
 // Describes a route table.
 type RouteTable struct {
 	// The associations between the route table and one or more subnets.
@@ -16826,6 +21407,16 @@ type metadataRouteTable struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RouteTable) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RouteTable) GoString() string {
+	return s.String()
+}
+
 // Describes an association between a route table and a subnet.
 type RouteTableAssociation struct {
 	// Indicates whether this is the main route table.
@@ -16845,6 +21436,16 @@ type RouteTableAssociation struct {
 
 type metadataRouteTableAssociation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RouteTableAssociation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RouteTableAssociation) GoString() string {
+	return s.String()
 }
 
 type RunInstancesInput struct {
@@ -16988,6 +21589,16 @@ type metadataRunInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RunInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RunInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Describes the monitoring for the instance.
 type RunInstancesMonitoringEnabled struct {
 	// Indicates whether monitoring is enabled for the instance.
@@ -16998,6 +21609,16 @@ type RunInstancesMonitoringEnabled struct {
 
 type metadataRunInstancesMonitoringEnabled struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RunInstancesMonitoringEnabled) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RunInstancesMonitoringEnabled) GoString() string {
+	return s.String()
 }
 
 // Describes the storage parameters for S3 and S3 buckets for an instance store-backed
@@ -17028,6 +21649,16 @@ type S3Storage struct {
 
 type metadataS3Storage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s S3Storage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s S3Storage) GoString() string {
+	return s.String()
 }
 
 // Describes a security group
@@ -17061,6 +21692,16 @@ type SecurityGroup struct {
 
 type metadataSecurityGroup struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SecurityGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SecurityGroup) GoString() string {
+	return s.String()
 }
 
 // Describes a snapshot.
@@ -17110,6 +21751,16 @@ type metadataSnapshot struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Snapshot) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Snapshot) GoString() string {
+	return s.String()
+}
+
 // Describes the snapshot created from the imported disk.
 type SnapshotDetail struct {
 	// A description for the snapshot.
@@ -17149,6 +21800,16 @@ type metadataSnapshotDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SnapshotDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SnapshotDetail) GoString() string {
+	return s.String()
+}
+
 // The disk container object for the import snapshot request.
 type SnapshotDiskContainer struct {
 	// The description of the disk image being imported.
@@ -17171,6 +21832,16 @@ type SnapshotDiskContainer struct {
 
 type metadataSnapshotDiskContainer struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SnapshotDiskContainer) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SnapshotDiskContainer) GoString() string {
+	return s.String()
 }
 
 // Details about the import snapshot task.
@@ -17209,6 +21880,16 @@ type metadataSnapshotTaskDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SnapshotTaskDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SnapshotTaskDetail) GoString() string {
+	return s.String()
+}
+
 // Describes the data feed for a Spot Instance.
 type SpotDatafeedSubscription struct {
 	// The Amazon S3 bucket where the Spot Instance data feed is located.
@@ -17233,6 +21914,16 @@ type metadataSpotDatafeedSubscription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SpotDatafeedSubscription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SpotDatafeedSubscription) GoString() string {
+	return s.String()
+}
+
 // Describes a Spot fleet request.
 type SpotFleetRequestConfig struct {
 	// Information about the configuration of the Spot fleet request.
@@ -17249,6 +21940,16 @@ type SpotFleetRequestConfig struct {
 
 type metadataSpotFleetRequestConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SpotFleetRequestConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SpotFleetRequestConfig) GoString() string {
+	return s.String()
 }
 
 // Describes the configuration of a Spot fleet request.
@@ -17291,6 +21992,16 @@ type SpotFleetRequestConfigData struct {
 
 type metadataSpotFleetRequestConfigData struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SpotFleetRequestConfigData) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SpotFleetRequestConfigData) GoString() string {
+	return s.String()
 }
 
 // Describe a Spot Instance request.
@@ -17366,6 +22077,16 @@ type metadataSpotInstanceRequest struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SpotInstanceRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SpotInstanceRequest) GoString() string {
+	return s.String()
+}
+
 // Describes a Spot Instance state change.
 type SpotInstanceStateFault struct {
 	// The reason code for the Spot Instance state change.
@@ -17379,6 +22100,16 @@ type SpotInstanceStateFault struct {
 
 type metadataSpotInstanceStateFault struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SpotInstanceStateFault) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SpotInstanceStateFault) GoString() string {
+	return s.String()
 }
 
 // Describes the status of a Spot Instance request.
@@ -17400,6 +22131,16 @@ type metadataSpotInstanceStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SpotInstanceStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SpotInstanceStatus) GoString() string {
+	return s.String()
+}
+
 // Describes Spot Instance placement.
 type SpotPlacement struct {
 	// The Availability Zone.
@@ -17413,6 +22154,16 @@ type SpotPlacement struct {
 
 type metadataSpotPlacement struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SpotPlacement) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SpotPlacement) GoString() string {
+	return s.String()
 }
 
 // Describes the maximum hourly price (bid) for any Spot Instance launched to
@@ -17440,6 +22191,16 @@ type metadataSpotPrice struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SpotPrice) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SpotPrice) GoString() string {
+	return s.String()
+}
+
 type StartInstancesInput struct {
 	// Reserved.
 	AdditionalInfo *string `locationName:"additionalInfo" type:"string"`
@@ -17460,6 +22221,16 @@ type metadataStartInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartInstancesInput) GoString() string {
+	return s.String()
+}
+
 type StartInstancesOutput struct {
 	// Information about one or more started instances.
 	StartingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
@@ -17469,6 +22240,16 @@ type StartInstancesOutput struct {
 
 type metadataStartInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a state change.
@@ -17508,6 +22289,16 @@ type metadataStateReason struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StateReason) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StateReason) GoString() string {
+	return s.String()
+}
+
 type StopInstancesInput struct {
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
@@ -17533,6 +22324,16 @@ type metadataStopInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StopInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopInstancesInput) GoString() string {
+	return s.String()
+}
+
 type StopInstancesOutput struct {
 	// Information about one or more stopped instances.
 	StoppingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
@@ -17542,6 +22343,16 @@ type StopInstancesOutput struct {
 
 type metadataStopInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the storage location for an instance store-backed AMI.
@@ -17554,6 +22365,16 @@ type Storage struct {
 
 type metadataStorage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Storage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Storage) GoString() string {
+	return s.String()
 }
 
 // Describes a subnet.
@@ -17593,6 +22414,16 @@ type metadataSubnet struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Subnet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Subnet) GoString() string {
+	return s.String()
+}
+
 // Describes a tag.
 type Tag struct {
 	// The key of the tag.
@@ -17612,6 +22443,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // Describes a tag.
@@ -17635,6 +22476,16 @@ type metadataTagDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TagDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TagDescription) GoString() string {
+	return s.String()
+}
+
 type TerminateInstancesInput struct {
 	// Checks whether you have the required permissions for the action, without
 	// actually making the request, and provides an error response. If you have
@@ -17652,6 +22503,16 @@ type metadataTerminateInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TerminateInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateInstancesInput) GoString() string {
+	return s.String()
+}
+
 type TerminateInstancesOutput struct {
 	// Information about one or more terminated instances.
 	TerminatingInstances []*InstanceStateChange `locationName:"instancesSet" locationNameList:"item" type:"list"`
@@ -17661,6 +22522,16 @@ type TerminateInstancesOutput struct {
 
 type metadataTerminateInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TerminateInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type UnassignPrivateIPAddressesInput struct {
@@ -17678,12 +22549,32 @@ type metadataUnassignPrivateIPAddressesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnassignPrivateIPAddressesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnassignPrivateIPAddressesInput) GoString() string {
+	return s.String()
+}
+
 type UnassignPrivateIPAddressesOutput struct {
 	metadataUnassignPrivateIPAddressesOutput `json:"-" xml:"-"`
 }
 
 type metadataUnassignPrivateIPAddressesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnassignPrivateIPAddressesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnassignPrivateIPAddressesOutput) GoString() string {
+	return s.String()
 }
 
 type UnmonitorInstancesInput struct {
@@ -17703,6 +22594,16 @@ type metadataUnmonitorInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnmonitorInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnmonitorInstancesInput) GoString() string {
+	return s.String()
+}
+
 type UnmonitorInstancesOutput struct {
 	// Monitoring information for one or more instances.
 	InstanceMonitorings []*InstanceMonitoring `locationName:"instancesSet" locationNameList:"item" type:"list"`
@@ -17712,6 +22613,16 @@ type UnmonitorInstancesOutput struct {
 
 type metadataUnmonitorInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnmonitorInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnmonitorInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // Information about items that were not successfully processed in a batch call.
@@ -17727,6 +22638,16 @@ type UnsuccessfulItem struct {
 
 type metadataUnsuccessfulItem struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnsuccessfulItem) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnsuccessfulItem) GoString() string {
+	return s.String()
 }
 
 // Information about the error that occured. For more information about errors,
@@ -17745,6 +22666,16 @@ type metadataUnsuccessfulItemError struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnsuccessfulItemError) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnsuccessfulItemError) GoString() string {
+	return s.String()
+}
+
 // Describes the S3 bucket for the disk image.
 type UserBucket struct {
 	// The name of the S3 bucket where the disk image is located.
@@ -17758,6 +22689,16 @@ type UserBucket struct {
 
 type metadataUserBucket struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UserBucket) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UserBucket) GoString() string {
+	return s.String()
 }
 
 // Describes the S3 bucket for the disk image.
@@ -17775,6 +22716,16 @@ type metadataUserBucketDetails struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UserBucketDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UserBucketDetails) GoString() string {
+	return s.String()
+}
+
 // Describes the user data to be made available to an instance.
 type UserData struct {
 	// The Base64-encoded MIME user data for the instance.
@@ -17785,6 +22736,16 @@ type UserData struct {
 
 type metadataUserData struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UserData) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UserData) GoString() string {
+	return s.String()
 }
 
 // Describes a security group and AWS account ID pair.
@@ -17805,6 +22766,16 @@ type UserIDGroupPair struct {
 
 type metadataUserIDGroupPair struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UserIDGroupPair) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UserIDGroupPair) GoString() string {
+	return s.String()
 }
 
 // Describes telemetry for a VPN tunnel.
@@ -17830,6 +22801,16 @@ type VGWTelemetry struct {
 
 type metadataVGWTelemetry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VGWTelemetry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VGWTelemetry) GoString() string {
+	return s.String()
 }
 
 // Describes a VPC.
@@ -17863,6 +22844,16 @@ type metadataVPC struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VPC) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPC) GoString() string {
+	return s.String()
+}
+
 // Describes an attachment between a virtual private gateway and a VPC.
 type VPCAttachment struct {
 	// The current state of the attachment.
@@ -17876,6 +22867,16 @@ type VPCAttachment struct {
 
 type metadataVPCAttachment struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPCAttachment) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPCAttachment) GoString() string {
+	return s.String()
 }
 
 // Describes whether a VPC is enabled for ClassicLink.
@@ -17894,6 +22895,16 @@ type VPCClassicLink struct {
 
 type metadataVPCClassicLink struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPCClassicLink) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPCClassicLink) GoString() string {
+	return s.String()
 }
 
 // Describes a VPC endpoint.
@@ -17926,6 +22937,16 @@ type metadataVPCEndpoint struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VPCEndpoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPCEndpoint) GoString() string {
+	return s.String()
+}
+
 // Describes a VPC peering connection.
 type VPCPeeringConnection struct {
 	// The information of the peer VPC.
@@ -17953,6 +22974,16 @@ type metadataVPCPeeringConnection struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VPCPeeringConnection) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPCPeeringConnection) GoString() string {
+	return s.String()
+}
+
 // Describes the status of a VPC peering connection.
 type VPCPeeringConnectionStateReason struct {
 	// The status of the VPC peering connection.
@@ -17966,6 +22997,16 @@ type VPCPeeringConnectionStateReason struct {
 
 type metadataVPCPeeringConnectionStateReason struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPCPeeringConnectionStateReason) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPCPeeringConnectionStateReason) GoString() string {
+	return s.String()
 }
 
 // Describes a VPC in a VPC peering connection.
@@ -17984,6 +23025,16 @@ type VPCPeeringConnectionVPCInfo struct {
 
 type metadataVPCPeeringConnectionVPCInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPCPeeringConnectionVPCInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPCPeeringConnectionVPCInfo) GoString() string {
+	return s.String()
 }
 
 // Describes a VPN connection.
@@ -18028,6 +23079,16 @@ type metadataVPNConnection struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VPNConnection) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPNConnection) GoString() string {
+	return s.String()
+}
+
 // Describes VPN connection options.
 type VPNConnectionOptions struct {
 	// Indicates whether the VPN connection uses static routes only. Static routes
@@ -18041,6 +23102,16 @@ type metadataVPNConnectionOptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VPNConnectionOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPNConnectionOptions) GoString() string {
+	return s.String()
+}
+
 // Describes VPN connection options.
 type VPNConnectionOptionsSpecification struct {
 	// Indicates whether the VPN connection uses static routes only. Static routes
@@ -18052,6 +23123,16 @@ type VPNConnectionOptionsSpecification struct {
 
 type metadataVPNConnectionOptionsSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPNConnectionOptionsSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPNConnectionOptionsSpecification) GoString() string {
+	return s.String()
 }
 
 // Describes a virtual private gateway.
@@ -18081,6 +23162,16 @@ type metadataVPNGateway struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VPNGateway) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPNGateway) GoString() string {
+	return s.String()
+}
+
 // Describes a static route for a VPN connection.
 type VPNStaticRoute struct {
 	// The CIDR block associated with the local subnet of the customer data center.
@@ -18097,6 +23188,16 @@ type VPNStaticRoute struct {
 
 type metadataVPNStaticRoute struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPNStaticRoute) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPNStaticRoute) GoString() string {
+	return s.String()
 }
 
 // Describes a volume.
@@ -18158,6 +23259,16 @@ type metadataVolume struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Volume) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Volume) GoString() string {
+	return s.String()
+}
+
 // Describes volume attachment details.
 type VolumeAttachment struct {
 	// The time stamp when the attachment initiated.
@@ -18185,6 +23296,16 @@ type metadataVolumeAttachment struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VolumeAttachment) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeAttachment) GoString() string {
+	return s.String()
+}
+
 // Describes an EBS volume.
 type VolumeDetail struct {
 	// The size of the volume, in GiB.
@@ -18195,6 +23316,16 @@ type VolumeDetail struct {
 
 type metadataVolumeDetail struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeDetail) GoString() string {
+	return s.String()
 }
 
 // Describes a volume status operation code.
@@ -18218,6 +23349,16 @@ type metadataVolumeStatusAction struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VolumeStatusAction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeStatusAction) GoString() string {
+	return s.String()
+}
+
 // Describes a volume status.
 type VolumeStatusDetails struct {
 	// The name of the volume status.
@@ -18231,6 +23372,16 @@ type VolumeStatusDetails struct {
 
 type metadataVolumeStatusDetails struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeStatusDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeStatusDetails) GoString() string {
+	return s.String()
 }
 
 // Describes a volume status event.
@@ -18257,6 +23408,16 @@ type metadataVolumeStatusEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VolumeStatusEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeStatusEvent) GoString() string {
+	return s.String()
+}
+
 // Describes the status of a volume.
 type VolumeStatusInfo struct {
 	// The details of the volume status.
@@ -18270,6 +23431,16 @@ type VolumeStatusInfo struct {
 
 type metadataVolumeStatusInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeStatusInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeStatusInfo) GoString() string {
+	return s.String()
 }
 
 // Describes the volume status.
@@ -18294,4 +23465,14 @@ type VolumeStatusItem struct {
 
 type metadataVolumeStatusItem struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeStatusItem) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeStatusItem) GoString() string {
+	return s.String()
 }

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateCluster = "CreateCluster"
@@ -923,6 +924,16 @@ type metadataCluster struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Cluster) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Cluster) GoString() string {
+	return s.String()
+}
+
 type Container struct {
 	// The Amazon Resource Name (ARN) of the container.
 	ContainerARN *string `locationName:"containerArn" type:"string"`
@@ -950,6 +961,16 @@ type Container struct {
 
 type metadataContainer struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Container) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Container) GoString() string {
+	return s.String()
 }
 
 // Container definitions are used in task definitions to describe the different
@@ -1052,6 +1073,16 @@ type metadataContainerDefinition struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ContainerDefinition) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ContainerDefinition) GoString() string {
+	return s.String()
+}
+
 // An Amazon EC2 instance that is running the Amazon ECS agent and has been
 // registered with a cluster.
 type ContainerInstance struct {
@@ -1103,6 +1134,16 @@ type metadataContainerInstance struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ContainerInstance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ContainerInstance) GoString() string {
+	return s.String()
+}
+
 // The name of a container in a task definition and the command it should run
 // instead of its default.
 type ContainerOverride struct {
@@ -1125,6 +1166,16 @@ type metadataContainerOverride struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ContainerOverride) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ContainerOverride) GoString() string {
+	return s.String()
+}
+
 type CreateClusterInput struct {
 	// The name of your cluster. If you do not specify a name for your cluster,
 	// you will create a cluster named default. Up to 255 letters (uppercase and
@@ -1138,6 +1189,16 @@ type metadataCreateClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterInput) GoString() string {
+	return s.String()
+}
+
 type CreateClusterOutput struct {
 	// The full description of your new cluster.
 	Cluster *Cluster `locationName:"cluster" type:"structure"`
@@ -1147,6 +1208,16 @@ type CreateClusterOutput struct {
 
 type metadataCreateClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterOutput) GoString() string {
+	return s.String()
 }
 
 type CreateServiceInput struct {
@@ -1190,6 +1261,16 @@ type metadataCreateServiceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateServiceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateServiceInput) GoString() string {
+	return s.String()
+}
+
 type CreateServiceOutput struct {
 	// The full description of your service following the create call.
 	Service *Service `locationName:"service" type:"structure"`
@@ -1199,6 +1280,16 @@ type CreateServiceOutput struct {
 
 type metadataCreateServiceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateServiceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateServiceOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteClusterInput struct {
@@ -1213,6 +1304,16 @@ type metadataDeleteClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterInput) GoString() string {
+	return s.String()
+}
+
 type DeleteClusterOutput struct {
 	// The full description of the deleted cluster.
 	Cluster *Cluster `locationName:"cluster" type:"structure"`
@@ -1222,6 +1323,16 @@ type DeleteClusterOutput struct {
 
 type metadataDeleteClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteServiceInput struct {
@@ -1238,6 +1349,16 @@ type metadataDeleteServiceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteServiceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteServiceInput) GoString() string {
+	return s.String()
+}
+
 type DeleteServiceOutput struct {
 	Service *Service `locationName:"service" type:"structure"`
 
@@ -1246,6 +1367,16 @@ type DeleteServiceOutput struct {
 
 type metadataDeleteServiceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteServiceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteServiceOutput) GoString() string {
+	return s.String()
 }
 
 type Deployment struct {
@@ -1284,6 +1415,16 @@ type metadataDeployment struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Deployment) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Deployment) GoString() string {
+	return s.String()
+}
+
 type DeregisterContainerInstanceInput struct {
 	// The short name or full Amazon Resource Name (ARN) of the cluster that hosts
 	// the container instance you want to deregister. If you do not specify a cluster,
@@ -1310,6 +1451,16 @@ type metadataDeregisterContainerInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterContainerInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterContainerInstanceInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterContainerInstanceOutput struct {
 	// An Amazon EC2 instance that is running the Amazon ECS agent and has been
 	// registered with a cluster.
@@ -1320,6 +1471,16 @@ type DeregisterContainerInstanceOutput struct {
 
 type metadataDeregisterContainerInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterContainerInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterContainerInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type DeregisterTaskDefinitionInput struct {
@@ -1334,6 +1495,16 @@ type metadataDeregisterTaskDefinitionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterTaskDefinitionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterTaskDefinitionInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterTaskDefinitionOutput struct {
 	// The full description of the deregistered task.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
@@ -1343,6 +1514,16 @@ type DeregisterTaskDefinitionOutput struct {
 
 type metadataDeregisterTaskDefinitionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterTaskDefinitionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterTaskDefinitionOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeClustersInput struct {
@@ -1357,6 +1538,16 @@ type metadataDescribeClustersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClustersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClustersInput) GoString() string {
+	return s.String()
+}
+
 type DescribeClustersOutput struct {
 	// The list of clusters.
 	Clusters []*Cluster `locationName:"clusters" type:"list"`
@@ -1368,6 +1559,16 @@ type DescribeClustersOutput struct {
 
 type metadataDescribeClustersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClustersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClustersOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeContainerInstancesInput struct {
@@ -1387,6 +1588,16 @@ type metadataDescribeContainerInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeContainerInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeContainerInstancesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeContainerInstancesOutput struct {
 	// The list of container instances.
 	ContainerInstances []*ContainerInstance `locationName:"containerInstances" type:"list"`
@@ -1398,6 +1609,16 @@ type DescribeContainerInstancesOutput struct {
 
 type metadataDescribeContainerInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeContainerInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeContainerInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeServicesInput struct {
@@ -1414,6 +1635,16 @@ type metadataDescribeServicesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeServicesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeServicesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeServicesOutput struct {
 	// Any failures associated with the call.
 	Failures []*Failure `locationName:"failures" type:"list"`
@@ -1426,6 +1657,16 @@ type DescribeServicesOutput struct {
 
 type metadataDescribeServicesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeServicesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeServicesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeTaskDefinitionInput struct {
@@ -1441,6 +1682,16 @@ type metadataDescribeTaskDefinitionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTaskDefinitionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTaskDefinitionInput) GoString() string {
+	return s.String()
+}
+
 type DescribeTaskDefinitionOutput struct {
 	// The full task definition description.
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
@@ -1450,6 +1701,16 @@ type DescribeTaskDefinitionOutput struct {
 
 type metadataDescribeTaskDefinitionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTaskDefinitionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTaskDefinitionOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeTasksInput struct {
@@ -1468,6 +1729,16 @@ type metadataDescribeTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTasksInput) GoString() string {
+	return s.String()
+}
+
 type DescribeTasksOutput struct {
 	Failures []*Failure `locationName:"failures" type:"list"`
 
@@ -1479,6 +1750,16 @@ type DescribeTasksOutput struct {
 
 type metadataDescribeTasksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTasksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTasksOutput) GoString() string {
+	return s.String()
 }
 
 type DiscoverPollEndpointInput struct {
@@ -1499,6 +1780,16 @@ type metadataDiscoverPollEndpointInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DiscoverPollEndpointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DiscoverPollEndpointInput) GoString() string {
+	return s.String()
+}
+
 type DiscoverPollEndpointOutput struct {
 	// The endpoint for the Amazon ECS agent to poll.
 	Endpoint *string `locationName:"endpoint" type:"string"`
@@ -1511,6 +1802,16 @@ type DiscoverPollEndpointOutput struct {
 
 type metadataDiscoverPollEndpointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DiscoverPollEndpointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DiscoverPollEndpointOutput) GoString() string {
+	return s.String()
 }
 
 type Failure struct {
@@ -1527,6 +1828,16 @@ type metadataFailure struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Failure) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Failure) GoString() string {
+	return s.String()
+}
+
 type HostVolumeProperties struct {
 	// The path on the host container instance that is presented to the container.
 	// If this parameter is empty, then the Docker daemon has assigned a host path
@@ -1538,6 +1849,16 @@ type HostVolumeProperties struct {
 
 type metadataHostVolumeProperties struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HostVolumeProperties) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HostVolumeProperties) GoString() string {
+	return s.String()
 }
 
 // A key and value pair object.
@@ -1555,6 +1876,16 @@ type KeyValuePair struct {
 
 type metadataKeyValuePair struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s KeyValuePair) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s KeyValuePair) GoString() string {
+	return s.String()
 }
 
 type ListClustersInput struct {
@@ -1580,6 +1911,16 @@ type metadataListClustersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListClustersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListClustersInput) GoString() string {
+	return s.String()
+}
+
 type ListClustersOutput struct {
 	// The list of full Amazon Resource Name (ARN) entries for each cluster associated
 	// with your account.
@@ -1596,6 +1937,16 @@ type ListClustersOutput struct {
 
 type metadataListClustersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListClustersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListClustersOutput) GoString() string {
+	return s.String()
 }
 
 type ListContainerInstancesInput struct {
@@ -1628,6 +1979,16 @@ type metadataListContainerInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListContainerInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListContainerInstancesInput) GoString() string {
+	return s.String()
+}
+
 type ListContainerInstancesOutput struct {
 	// The list of container instance full Amazon Resource Name (ARN) entries for
 	// each container instance associated with the specified cluster.
@@ -1644,6 +2005,16 @@ type ListContainerInstancesOutput struct {
 
 type metadataListContainerInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListContainerInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListContainerInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type ListServicesInput struct {
@@ -1674,6 +2045,16 @@ type metadataListServicesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListServicesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListServicesInput) GoString() string {
+	return s.String()
+}
+
 type ListServicesOutput struct {
 	// The nextToken value to include in a future ListServices request. When the
 	// results of a ListServices request exceed maxResults, this value can be used
@@ -1690,6 +2071,16 @@ type ListServicesOutput struct {
 
 type metadataListServicesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListServicesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListServicesOutput) GoString() string {
+	return s.String()
 }
 
 type ListTaskDefinitionFamiliesInput struct {
@@ -1722,6 +2113,16 @@ type metadataListTaskDefinitionFamiliesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListTaskDefinitionFamiliesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTaskDefinitionFamiliesInput) GoString() string {
+	return s.String()
+}
+
 type ListTaskDefinitionFamiliesOutput struct {
 	// The list of task definition family names that match the ListTaskDefinitionFamilies
 	// request.
@@ -1738,6 +2139,16 @@ type ListTaskDefinitionFamiliesOutput struct {
 
 type metadataListTaskDefinitionFamiliesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTaskDefinitionFamiliesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTaskDefinitionFamiliesOutput) GoString() string {
+	return s.String()
 }
 
 type ListTaskDefinitionsInput struct {
@@ -1785,6 +2196,16 @@ type metadataListTaskDefinitionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListTaskDefinitionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTaskDefinitionsInput) GoString() string {
+	return s.String()
+}
+
 type ListTaskDefinitionsOutput struct {
 	// The nextToken value to include in a future ListTaskDefinitions request. When
 	// the results of a ListTaskDefinitions request exceed maxResults, this value
@@ -1801,6 +2222,16 @@ type ListTaskDefinitionsOutput struct {
 
 type metadataListTaskDefinitionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTaskDefinitionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTaskDefinitionsOutput) GoString() string {
+	return s.String()
 }
 
 type ListTasksInput struct {
@@ -1857,6 +2288,16 @@ type metadataListTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTasksInput) GoString() string {
+	return s.String()
+}
+
 type ListTasksOutput struct {
 	// The nextToken value to include in a future ListTasks request. When the results
 	// of a ListTasks request exceed maxResults, this value can be used to retrieve
@@ -1872,6 +2313,16 @@ type ListTasksOutput struct {
 
 type metadataListTasksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTasksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTasksOutput) GoString() string {
+	return s.String()
 }
 
 type LoadBalancer struct {
@@ -1894,6 +2345,16 @@ type metadataLoadBalancer struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LoadBalancer) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancer) GoString() string {
+	return s.String()
+}
+
 type MountPoint struct {
 	// The path on the container to mount the host volume at.
 	ContainerPath *string `locationName:"containerPath" type:"string"`
@@ -1911,6 +2372,16 @@ type MountPoint struct {
 
 type metadataMountPoint struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MountPoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MountPoint) GoString() string {
+	return s.String()
 }
 
 type NetworkBinding struct {
@@ -1931,6 +2402,16 @@ type NetworkBinding struct {
 
 type metadataNetworkBinding struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NetworkBinding) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkBinding) GoString() string {
+	return s.String()
 }
 
 // Port mappings allow containers to access ports on the host container instance
@@ -1977,6 +2458,16 @@ type metadataPortMapping struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PortMapping) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PortMapping) GoString() string {
+	return s.String()
+}
+
 type RegisterContainerInstanceInput struct {
 	// The short name or full Amazon Resource Name (ARN) of the cluster that you
 	// want to register your container instance with. If you do not specify a cluster,
@@ -2007,6 +2498,16 @@ type metadataRegisterContainerInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterContainerInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterContainerInstanceInput) GoString() string {
+	return s.String()
+}
+
 type RegisterContainerInstanceOutput struct {
 	// An Amazon EC2 instance that is running the Amazon ECS agent and has been
 	// registered with a cluster.
@@ -2017,6 +2518,16 @@ type RegisterContainerInstanceOutput struct {
 
 type metadataRegisterContainerInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterContainerInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterContainerInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type RegisterTaskDefinitionInput struct {
@@ -2041,6 +2552,16 @@ type metadataRegisterTaskDefinitionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterTaskDefinitionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterTaskDefinitionInput) GoString() string {
+	return s.String()
+}
+
 type RegisterTaskDefinitionOutput struct {
 	TaskDefinition *TaskDefinition `locationName:"taskDefinition" type:"structure"`
 
@@ -2049,6 +2570,16 @@ type RegisterTaskDefinitionOutput struct {
 
 type metadataRegisterTaskDefinitionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterTaskDefinitionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterTaskDefinitionOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the resources available for a container instance.
@@ -2079,6 +2610,16 @@ type Resource struct {
 
 type metadataResource struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Resource) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Resource) GoString() string {
+	return s.String()
 }
 
 type RunTaskInput struct {
@@ -2127,6 +2668,16 @@ type metadataRunTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RunTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RunTaskInput) GoString() string {
+	return s.String()
+}
+
 type RunTaskOutput struct {
 	// Any failed tasks from your RunTask action are listed here.
 	Failures []*Failure `locationName:"failures" type:"list"`
@@ -2140,6 +2691,16 @@ type RunTaskOutput struct {
 
 type metadataRunTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RunTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RunTaskOutput) GoString() string {
+	return s.String()
 }
 
 type Service struct {
@@ -2198,6 +2759,16 @@ type metadataService struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Service) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Service) GoString() string {
+	return s.String()
+}
+
 type ServiceEvent struct {
 	// The Unix time in seconds and milliseconds when the event was triggered.
 	CreatedAt *time.Time `locationName:"createdAt" type:"timestamp" timestampFormat:"unix"`
@@ -2213,6 +2784,16 @@ type ServiceEvent struct {
 
 type metadataServiceEvent struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ServiceEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ServiceEvent) GoString() string {
+	return s.String()
 }
 
 type StartTaskInput struct {
@@ -2261,6 +2842,16 @@ type metadataStartTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartTaskInput) GoString() string {
+	return s.String()
+}
+
 type StartTaskOutput struct {
 	// Any failed tasks from your StartTask action are listed here.
 	Failures []*Failure `locationName:"failures" type:"list"`
@@ -2274,6 +2865,16 @@ type StartTaskOutput struct {
 
 type metadataStartTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartTaskOutput) GoString() string {
+	return s.String()
 }
 
 type StopTaskInput struct {
@@ -2293,6 +2894,16 @@ type metadataStopTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StopTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopTaskInput) GoString() string {
+	return s.String()
+}
+
 type StopTaskOutput struct {
 	Task *Task `locationName:"task" type:"structure"`
 
@@ -2301,6 +2912,16 @@ type StopTaskOutput struct {
 
 type metadataStopTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopTaskOutput) GoString() string {
+	return s.String()
 }
 
 type SubmitContainerStateChangeInput struct {
@@ -2334,6 +2955,16 @@ type metadataSubmitContainerStateChangeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SubmitContainerStateChangeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubmitContainerStateChangeInput) GoString() string {
+	return s.String()
+}
+
 type SubmitContainerStateChangeOutput struct {
 	// Acknowledgement of the state change.
 	Acknowledgment *string `locationName:"acknowledgment" type:"string"`
@@ -2343,6 +2974,16 @@ type SubmitContainerStateChangeOutput struct {
 
 type metadataSubmitContainerStateChangeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SubmitContainerStateChangeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubmitContainerStateChangeOutput) GoString() string {
+	return s.String()
 }
 
 type SubmitTaskStateChangeInput struct {
@@ -2367,6 +3008,16 @@ type metadataSubmitTaskStateChangeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SubmitTaskStateChangeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubmitTaskStateChangeInput) GoString() string {
+	return s.String()
+}
+
 type SubmitTaskStateChangeOutput struct {
 	// Acknowledgement of the state change.
 	Acknowledgment *string `locationName:"acknowledgment" type:"string"`
@@ -2376,6 +3027,16 @@ type SubmitTaskStateChangeOutput struct {
 
 type metadataSubmitTaskStateChangeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SubmitTaskStateChangeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubmitTaskStateChangeOutput) GoString() string {
+	return s.String()
 }
 
 type Task struct {
@@ -2416,6 +3077,16 @@ type metadataTask struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Task) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Task) GoString() string {
+	return s.String()
+}
+
 type TaskDefinition struct {
 	// A list of container definitions in JSON format that describe the different
 	// containers that make up your task. For more information on container definition
@@ -2453,6 +3124,16 @@ type metadataTaskDefinition struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TaskDefinition) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TaskDefinition) GoString() string {
+	return s.String()
+}
+
 // A list of container overrides in JSON format that specify the name of a container
 // in a task definition and the command it should run instead of its default.
 type TaskOverride struct {
@@ -2464,6 +3145,16 @@ type TaskOverride struct {
 
 type metadataTaskOverride struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TaskOverride) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TaskOverride) GoString() string {
+	return s.String()
 }
 
 type UpdateContainerAgentInput struct {
@@ -2484,6 +3175,16 @@ type metadataUpdateContainerAgentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateContainerAgentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateContainerAgentInput) GoString() string {
+	return s.String()
+}
+
 type UpdateContainerAgentOutput struct {
 	// An Amazon EC2 instance that is running the Amazon ECS agent and has been
 	// registered with a cluster.
@@ -2494,6 +3195,16 @@ type UpdateContainerAgentOutput struct {
 
 type metadataUpdateContainerAgentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateContainerAgentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateContainerAgentOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateServiceInput struct {
@@ -2524,6 +3235,16 @@ type metadataUpdateServiceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateServiceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateServiceInput) GoString() string {
+	return s.String()
+}
+
 type UpdateServiceOutput struct {
 	// The full description of your service following the update call.
 	Service *Service `locationName:"service" type:"structure"`
@@ -2533,6 +3254,16 @@ type UpdateServiceOutput struct {
 
 type metadataUpdateServiceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateServiceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateServiceOutput) GoString() string {
+	return s.String()
 }
 
 type VersionInfo struct {
@@ -2553,6 +3284,16 @@ type metadataVersionInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VersionInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VersionInfo) GoString() string {
+	return s.String()
+}
+
 type Volume struct {
 	// The path on the host container instance that is presented to the containers
 	// which access the volume. If this parameter is empty, then the Docker daemon
@@ -2570,6 +3311,16 @@ type metadataVolume struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Volume) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Volume) GoString() string {
+	return s.String()
+}
+
 type VolumeFrom struct {
 	// If this value is true, the container has read-only access to the volume.
 	// If this value is false, then the container can write to the volume. The default
@@ -2584,4 +3335,14 @@ type VolumeFrom struct {
 
 type metadataVolumeFrom struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeFrom) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeFrom) GoString() string {
+	return s.String()
 }

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateFileSystem = "CreateFileSystem"
@@ -527,6 +528,16 @@ type metadataCreateFileSystemInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateFileSystemInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateFileSystemInput) GoString() string {
+	return s.String()
+}
+
 type CreateMountTargetInput struct {
 	// The ID of the file system for which to create the mount target.
 	FileSystemID *string `locationName:"FileSystemId" type:"string" required:"true"`
@@ -548,6 +559,16 @@ type metadataCreateMountTargetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateMountTargetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateMountTargetInput) GoString() string {
+	return s.String()
+}
+
 type CreateTagsInput struct {
 	// String. The ID of the file system whose tags you want to modify. This operation
 	// modifies only the tags and not the file system.
@@ -563,12 +584,32 @@ type metadataCreateTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTagsInput) GoString() string {
+	return s.String()
+}
+
 type CreateTagsOutput struct {
 	metadataCreateTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTagsOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteFileSystemInput struct {
@@ -582,12 +623,32 @@ type metadataDeleteFileSystemInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteFileSystemInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteFileSystemInput) GoString() string {
+	return s.String()
+}
+
 type DeleteFileSystemOutput struct {
 	metadataDeleteFileSystemOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteFileSystemOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteFileSystemOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteFileSystemOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteMountTargetInput struct {
@@ -601,12 +662,32 @@ type metadataDeleteMountTargetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteMountTargetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMountTargetInput) GoString() string {
+	return s.String()
+}
+
 type DeleteMountTargetOutput struct {
 	metadataDeleteMountTargetOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMountTargetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteMountTargetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMountTargetOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteTagsInput struct {
@@ -623,12 +704,32 @@ type metadataDeleteTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteTagsOutput struct {
 	metadataDeleteTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeFileSystemsInput struct {
@@ -659,6 +760,16 @@ type metadataDescribeFileSystemsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeFileSystemsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFileSystemsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeFileSystemsOutput struct {
 	// An array of file system descriptions.
 	FileSystems []*FileSystemDescription `type:"list"`
@@ -677,6 +788,16 @@ type metadataDescribeFileSystemsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeFileSystemsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeFileSystemsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeMountTargetSecurityGroupsInput struct {
 	// The ID of the mount target whose security groups you want to retrieve.
 	MountTargetID *string `location:"uri" locationName:"MountTargetId" type:"string" required:"true"`
@@ -688,6 +809,16 @@ type metadataDescribeMountTargetSecurityGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeMountTargetSecurityGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMountTargetSecurityGroupsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeMountTargetSecurityGroupsOutput struct {
 	// An array of security groups.
 	SecurityGroups []*string `type:"list" required:"true"`
@@ -697,6 +828,16 @@ type DescribeMountTargetSecurityGroupsOutput struct {
 
 type metadataDescribeMountTargetSecurityGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMountTargetSecurityGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMountTargetSecurityGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeMountTargetsInput struct {
@@ -717,6 +858,16 @@ type DescribeMountTargetsInput struct {
 
 type metadataDescribeMountTargetsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMountTargetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMountTargetsInput) GoString() string {
+	return s.String()
 }
 
 type DescribeMountTargetsOutput struct {
@@ -740,6 +891,16 @@ type metadataDescribeMountTargetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeMountTargetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMountTargetsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeTagsInput struct {
 	// The ID of the file system whose tag set you want to retrieve.
 	FileSystemID *string `location:"uri" locationName:"FileSystemId" type:"string" required:"true"`
@@ -760,6 +921,16 @@ type metadataDescribeTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeTagsOutput struct {
 	// If the request included a Marker, the response returns that value in this
 	// field.
@@ -778,6 +949,16 @@ type DescribeTagsOutput struct {
 
 type metadataDescribeTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsOutput) GoString() string {
+	return s.String()
 }
 
 // This object provides description of a file system.
@@ -826,6 +1007,16 @@ type metadataFileSystemDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FileSystemDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FileSystemDescription) GoString() string {
+	return s.String()
+}
+
 // This object provides the latest known metered size, in bytes, of data stored
 // in the file system, in its Value field, and the time at which that size was
 // determined in its Timestamp field. Note that the value does not represent
@@ -849,6 +1040,16 @@ type metadataFileSystemSize struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FileSystemSize) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FileSystemSize) GoString() string {
+	return s.String()
+}
+
 type ModifyMountTargetSecurityGroupsInput struct {
 	// The ID of the mount target whose security groups you want to modify.
 	MountTargetID *string `location:"uri" locationName:"MountTargetId" type:"string" required:"true"`
@@ -863,12 +1064,32 @@ type metadataModifyMountTargetSecurityGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyMountTargetSecurityGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyMountTargetSecurityGroupsInput) GoString() string {
+	return s.String()
+}
+
 type ModifyMountTargetSecurityGroupsOutput struct {
 	metadataModifyMountTargetSecurityGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyMountTargetSecurityGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyMountTargetSecurityGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyMountTargetSecurityGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // This object provides description of a mount target.
@@ -902,6 +1123,16 @@ type metadataMountTargetDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MountTargetDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MountTargetDescription) GoString() string {
+	return s.String()
+}
+
 // A tag is a pair of key and value. The allowed characters in keys and values
 // are letters, whitespace, and numbers, representable in UTF-8, and the characters
 // '+', '-', '=', '.', '_', ':', and '/'.
@@ -917,4 +1148,14 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddTagsToResource = "AddTagsToResource"
@@ -1314,6 +1315,16 @@ type metadataAddTagsToResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddTagsToResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToResourceInput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of an AuthorizeCacheSecurityGroupIngress action.
 type AuthorizeCacheSecurityGroupIngressInput struct {
 	// The cache security group which will allow network ingress.
@@ -1335,6 +1346,16 @@ type metadataAuthorizeCacheSecurityGroupIngressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AuthorizeCacheSecurityGroupIngressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeCacheSecurityGroupIngressInput) GoString() string {
+	return s.String()
+}
+
 type AuthorizeCacheSecurityGroupIngressOutput struct {
 	// Represents the output of one of the following actions:
 	//
@@ -1348,6 +1369,16 @@ type metadataAuthorizeCacheSecurityGroupIngressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AuthorizeCacheSecurityGroupIngressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeCacheSecurityGroupIngressOutput) GoString() string {
+	return s.String()
+}
+
 // Describes an Availability Zone in which the cache cluster is launched.
 type AvailabilityZone struct {
 	// The name of the Availability Zone.
@@ -1358,6 +1389,16 @@ type AvailabilityZone struct {
 
 type metadataAvailabilityZone struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AvailabilityZone) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AvailabilityZone) GoString() string {
+	return s.String()
 }
 
 // Contains all of the attributes of a specific cache cluster.
@@ -1481,6 +1522,16 @@ type metadataCacheCluster struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CacheCluster) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheCluster) GoString() string {
+	return s.String()
+}
+
 // Provides all of the details about a particular cache engine version.
 type CacheEngineVersion struct {
 	// The description of the cache engine.
@@ -1503,6 +1554,16 @@ type CacheEngineVersion struct {
 
 type metadataCacheEngineVersion struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CacheEngineVersion) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheEngineVersion) GoString() string {
+	return s.String()
 }
 
 // Represents an individual cache node within a cache cluster. Each cache node
@@ -1559,6 +1620,16 @@ type metadataCacheNode struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CacheNode) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheNode) GoString() string {
+	return s.String()
+}
+
 // A parameter that has a different value for each cache node type it is applied
 // to. For example, in a Redis cache cluster, a cache.m1.large cache node type
 // would have a larger maxmemory value than a cache.m1.small type.
@@ -1596,6 +1667,16 @@ type metadataCacheNodeTypeSpecificParameter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CacheNodeTypeSpecificParameter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheNodeTypeSpecificParameter) GoString() string {
+	return s.String()
+}
+
 // A value that applies only to a certain cache node type.
 type CacheNodeTypeSpecificValue struct {
 	// The cache node type for which this value applies.
@@ -1609,6 +1690,16 @@ type CacheNodeTypeSpecificValue struct {
 
 type metadataCacheNodeTypeSpecificValue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CacheNodeTypeSpecificValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheNodeTypeSpecificValue) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a CreateCacheParameterGroup action.
@@ -1630,6 +1721,16 @@ type metadataCacheParameterGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CacheParameterGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheParameterGroup) GoString() string {
+	return s.String()
+}
+
 // Represents the output of one of the following actions:
 //
 //   ModifyCacheParameterGroup   ResetCacheParameterGroup
@@ -1642,6 +1743,16 @@ type CacheParameterGroupNameMessage struct {
 
 type metadataCacheParameterGroupNameMessage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CacheParameterGroupNameMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheParameterGroupNameMessage) GoString() string {
+	return s.String()
 }
 
 // The status of the cache parameter group.
@@ -1661,6 +1772,16 @@ type CacheParameterGroupStatus struct {
 
 type metadataCacheParameterGroupStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CacheParameterGroupStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheParameterGroupStatus) GoString() string {
+	return s.String()
 }
 
 // Represents the output of one of the following actions:
@@ -1687,6 +1808,16 @@ type metadataCacheSecurityGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CacheSecurityGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheSecurityGroup) GoString() string {
+	return s.String()
+}
+
 // Represents a cache cluster's status within a particular cache security group.
 type CacheSecurityGroupMembership struct {
 	// The name of the cache security group.
@@ -1702,6 +1833,16 @@ type CacheSecurityGroupMembership struct {
 
 type metadataCacheSecurityGroupMembership struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CacheSecurityGroupMembership) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheSecurityGroupMembership) GoString() string {
+	return s.String()
 }
 
 // Represents the output of one of the following actions:
@@ -1728,6 +1869,16 @@ type metadataCacheSubnetGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CacheSubnetGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CacheSubnetGroup) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a CopySnapshotMessage action.
 type CopySnapshotInput struct {
 	// The name of an existing snapshot from which to copy.
@@ -1743,6 +1894,16 @@ type metadataCopySnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopySnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopySnapshotInput) GoString() string {
+	return s.String()
+}
+
 type CopySnapshotOutput struct {
 	// Represents a copy of an entire cache cluster as of the time when the snapshot
 	// was taken.
@@ -1753,6 +1914,16 @@ type CopySnapshotOutput struct {
 
 type metadataCopySnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CopySnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopySnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a CreateCacheCluster action.
@@ -1954,6 +2125,16 @@ type metadataCreateCacheClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateCacheClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCacheClusterInput) GoString() string {
+	return s.String()
+}
+
 type CreateCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
@@ -1963,6 +2144,16 @@ type CreateCacheClusterOutput struct {
 
 type metadataCreateCacheClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateCacheClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCacheClusterOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a CreateCacheParameterGroup action.
@@ -1986,6 +2177,16 @@ type metadataCreateCacheParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateCacheParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCacheParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateCacheParameterGroupOutput struct {
 	// Represents the output of a CreateCacheParameterGroup action.
 	CacheParameterGroup *CacheParameterGroup `type:"structure"`
@@ -1995,6 +2196,16 @@ type CreateCacheParameterGroupOutput struct {
 
 type metadataCreateCacheParameterGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateCacheParameterGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCacheParameterGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a CreateCacheSecurityGroup action.
@@ -2018,6 +2229,16 @@ type metadataCreateCacheSecurityGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateCacheSecurityGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCacheSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateCacheSecurityGroupOutput struct {
 	// Represents the output of one of the following actions:
 	//
@@ -2029,6 +2250,16 @@ type CreateCacheSecurityGroupOutput struct {
 
 type metadataCreateCacheSecurityGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateCacheSecurityGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCacheSecurityGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a CreateCacheSubnetGroup action.
@@ -2053,6 +2284,16 @@ type metadataCreateCacheSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateCacheSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCacheSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateCacheSubnetGroupOutput struct {
 	// Represents the output of one of the following actions:
 	//
@@ -2064,6 +2305,16 @@ type CreateCacheSubnetGroupOutput struct {
 
 type metadataCreateCacheSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateCacheSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCacheSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a CreateReplicationGroup action.
@@ -2244,6 +2495,16 @@ type metadataCreateReplicationGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateReplicationGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateReplicationGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
@@ -2253,6 +2514,16 @@ type CreateReplicationGroupOutput struct {
 
 type metadataCreateReplicationGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateReplicationGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateReplicationGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a CreateSnapshot action.
@@ -2271,6 +2542,16 @@ type metadataCreateSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type CreateSnapshotOutput struct {
 	// Represents a copy of an entire cache cluster as of the time when the snapshot
 	// was taken.
@@ -2281,6 +2562,16 @@ type CreateSnapshotOutput struct {
 
 type metadataCreateSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DeleteCacheCluster action.
@@ -2301,6 +2592,16 @@ type metadataDeleteCacheClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteCacheClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCacheClusterInput) GoString() string {
+	return s.String()
+}
+
 type DeleteCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
@@ -2310,6 +2611,16 @@ type DeleteCacheClusterOutput struct {
 
 type metadataDeleteCacheClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteCacheClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCacheClusterOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DeleteCacheParameterGroup action.
@@ -2327,12 +2638,32 @@ type metadataDeleteCacheParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteCacheParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCacheParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteCacheParameterGroupOutput struct {
 	metadataDeleteCacheParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheParameterGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteCacheParameterGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCacheParameterGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DeleteCacheSecurityGroup action.
@@ -2349,12 +2680,32 @@ type metadataDeleteCacheSecurityGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteCacheSecurityGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCacheSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteCacheSecurityGroupOutput struct {
 	metadataDeleteCacheSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheSecurityGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteCacheSecurityGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCacheSecurityGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DeleteCacheSubnetGroup action.
@@ -2371,12 +2722,32 @@ type metadataDeleteCacheSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteCacheSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCacheSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteCacheSubnetGroupOutput struct {
 	metadataDeleteCacheSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteCacheSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteCacheSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteCacheSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DeleteReplicationGroup action.
@@ -2402,6 +2773,16 @@ type metadataDeleteReplicationGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteReplicationGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteReplicationGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
@@ -2411,6 +2792,16 @@ type DeleteReplicationGroupOutput struct {
 
 type metadataDeleteReplicationGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteReplicationGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteReplicationGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DeleteSnapshot action.
@@ -2425,6 +2816,16 @@ type metadataDeleteSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSnapshotOutput struct {
 	// Represents a copy of an entire cache cluster as of the time when the snapshot
 	// was taken.
@@ -2435,6 +2836,16 @@ type DeleteSnapshotOutput struct {
 
 type metadataDeleteSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeCacheClusters action.
@@ -2469,6 +2880,16 @@ type metadataDescribeCacheClustersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCacheClustersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheClustersInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeCacheClusters action.
 type DescribeCacheClustersOutput struct {
 	// A list of cache clusters. Each item in the list contains detailed information
@@ -2483,6 +2904,16 @@ type DescribeCacheClustersOutput struct {
 
 type metadataDescribeCacheClustersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCacheClustersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheClustersOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeCacheEngineVersions action.
@@ -2528,6 +2959,16 @@ type metadataDescribeCacheEngineVersionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCacheEngineVersionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheEngineVersionsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeCacheEngineVersions action.
 type DescribeCacheEngineVersionsOutput struct {
 	// A list of cache engine version details. Each element in the list contains
@@ -2542,6 +2983,16 @@ type DescribeCacheEngineVersionsOutput struct {
 
 type metadataDescribeCacheEngineVersionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCacheEngineVersionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheEngineVersionsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeCacheParameterGroups action.
@@ -2570,6 +3021,16 @@ type metadataDescribeCacheParameterGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCacheParameterGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheParameterGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeCacheParameterGroups action.
 type DescribeCacheParameterGroupsOutput struct {
 	// A list of cache parameter groups. Each element in the list contains detailed
@@ -2584,6 +3045,16 @@ type DescribeCacheParameterGroupsOutput struct {
 
 type metadataDescribeCacheParameterGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCacheParameterGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheParameterGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeCacheParameters action.
@@ -2617,6 +3088,16 @@ type metadataDescribeCacheParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCacheParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheParametersInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeCacheParameters action.
 type DescribeCacheParametersOutput struct {
 	// A list of parameters specific to a particular cache node type. Each element
@@ -2634,6 +3115,16 @@ type DescribeCacheParametersOutput struct {
 
 type metadataDescribeCacheParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCacheParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheParametersOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeCacheSecurityGroups action.
@@ -2662,6 +3153,16 @@ type metadataDescribeCacheSecurityGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCacheSecurityGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheSecurityGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeCacheSecurityGroups action.
 type DescribeCacheSecurityGroupsOutput struct {
 	// A list of cache security groups. Each element in the list contains detailed
@@ -2676,6 +3177,16 @@ type DescribeCacheSecurityGroupsOutput struct {
 
 type metadataDescribeCacheSecurityGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCacheSecurityGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheSecurityGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeCacheSubnetGroups action.
@@ -2704,6 +3215,16 @@ type metadataDescribeCacheSubnetGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCacheSubnetGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheSubnetGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeCacheSubnetGroups action.
 type DescribeCacheSubnetGroupsOutput struct {
 	// A list of cache subnet groups. Each element in the list contains detailed
@@ -2718,6 +3239,16 @@ type DescribeCacheSubnetGroupsOutput struct {
 
 type metadataDescribeCacheSubnetGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCacheSubnetGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheSubnetGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeEngineDefaultParameters action.
@@ -2747,6 +3278,16 @@ type metadataDescribeEngineDefaultParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEngineDefaultParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEngineDefaultParametersInput) GoString() string {
+	return s.String()
+}
+
 type DescribeEngineDefaultParametersOutput struct {
 	// Represents the output of a DescribeEngineDefaultParameters action.
 	EngineDefaults *EngineDefaults `type:"structure"`
@@ -2756,6 +3297,16 @@ type DescribeEngineDefaultParametersOutput struct {
 
 type metadataDescribeEngineDefaultParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEngineDefaultParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEngineDefaultParametersOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeEvents action.
@@ -2803,6 +3354,16 @@ type metadataDescribeEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeEvents action.
 type DescribeEventsOutput struct {
 	// A list of events. Each element in the list contains detailed information
@@ -2817,6 +3378,16 @@ type DescribeEventsOutput struct {
 
 type metadataDescribeEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeReplicationGroups action.
@@ -2849,6 +3420,16 @@ type metadataDescribeReplicationGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReplicationGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReplicationGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeReplicationGroups action.
 type DescribeReplicationGroupsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
@@ -2863,6 +3444,16 @@ type DescribeReplicationGroupsOutput struct {
 
 type metadataDescribeReplicationGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeReplicationGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReplicationGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeReservedCacheNodes action.
@@ -2934,6 +3525,16 @@ type metadataDescribeReservedCacheNodesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedCacheNodesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedCacheNodesInput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a DescribeReservedCacheNodesOfferings action.
 type DescribeReservedCacheNodesOfferingsInput struct {
 	// The cache node type filter value. Use this parameter to show only the available
@@ -3001,6 +3602,16 @@ type metadataDescribeReservedCacheNodesOfferingsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedCacheNodesOfferingsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedCacheNodesOfferingsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeReservedCacheNodesOfferings action.
 type DescribeReservedCacheNodesOfferingsOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
@@ -3017,6 +3628,16 @@ type metadataDescribeReservedCacheNodesOfferingsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedCacheNodesOfferingsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedCacheNodesOfferingsOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeReservedCacheNodes action.
 type DescribeReservedCacheNodesOutput struct {
 	// Provides an identifier to allow retrieval of paginated results.
@@ -3031,6 +3652,16 @@ type DescribeReservedCacheNodesOutput struct {
 
 type metadataDescribeReservedCacheNodesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeReservedCacheNodesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedCacheNodesOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a DescribeSnapshotsMessage action.
@@ -3070,6 +3701,16 @@ type metadataDescribeSnapshotsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSnapshotsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeSnapshots action.
 type DescribeSnapshotsOutput struct {
 	// An optional marker returned from a prior request. Use this marker for pagination
@@ -3086,6 +3727,16 @@ type DescribeSnapshotsOutput struct {
 
 type metadataDescribeSnapshotsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSnapshotsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotsOutput) GoString() string {
+	return s.String()
 }
 
 // Provides ownership and status information for an Amazon EC2 security group.
@@ -3106,6 +3757,16 @@ type metadataEC2SecurityGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EC2SecurityGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EC2SecurityGroup) GoString() string {
+	return s.String()
+}
+
 // Represents the information required for client programs to connect to a cache
 // node.
 type Endpoint struct {
@@ -3120,6 +3781,16 @@ type Endpoint struct {
 
 type metadataEndpoint struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Endpoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Endpoint) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a DescribeEngineDefaultParameters action.
@@ -3143,6 +3814,16 @@ type EngineDefaults struct {
 
 type metadataEngineDefaults struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EngineDefaults) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EngineDefaults) GoString() string {
+	return s.String()
 }
 
 // Represents a single occurrence of something interesting within the system.
@@ -3171,6 +3852,16 @@ type metadataEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Event) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Event) GoString() string {
+	return s.String()
+}
+
 // The input parameters for the ListTagsForResource action.
 type ListTagsForResourceInput struct {
 	// The name of the resource for which you want the list of tags, for example
@@ -3182,6 +3873,16 @@ type ListTagsForResourceInput struct {
 
 type metadataListTagsForResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceInput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a ModifyCacheCluster action.
@@ -3371,6 +4072,16 @@ type metadataModifyCacheClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyCacheClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyCacheClusterInput) GoString() string {
+	return s.String()
+}
+
 type ModifyCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
@@ -3380,6 +4091,16 @@ type ModifyCacheClusterOutput struct {
 
 type metadataModifyCacheClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyCacheClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyCacheClusterOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a ModifyCacheParameterGroup action.
@@ -3397,6 +4118,16 @@ type ModifyCacheParameterGroupInput struct {
 
 type metadataModifyCacheParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyCacheParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyCacheParameterGroupInput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a ModifyCacheSubnetGroup action.
@@ -3422,6 +4153,16 @@ type metadataModifyCacheSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyCacheSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyCacheSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type ModifyCacheSubnetGroupOutput struct {
 	// Represents the output of one of the following actions:
 	//
@@ -3433,6 +4174,16 @@ type ModifyCacheSubnetGroupOutput struct {
 
 type metadataModifyCacheSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyCacheSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyCacheSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a ModifyReplicationGroups action.
@@ -3551,6 +4302,16 @@ type metadataModifyReplicationGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyReplicationGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyReplicationGroupInput) GoString() string {
+	return s.String()
+}
+
 type ModifyReplicationGroupOutput struct {
 	// Contains all of the attributes of a specific replication group.
 	ReplicationGroup *ReplicationGroup `type:"structure"`
@@ -3560,6 +4321,16 @@ type ModifyReplicationGroupOutput struct {
 
 type metadataModifyReplicationGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyReplicationGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyReplicationGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a collection of cache nodes in a replication group.
@@ -3583,6 +4354,16 @@ type NodeGroup struct {
 
 type metadataNodeGroup struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NodeGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NodeGroup) GoString() string {
+	return s.String()
 }
 
 // Represents a single node within a node group.
@@ -3611,6 +4392,16 @@ type metadataNodeGroupMember struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NodeGroupMember) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NodeGroupMember) GoString() string {
+	return s.String()
+}
+
 // Represents an individual cache node in a snapshot of a cache cluster.
 type NodeSnapshot struct {
 	// The date and time when the cache node was created in the source cache cluster.
@@ -3633,6 +4424,16 @@ type metadataNodeSnapshot struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NodeSnapshot) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NodeSnapshot) GoString() string {
+	return s.String()
+}
+
 // Describes a notification topic and its status. Notification topics are used
 // for publishing ElastiCache events to subscribers using Amazon Simple Notification
 // Service (SNS).
@@ -3648,6 +4449,16 @@ type NotificationConfiguration struct {
 
 type metadataNotificationConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NotificationConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NotificationConfiguration) GoString() string {
+	return s.String()
 }
 
 // Describes an individual setting that controls some aspect of ElastiCache
@@ -3686,6 +4497,16 @@ type metadataParameter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Parameter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Parameter) GoString() string {
+	return s.String()
+}
+
 // Describes a name-value pair that is used to update the value of a parameter.
 type ParameterNameValue struct {
 	// The name of the parameter.
@@ -3699,6 +4520,16 @@ type ParameterNameValue struct {
 
 type metadataParameterNameValue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ParameterNameValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ParameterNameValue) GoString() string {
+	return s.String()
 }
 
 // A group of settings that will be applied to the cache cluster in the future,
@@ -3722,6 +4553,16 @@ type PendingModifiedValues struct {
 
 type metadataPendingModifiedValues struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PendingModifiedValues) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PendingModifiedValues) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a PurchaseReservedCacheNodesOffering action.
@@ -3748,6 +4589,16 @@ type metadataPurchaseReservedCacheNodesOfferingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PurchaseReservedCacheNodesOfferingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedCacheNodesOfferingInput) GoString() string {
+	return s.String()
+}
+
 type PurchaseReservedCacheNodesOfferingOutput struct {
 	// Represents the output of a PurchaseReservedCacheNodesOffering action.
 	ReservedCacheNode *ReservedCacheNode `type:"structure"`
@@ -3757,6 +4608,16 @@ type PurchaseReservedCacheNodesOfferingOutput struct {
 
 type metadataPurchaseReservedCacheNodesOfferingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PurchaseReservedCacheNodesOfferingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedCacheNodesOfferingOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input of a RebootCacheCluster action.
@@ -3776,6 +4637,16 @@ type metadataRebootCacheClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebootCacheClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootCacheClusterInput) GoString() string {
+	return s.String()
+}
+
 type RebootCacheClusterOutput struct {
 	// Contains all of the attributes of a specific cache cluster.
 	CacheCluster *CacheCluster `type:"structure"`
@@ -3785,6 +4656,16 @@ type RebootCacheClusterOutput struct {
 
 type metadataRebootCacheClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebootCacheClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootCacheClusterOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the specific price and frequency of a recurring charges for a reserved
@@ -3803,6 +4684,16 @@ type metadataRecurringCharge struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecurringCharge) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecurringCharge) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a RemoveTagsFromResource action.
 type RemoveTagsFromResourceInput struct {
 	// The name of the ElastiCache resource from which you want the listed tags
@@ -3819,6 +4710,16 @@ type RemoveTagsFromResourceInput struct {
 
 type metadataRemoveTagsFromResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveTagsFromResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromResourceInput) GoString() string {
+	return s.String()
 }
 
 // Contains all of the attributes of a specific replication group.
@@ -3861,6 +4762,16 @@ type metadataReplicationGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReplicationGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplicationGroup) GoString() string {
+	return s.String()
+}
+
 // The settings to be applied to the replication group, either immediately or
 // during the next maintenance window.
 type ReplicationGroupPendingModifiedValues struct {
@@ -3880,6 +4791,16 @@ type ReplicationGroupPendingModifiedValues struct {
 
 type metadataReplicationGroupPendingModifiedValues struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReplicationGroupPendingModifiedValues) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplicationGroupPendingModifiedValues) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a PurchaseReservedCacheNodesOffering action.
@@ -3945,6 +4866,16 @@ type metadataReservedCacheNode struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedCacheNode) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedCacheNode) GoString() string {
+	return s.String()
+}
+
 // Describes all of the attributes of a reserved cache node offering.
 type ReservedCacheNodesOffering struct {
 	// The cache node type for the reserved cache node.
@@ -3996,6 +4927,16 @@ type metadataReservedCacheNodesOffering struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedCacheNodesOffering) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedCacheNodesOffering) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a ResetCacheParameterGroup action.
 type ResetCacheParameterGroupInput struct {
 	// The name of the cache parameter group to reset.
@@ -4018,6 +4959,16 @@ type metadataResetCacheParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResetCacheParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetCacheParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 // Represents the input of a RevokeCacheSecurityGroupIngress action.
 type RevokeCacheSecurityGroupIngressInput struct {
 	// The name of the cache security group to revoke ingress from.
@@ -4038,6 +4989,16 @@ type metadataRevokeCacheSecurityGroupIngressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RevokeCacheSecurityGroupIngressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeCacheSecurityGroupIngressInput) GoString() string {
+	return s.String()
+}
+
 type RevokeCacheSecurityGroupIngressOutput struct {
 	// Represents the output of one of the following actions:
 	//
@@ -4049,6 +5010,16 @@ type RevokeCacheSecurityGroupIngressOutput struct {
 
 type metadataRevokeCacheSecurityGroupIngressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RevokeCacheSecurityGroupIngressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeCacheSecurityGroupIngressOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a single cache security group and its status.
@@ -4066,6 +5037,16 @@ type SecurityGroupMembership struct {
 
 type metadataSecurityGroupMembership struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SecurityGroupMembership) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SecurityGroupMembership) GoString() string {
+	return s.String()
 }
 
 // Represents a copy of an entire cache cluster as of the time when the snapshot
@@ -4182,6 +5163,16 @@ type metadataSnapshot struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Snapshot) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Snapshot) GoString() string {
+	return s.String()
+}
+
 // Represents the subnet associated with a cache cluster. This parameter refers
 // to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used
 // with ElastiCache.
@@ -4197,6 +5188,16 @@ type Subnet struct {
 
 type metadataSubnet struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Subnet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Subnet) GoString() string {
+	return s.String()
 }
 
 // A cost allocation Tag that can be added to an ElastiCache cluster or replication
@@ -4216,6 +5217,16 @@ type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
 // Represents the output from the AddTagsToResource, ListTagsOnResource, and
 // RemoveTagsFromResource actions.
 type TagListMessage struct {
@@ -4227,4 +5238,14 @@ type TagListMessage struct {
 
 type metadataTagListMessage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TagListMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TagListMessage) GoString() string {
+	return s.String()
 }

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAbortEnvironmentUpdate = "AbortEnvironmentUpdate"
@@ -947,12 +948,32 @@ type metadataAbortEnvironmentUpdateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AbortEnvironmentUpdateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AbortEnvironmentUpdateInput) GoString() string {
+	return s.String()
+}
+
 type AbortEnvironmentUpdateOutput struct {
 	metadataAbortEnvironmentUpdateOutput `json:"-" xml:"-"`
 }
 
 type metadataAbortEnvironmentUpdateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AbortEnvironmentUpdateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AbortEnvironmentUpdateOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the properties of an application.
@@ -982,6 +1003,16 @@ type metadataApplicationDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ApplicationDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplicationDescription) GoString() string {
+	return s.String()
+}
+
 // Result message containing a single description of an application.
 type ApplicationDescriptionMessage struct {
 	// The ApplicationDescription of the application.
@@ -992,6 +1023,16 @@ type ApplicationDescriptionMessage struct {
 
 type metadataApplicationDescriptionMessage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ApplicationDescriptionMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplicationDescriptionMessage) GoString() string {
+	return s.String()
 }
 
 // Describes the properties of an application version.
@@ -1021,6 +1062,16 @@ type metadataApplicationVersionDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ApplicationVersionDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplicationVersionDescription) GoString() string {
+	return s.String()
+}
+
 // Result message wrapping a single description of an application version.
 type ApplicationVersionDescriptionMessage struct {
 	// The ApplicationVersionDescription of the application version.
@@ -1031,6 +1082,16 @@ type ApplicationVersionDescriptionMessage struct {
 
 type metadataApplicationVersionDescriptionMessage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ApplicationVersionDescriptionMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplicationVersionDescriptionMessage) GoString() string {
+	return s.String()
 }
 
 // Describes an Auto Scaling launch configuration.
@@ -1045,6 +1106,16 @@ type metadataAutoScalingGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AutoScalingGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingGroup) GoString() string {
+	return s.String()
+}
+
 // Results message indicating whether a CNAME is available.
 type CheckDNSAvailabilityInput struct {
 	// The prefix used when this CNAME is reserved.
@@ -1055,6 +1126,16 @@ type CheckDNSAvailabilityInput struct {
 
 type metadataCheckDNSAvailabilityInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CheckDNSAvailabilityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CheckDNSAvailabilityInput) GoString() string {
+	return s.String()
 }
 
 // Indicates if the specified CNAME is available.
@@ -1077,6 +1158,16 @@ type CheckDNSAvailabilityOutput struct {
 
 type metadataCheckDNSAvailabilityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CheckDNSAvailabilityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CheckDNSAvailabilityOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the possible values for a configuration option.
@@ -1176,6 +1267,16 @@ type metadataConfigurationOptionDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfigurationOptionDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigurationOptionDescription) GoString() string {
+	return s.String()
+}
+
 // A specification identifying an individual configuration option along with
 // its current value. For a list of possible option values, go to Option Values
 // (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html)
@@ -1198,6 +1299,16 @@ type ConfigurationOptionSetting struct {
 
 type metadataConfigurationOptionSetting struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfigurationOptionSetting) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigurationOptionSetting) GoString() string {
+	return s.String()
 }
 
 // Describes the settings for a configuration set.
@@ -1255,6 +1366,16 @@ type metadataConfigurationSettingsDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfigurationSettingsDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigurationSettingsDescription) GoString() string {
+	return s.String()
+}
+
 // This documentation target is not reported in the API reference.
 type CreateApplicationInput struct {
 	// The name of the application.
@@ -1271,6 +1392,16 @@ type CreateApplicationInput struct {
 
 type metadataCreateApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateApplicationInput) GoString() string {
+	return s.String()
 }
 
 type CreateApplicationVersionInput struct {
@@ -1323,6 +1454,16 @@ type CreateApplicationVersionInput struct {
 
 type metadataCreateApplicationVersionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateApplicationVersionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateApplicationVersionInput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1387,6 +1528,16 @@ type CreateConfigurationTemplateInput struct {
 
 type metadataCreateConfigurationTemplateInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateConfigurationTemplateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateConfigurationTemplateInput) GoString() string {
+	return s.String()
 }
 
 type CreateEnvironmentInput struct {
@@ -1467,12 +1618,32 @@ type metadataCreateEnvironmentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateEnvironmentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateEnvironmentInput) GoString() string {
+	return s.String()
+}
+
 type CreateStorageLocationInput struct {
 	metadataCreateStorageLocationInput `json:"-" xml:"-"`
 }
 
 type metadataCreateStorageLocationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateStorageLocationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStorageLocationInput) GoString() string {
+	return s.String()
 }
 
 // Results of a CreateStorageLocationResult call.
@@ -1485,6 +1656,16 @@ type CreateStorageLocationOutput struct {
 
 type metadataCreateStorageLocationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateStorageLocationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStorageLocationOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1503,12 +1684,32 @@ type metadataDeleteApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteApplicationInput) GoString() string {
+	return s.String()
+}
+
 type DeleteApplicationOutput struct {
 	metadataDeleteApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteApplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteApplicationOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1533,12 +1734,32 @@ type metadataDeleteApplicationVersionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteApplicationVersionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteApplicationVersionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteApplicationVersionOutput struct {
 	metadataDeleteApplicationVersionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteApplicationVersionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteApplicationVersionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteApplicationVersionOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1556,12 +1777,32 @@ type metadataDeleteConfigurationTemplateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteConfigurationTemplateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteConfigurationTemplateInput) GoString() string {
+	return s.String()
+}
+
 type DeleteConfigurationTemplateOutput struct {
 	metadataDeleteConfigurationTemplateOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteConfigurationTemplateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteConfigurationTemplateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteConfigurationTemplateOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1579,12 +1820,32 @@ type metadataDeleteEnvironmentConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteEnvironmentConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEnvironmentConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type DeleteEnvironmentConfigurationOutput struct {
 	metadataDeleteEnvironmentConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEnvironmentConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteEnvironmentConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEnvironmentConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 // Result message containing a list of configuration descriptions.
@@ -1604,6 +1865,16 @@ type metadataDescribeApplicationVersionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeApplicationVersionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeApplicationVersionsInput) GoString() string {
+	return s.String()
+}
+
 // Result message wrapping a list of application version descriptions.
 type DescribeApplicationVersionsOutput struct {
 	// A list of ApplicationVersionDescription .
@@ -1614,6 +1885,16 @@ type DescribeApplicationVersionsOutput struct {
 
 type metadataDescribeApplicationVersionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeApplicationVersionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeApplicationVersionsOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1629,6 +1910,16 @@ type metadataDescribeApplicationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeApplicationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeApplicationsInput) GoString() string {
+	return s.String()
+}
+
 // Result message containing a list of application descriptions.
 type DescribeApplicationsOutput struct {
 	// This parameter contains a list of ApplicationDescription.
@@ -1639,6 +1930,16 @@ type DescribeApplicationsOutput struct {
 
 type metadataDescribeApplicationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeApplicationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeApplicationsOutput) GoString() string {
+	return s.String()
 }
 
 // Result message containig a list of application version descriptions.
@@ -1668,6 +1969,16 @@ type metadataDescribeConfigurationOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeConfigurationOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConfigurationOptionsInput) GoString() string {
+	return s.String()
+}
+
 // Describes the settings for a specified configuration set.
 type DescribeConfigurationOptionsOutput struct {
 	// A list of ConfigurationOptionDescription.
@@ -1681,6 +1992,16 @@ type DescribeConfigurationOptionsOutput struct {
 
 type metadataDescribeConfigurationOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeConfigurationOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConfigurationOptionsOutput) GoString() string {
+	return s.String()
 }
 
 // Result message containing all of the configuration settings for a specified
@@ -1712,6 +2033,16 @@ type metadataDescribeConfigurationSettingsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeConfigurationSettingsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConfigurationSettingsInput) GoString() string {
+	return s.String()
+}
+
 // The results from a request to change the configuration settings of an environment.
 type DescribeConfigurationSettingsOutput struct {
 	// A list of ConfigurationSettingsDescription.
@@ -1722,6 +2053,16 @@ type DescribeConfigurationSettingsOutput struct {
 
 type metadataDescribeConfigurationSettingsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeConfigurationSettingsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeConfigurationSettingsOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1747,6 +2088,16 @@ type metadataDescribeEnvironmentResourcesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEnvironmentResourcesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEnvironmentResourcesInput) GoString() string {
+	return s.String()
+}
+
 // Result message containing a list of environment resource descriptions.
 type DescribeEnvironmentResourcesOutput struct {
 	// A list of EnvironmentResourceDescription.
@@ -1757,6 +2108,16 @@ type DescribeEnvironmentResourcesOutput struct {
 
 type metadataDescribeEnvironmentResourcesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEnvironmentResourcesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEnvironmentResourcesOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1796,6 +2157,16 @@ type metadataDescribeEnvironmentsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEnvironmentsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEnvironmentsInput) GoString() string {
+	return s.String()
+}
+
 // Result message containing a list of environment descriptions.
 type DescribeEnvironmentsOutput struct {
 	// Returns an EnvironmentDescription list.
@@ -1806,6 +2177,16 @@ type DescribeEnvironmentsOutput struct {
 
 type metadataDescribeEnvironmentsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEnvironmentsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEnvironmentsOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -1860,6 +2241,16 @@ type metadataDescribeEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsInput) GoString() string {
+	return s.String()
+}
+
 // Result message wrapping a list of event descriptions.
 type DescribeEventsOutput struct {
 	// A list of EventDescription.
@@ -1874,6 +2265,16 @@ type DescribeEventsOutput struct {
 
 type metadataDescribeEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the properties of an environment.
@@ -1961,6 +2362,16 @@ type metadataEnvironmentDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnvironmentDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnvironmentDescription) GoString() string {
+	return s.String()
+}
+
 // The information retrieved from the Amazon EC2 instances.
 type EnvironmentInfoDescription struct {
 	// The Amazon EC2 Instance ID for this information.
@@ -1980,6 +2391,16 @@ type EnvironmentInfoDescription struct {
 
 type metadataEnvironmentInfoDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnvironmentInfoDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnvironmentInfoDescription) GoString() string {
+	return s.String()
 }
 
 // Describes the AWS resources in use by this environment. This data is live.
@@ -2012,6 +2433,16 @@ type metadataEnvironmentResourceDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnvironmentResourceDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnvironmentResourceDescription) GoString() string {
+	return s.String()
+}
+
 // Describes the AWS resources in use by this environment. This data is not
 // live data.
 type EnvironmentResourcesDescription struct {
@@ -2023,6 +2454,16 @@ type EnvironmentResourcesDescription struct {
 
 type metadataEnvironmentResourcesDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnvironmentResourcesDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnvironmentResourcesDescription) GoString() string {
+	return s.String()
 }
 
 // Describes the properties of an environment tier
@@ -2041,6 +2482,16 @@ type EnvironmentTier struct {
 
 type metadataEnvironmentTier struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnvironmentTier) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnvironmentTier) GoString() string {
+	return s.String()
 }
 
 // Describes an event.
@@ -2076,6 +2527,16 @@ type metadataEventDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EventDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EventDescription) GoString() string {
+	return s.String()
+}
+
 // The description of an Amazon EC2 instance.
 type Instance struct {
 	// The ID of the Amazon EC2 instance.
@@ -2086,6 +2547,16 @@ type Instance struct {
 
 type metadataInstance struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Instance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Instance) GoString() string {
+	return s.String()
 }
 
 // Describes an Auto Scaling launch configuration.
@@ -2100,12 +2571,32 @@ type metadataLaunchConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LaunchConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LaunchConfiguration) GoString() string {
+	return s.String()
+}
+
 type ListAvailableSolutionStacksInput struct {
 	metadataListAvailableSolutionStacksInput `json:"-" xml:"-"`
 }
 
 type metadataListAvailableSolutionStacksInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAvailableSolutionStacksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAvailableSolutionStacksInput) GoString() string {
+	return s.String()
 }
 
 // A list of available AWS Elastic Beanstalk solution stacks.
@@ -2123,6 +2614,16 @@ type metadataListAvailableSolutionStacksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListAvailableSolutionStacksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAvailableSolutionStacksOutput) GoString() string {
+	return s.String()
+}
+
 // Describes the properties of a Listener for the LoadBalancer.
 type Listener struct {
 	// The port that is used by the Listener.
@@ -2138,6 +2639,16 @@ type metadataListener struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Listener) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Listener) GoString() string {
+	return s.String()
+}
+
 // Describes a LoadBalancer.
 type LoadBalancer struct {
 	// The name of the LoadBalancer.
@@ -2148,6 +2659,16 @@ type LoadBalancer struct {
 
 type metadataLoadBalancer struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LoadBalancer) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancer) GoString() string {
+	return s.String()
 }
 
 // Describes the details of a LoadBalancer.
@@ -2168,6 +2689,16 @@ type metadataLoadBalancerDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LoadBalancerDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerDescription) GoString() string {
+	return s.String()
+}
+
 // A regular expression representing a restriction on a string configuration
 // option value.
 type OptionRestrictionRegex struct {
@@ -2183,6 +2714,16 @@ type OptionRestrictionRegex struct {
 
 type metadataOptionRestrictionRegex struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OptionRestrictionRegex) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionRestrictionRegex) GoString() string {
+	return s.String()
 }
 
 // A specification identifying an individual configuration option.
@@ -2203,6 +2744,16 @@ type metadataOptionSpecification struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s OptionSpecification) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionSpecification) GoString() string {
+	return s.String()
+}
+
 // Describes a queue.
 type Queue struct {
 	// The name of the queue.
@@ -2216,6 +2767,16 @@ type Queue struct {
 
 type metadataQueue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Queue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Queue) GoString() string {
+	return s.String()
 }
 
 type RebuildEnvironmentInput struct {
@@ -2240,12 +2801,32 @@ type metadataRebuildEnvironmentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebuildEnvironmentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebuildEnvironmentInput) GoString() string {
+	return s.String()
+}
+
 type RebuildEnvironmentOutput struct {
 	metadataRebuildEnvironmentOutput `json:"-" xml:"-"`
 }
 
 type metadataRebuildEnvironmentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebuildEnvironmentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebuildEnvironmentOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -2280,12 +2861,32 @@ type metadataRequestEnvironmentInfoInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RequestEnvironmentInfoInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestEnvironmentInfoInput) GoString() string {
+	return s.String()
+}
+
 type RequestEnvironmentInfoOutput struct {
 	metadataRequestEnvironmentInfoOutput `json:"-" xml:"-"`
 }
 
 type metadataRequestEnvironmentInfoOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RequestEnvironmentInfoOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestEnvironmentInfoOutput) GoString() string {
+	return s.String()
 }
 
 type RestartAppServerInput struct {
@@ -2310,12 +2911,32 @@ type metadataRestartAppServerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RestartAppServerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestartAppServerInput) GoString() string {
+	return s.String()
+}
+
 type RestartAppServerOutput struct {
 	metadataRestartAppServerOutput `json:"-" xml:"-"`
 }
 
 type metadataRestartAppServerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RestartAppServerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestartAppServerOutput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -2348,6 +2969,16 @@ type metadataRetrieveEnvironmentInfoInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RetrieveEnvironmentInfoInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetrieveEnvironmentInfoInput) GoString() string {
+	return s.String()
+}
+
 // Result message containing a description of the requested environment info.
 type RetrieveEnvironmentInfoOutput struct {
 	// The EnvironmentInfoDescription of the environment.
@@ -2358,6 +2989,16 @@ type RetrieveEnvironmentInfoOutput struct {
 
 type metadataRetrieveEnvironmentInfoOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RetrieveEnvironmentInfoOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetrieveEnvironmentInfoOutput) GoString() string {
+	return s.String()
 }
 
 // A specification of a location in Amazon S3.
@@ -2375,6 +3016,16 @@ type metadataS3Location struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s S3Location) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s S3Location) GoString() string {
+	return s.String()
+}
+
 // Describes the solution stack.
 type SolutionStackDescription struct {
 	// The permitted file types allowed for a solution stack.
@@ -2390,6 +3041,16 @@ type metadataSolutionStackDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SolutionStackDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SolutionStackDescription) GoString() string {
+	return s.String()
+}
+
 // A specification for an environment configuration
 type SourceConfiguration struct {
 	// The name of the application associated with the configuration.
@@ -2403,6 +3064,16 @@ type SourceConfiguration struct {
 
 type metadataSourceConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SourceConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SourceConfiguration) GoString() string {
+	return s.String()
 }
 
 // Swaps the CNAMEs of two environments.
@@ -2442,12 +3113,32 @@ type metadataSwapEnvironmentCNAMEsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SwapEnvironmentCNAMEsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SwapEnvironmentCNAMEsInput) GoString() string {
+	return s.String()
+}
+
 type SwapEnvironmentCNAMEsOutput struct {
 	metadataSwapEnvironmentCNAMEsOutput `json:"-" xml:"-"`
 }
 
 type metadataSwapEnvironmentCNAMEsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SwapEnvironmentCNAMEsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SwapEnvironmentCNAMEsOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a tag applied to a resource in an environment.
@@ -2463,6 +3154,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -2508,6 +3209,16 @@ type metadataTerminateEnvironmentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TerminateEnvironmentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateEnvironmentInput) GoString() string {
+	return s.String()
+}
+
 // Describes a trigger.
 type Trigger struct {
 	// The name of the trigger.
@@ -2518,6 +3229,16 @@ type Trigger struct {
 
 type metadataTrigger struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Trigger) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Trigger) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -2536,6 +3257,16 @@ type UpdateApplicationInput struct {
 
 type metadataUpdateApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateApplicationInput) GoString() string {
+	return s.String()
 }
 
 type UpdateApplicationVersionInput struct {
@@ -2559,6 +3290,16 @@ type UpdateApplicationVersionInput struct {
 
 type metadataUpdateApplicationVersionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateApplicationVersionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateApplicationVersionInput) GoString() string {
+	return s.String()
 }
 
 // The result message containing the options for the specified solution stack.
@@ -2593,6 +3334,16 @@ type UpdateConfigurationTemplateInput struct {
 
 type metadataUpdateConfigurationTemplateInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateConfigurationTemplateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateConfigurationTemplateInput) GoString() string {
+	return s.String()
 }
 
 // This documentation target is not reported in the API reference.
@@ -2655,6 +3406,16 @@ type metadataUpdateEnvironmentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateEnvironmentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateEnvironmentInput) GoString() string {
+	return s.String()
+}
+
 // A list of validation messages for a specified configuration template.
 type ValidateConfigurationSettingsInput struct {
 	// The name of the application that the configuration template or environment
@@ -2681,6 +3442,16 @@ type metadataValidateConfigurationSettingsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ValidateConfigurationSettingsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidateConfigurationSettingsInput) GoString() string {
+	return s.String()
+}
+
 // Provides a list of validation messages.
 type ValidateConfigurationSettingsOutput struct {
 	// A list of ValidationMessage.
@@ -2691,6 +3462,16 @@ type ValidateConfigurationSettingsOutput struct {
 
 type metadataValidateConfigurationSettingsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ValidateConfigurationSettingsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidateConfigurationSettingsOutput) GoString() string {
+	return s.String()
 }
 
 // An error or warning for a desired configuration option value.
@@ -2719,4 +3500,14 @@ type ValidationMessage struct {
 
 type metadataValidationMessage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ValidationMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ValidationMessage) GoString() string {
+	return s.String()
 }

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -5,6 +5,7 @@ package elastictranscoder
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCancelJob = "CancelJob"
@@ -650,6 +651,16 @@ type metadataArtwork struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Artwork) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Artwork) GoString() string {
+	return s.String()
+}
+
 // Options associated with your audio codec.
 type AudioCodecOptions struct {
 	// You can only choose an audio bit depth when you specify flac or pcm for the
@@ -705,6 +716,16 @@ type AudioCodecOptions struct {
 
 type metadataAudioCodecOptions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AudioCodecOptions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AudioCodecOptions) GoString() string {
+	return s.String()
 }
 
 // Parameters required for transcoding audio.
@@ -828,6 +849,16 @@ type metadataAudioParameters struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AudioParameters) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AudioParameters) GoString() string {
+	return s.String()
+}
+
 // The CancelJobRequest structure.
 type CancelJobInput struct {
 	// The identifier of the job that you want to cancel.
@@ -843,6 +874,16 @@ type metadataCancelJobInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelJobInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelJobInput) GoString() string {
+	return s.String()
+}
+
 // The response body contains a JSON object. If the job is successfully canceled,
 // the value of Success is true.
 type CancelJobOutput struct {
@@ -851,6 +892,16 @@ type CancelJobOutput struct {
 
 type metadataCancelJobOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelJobOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelJobOutput) GoString() string {
+	return s.String()
 }
 
 // The file format of the output captions. If you leave this value blank, Elastic
@@ -909,6 +960,16 @@ type metadataCaptionFormat struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CaptionFormat) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CaptionFormat) GoString() string {
+	return s.String()
+}
+
 // A source file for the input sidecar captions used during the transcoding
 // process.
 type CaptionSource struct {
@@ -950,6 +1011,16 @@ type metadataCaptionSource struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CaptionSource) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CaptionSource) GoString() string {
+	return s.String()
+}
+
 // The captions to be created, if any.
 type Captions struct {
 	// The array of file formats for the output captions. If you leave this value
@@ -987,6 +1058,16 @@ type metadataCaptions struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Captions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Captions) GoString() string {
+	return s.String()
+}
+
 // Settings for one clip in a composition. All jobs in a playlist must have
 // the same clip settings.
 type Clip struct {
@@ -998,6 +1079,16 @@ type Clip struct {
 
 type metadataClip struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Clip) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Clip) GoString() string {
+	return s.String()
 }
 
 // The CreateJobRequest structure.
@@ -1043,6 +1134,16 @@ type CreateJobInput struct {
 
 type metadataCreateJobInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateJobInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateJobInput) GoString() string {
+	return s.String()
 }
 
 // The CreateJobOutput structure.
@@ -1192,6 +1293,16 @@ type metadataCreateJobOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateJobOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateJobOutput) GoString() string {
+	return s.String()
+}
+
 // Information about the master playlist.
 type CreateJobPlaylist struct {
 	// The format of the output playlist. Valid formats include HLSv3, HLSv4, and
@@ -1264,6 +1375,16 @@ type metadataCreateJobPlaylist struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateJobPlaylist) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateJobPlaylist) GoString() string {
+	return s.String()
+}
+
 // The CreateJobResponse structure.
 type CreateJobResponse struct {
 	// A section of the response body that provides information about the job that
@@ -1275,6 +1396,16 @@ type CreateJobResponse struct {
 
 type metadataCreateJobResponse struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateJobResponse) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateJobResponse) GoString() string {
+	return s.String()
 }
 
 // The CreatePipelineRequest structure.
@@ -1437,6 +1568,16 @@ type metadataCreatePipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePipelineInput) GoString() string {
+	return s.String()
+}
+
 // When you create a pipeline, Elastic Transcoder returns the values that you
 // specified in the request.
 type CreatePipelineOutput struct {
@@ -1457,6 +1598,16 @@ type CreatePipelineOutput struct {
 
 type metadataCreatePipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreatePipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePipelineOutput) GoString() string {
+	return s.String()
 }
 
 // The CreatePresetRequest structure.
@@ -1489,6 +1640,16 @@ type metadataCreatePresetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePresetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePresetInput) GoString() string {
+	return s.String()
+}
+
 // The CreatePresetResponse structure.
 type CreatePresetOutput struct {
 	// A section of the response body that provides information about the preset
@@ -1508,6 +1669,16 @@ type metadataCreatePresetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePresetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePresetOutput) GoString() string {
+	return s.String()
+}
+
 // The DeletePipelineRequest structure.
 type DeletePipelineInput struct {
 	// The identifier of the pipeline that you want to delete.
@@ -1520,6 +1691,16 @@ type metadataDeletePipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletePipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePipelineInput) GoString() string {
+	return s.String()
+}
+
 // The DeletePipelineResponse structure.
 type DeletePipelineOutput struct {
 	metadataDeletePipelineOutput `json:"-" xml:"-"`
@@ -1527,6 +1708,16 @@ type DeletePipelineOutput struct {
 
 type metadataDeletePipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePipelineOutput) GoString() string {
+	return s.String()
 }
 
 // The DeletePresetRequest structure.
@@ -1541,6 +1732,16 @@ type metadataDeletePresetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletePresetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePresetInput) GoString() string {
+	return s.String()
+}
+
 // The DeletePresetResponse structure.
 type DeletePresetOutput struct {
 	metadataDeletePresetOutput `json:"-" xml:"-"`
@@ -1548,6 +1749,16 @@ type DeletePresetOutput struct {
 
 type metadataDeletePresetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePresetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePresetOutput) GoString() string {
+	return s.String()
 }
 
 // The detected properties of the input file. Elastic Transcoder identifies
@@ -1573,6 +1784,16 @@ type DetectedProperties struct {
 
 type metadataDetectedProperties struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetectedProperties) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetectedProperties) GoString() string {
+	return s.String()
 }
 
 // The encryption settings, if any, that are used for decrypting your input
@@ -1647,6 +1868,16 @@ type metadataEncryption struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Encryption) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Encryption) GoString() string {
+	return s.String()
+}
+
 // The HLS content protection settings, if any, that you want Elastic Transcoder
 // to apply to your output files.
 type HLSContentProtection struct {
@@ -1700,6 +1931,16 @@ type HLSContentProtection struct {
 
 type metadataHLSContentProtection struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HLSContentProtection) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HLSContentProtection) GoString() string {
+	return s.String()
 }
 
 // A section of the response body that provides information about the job that
@@ -1783,6 +2024,16 @@ type metadataJob struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Job) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Job) GoString() string {
+	return s.String()
+}
+
 // The .jpg or .png file associated with an audio file.
 type JobAlbumArt struct {
 	// The file to be used as album art. There can be multiple artworks associated
@@ -1806,6 +2057,16 @@ type JobAlbumArt struct {
 
 type metadataJobAlbumArt struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s JobAlbumArt) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobAlbumArt) GoString() string {
+	return s.String()
 }
 
 // Information about the file that you're transcoding.
@@ -1877,6 +2138,16 @@ type JobInput struct {
 
 type metadataJobInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s JobInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobInput) GoString() string {
+	return s.String()
 }
 
 // Outputs recommended instead.If you specified one output for a job, information
@@ -2088,6 +2359,16 @@ type metadataJobOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s JobOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobOutput) GoString() string {
+	return s.String()
+}
+
 // Watermarks can be in .png or .jpg format. If you want to display a watermark
 // that is not rectangular, use the .png format, which supports transparency.
 type JobWatermark struct {
@@ -2118,6 +2399,16 @@ type metadataJobWatermark struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s JobWatermark) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobWatermark) GoString() string {
+	return s.String()
+}
+
 // The ListJobsByPipelineRequest structure.
 type ListJobsByPipelineInput struct {
 	// To list jobs in chronological order by the date and time that they were submitted,
@@ -2138,6 +2429,16 @@ type metadataListJobsByPipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListJobsByPipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListJobsByPipelineInput) GoString() string {
+	return s.String()
+}
+
 // The ListJobsByPipelineResponse structure.
 type ListJobsByPipelineOutput struct {
 	// An array of Job objects that are in the specified pipeline.
@@ -2153,6 +2454,16 @@ type ListJobsByPipelineOutput struct {
 
 type metadataListJobsByPipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListJobsByPipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListJobsByPipelineOutput) GoString() string {
+	return s.String()
 }
 
 // The ListJobsByStatusRequest structure.
@@ -2177,6 +2488,16 @@ type metadataListJobsByStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListJobsByStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListJobsByStatusInput) GoString() string {
+	return s.String()
+}
+
 // The ListJobsByStatusResponse structure.
 type ListJobsByStatusOutput struct {
 	// An array of Job objects that have the specified status.
@@ -2192,6 +2513,16 @@ type ListJobsByStatusOutput struct {
 
 type metadataListJobsByStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListJobsByStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListJobsByStatusOutput) GoString() string {
+	return s.String()
 }
 
 // The ListPipelineRequest structure.
@@ -2212,6 +2543,16 @@ type metadataListPipelinesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPipelinesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPipelinesInput) GoString() string {
+	return s.String()
+}
+
 // A list of the pipelines associated with the current AWS account.
 type ListPipelinesOutput struct {
 	// A value that you use to access the second and subsequent pages of results,
@@ -2227,6 +2568,16 @@ type ListPipelinesOutput struct {
 
 type metadataListPipelinesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListPipelinesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPipelinesOutput) GoString() string {
+	return s.String()
 }
 
 // The ListPresetsRequest structure.
@@ -2247,6 +2598,16 @@ type metadataListPresetsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPresetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPresetsInput) GoString() string {
+	return s.String()
+}
+
 // The ListPresetsResponse structure.
 type ListPresetsOutput struct {
 	// A value that you use to access the second and subsequent pages of results,
@@ -2262,6 +2623,16 @@ type ListPresetsOutput struct {
 
 type metadataListPresetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListPresetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPresetsOutput) GoString() string {
+	return s.String()
 }
 
 // The Amazon Simple Notification Service (Amazon SNS) topic or topics to notify
@@ -2291,6 +2662,16 @@ type Notifications struct {
 
 type metadataNotifications struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Notifications) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Notifications) GoString() string {
+	return s.String()
 }
 
 // The Permission structure.
@@ -2325,6 +2706,16 @@ type Permission struct {
 
 type metadataPermission struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Permission) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Permission) GoString() string {
+	return s.String()
 }
 
 // The pipeline (queue) that is used to manage jobs.
@@ -2447,6 +2838,16 @@ type metadataPipeline struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Pipeline) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Pipeline) GoString() string {
+	return s.String()
+}
+
 // The PipelineOutputConfig structure.
 type PipelineOutputConfig struct {
 	// The Amazon S3 bucket in which you want Elastic Transcoder to save the transcoded
@@ -2488,6 +2889,16 @@ type PipelineOutputConfig struct {
 
 type metadataPipelineOutputConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PipelineOutputConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PipelineOutputConfig) GoString() string {
+	return s.String()
 }
 
 // The PlayReady DRM settings, if any, that you want Elastic Transcoder to apply
@@ -2544,6 +2955,16 @@ type PlayReadyDRM struct {
 
 type metadataPlayReadyDRM struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PlayReadyDRM) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PlayReadyDRM) GoString() string {
+	return s.String()
 }
 
 // Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for
@@ -2628,6 +3049,16 @@ type metadataPlaylist struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Playlist) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Playlist) GoString() string {
+	return s.String()
+}
+
 // Presets are templates that contain most of the settings for transcoding media
 // files from one format to another. Elastic Transcoder includes some default
 // presets for common formats, for example, several iPod and iPhone versions.
@@ -2673,6 +3104,16 @@ type Preset struct {
 
 type metadataPreset struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Preset) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Preset) GoString() string {
+	return s.String()
 }
 
 // Settings for the size, location, and opacity of graphics that you want Elastic
@@ -2808,6 +3249,16 @@ type metadataPresetWatermark struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PresetWatermark) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PresetWatermark) GoString() string {
+	return s.String()
+}
+
 // The ReadJobRequest structure.
 type ReadJobInput struct {
 	// The identifier of the job for which you want to get detailed information.
@@ -2818,6 +3269,16 @@ type ReadJobInput struct {
 
 type metadataReadJobInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReadJobInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReadJobInput) GoString() string {
+	return s.String()
 }
 
 // The ReadJobResponse structure.
@@ -2832,6 +3293,16 @@ type metadataReadJobOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReadJobOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReadJobOutput) GoString() string {
+	return s.String()
+}
+
 // The ReadPipelineRequest structure.
 type ReadPipelineInput struct {
 	// The identifier of the pipeline to read.
@@ -2842,6 +3313,16 @@ type ReadPipelineInput struct {
 
 type metadataReadPipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReadPipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReadPipelineInput) GoString() string {
+	return s.String()
 }
 
 // The ReadPipelineResponse structure.
@@ -2864,6 +3345,16 @@ type metadataReadPipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReadPipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReadPipelineOutput) GoString() string {
+	return s.String()
+}
+
 // The ReadPresetRequest structure.
 type ReadPresetInput struct {
 	// The identifier of the preset for which you want to get detailed information.
@@ -2876,6 +3367,16 @@ type metadataReadPresetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReadPresetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReadPresetInput) GoString() string {
+	return s.String()
+}
+
 // The ReadPresetResponse structure.
 type ReadPresetOutput struct {
 	// A section of the response body that provides information about the preset.
@@ -2886,6 +3387,16 @@ type ReadPresetOutput struct {
 
 type metadataReadPresetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReadPresetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReadPresetOutput) GoString() string {
+	return s.String()
 }
 
 // The TestRoleRequest structure.
@@ -2913,6 +3424,16 @@ type metadataTestRoleInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TestRoleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TestRoleInput) GoString() string {
+	return s.String()
+}
+
 // The TestRoleResponse structure.
 type TestRoleOutput struct {
 	// If the Success element contains false, this value is an array of one or more
@@ -2928,6 +3449,16 @@ type TestRoleOutput struct {
 
 type metadataTestRoleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TestRoleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TestRoleOutput) GoString() string {
+	return s.String()
 }
 
 // Thumbnails for videos.
@@ -3012,6 +3543,16 @@ type metadataThumbnails struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Thumbnails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Thumbnails) GoString() string {
+	return s.String()
+}
+
 // Settings that determine when a clip begins and how long it lasts.
 type TimeSpan struct {
 	// The duration of the clip. The format can be either HH:mm:ss.SSS (maximum
@@ -3036,6 +3577,16 @@ type metadataTimeSpan struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TimeSpan) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TimeSpan) GoString() string {
+	return s.String()
+}
+
 // Details about the timing of a job.
 type Timing struct {
 	// The time the job finished transcoding, in epoch milliseconds.
@@ -3052,6 +3603,16 @@ type Timing struct {
 
 type metadataTiming struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Timing) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Timing) GoString() string {
+	return s.String()
 }
 
 // The UpdatePipelineRequest structure.
@@ -3185,6 +3746,16 @@ type metadataUpdatePipelineInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdatePipelineInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePipelineInput) GoString() string {
+	return s.String()
+}
+
 // The UpdatePipelineNotificationsRequest structure.
 type UpdatePipelineNotificationsInput struct {
 	// The identifier of the pipeline for which you want to change notification
@@ -3216,6 +3787,16 @@ type metadataUpdatePipelineNotificationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdatePipelineNotificationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePipelineNotificationsInput) GoString() string {
+	return s.String()
+}
+
 // The UpdatePipelineNotificationsResponse structure.
 type UpdatePipelineNotificationsOutput struct {
 	// A section of the response body that provides information about the pipeline.
@@ -3226,6 +3807,16 @@ type UpdatePipelineNotificationsOutput struct {
 
 type metadataUpdatePipelineNotificationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdatePipelineNotificationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePipelineNotificationsOutput) GoString() string {
+	return s.String()
 }
 
 // When you update a pipeline, Elastic Transcoder returns the values that you
@@ -3249,6 +3840,16 @@ type metadataUpdatePipelineOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdatePipelineOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePipelineOutput) GoString() string {
+	return s.String()
+}
+
 // The UpdatePipelineStatusRequest structure.
 type UpdatePipelineStatusInput struct {
 	// The identifier of the pipeline to update.
@@ -3267,6 +3868,16 @@ type metadataUpdatePipelineStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdatePipelineStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePipelineStatusInput) GoString() string {
+	return s.String()
+}
+
 // When you update status for a pipeline, Elastic Transcoder returns the values
 // that you specified in the request.
 type UpdatePipelineStatusOutput struct {
@@ -3278,6 +3889,16 @@ type UpdatePipelineStatusOutput struct {
 
 type metadataUpdatePipelineStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdatePipelineStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdatePipelineStatusOutput) GoString() string {
+	return s.String()
 }
 
 // The VideoParameters structure.
@@ -3584,6 +4205,16 @@ type metadataVideoParameters struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VideoParameters) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VideoParameters) GoString() string {
+	return s.String()
+}
+
 // Elastic Transcoder returns a warning if the resources used by your pipeline
 // are not in the same region as the pipeline.
 //
@@ -3605,4 +4236,14 @@ type Warning struct {
 
 type metadataWarning struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Warning) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Warning) GoString() string {
+	return s.String()
 }

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddTags = "AddTags"
@@ -988,6 +989,16 @@ type metadataAccessLog struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AccessLog) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccessLog) GoString() string {
+	return s.String()
+}
+
 type AddTagsInput struct {
 	// The name of the load balancer. You can specify one load balancer only.
 	LoadBalancerNames []*string `type:"list" required:"true"`
@@ -1002,12 +1013,32 @@ type metadataAddTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsInput) GoString() string {
+	return s.String()
+}
+
 type AddTagsOutput struct {
 	metadataAddTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsOutput) GoString() string {
+	return s.String()
 }
 
 // This data type is reserved.
@@ -1023,6 +1054,16 @@ type AdditionalAttribute struct {
 
 type metadataAdditionalAttribute struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AdditionalAttribute) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AdditionalAttribute) GoString() string {
+	return s.String()
 }
 
 // Information about a policy for application-controlled session stickiness.
@@ -1041,6 +1082,16 @@ type metadataAppCookieStickinessPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AppCookieStickinessPolicy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AppCookieStickinessPolicy) GoString() string {
+	return s.String()
+}
+
 type ApplySecurityGroupsToLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
@@ -1056,6 +1107,16 @@ type metadataApplySecurityGroupsToLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ApplySecurityGroupsToLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplySecurityGroupsToLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
 type ApplySecurityGroupsToLoadBalancerOutput struct {
 	// The IDs of the security groups associated with the load balancer.
 	SecurityGroups []*string `type:"list"`
@@ -1065,6 +1126,16 @@ type ApplySecurityGroupsToLoadBalancerOutput struct {
 
 type metadataApplySecurityGroupsToLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ApplySecurityGroupsToLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplySecurityGroupsToLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 type AttachLoadBalancerToSubnetsInput struct {
@@ -1082,6 +1153,16 @@ type metadataAttachLoadBalancerToSubnetsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachLoadBalancerToSubnetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachLoadBalancerToSubnetsInput) GoString() string {
+	return s.String()
+}
+
 type AttachLoadBalancerToSubnetsOutput struct {
 	// The IDs of the subnets attached to the load balancer.
 	Subnets []*string `type:"list"`
@@ -1091,6 +1172,16 @@ type AttachLoadBalancerToSubnetsOutput struct {
 
 type metadataAttachLoadBalancerToSubnetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachLoadBalancerToSubnetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachLoadBalancerToSubnetsOutput) GoString() string {
+	return s.String()
 }
 
 // Information about the configuration of a back-end server.
@@ -1108,6 +1199,16 @@ type metadataBackendServerDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BackendServerDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BackendServerDescription) GoString() string {
+	return s.String()
+}
+
 type ConfigureHealthCheckInput struct {
 	// The configuration information for the new health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
@@ -1122,6 +1223,16 @@ type metadataConfigureHealthCheckInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfigureHealthCheckInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigureHealthCheckInput) GoString() string {
+	return s.String()
+}
+
 type ConfigureHealthCheckOutput struct {
 	// The updated health check.
 	HealthCheck *HealthCheck `type:"structure"`
@@ -1131,6 +1242,16 @@ type ConfigureHealthCheckOutput struct {
 
 type metadataConfigureHealthCheckOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfigureHealthCheckOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfigureHealthCheckOutput) GoString() string {
+	return s.String()
 }
 
 // Information about the ConnectionDraining attribute.
@@ -1149,6 +1270,16 @@ type metadataConnectionDraining struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConnectionDraining) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConnectionDraining) GoString() string {
+	return s.String()
+}
+
 // Information about the ConnectionSettings attribute.
 type ConnectionSettings struct {
 	// The time, in seconds, that the connection is allowed to be idle (no data
@@ -1160,6 +1291,16 @@ type ConnectionSettings struct {
 
 type metadataConnectionSettings struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConnectionSettings) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConnectionSettings) GoString() string {
+	return s.String()
 }
 
 type CreateAppCookieStickinessPolicyInput struct {
@@ -1180,12 +1321,32 @@ type metadataCreateAppCookieStickinessPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAppCookieStickinessPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAppCookieStickinessPolicyInput) GoString() string {
+	return s.String()
+}
+
 type CreateAppCookieStickinessPolicyOutput struct {
 	metadataCreateAppCookieStickinessPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAppCookieStickinessPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAppCookieStickinessPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAppCookieStickinessPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type CreateLBCookieStickinessPolicyInput struct {
@@ -1208,12 +1369,32 @@ type metadataCreateLBCookieStickinessPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLBCookieStickinessPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLBCookieStickinessPolicyInput) GoString() string {
+	return s.String()
+}
+
 type CreateLBCookieStickinessPolicyOutput struct {
 	metadataCreateLBCookieStickinessPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLBCookieStickinessPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLBCookieStickinessPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLBCookieStickinessPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type CreateLoadBalancerInput struct {
@@ -1271,6 +1452,16 @@ type metadataCreateLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
 type CreateLoadBalancerListenersInput struct {
 	// The listeners.
 	Listeners []*Listener `type:"list" required:"true"`
@@ -1285,12 +1476,32 @@ type metadataCreateLoadBalancerListenersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLoadBalancerListenersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerListenersInput) GoString() string {
+	return s.String()
+}
+
 type CreateLoadBalancerListenersOutput struct {
 	metadataCreateLoadBalancerListenersOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoadBalancerListenersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLoadBalancerListenersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerListenersOutput) GoString() string {
+	return s.String()
 }
 
 type CreateLoadBalancerOutput struct {
@@ -1302,6 +1513,16 @@ type CreateLoadBalancerOutput struct {
 
 type metadataCreateLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 type CreateLoadBalancerPolicyInput struct {
@@ -1325,12 +1546,32 @@ type metadataCreateLoadBalancerPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLoadBalancerPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerPolicyInput) GoString() string {
+	return s.String()
+}
+
 type CreateLoadBalancerPolicyOutput struct {
 	metadataCreateLoadBalancerPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateLoadBalancerPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLoadBalancerPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoadBalancerPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // Information about the CrossZoneLoadBalancing attribute.
@@ -1345,6 +1586,16 @@ type metadataCrossZoneLoadBalancing struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CrossZoneLoadBalancing) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CrossZoneLoadBalancing) GoString() string {
+	return s.String()
+}
+
 type DeleteLoadBalancerInput struct {
 	// The name of the load balancer.
 	LoadBalancerName *string `type:"string" required:"true"`
@@ -1354,6 +1605,16 @@ type DeleteLoadBalancerInput struct {
 
 type metadataDeleteLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerInput) GoString() string {
+	return s.String()
 }
 
 type DeleteLoadBalancerListenersInput struct {
@@ -1370,6 +1631,16 @@ type metadataDeleteLoadBalancerListenersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLoadBalancerListenersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerListenersInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLoadBalancerListenersOutput struct {
 	metadataDeleteLoadBalancerListenersOutput `json:"-" xml:"-"`
 }
@@ -1378,12 +1649,32 @@ type metadataDeleteLoadBalancerListenersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLoadBalancerListenersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerListenersOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteLoadBalancerOutput struct {
 	metadataDeleteLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 // =
@@ -1401,12 +1692,32 @@ type metadataDeleteLoadBalancerPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLoadBalancerPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLoadBalancerPolicyOutput struct {
 	metadataDeleteLoadBalancerPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoadBalancerPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLoadBalancerPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoadBalancerPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeregisterInstancesFromLoadBalancerInput struct {
@@ -1423,6 +1734,16 @@ type metadataDeregisterInstancesFromLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterInstancesFromLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterInstancesFromLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterInstancesFromLoadBalancerOutput struct {
 	// The remaining instances registered with the load balancer.
 	Instances []*Instance `type:"list"`
@@ -1432,6 +1753,16 @@ type DeregisterInstancesFromLoadBalancerOutput struct {
 
 type metadataDeregisterInstancesFromLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterInstancesFromLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterInstancesFromLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeInstanceHealthInput struct {
@@ -1448,6 +1779,16 @@ type metadataDescribeInstanceHealthInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeInstanceHealthInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceHealthInput) GoString() string {
+	return s.String()
+}
+
 type DescribeInstanceHealthOutput struct {
 	// Information about the health of the instances.
 	InstanceStates []*InstanceState `type:"list"`
@@ -1457,6 +1798,16 @@ type DescribeInstanceHealthOutput struct {
 
 type metadataDescribeInstanceHealthOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeInstanceHealthOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstanceHealthOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeLoadBalancerAttributesInput struct {
@@ -1470,6 +1821,16 @@ type metadataDescribeLoadBalancerAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLoadBalancerAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancerAttributesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLoadBalancerAttributesOutput struct {
 	// Information about the load balancer attributes.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure"`
@@ -1479,6 +1840,16 @@ type DescribeLoadBalancerAttributesOutput struct {
 
 type metadataDescribeLoadBalancerAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLoadBalancerAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancerAttributesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeLoadBalancerPoliciesInput struct {
@@ -1495,6 +1866,16 @@ type metadataDescribeLoadBalancerPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLoadBalancerPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancerPoliciesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLoadBalancerPoliciesOutput struct {
 	// Information about the policies.
 	PolicyDescriptions []*PolicyDescription `type:"list"`
@@ -1504,6 +1885,16 @@ type DescribeLoadBalancerPoliciesOutput struct {
 
 type metadataDescribeLoadBalancerPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLoadBalancerPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancerPoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeLoadBalancerPolicyTypesInput struct {
@@ -1518,6 +1909,16 @@ type metadataDescribeLoadBalancerPolicyTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLoadBalancerPolicyTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancerPolicyTypesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLoadBalancerPolicyTypesOutput struct {
 	// Information about the policy types.
 	PolicyTypeDescriptions []*PolicyTypeDescription `type:"list"`
@@ -1527,6 +1928,16 @@ type DescribeLoadBalancerPolicyTypesOutput struct {
 
 type metadataDescribeLoadBalancerPolicyTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLoadBalancerPolicyTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancerPolicyTypesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeLoadBalancersInput struct {
@@ -1548,6 +1959,16 @@ type metadataDescribeLoadBalancersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLoadBalancersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancersInput) GoString() string {
+	return s.String()
+}
+
 type DescribeLoadBalancersOutput struct {
 	// Information about the load balancers.
 	LoadBalancerDescriptions []*LoadBalancerDescription `type:"list"`
@@ -1563,6 +1984,16 @@ type metadataDescribeLoadBalancersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLoadBalancersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBalancersOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeTagsInput struct {
 	// The names of the load balancers.
 	LoadBalancerNames []*string `type:"list" required:"true"`
@@ -1574,6 +2005,16 @@ type metadataDescribeTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeTagsOutput struct {
 	// Information about the tags.
 	TagDescriptions []*TagDescription `type:"list"`
@@ -1583,6 +2024,16 @@ type DescribeTagsOutput struct {
 
 type metadataDescribeTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsOutput) GoString() string {
+	return s.String()
 }
 
 type DetachLoadBalancerFromSubnetsInput struct {
@@ -1599,6 +2050,16 @@ type metadataDetachLoadBalancerFromSubnetsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachLoadBalancerFromSubnetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachLoadBalancerFromSubnetsInput) GoString() string {
+	return s.String()
+}
+
 type DetachLoadBalancerFromSubnetsOutput struct {
 	// The IDs of the remaining subnets for the load balancer.
 	Subnets []*string `type:"list"`
@@ -1608,6 +2069,16 @@ type DetachLoadBalancerFromSubnetsOutput struct {
 
 type metadataDetachLoadBalancerFromSubnetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachLoadBalancerFromSubnetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachLoadBalancerFromSubnetsOutput) GoString() string {
+	return s.String()
 }
 
 type DisableAvailabilityZonesForLoadBalancerInput struct {
@@ -1624,6 +2095,16 @@ type metadataDisableAvailabilityZonesForLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableAvailabilityZonesForLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableAvailabilityZonesForLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
 type DisableAvailabilityZonesForLoadBalancerOutput struct {
 	// The remaining Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
@@ -1633,6 +2114,16 @@ type DisableAvailabilityZonesForLoadBalancerOutput struct {
 
 type metadataDisableAvailabilityZonesForLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableAvailabilityZonesForLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableAvailabilityZonesForLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 type EnableAvailabilityZonesForLoadBalancerInput struct {
@@ -1649,6 +2140,16 @@ type metadataEnableAvailabilityZonesForLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableAvailabilityZonesForLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableAvailabilityZonesForLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
 type EnableAvailabilityZonesForLoadBalancerOutput struct {
 	// The updated list of Availability Zones for the load balancer.
 	AvailabilityZones []*string `type:"list"`
@@ -1658,6 +2159,16 @@ type EnableAvailabilityZonesForLoadBalancerOutput struct {
 
 type metadataEnableAvailabilityZonesForLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableAvailabilityZonesForLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableAvailabilityZonesForLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 // Information about a health check.
@@ -1707,6 +2218,16 @@ type metadataHealthCheck struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HealthCheck) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HealthCheck) GoString() string {
+	return s.String()
+}
+
 // The ID of a back-end instance.
 type Instance struct {
 	// The ID of the instance.
@@ -1717,6 +2238,16 @@ type Instance struct {
 
 type metadataInstance struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Instance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Instance) GoString() string {
+	return s.String()
 }
 
 // Information about the state of a back-end instance.
@@ -1773,6 +2304,16 @@ type metadataInstanceState struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceState) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceState) GoString() string {
+	return s.String()
+}
+
 // Information about a policy for duration-based session stickiness.
 type LBCookieStickinessPolicy struct {
 	// The time period, in seconds, after which the cookie should be considered
@@ -1789,6 +2330,16 @@ type LBCookieStickinessPolicy struct {
 
 type metadataLBCookieStickinessPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LBCookieStickinessPolicy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LBCookieStickinessPolicy) GoString() string {
+	return s.String()
 }
 
 // Information about a listener.
@@ -1831,6 +2382,16 @@ type metadataListener struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Listener) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Listener) GoString() string {
+	return s.String()
+}
+
 // The policies enabled for a listener.
 type ListenerDescription struct {
 	// Information about a listener.
@@ -1848,6 +2409,16 @@ type ListenerDescription struct {
 
 type metadataListenerDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListenerDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListenerDescription) GoString() string {
+	return s.String()
 }
 
 // The attributes for a load balancer.
@@ -1891,6 +2462,16 @@ type LoadBalancerAttributes struct {
 
 type metadataLoadBalancerAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LoadBalancerAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerAttributes) GoString() string {
+	return s.String()
 }
 
 // Information about a load balancer.
@@ -1964,6 +2545,16 @@ type metadataLoadBalancerDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LoadBalancerDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoadBalancerDescription) GoString() string {
+	return s.String()
+}
+
 type ModifyLoadBalancerAttributesInput struct {
 	// The attributes of the load balancer.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure" required:"true"`
@@ -1978,6 +2569,16 @@ type metadataModifyLoadBalancerAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyLoadBalancerAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyLoadBalancerAttributesInput) GoString() string {
+	return s.String()
+}
+
 type ModifyLoadBalancerAttributesOutput struct {
 	// The attributes for a load balancer.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure"`
@@ -1990,6 +2591,16 @@ type ModifyLoadBalancerAttributesOutput struct {
 
 type metadataModifyLoadBalancerAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyLoadBalancerAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyLoadBalancerAttributesOutput) GoString() string {
+	return s.String()
 }
 
 // The policies for a load balancer.
@@ -2010,6 +2621,16 @@ type metadataPolicies struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Policies) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Policies) GoString() string {
+	return s.String()
+}
+
 // Information about a policy attribute.
 type PolicyAttribute struct {
 	// The name of the attribute.
@@ -2025,6 +2646,16 @@ type metadataPolicyAttribute struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PolicyAttribute) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyAttribute) GoString() string {
+	return s.String()
+}
+
 // Information about a policy attribute.
 type PolicyAttributeDescription struct {
 	// The name of the attribute.
@@ -2038,6 +2669,16 @@ type PolicyAttributeDescription struct {
 
 type metadataPolicyAttributeDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PolicyAttributeDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyAttributeDescription) GoString() string {
+	return s.String()
 }
 
 // Information about a policy attribute type.
@@ -2070,6 +2711,16 @@ type metadataPolicyAttributeTypeDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PolicyAttributeTypeDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyAttributeTypeDescription) GoString() string {
+	return s.String()
+}
+
 // Information about a policy.
 type PolicyDescription struct {
 	// The policy attributes.
@@ -2086,6 +2737,16 @@ type PolicyDescription struct {
 
 type metadataPolicyDescription struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PolicyDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyDescription) GoString() string {
+	return s.String()
 }
 
 // Information about a policy type.
@@ -2107,6 +2768,16 @@ type metadataPolicyTypeDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PolicyTypeDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyTypeDescription) GoString() string {
+	return s.String()
+}
+
 type RegisterInstancesWithLoadBalancerInput struct {
 	// The IDs of the instances.
 	Instances []*Instance `type:"list" required:"true"`
@@ -2121,6 +2792,16 @@ type metadataRegisterInstancesWithLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterInstancesWithLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterInstancesWithLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
 type RegisterInstancesWithLoadBalancerOutput struct {
 	// The updated list of instances for the load balancer.
 	Instances []*Instance `type:"list"`
@@ -2130,6 +2811,16 @@ type RegisterInstancesWithLoadBalancerOutput struct {
 
 type metadataRegisterInstancesWithLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterInstancesWithLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterInstancesWithLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 type RemoveTagsInput struct {
@@ -2147,12 +2838,32 @@ type metadataRemoveTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsInput) GoString() string {
+	return s.String()
+}
+
 type RemoveTagsOutput struct {
 	metadataRemoveTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsOutput) GoString() string {
+	return s.String()
 }
 
 type SetLoadBalancerListenerSSLCertificateInput struct {
@@ -2172,12 +2883,32 @@ type metadataSetLoadBalancerListenerSSLCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetLoadBalancerListenerSSLCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetLoadBalancerListenerSSLCertificateInput) GoString() string {
+	return s.String()
+}
+
 type SetLoadBalancerListenerSSLCertificateOutput struct {
 	metadataSetLoadBalancerListenerSSLCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerListenerSSLCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetLoadBalancerListenerSSLCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetLoadBalancerListenerSSLCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type SetLoadBalancerPoliciesForBackendServerInput struct {
@@ -2198,12 +2929,32 @@ type metadataSetLoadBalancerPoliciesForBackendServerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetLoadBalancerPoliciesForBackendServerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetLoadBalancerPoliciesForBackendServerInput) GoString() string {
+	return s.String()
+}
+
 type SetLoadBalancerPoliciesForBackendServerOutput struct {
 	metadataSetLoadBalancerPoliciesForBackendServerOutput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerPoliciesForBackendServerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetLoadBalancerPoliciesForBackendServerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetLoadBalancerPoliciesForBackendServerOutput) GoString() string {
+	return s.String()
 }
 
 type SetLoadBalancerPoliciesOfListenerInput struct {
@@ -2224,12 +2975,32 @@ type metadataSetLoadBalancerPoliciesOfListenerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetLoadBalancerPoliciesOfListenerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetLoadBalancerPoliciesOfListenerInput) GoString() string {
+	return s.String()
+}
+
 type SetLoadBalancerPoliciesOfListenerOutput struct {
 	metadataSetLoadBalancerPoliciesOfListenerOutput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBalancerPoliciesOfListenerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetLoadBalancerPoliciesOfListenerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetLoadBalancerPoliciesOfListenerOutput) GoString() string {
+	return s.String()
 }
 
 // Information about a source security group.
@@ -2247,6 +3018,16 @@ type metadataSourceSecurityGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SourceSecurityGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SourceSecurityGroup) GoString() string {
+	return s.String()
+}
+
 // Information about a tag.
 type Tag struct {
 	// The key of the tag.
@@ -2260,6 +3041,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // The tags associated with a load balancer.
@@ -2277,6 +3068,16 @@ type metadataTagDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TagDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TagDescription) GoString() string {
+	return s.String()
+}
+
 // The key of a tag.
 type TagKeyOnly struct {
 	// The name of the key.
@@ -2287,4 +3088,14 @@ type TagKeyOnly struct {
 
 type metadataTagKeyOnly struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TagKeyOnly) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TagKeyOnly) GoString() string {
+	return s.String()
 }

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddInstanceGroups = "AddInstanceGroups"
@@ -659,6 +660,16 @@ type metadataAddInstanceGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddInstanceGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddInstanceGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Output from an AddInstanceGroups call.
 type AddInstanceGroupsOutput struct {
 	// Instance group IDs of the newly created instance groups.
@@ -672,6 +683,16 @@ type AddInstanceGroupsOutput struct {
 
 type metadataAddInstanceGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddInstanceGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddInstanceGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // The input argument to the AddJobFlowSteps operation.
@@ -690,6 +711,16 @@ type metadataAddJobFlowStepsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddJobFlowStepsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddJobFlowStepsInput) GoString() string {
+	return s.String()
+}
+
 // The output for the AddJobFlowSteps operation.
 type AddJobFlowStepsOutput struct {
 	// The identifiers of the list of steps added to the job flow.
@@ -700,6 +731,16 @@ type AddJobFlowStepsOutput struct {
 
 type metadataAddJobFlowStepsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddJobFlowStepsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddJobFlowStepsOutput) GoString() string {
+	return s.String()
 }
 
 // This input identifies a cluster and a list of tags to attach.
@@ -721,6 +762,16 @@ type metadataAddTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsInput) GoString() string {
+	return s.String()
+}
+
 // This output indicates the result of adding tags to a resource.
 type AddTagsOutput struct {
 	metadataAddTagsOutput `json:"-" xml:"-"`
@@ -728,6 +779,16 @@ type AddTagsOutput struct {
 
 type metadataAddTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsOutput) GoString() string {
+	return s.String()
 }
 
 // An application is any Amazon or third-party software that you can add to
@@ -763,6 +824,16 @@ type metadataApplication struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Application) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Application) GoString() string {
+	return s.String()
+}
+
 // Configuration of a bootstrap action.
 type BootstrapActionConfig struct {
 	// The name of the bootstrap action.
@@ -778,6 +849,16 @@ type metadataBootstrapActionConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BootstrapActionConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BootstrapActionConfig) GoString() string {
+	return s.String()
+}
+
 // Reports the configuration of a bootstrap action in a job flow.
 type BootstrapActionDetail struct {
 	// A description of the bootstrap action.
@@ -788,6 +869,16 @@ type BootstrapActionDetail struct {
 
 type metadataBootstrapActionDetail struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s BootstrapActionDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BootstrapActionDetail) GoString() string {
+	return s.String()
 }
 
 // The detailed description of the cluster.
@@ -859,6 +950,16 @@ type metadataCluster struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Cluster) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Cluster) GoString() string {
+	return s.String()
+}
+
 // The reason that the cluster changed to its current state.
 type ClusterStateChangeReason struct {
 	// The programmatic code for the state change reason.
@@ -872,6 +973,16 @@ type ClusterStateChangeReason struct {
 
 type metadataClusterStateChangeReason struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterStateChangeReason) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterStateChangeReason) GoString() string {
+	return s.String()
 }
 
 // The detailed status of the cluster.
@@ -891,6 +1002,16 @@ type ClusterStatus struct {
 
 type metadataClusterStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterStatus) GoString() string {
+	return s.String()
 }
 
 // The summary description of the cluster.
@@ -919,6 +1040,16 @@ type metadataClusterSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ClusterSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterSummary) GoString() string {
+	return s.String()
+}
+
 // Represents the timeline of the cluster's lifecycle.
 type ClusterTimeline struct {
 	// The creation date and time of the cluster.
@@ -935,6 +1066,16 @@ type ClusterTimeline struct {
 
 type metadataClusterTimeline struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterTimeline) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterTimeline) GoString() string {
+	return s.String()
 }
 
 // An entity describing an executable that runs on a cluster.
@@ -955,6 +1096,16 @@ type metadataCommand struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Command) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Command) GoString() string {
+	return s.String()
+}
+
 // This input determines which cluster to describe.
 type DescribeClusterInput struct {
 	// The identifier of the cluster to describe.
@@ -967,6 +1118,16 @@ type metadataDescribeClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterInput) GoString() string {
+	return s.String()
+}
+
 // This output contains the description of the cluster.
 type DescribeClusterOutput struct {
 	// This output contains the details for the requested cluster.
@@ -977,6 +1138,16 @@ type DescribeClusterOutput struct {
 
 type metadataDescribeClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterOutput) GoString() string {
+	return s.String()
 }
 
 // The input for the DescribeJobFlows operation.
@@ -1000,6 +1171,16 @@ type metadataDescribeJobFlowsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeJobFlowsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeJobFlowsInput) GoString() string {
+	return s.String()
+}
+
 // The output for the DescribeJobFlows operation.
 type DescribeJobFlowsOutput struct {
 	// A list of job flows matching the parameters supplied.
@@ -1010,6 +1191,16 @@ type DescribeJobFlowsOutput struct {
 
 type metadataDescribeJobFlowsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeJobFlowsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeJobFlowsOutput) GoString() string {
+	return s.String()
 }
 
 // This input determines which step to describe.
@@ -1027,6 +1218,16 @@ type metadataDescribeStepInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStepInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStepInput) GoString() string {
+	return s.String()
+}
+
 // This output contains the description of the cluster step.
 type DescribeStepOutput struct {
 	// The step details for the requested step identifier.
@@ -1037,6 +1238,16 @@ type DescribeStepOutput struct {
 
 type metadataDescribeStepOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStepOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStepOutput) GoString() string {
+	return s.String()
 }
 
 // Provides information about the EC2 instances in a cluster grouped by category.
@@ -1084,6 +1295,16 @@ type metadataEC2InstanceAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EC2InstanceAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EC2InstanceAttributes) GoString() string {
+	return s.String()
+}
+
 // A job flow step consisting of a JAR file whose main function will be executed.
 // The main function submits a job for Hadoop to execute and waits for the job
 // to finish or fail.
@@ -1110,6 +1331,16 @@ type metadataHadoopJARStepConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HadoopJARStepConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HadoopJARStepConfig) GoString() string {
+	return s.String()
+}
+
 // A cluster step consisting of a JAR file whose main function will be executed.
 // The main function submits a job for Hadoop to execute and waits for the job
 // to finish or fail.
@@ -1134,6 +1365,16 @@ type HadoopStepConfig struct {
 
 type metadataHadoopStepConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HadoopStepConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HadoopStepConfig) GoString() string {
+	return s.String()
 }
 
 // Represents an EC2 instance provisioned as part of cluster.
@@ -1164,6 +1405,16 @@ type Instance struct {
 
 type metadataInstance struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Instance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Instance) GoString() string {
+	return s.String()
 }
 
 // This entity represents an instance group, which is a group of instances that
@@ -1205,6 +1456,16 @@ type metadataInstanceGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceGroup) GoString() string {
+	return s.String()
+}
+
 // Configuration defining a new instance group.
 type InstanceGroupConfig struct {
 	// Bid price for each Amazon EC2 instance in the instance group when launching
@@ -1231,6 +1492,16 @@ type InstanceGroupConfig struct {
 
 type metadataInstanceGroupConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceGroupConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceGroupConfig) GoString() string {
+	return s.String()
 }
 
 // Detailed information about an instance group.
@@ -1286,6 +1557,16 @@ type metadataInstanceGroupDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceGroupDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceGroupDetail) GoString() string {
+	return s.String()
+}
+
 // Modify an instance group size.
 type InstanceGroupModifyConfig struct {
 	// The EC2 InstanceIds to terminate. For advanced users only. Once you terminate
@@ -1306,6 +1587,16 @@ type metadataInstanceGroupModifyConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceGroupModifyConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceGroupModifyConfig) GoString() string {
+	return s.String()
+}
+
 // The status change reason details for the instance group.
 type InstanceGroupStateChangeReason struct {
 	// The programmable code for the state change reason.
@@ -1319,6 +1610,16 @@ type InstanceGroupStateChangeReason struct {
 
 type metadataInstanceGroupStateChangeReason struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceGroupStateChangeReason) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceGroupStateChangeReason) GoString() string {
+	return s.String()
 }
 
 // The details of the instance group status.
@@ -1339,6 +1640,16 @@ type metadataInstanceGroupStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceGroupStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceGroupStatus) GoString() string {
+	return s.String()
+}
+
 // The timeline of the instance group lifecycle.
 type InstanceGroupTimeline struct {
 	// The creation date and time of the instance group.
@@ -1357,6 +1668,16 @@ type metadataInstanceGroupTimeline struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceGroupTimeline) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceGroupTimeline) GoString() string {
+	return s.String()
+}
+
 // The details of the status change reason for the instance.
 type InstanceStateChangeReason struct {
 	// The programmable code for the state change reason.
@@ -1370,6 +1691,16 @@ type InstanceStateChangeReason struct {
 
 type metadataInstanceStateChangeReason struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceStateChangeReason) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStateChangeReason) GoString() string {
+	return s.String()
 }
 
 // The instance status details.
@@ -1390,6 +1721,16 @@ type metadataInstanceStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceStatus) GoString() string {
+	return s.String()
+}
+
 // The timeline of the instance lifecycle.
 type InstanceTimeline struct {
 	// The creation date and time of the instance.
@@ -1406,6 +1747,16 @@ type InstanceTimeline struct {
 
 type metadataInstanceTimeline struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceTimeline) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceTimeline) GoString() string {
+	return s.String()
 }
 
 // A description of a job flow.
@@ -1465,6 +1816,16 @@ type metadataJobFlowDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s JobFlowDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobFlowDetail) GoString() string {
+	return s.String()
+}
+
 // Describes the status of the job flow.
 type JobFlowExecutionStatusDetail struct {
 	// The creation date and time of the job flow.
@@ -1491,6 +1852,16 @@ type JobFlowExecutionStatusDetail struct {
 
 type metadataJobFlowExecutionStatusDetail struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s JobFlowExecutionStatusDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobFlowExecutionStatusDetail) GoString() string {
+	return s.String()
 }
 
 // A description of the Amazon EC2 instance running the job flow. A valid JobFlowInstancesConfig
@@ -1562,6 +1933,16 @@ type metadataJobFlowInstancesConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s JobFlowInstancesConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobFlowInstancesConfig) GoString() string {
+	return s.String()
+}
+
 // Specify the type of Amazon EC2 instances to run the job flow on.
 type JobFlowInstancesDetail struct {
 	// The name of an Amazon EC2 key pair that can be used to ssh to the master
@@ -1621,6 +2002,16 @@ type metadataJobFlowInstancesDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s JobFlowInstancesDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobFlowInstancesDetail) GoString() string {
+	return s.String()
+}
+
 // A key value pair.
 type KeyValue struct {
 	// The unique identifier of a key value pair.
@@ -1634,6 +2025,16 @@ type KeyValue struct {
 
 type metadataKeyValue struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s KeyValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s KeyValue) GoString() string {
+	return s.String()
 }
 
 // This input determines which bootstrap actions to retrieve.
@@ -1651,6 +2052,16 @@ type metadataListBootstrapActionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListBootstrapActionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListBootstrapActionsInput) GoString() string {
+	return s.String()
+}
+
 // This output contains the boostrap actions detail .
 type ListBootstrapActionsOutput struct {
 	// The bootstrap actions associated with the cluster .
@@ -1664,6 +2075,16 @@ type ListBootstrapActionsOutput struct {
 
 type metadataListBootstrapActionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListBootstrapActionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListBootstrapActionsOutput) GoString() string {
+	return s.String()
 }
 
 // This input determines how the ListClusters action filters the list of clusters
@@ -1688,6 +2109,16 @@ type metadataListClustersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListClustersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListClustersInput) GoString() string {
+	return s.String()
+}
+
 // This contains a ClusterSummaryList with the cluster details; for example,
 // the cluster IDs, names, and status.
 type ListClustersOutput struct {
@@ -1702,6 +2133,16 @@ type ListClustersOutput struct {
 
 type metadataListClustersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListClustersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListClustersOutput) GoString() string {
+	return s.String()
 }
 
 // This input determines which instance groups to retrieve.
@@ -1719,6 +2160,16 @@ type metadataListInstanceGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListInstanceGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInstanceGroupsInput) GoString() string {
+	return s.String()
+}
+
 // This input determines which instance groups to retrieve.
 type ListInstanceGroupsOutput struct {
 	// The list of instance groups for the cluster and given filters.
@@ -1732,6 +2183,16 @@ type ListInstanceGroupsOutput struct {
 
 type metadataListInstanceGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListInstanceGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInstanceGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // This input determines which instances to list.
@@ -1755,6 +2216,16 @@ type metadataListInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInstancesInput) GoString() string {
+	return s.String()
+}
+
 // This output contains the list of instances.
 type ListInstancesOutput struct {
 	// The list of instances for the cluster and given filters.
@@ -1768,6 +2239,16 @@ type ListInstancesOutput struct {
 
 type metadataListInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInstancesOutput) GoString() string {
+	return s.String()
 }
 
 // This input determines which steps to list.
@@ -1791,6 +2272,16 @@ type metadataListStepsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListStepsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStepsInput) GoString() string {
+	return s.String()
+}
+
 // This output contains the list of steps.
 type ListStepsOutput struct {
 	// The pagination token that indicates the next set of results to retrieve.
@@ -1806,6 +2297,16 @@ type metadataListStepsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListStepsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStepsOutput) GoString() string {
+	return s.String()
+}
+
 // Change the size of some instance groups.
 type ModifyInstanceGroupsInput struct {
 	// Instance groups to change.
@@ -1818,12 +2319,32 @@ type metadataModifyInstanceGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyInstanceGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyInstanceGroupsInput) GoString() string {
+	return s.String()
+}
+
 type ModifyInstanceGroupsOutput struct {
 	metadataModifyInstanceGroupsOutput `json:"-" xml:"-"`
 }
 
 type metadataModifyInstanceGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyInstanceGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyInstanceGroupsOutput) GoString() string {
+	return s.String()
 }
 
 // The Amazon EC2 location for the job flow.
@@ -1836,6 +2357,16 @@ type PlacementType struct {
 
 type metadataPlacementType struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PlacementType) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PlacementType) GoString() string {
+	return s.String()
 }
 
 // This input identifies a cluster and a list of tags to remove.
@@ -1854,6 +2385,16 @@ type metadataRemoveTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsInput) GoString() string {
+	return s.String()
+}
+
 // This output indicates the result of removing tags from a resource.
 type RemoveTagsOutput struct {
 	metadataRemoveTagsOutput `json:"-" xml:"-"`
@@ -1861,6 +2402,16 @@ type RemoveTagsOutput struct {
 
 type metadataRemoveTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsOutput) GoString() string {
+	return s.String()
 }
 
 // Input to the RunJobFlow operation.
@@ -1948,6 +2499,16 @@ type metadataRunJobFlowInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RunJobFlowInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RunJobFlowInput) GoString() string {
+	return s.String()
+}
+
 // The result of the RunJobFlow operation.
 type RunJobFlowOutput struct {
 	// An unique identifier for the job flow.
@@ -1958,6 +2519,16 @@ type RunJobFlowOutput struct {
 
 type metadataRunJobFlowOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RunJobFlowOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RunJobFlowOutput) GoString() string {
+	return s.String()
 }
 
 // Configuration of the script to run during a bootstrap action.
@@ -1974,6 +2545,16 @@ type ScriptBootstrapActionConfig struct {
 
 type metadataScriptBootstrapActionConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ScriptBootstrapActionConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScriptBootstrapActionConfig) GoString() string {
+	return s.String()
 }
 
 // The input argument to the TerminationProtection operation.
@@ -1995,12 +2576,32 @@ type metadataSetTerminationProtectionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetTerminationProtectionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetTerminationProtectionInput) GoString() string {
+	return s.String()
+}
+
 type SetTerminationProtectionOutput struct {
 	metadataSetTerminationProtectionOutput `json:"-" xml:"-"`
 }
 
 type metadataSetTerminationProtectionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetTerminationProtectionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetTerminationProtectionOutput) GoString() string {
+	return s.String()
 }
 
 // The input to the SetVisibleToAllUsers action.
@@ -2022,12 +2623,32 @@ type metadataSetVisibleToAllUsersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetVisibleToAllUsersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetVisibleToAllUsersInput) GoString() string {
+	return s.String()
+}
+
 type SetVisibleToAllUsersOutput struct {
 	metadataSetVisibleToAllUsersOutput `json:"-" xml:"-"`
 }
 
 type metadataSetVisibleToAllUsersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetVisibleToAllUsersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetVisibleToAllUsersOutput) GoString() string {
+	return s.String()
 }
 
 // This represents a step in a cluster.
@@ -2055,6 +2676,16 @@ type metadataStep struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Step) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Step) GoString() string {
+	return s.String()
+}
+
 // Specification of a job flow step.
 type StepConfig struct {
 	// The action to take if the job flow step fails.
@@ -2073,6 +2704,16 @@ type metadataStepConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StepConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StepConfig) GoString() string {
+	return s.String()
+}
+
 // Combines the execution state and configuration of a step.
 type StepDetail struct {
 	// The description of the step status.
@@ -2086,6 +2727,16 @@ type StepDetail struct {
 
 type metadataStepDetail struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StepDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StepDetail) GoString() string {
+	return s.String()
 }
 
 // The execution state of a step.
@@ -2112,6 +2763,16 @@ type metadataStepExecutionStatusDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StepExecutionStatusDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StepExecutionStatusDetail) GoString() string {
+	return s.String()
+}
+
 // The details of the step state change reason.
 type StepStateChangeReason struct {
 	// The programmable code for the state change reason.
@@ -2125,6 +2786,16 @@ type StepStateChangeReason struct {
 
 type metadataStepStateChangeReason struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StepStateChangeReason) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StepStateChangeReason) GoString() string {
+	return s.String()
 }
 
 // The execution status details of the cluster step.
@@ -2143,6 +2814,16 @@ type StepStatus struct {
 
 type metadataStepStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StepStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StepStatus) GoString() string {
+	return s.String()
 }
 
 // The summary of the cluster step.
@@ -2170,6 +2851,16 @@ type metadataStepSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StepSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StepSummary) GoString() string {
+	return s.String()
+}
+
 // The timeline of the cluster step lifecycle.
 type StepTimeline struct {
 	// The date and time when the cluster step was created.
@@ -2188,6 +2879,16 @@ type metadataStepTimeline struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StepTimeline) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StepTimeline) GoString() string {
+	return s.String()
+}
+
 // The list of supported product configurations which allow user-supplied arguments.
 // EMR accepts these arguments and forwards them to the corresponding installation
 // script as bootstrap action arguments.
@@ -2203,6 +2904,16 @@ type SupportedProductConfig struct {
 
 type metadataSupportedProductConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SupportedProductConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SupportedProductConfig) GoString() string {
+	return s.String()
 }
 
 // A key/value pair containing user-defined metadata that you can associate
@@ -2226,6 +2937,16 @@ type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
 // Input to the TerminateJobFlows operation.
 type TerminateJobFlowsInput struct {
 	// A list of job flows to be shutdown.
@@ -2238,10 +2959,30 @@ type metadataTerminateJobFlowsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TerminateJobFlowsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateJobFlowsInput) GoString() string {
+	return s.String()
+}
+
 type TerminateJobFlowsOutput struct {
 	metadataTerminateJobFlowsOutput `json:"-" xml:"-"`
 }
 
 type metadataTerminateJobFlowsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TerminateJobFlowsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateJobFlowsOutput) GoString() string {
+	return s.String()
 }

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAbortMultipartUpload = "AbortMultipartUpload"
@@ -1464,12 +1465,32 @@ type metadataAbortMultipartUploadInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AbortMultipartUploadInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AbortMultipartUploadInput) GoString() string {
+	return s.String()
+}
+
 type AbortMultipartUploadOutput struct {
 	metadataAbortMultipartUploadOutput `json:"-" xml:"-"`
 }
 
 type metadataAbortMultipartUploadOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AbortMultipartUploadOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AbortMultipartUploadOutput) GoString() string {
+	return s.String()
 }
 
 // The input value for AddTagsToVault.
@@ -1495,12 +1516,32 @@ type metadataAddTagsToVaultInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddTagsToVaultInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToVaultInput) GoString() string {
+	return s.String()
+}
+
 type AddTagsToVaultOutput struct {
 	metadataAddTagsToVaultOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToVaultOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddTagsToVaultOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToVaultOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -1523,6 +1564,16 @@ type ArchiveCreationOutput struct {
 
 type metadataArchiveCreationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ArchiveCreationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ArchiveCreationOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options to complete a multipart upload operation. This informs Amazon
@@ -1561,6 +1612,16 @@ type metadataCompleteMultipartUploadInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CompleteMultipartUploadInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompleteMultipartUploadInput) GoString() string {
+	return s.String()
+}
+
 // Provides options to create a vault.
 type CreateVaultInput struct {
 	// The AccountId value is the AWS account ID. This value must match the AWS
@@ -1581,6 +1642,16 @@ type metadataCreateVaultInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVaultInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVaultInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type CreateVaultOutput struct {
 	// The URI of the vault that was created.
@@ -1591,6 +1662,16 @@ type CreateVaultOutput struct {
 
 type metadataCreateVaultOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVaultOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVaultOutput) GoString() string {
+	return s.String()
 }
 
 // Data retrieval policy.
@@ -1604,6 +1685,16 @@ type DataRetrievalPolicy struct {
 
 type metadataDataRetrievalPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DataRetrievalPolicy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DataRetrievalPolicy) GoString() string {
+	return s.String()
 }
 
 // Data retrieval policy rule.
@@ -1625,6 +1716,16 @@ type DataRetrievalRule struct {
 
 type metadataDataRetrievalRule struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DataRetrievalRule) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DataRetrievalRule) GoString() string {
+	return s.String()
 }
 
 // Provides options for deleting an archive from an Amazon Glacier vault.
@@ -1649,12 +1750,32 @@ type metadataDeleteArchiveInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteArchiveInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteArchiveInput) GoString() string {
+	return s.String()
+}
+
 type DeleteArchiveOutput struct {
 	metadataDeleteArchiveOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteArchiveOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteArchiveOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteArchiveOutput) GoString() string {
+	return s.String()
 }
 
 // DeleteVaultAccessPolicy input.
@@ -1676,12 +1797,32 @@ type metadataDeleteVaultAccessPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVaultAccessPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVaultAccessPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVaultAccessPolicyOutput struct {
 	metadataDeleteVaultAccessPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVaultAccessPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVaultAccessPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVaultAccessPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options for deleting a vault from Amazon Glacier.
@@ -1701,6 +1842,16 @@ type DeleteVaultInput struct {
 
 type metadataDeleteVaultInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVaultInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVaultInput) GoString() string {
+	return s.String()
 }
 
 // Provides options for deleting a vault notification configuration from an
@@ -1723,6 +1874,16 @@ type metadataDeleteVaultNotificationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVaultNotificationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVaultNotificationsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVaultNotificationsOutput struct {
 	metadataDeleteVaultNotificationsOutput `json:"-" xml:"-"`
 }
@@ -1731,12 +1892,32 @@ type metadataDeleteVaultNotificationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVaultNotificationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVaultNotificationsOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteVaultOutput struct {
 	metadataDeleteVaultOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVaultOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVaultOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVaultOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options for retrieving a job description.
@@ -1761,6 +1942,16 @@ type metadataDescribeJobInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeJobInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeJobInput) GoString() string {
+	return s.String()
+}
+
 // Provides options for retrieving metadata for a specific vault in Amazon Glacier.
 type DescribeVaultInput struct {
 	// The AccountId value is the AWS account ID of the account that owns the vault.
@@ -1778,6 +1969,16 @@ type DescribeVaultInput struct {
 
 type metadataDescribeVaultInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVaultInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVaultInput) GoString() string {
+	return s.String()
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -1813,6 +2014,16 @@ type metadataDescribeVaultOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVaultOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVaultOutput) GoString() string {
+	return s.String()
+}
+
 // Input for GetDataRetrievalPolicy.
 type GetDataRetrievalPolicyInput struct {
 	// The AccountId value is the AWS account ID. This value must match the AWS
@@ -1830,6 +2041,16 @@ type metadataGetDataRetrievalPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetDataRetrievalPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDataRetrievalPolicyInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to the GetDataRetrievalPolicy request.
 type GetDataRetrievalPolicyOutput struct {
 	// Contains the returned data retrieval policy in JSON format.
@@ -1840,6 +2061,16 @@ type GetDataRetrievalPolicyOutput struct {
 
 type metadataGetDataRetrievalPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDataRetrievalPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDataRetrievalPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options for downloading output of an Amazon Glacier job.
@@ -1867,6 +2098,16 @@ type GetJobOutputInput struct {
 
 type metadataGetJobOutputInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetJobOutputInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetJobOutputInput) GoString() string {
+	return s.String()
 }
 
 // Contains the Amazon Glacier response to your request.
@@ -1916,6 +2157,16 @@ type metadataGetJobOutputOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Body"`
 }
 
+// String returns the string representation
+func (s GetJobOutputOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetJobOutputOutput) GoString() string {
+	return s.String()
+}
+
 // Input for GetVaultAccessPolicy.
 type GetVaultAccessPolicyInput struct {
 	// The AccountId value is the AWS account ID of the account that owns the vault.
@@ -1935,6 +2186,16 @@ type metadataGetVaultAccessPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetVaultAccessPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetVaultAccessPolicyInput) GoString() string {
+	return s.String()
+}
+
 // Output for GetVaultAccessPolicy.
 type GetVaultAccessPolicyOutput struct {
 	// Contains the returned vault access policy as a JSON string.
@@ -1945,6 +2206,16 @@ type GetVaultAccessPolicyOutput struct {
 
 type metadataGetVaultAccessPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Policy"`
+}
+
+// String returns the string representation
+func (s GetVaultAccessPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetVaultAccessPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options for retrieving the notification configuration set on an
@@ -1967,6 +2238,16 @@ type metadataGetVaultNotificationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetVaultNotificationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetVaultNotificationsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type GetVaultNotificationsOutput struct {
 	// Returns the notification configuration set on the vault.
@@ -1977,6 +2258,16 @@ type GetVaultNotificationsOutput struct {
 
 type metadataGetVaultNotificationsOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"VaultNotificationConfig"`
+}
+
+// String returns the string representation
+func (s GetVaultNotificationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetVaultNotificationsOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options for initiating an Amazon Glacier job.
@@ -2001,6 +2292,16 @@ type metadataInitiateJobInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"JobParameters"`
 }
 
+// String returns the string representation
+func (s InitiateJobInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InitiateJobInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type InitiateJobOutput struct {
 	// The ID of the job.
@@ -2014,6 +2315,16 @@ type InitiateJobOutput struct {
 
 type metadataInitiateJobOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InitiateJobOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InitiateJobOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options for initiating a multipart upload to an Amazon Glacier vault.
@@ -2047,6 +2358,16 @@ type metadataInitiateMultipartUploadInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InitiateMultipartUploadInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InitiateMultipartUploadInput) GoString() string {
+	return s.String()
+}
+
 // The Amazon Glacier response to your request.
 type InitiateMultipartUploadOutput struct {
 	// The relative URI path of the multipart upload ID Amazon Glacier created.
@@ -2061,6 +2382,16 @@ type InitiateMultipartUploadOutput struct {
 
 type metadataInitiateMultipartUploadOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InitiateMultipartUploadOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InitiateMultipartUploadOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the options for a range inventory retrieval job.
@@ -2099,6 +2430,16 @@ type metadataInventoryRetrievalJobDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InventoryRetrievalJobDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InventoryRetrievalJobDescription) GoString() string {
+	return s.String()
+}
+
 // Provides options for specifying a range inventory retrieval job.
 type InventoryRetrievalJobInput struct {
 	// The end of the date range in UTC for vault inventory retrieval that includes
@@ -2126,6 +2467,16 @@ type InventoryRetrievalJobInput struct {
 
 type metadataInventoryRetrievalJobInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InventoryRetrievalJobInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InventoryRetrievalJobInput) GoString() string {
+	return s.String()
 }
 
 // Describes an Amazon Glacier job.
@@ -2215,6 +2566,16 @@ type metadataJobDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s JobDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobDescription) GoString() string {
+	return s.String()
+}
+
 // Provides options for defining a job.
 type JobParameters struct {
 	// The ID of the archive that you want to retrieve. This field is required only
@@ -2264,6 +2625,16 @@ type metadataJobParameters struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s JobParameters) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s JobParameters) GoString() string {
+	return s.String()
+}
+
 // Provides options for retrieving a job list for an Amazon Glacier vault.
 type ListJobsInput struct {
 	// The AccountId value is the AWS account ID of the account that owns the vault.
@@ -2300,6 +2671,16 @@ type metadataListJobsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListJobsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListJobsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListJobsOutput struct {
 	// A list of job objects. Each job object contains metadata describing the job.
@@ -2315,6 +2696,16 @@ type ListJobsOutput struct {
 
 type metadataListJobsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListJobsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListJobsOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options for retrieving list of in-progress multipart uploads for
@@ -2348,6 +2739,16 @@ type metadataListMultipartUploadsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListMultipartUploadsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListMultipartUploadsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListMultipartUploadsOutput struct {
 	// An opaque string that represents where to continue pagination of the results.
@@ -2363,6 +2764,16 @@ type ListMultipartUploadsOutput struct {
 
 type metadataListMultipartUploadsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListMultipartUploadsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListMultipartUploadsOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options for retrieving a list of parts of an archive that have been
@@ -2399,6 +2810,16 @@ type metadataListPartsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPartsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPartsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListPartsOutput struct {
 	// The description of the archive that was specified in the Initiate Multipart
@@ -2433,6 +2854,16 @@ type metadataListPartsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPartsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPartsOutput) GoString() string {
+	return s.String()
+}
+
 // The input value for ListTagsForVaultInput.
 type ListTagsForVaultInput struct {
 	// The AccountId value is the AWS account ID of the account that owns the vault.
@@ -2452,6 +2883,16 @@ type metadataListTagsForVaultInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListTagsForVaultInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForVaultInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListTagsForVaultOutput struct {
 	// The tags attached to the vault. Each tag is composed of a key and a value.
@@ -2462,6 +2903,16 @@ type ListTagsForVaultOutput struct {
 
 type metadataListTagsForVaultOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForVaultOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForVaultOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options to retrieve the vault list owned by the calling user's account.
@@ -2490,6 +2941,16 @@ type metadataListVaultsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListVaultsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVaultsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type ListVaultsOutput struct {
 	// The vault ARN at which to continue pagination of the results. You use the
@@ -2506,6 +2967,16 @@ type metadataListVaultsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListVaultsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVaultsOutput) GoString() string {
+	return s.String()
+}
+
 // A list of the part sizes of the multipart upload.
 type PartListElement struct {
 	// The byte range of a part, inclusive of the upper value of the range.
@@ -2520,6 +2991,16 @@ type PartListElement struct {
 
 type metadataPartListElement struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PartListElement) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PartListElement) GoString() string {
+	return s.String()
 }
 
 // The input value for RemoveTagsFromVaultInput.
@@ -2544,12 +3025,32 @@ type metadataRemoveTagsFromVaultInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveTagsFromVaultInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromVaultInput) GoString() string {
+	return s.String()
+}
+
 type RemoveTagsFromVaultOutput struct {
 	metadataRemoveTagsFromVaultOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromVaultOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveTagsFromVaultOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromVaultOutput) GoString() string {
+	return s.String()
 }
 
 // SetDataRetrievalPolicy input.
@@ -2572,12 +3073,32 @@ type metadataSetDataRetrievalPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetDataRetrievalPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetDataRetrievalPolicyInput) GoString() string {
+	return s.String()
+}
+
 type SetDataRetrievalPolicyOutput struct {
 	metadataSetDataRetrievalPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataSetDataRetrievalPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetDataRetrievalPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetDataRetrievalPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // SetVaultAccessPolicy input.
@@ -2602,12 +3123,32 @@ type metadataSetVaultAccessPolicyInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Policy"`
 }
 
+// String returns the string representation
+func (s SetVaultAccessPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetVaultAccessPolicyInput) GoString() string {
+	return s.String()
+}
+
 type SetVaultAccessPolicyOutput struct {
 	metadataSetVaultAccessPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataSetVaultAccessPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetVaultAccessPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetVaultAccessPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options to configure notifications that will be sent when specific
@@ -2633,12 +3174,32 @@ type metadataSetVaultNotificationsInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"VaultNotificationConfig"`
 }
 
+// String returns the string representation
+func (s SetVaultNotificationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetVaultNotificationsInput) GoString() string {
+	return s.String()
+}
+
 type SetVaultNotificationsOutput struct {
 	metadataSetVaultNotificationsOutput `json:"-" xml:"-"`
 }
 
 type metadataSetVaultNotificationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetVaultNotificationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetVaultNotificationsOutput) GoString() string {
+	return s.String()
 }
 
 // Provides options to add an archive to a vault.
@@ -2669,6 +3230,16 @@ type metadataUploadArchiveInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Body"`
 }
 
+// String returns the string representation
+func (s UploadArchiveInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadArchiveInput) GoString() string {
+	return s.String()
+}
+
 // A list of in-progress multipart uploads for a vault.
 type UploadListElement struct {
 	// The description of the archive that was specified in the Initiate Multipart
@@ -2694,6 +3265,16 @@ type UploadListElement struct {
 
 type metadataUploadListElement struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UploadListElement) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadListElement) GoString() string {
+	return s.String()
 }
 
 // Provides options to upload a part of an archive in a multipart upload operation.
@@ -2730,6 +3311,16 @@ type metadataUploadMultipartPartInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Body"`
 }
 
+// String returns the string representation
+func (s UploadMultipartPartInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadMultipartPartInput) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Glacier response to your request.
 type UploadMultipartPartOutput struct {
 	// The SHA256 tree hash that Amazon Glacier computed for the uploaded part.
@@ -2742,6 +3333,16 @@ type metadataUploadMultipartPartOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UploadMultipartPartOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadMultipartPartOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the vault access policy.
 type VaultAccessPolicy struct {
 	// The vault access policy.
@@ -2752,6 +3353,16 @@ type VaultAccessPolicy struct {
 
 type metadataVaultAccessPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VaultAccessPolicy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VaultAccessPolicy) GoString() string {
+	return s.String()
 }
 
 // Represents a vault's notification configuration.
@@ -2769,4 +3380,14 @@ type VaultNotificationConfig struct {
 
 type metadataVaultNotificationConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VaultNotificationConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VaultNotificationConfig) GoString() string {
+	return s.String()
 }

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddClientIDToOpenIDConnectProvider = "AddClientIDToOpenIDConnectProvider"
@@ -3829,6 +3830,16 @@ type metadataAccessKey struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AccessKey) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccessKey) GoString() string {
+	return s.String()
+}
+
 // Contains information about the last time an AWS access key was used.
 //
 // This data type is used as a response element in the GetAccessKeyLastUsed
@@ -3877,6 +3888,16 @@ type metadataAccessKeyLastUsed struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AccessKeyLastUsed) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccessKeyLastUsed) GoString() string {
+	return s.String()
+}
+
 // Contains information about an AWS access key, without its secret key.
 //
 // This data type is used as a response element in the ListAccessKeys action.
@@ -3901,6 +3922,16 @@ type metadataAccessKeyMetadata struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AccessKeyMetadata) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccessKeyMetadata) GoString() string {
+	return s.String()
+}
+
 type AddClientIDToOpenIDConnectProviderInput struct {
 	// The client ID (also known as audience) to add to the IAM OpenID Connect provider.
 	ClientID *string `type:"string" required:"true"`
@@ -3917,12 +3948,32 @@ type metadataAddClientIDToOpenIDConnectProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddClientIDToOpenIDConnectProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddClientIDToOpenIDConnectProviderInput) GoString() string {
+	return s.String()
+}
+
 type AddClientIDToOpenIDConnectProviderOutput struct {
 	metadataAddClientIDToOpenIDConnectProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataAddClientIDToOpenIDConnectProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddClientIDToOpenIDConnectProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddClientIDToOpenIDConnectProviderOutput) GoString() string {
+	return s.String()
 }
 
 type AddRoleToInstanceProfileInput struct {
@@ -3939,12 +3990,32 @@ type metadataAddRoleToInstanceProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddRoleToInstanceProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddRoleToInstanceProfileInput) GoString() string {
+	return s.String()
+}
+
 type AddRoleToInstanceProfileOutput struct {
 	metadataAddRoleToInstanceProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataAddRoleToInstanceProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddRoleToInstanceProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddRoleToInstanceProfileOutput) GoString() string {
+	return s.String()
 }
 
 type AddUserToGroupInput struct {
@@ -3961,12 +4032,32 @@ type metadataAddUserToGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddUserToGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddUserToGroupInput) GoString() string {
+	return s.String()
+}
+
 type AddUserToGroupOutput struct {
 	metadataAddUserToGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataAddUserToGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddUserToGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddUserToGroupOutput) GoString() string {
+	return s.String()
 }
 
 type AttachGroupPolicyInput struct {
@@ -3987,12 +4078,32 @@ type metadataAttachGroupPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachGroupPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachGroupPolicyInput) GoString() string {
+	return s.String()
+}
+
 type AttachGroupPolicyOutput struct {
 	metadataAttachGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachGroupPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachGroupPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachGroupPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type AttachRolePolicyInput struct {
@@ -4013,12 +4124,32 @@ type metadataAttachRolePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachRolePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachRolePolicyInput) GoString() string {
+	return s.String()
+}
+
 type AttachRolePolicyOutput struct {
 	metadataAttachRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachRolePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachRolePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachRolePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type AttachUserPolicyInput struct {
@@ -4039,12 +4170,32 @@ type metadataAttachUserPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachUserPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachUserPolicyInput) GoString() string {
+	return s.String()
+}
+
 type AttachUserPolicyOutput struct {
 	metadataAttachUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachUserPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachUserPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachUserPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information about an attached policy.
@@ -4075,6 +4226,16 @@ type metadataAttachedPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachedPolicy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachedPolicy) GoString() string {
+	return s.String()
+}
+
 type ChangePasswordInput struct {
 	// The new password. The new password must conform to the AWS account's password
 	// policy, if one exists.
@@ -4090,12 +4251,32 @@ type metadataChangePasswordInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ChangePasswordInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangePasswordInput) GoString() string {
+	return s.String()
+}
+
 type ChangePasswordOutput struct {
 	metadataChangePasswordOutput `json:"-" xml:"-"`
 }
 
 type metadataChangePasswordOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChangePasswordOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangePasswordOutput) GoString() string {
+	return s.String()
 }
 
 type CreateAccessKeyInput struct {
@@ -4107,6 +4288,16 @@ type CreateAccessKeyInput struct {
 
 type metadataCreateAccessKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAccessKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAccessKeyInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful CreateAccessKey request.
@@ -4121,6 +4312,16 @@ type metadataCreateAccessKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAccessKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAccessKeyOutput) GoString() string {
+	return s.String()
+}
+
 type CreateAccountAliasInput struct {
 	// The account alias to create.
 	AccountAlias *string `type:"string" required:"true"`
@@ -4132,12 +4333,32 @@ type metadataCreateAccountAliasInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAccountAliasInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAccountAliasInput) GoString() string {
+	return s.String()
+}
+
 type CreateAccountAliasOutput struct {
 	metadataCreateAccountAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAccountAliasOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAccountAliasOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAccountAliasOutput) GoString() string {
+	return s.String()
 }
 
 type CreateGroupInput struct {
@@ -4159,6 +4380,16 @@ type metadataCreateGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateGroupInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreateGroup request.
 type CreateGroupOutput struct {
 	// Information about the group.
@@ -4169,6 +4400,16 @@ type CreateGroupOutput struct {
 
 type metadataCreateGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateInstanceProfileInput struct {
@@ -4190,6 +4431,16 @@ type metadataCreateInstanceProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateInstanceProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInstanceProfileInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreateInstanceProfile request.
 type CreateInstanceProfileOutput struct {
 	// Information about the instance profile.
@@ -4200,6 +4451,16 @@ type CreateInstanceProfileOutput struct {
 
 type metadataCreateInstanceProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateInstanceProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInstanceProfileOutput) GoString() string {
+	return s.String()
 }
 
 type CreateLoginProfileInput struct {
@@ -4219,6 +4480,16 @@ type metadataCreateLoginProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLoginProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoginProfileInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreateLoginProfile request.
 type CreateLoginProfileOutput struct {
 	// The user name and password create date.
@@ -4229,6 +4500,16 @@ type CreateLoginProfileOutput struct {
 
 type metadataCreateLoginProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLoginProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLoginProfileOutput) GoString() string {
+	return s.String()
 }
 
 type CreateOpenIDConnectProviderInput struct {
@@ -4284,6 +4565,16 @@ type metadataCreateOpenIDConnectProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateOpenIDConnectProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateOpenIDConnectProviderInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreateOpenIDConnectProvider request.
 type CreateOpenIDConnectProviderOutput struct {
 	// The Amazon Resource Name (ARN) of the IAM OpenID Connect provider that was
@@ -4295,6 +4586,16 @@ type CreateOpenIDConnectProviderOutput struct {
 
 type metadataCreateOpenIDConnectProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateOpenIDConnectProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateOpenIDConnectProviderOutput) GoString() string {
+	return s.String()
 }
 
 type CreatePolicyInput struct {
@@ -4329,6 +4630,16 @@ type metadataCreatePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePolicyInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreatePolicy request.
 type CreatePolicyOutput struct {
 	// Information about the policy.
@@ -4339,6 +4650,16 @@ type CreatePolicyOutput struct {
 
 type metadataCreatePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreatePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type CreatePolicyVersionInput struct {
@@ -4370,6 +4691,16 @@ type metadataCreatePolicyVersionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePolicyVersionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePolicyVersionInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreatePolicyVersion request.
 type CreatePolicyVersionOutput struct {
 	// Information about the policy version.
@@ -4380,6 +4711,16 @@ type CreatePolicyVersionOutput struct {
 
 type metadataCreatePolicyVersionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreatePolicyVersionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePolicyVersionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateRoleInput struct {
@@ -4404,6 +4745,16 @@ type metadataCreateRoleInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateRoleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateRoleInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreateRole request.
 type CreateRoleOutput struct {
 	// Information about the role.
@@ -4414,6 +4765,16 @@ type CreateRoleOutput struct {
 
 type metadataCreateRoleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateRoleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateRoleOutput) GoString() string {
+	return s.String()
 }
 
 type CreateSAMLProviderInput struct {
@@ -4438,6 +4799,16 @@ type metadataCreateSAMLProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSAMLProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSAMLProviderInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreateSAMLProvider request.
 type CreateSAMLProviderOutput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider.
@@ -4448,6 +4819,16 @@ type CreateSAMLProviderOutput struct {
 
 type metadataCreateSAMLProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSAMLProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSAMLProviderOutput) GoString() string {
+	return s.String()
 }
 
 type CreateUserInput struct {
@@ -4469,6 +4850,16 @@ type metadataCreateUserInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateUserInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateUserInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreateUser request.
 type CreateUserOutput struct {
 	// Information about the user.
@@ -4479,6 +4870,16 @@ type CreateUserOutput struct {
 
 type metadataCreateUserOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateUserOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateUserOutput) GoString() string {
+	return s.String()
 }
 
 type CreateVirtualMFADeviceInput struct {
@@ -4501,6 +4902,16 @@ type metadataCreateVirtualMFADeviceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateVirtualMFADeviceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVirtualMFADeviceInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful CreateVirtualMFADevice request.
 type CreateVirtualMFADeviceOutput struct {
 	// A newly created virtual MFA device.
@@ -4511,6 +4922,16 @@ type CreateVirtualMFADeviceOutput struct {
 
 type metadataCreateVirtualMFADeviceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateVirtualMFADeviceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateVirtualMFADeviceOutput) GoString() string {
+	return s.String()
 }
 
 type DeactivateMFADeviceInput struct {
@@ -4528,12 +4949,32 @@ type metadataDeactivateMFADeviceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeactivateMFADeviceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeactivateMFADeviceInput) GoString() string {
+	return s.String()
+}
+
 type DeactivateMFADeviceOutput struct {
 	metadataDeactivateMFADeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeactivateMFADeviceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeactivateMFADeviceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeactivateMFADeviceOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteAccessKeyInput struct {
@@ -4551,12 +4992,32 @@ type metadataDeleteAccessKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAccessKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccessKeyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteAccessKeyOutput struct {
 	metadataDeleteAccessKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccessKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAccessKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccessKeyOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteAccountAliasInput struct {
@@ -4570,12 +5031,32 @@ type metadataDeleteAccountAliasInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAccountAliasInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccountAliasInput) GoString() string {
+	return s.String()
+}
+
 type DeleteAccountAliasOutput struct {
 	metadataDeleteAccountAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccountAliasOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAccountAliasOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccountAliasOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteAccountPasswordPolicyInput struct {
@@ -4586,12 +5067,32 @@ type metadataDeleteAccountPasswordPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAccountPasswordPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccountPasswordPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteAccountPasswordPolicyOutput struct {
 	metadataDeleteAccountPasswordPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAccountPasswordPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAccountPasswordPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAccountPasswordPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteGroupInput struct {
@@ -4605,12 +5106,32 @@ type metadataDeleteGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteGroupOutput struct {
 	metadataDeleteGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteGroupPolicyInput struct {
@@ -4628,12 +5149,32 @@ type metadataDeleteGroupPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteGroupPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteGroupPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteGroupPolicyOutput struct {
 	metadataDeleteGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteGroupPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteGroupPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteGroupPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteInstanceProfileInput struct {
@@ -4647,12 +5188,32 @@ type metadataDeleteInstanceProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteInstanceProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteInstanceProfileInput) GoString() string {
+	return s.String()
+}
+
 type DeleteInstanceProfileOutput struct {
 	metadataDeleteInstanceProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInstanceProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteInstanceProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteInstanceProfileOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteLoginProfileInput struct {
@@ -4666,12 +5227,32 @@ type metadataDeleteLoginProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLoginProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoginProfileInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLoginProfileOutput struct {
 	metadataDeleteLoginProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLoginProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLoginProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLoginProfileOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteOpenIDConnectProviderInput struct {
@@ -4687,12 +5268,32 @@ type metadataDeleteOpenIDConnectProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteOpenIDConnectProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteOpenIDConnectProviderInput) GoString() string {
+	return s.String()
+}
+
 type DeleteOpenIDConnectProviderOutput struct {
 	metadataDeleteOpenIDConnectProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteOpenIDConnectProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteOpenIDConnectProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteOpenIDConnectProviderOutput) GoString() string {
+	return s.String()
 }
 
 type DeletePolicyInput struct {
@@ -4710,12 +5311,32 @@ type metadataDeletePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeletePolicyOutput struct {
 	metadataDeletePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeletePolicyVersionInput struct {
@@ -4740,12 +5361,32 @@ type metadataDeletePolicyVersionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletePolicyVersionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePolicyVersionInput) GoString() string {
+	return s.String()
+}
+
 type DeletePolicyVersionOutput struct {
 	metadataDeletePolicyVersionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePolicyVersionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePolicyVersionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePolicyVersionOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteRoleInput struct {
@@ -4759,12 +5400,32 @@ type metadataDeleteRoleInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteRoleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRoleInput) GoString() string {
+	return s.String()
+}
+
 type DeleteRoleOutput struct {
 	metadataDeleteRoleOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRoleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRoleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRoleOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteRolePolicyInput struct {
@@ -4782,12 +5443,32 @@ type metadataDeleteRolePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteRolePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRolePolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteRolePolicyOutput struct {
 	metadataDeleteRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteRolePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRolePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRolePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteSAMLProviderInput struct {
@@ -4801,12 +5482,32 @@ type metadataDeleteSAMLProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSAMLProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSAMLProviderInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSAMLProviderOutput struct {
 	metadataDeleteSAMLProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSAMLProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSAMLProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSAMLProviderOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteServerCertificateInput struct {
@@ -4820,12 +5521,32 @@ type metadataDeleteServerCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteServerCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteServerCertificateInput) GoString() string {
+	return s.String()
+}
+
 type DeleteServerCertificateOutput struct {
 	metadataDeleteServerCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteServerCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteServerCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteServerCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteSigningCertificateInput struct {
@@ -4842,12 +5563,32 @@ type metadataDeleteSigningCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSigningCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSigningCertificateInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSigningCertificateOutput struct {
 	metadataDeleteSigningCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSigningCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSigningCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSigningCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteUserInput struct {
@@ -4861,12 +5602,32 @@ type metadataDeleteUserInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteUserInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteUserInput) GoString() string {
+	return s.String()
+}
+
 type DeleteUserOutput struct {
 	metadataDeleteUserOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteUserOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteUserOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteUserPolicyInput struct {
@@ -4884,12 +5645,32 @@ type metadataDeleteUserPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteUserPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteUserPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteUserPolicyOutput struct {
 	metadataDeleteUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteUserPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteUserPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteVirtualMFADeviceInput struct {
@@ -4904,12 +5685,32 @@ type metadataDeleteVirtualMFADeviceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVirtualMFADeviceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVirtualMFADeviceInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVirtualMFADeviceOutput struct {
 	metadataDeleteVirtualMFADeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVirtualMFADeviceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVirtualMFADeviceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVirtualMFADeviceOutput) GoString() string {
+	return s.String()
 }
 
 type DetachGroupPolicyInput struct {
@@ -4930,12 +5731,32 @@ type metadataDetachGroupPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachGroupPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachGroupPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DetachGroupPolicyOutput struct {
 	metadataDetachGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachGroupPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachGroupPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachGroupPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DetachRolePolicyInput struct {
@@ -4956,12 +5777,32 @@ type metadataDetachRolePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachRolePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachRolePolicyInput) GoString() string {
+	return s.String()
+}
+
 type DetachRolePolicyOutput struct {
 	metadataDetachRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachRolePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachRolePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachRolePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DetachUserPolicyInput struct {
@@ -4982,12 +5823,32 @@ type metadataDetachUserPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachUserPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachUserPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DetachUserPolicyOutput struct {
 	metadataDetachUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachUserPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachUserPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachUserPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type EnableMFADeviceInput struct {
@@ -5011,6 +5872,16 @@ type metadataEnableMFADeviceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableMFADeviceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableMFADeviceInput) GoString() string {
+	return s.String()
+}
+
 type EnableMFADeviceOutput struct {
 	metadataEnableMFADeviceOutput `json:"-" xml:"-"`
 }
@@ -5019,12 +5890,32 @@ type metadataEnableMFADeviceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableMFADeviceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableMFADeviceOutput) GoString() string {
+	return s.String()
+}
+
 type GenerateCredentialReportInput struct {
 	metadataGenerateCredentialReportInput `json:"-" xml:"-"`
 }
 
 type metadataGenerateCredentialReportInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GenerateCredentialReportInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenerateCredentialReportInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GenerateCredentialReport request.
@@ -5042,6 +5933,16 @@ type metadataGenerateCredentialReportOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GenerateCredentialReportOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenerateCredentialReportOutput) GoString() string {
+	return s.String()
+}
+
 type GetAccessKeyLastUsedInput struct {
 	// The identifier of an access key.
 	AccessKeyID *string `locationName:"AccessKeyId" type:"string" required:"true"`
@@ -5051,6 +5952,16 @@ type GetAccessKeyLastUsedInput struct {
 
 type metadataGetAccessKeyLastUsedInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetAccessKeyLastUsedInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetAccessKeyLastUsedInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetAccessKeyLastUsed request. It is
@@ -5068,6 +5979,16 @@ type GetAccessKeyLastUsedOutput struct {
 
 type metadataGetAccessKeyLastUsedOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetAccessKeyLastUsedOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetAccessKeyLastUsedOutput) GoString() string {
+	return s.String()
 }
 
 type GetAccountAuthorizationDetailsInput struct {
@@ -5091,6 +6012,16 @@ type GetAccountAuthorizationDetailsInput struct {
 
 type metadataGetAccountAuthorizationDetailsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetAccountAuthorizationDetailsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetAccountAuthorizationDetailsInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetAccountAuthorizationDetails request.
@@ -5123,12 +6054,32 @@ type metadataGetAccountAuthorizationDetailsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetAccountAuthorizationDetailsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetAccountAuthorizationDetailsOutput) GoString() string {
+	return s.String()
+}
+
 type GetAccountPasswordPolicyInput struct {
 	metadataGetAccountPasswordPolicyInput `json:"-" xml:"-"`
 }
 
 type metadataGetAccountPasswordPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetAccountPasswordPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetAccountPasswordPolicyInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetAccountPasswordPolicy request.
@@ -5146,12 +6097,32 @@ type metadataGetAccountPasswordPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetAccountPasswordPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetAccountPasswordPolicyOutput) GoString() string {
+	return s.String()
+}
+
 type GetAccountSummaryInput struct {
 	metadataGetAccountSummaryInput `json:"-" xml:"-"`
 }
 
 type metadataGetAccountSummaryInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetAccountSummaryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetAccountSummaryInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetAccountSummary request.
@@ -5308,12 +6279,32 @@ type metadataGetAccountSummaryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetAccountSummaryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetAccountSummaryOutput) GoString() string {
+	return s.String()
+}
+
 type GetCredentialReportInput struct {
 	metadataGetCredentialReportInput `json:"-" xml:"-"`
 }
 
 type metadataGetCredentialReportInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCredentialReportInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCredentialReportInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetCredentialReport request.
@@ -5333,6 +6324,16 @@ type GetCredentialReportOutput struct {
 
 type metadataGetCredentialReportOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCredentialReportOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCredentialReportOutput) GoString() string {
+	return s.String()
 }
 
 type GetGroupInput struct {
@@ -5355,6 +6356,16 @@ type GetGroupInput struct {
 
 type metadataGetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetGroupInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetGroup request.
@@ -5381,6 +6392,16 @@ type metadataGetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetGroupOutput) GoString() string {
+	return s.String()
+}
+
 type GetGroupPolicyInput struct {
 	// The name of the group the policy is associated with.
 	GroupName *string `type:"string" required:"true"`
@@ -5393,6 +6414,16 @@ type GetGroupPolicyInput struct {
 
 type metadataGetGroupPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetGroupPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetGroupPolicyInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetGroupPolicy request.
@@ -5413,6 +6444,16 @@ type metadataGetGroupPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetGroupPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetGroupPolicyOutput) GoString() string {
+	return s.String()
+}
+
 type GetInstanceProfileInput struct {
 	// The name of the instance profile to get information about.
 	InstanceProfileName *string `type:"string" required:"true"`
@@ -5422,6 +6463,16 @@ type GetInstanceProfileInput struct {
 
 type metadataGetInstanceProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetInstanceProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetInstanceProfileInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetInstanceProfile request.
@@ -5436,6 +6487,16 @@ type metadataGetInstanceProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetInstanceProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetInstanceProfileOutput) GoString() string {
+	return s.String()
+}
+
 type GetLoginProfileInput struct {
 	// The name of the user whose login profile you want to retrieve.
 	UserName *string `type:"string" required:"true"`
@@ -5445,6 +6506,16 @@ type GetLoginProfileInput struct {
 
 type metadataGetLoginProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetLoginProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetLoginProfileInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetLoginProfile request.
@@ -5459,6 +6530,16 @@ type metadataGetLoginProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetLoginProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetLoginProfileOutput) GoString() string {
+	return s.String()
+}
+
 type GetOpenIDConnectProviderInput struct {
 	// The Amazon Resource Name (ARN) of the IAM OpenID Connect (OIDC) provider
 	// to get information for. You can get a list of OIDC provider ARNs by using
@@ -5470,6 +6551,16 @@ type GetOpenIDConnectProviderInput struct {
 
 type metadataGetOpenIDConnectProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetOpenIDConnectProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOpenIDConnectProviderInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetOpenIDConnectProvider request.
@@ -5497,6 +6588,16 @@ type metadataGetOpenIDConnectProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetOpenIDConnectProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOpenIDConnectProviderOutput) GoString() string {
+	return s.String()
+}
+
 type GetPolicyInput struct {
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
@@ -5512,6 +6613,16 @@ type metadataGetPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPolicyInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful GetPolicy request.
 type GetPolicyOutput struct {
 	// Information about the policy.
@@ -5522,6 +6633,16 @@ type GetPolicyOutput struct {
 
 type metadataGetPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type GetPolicyVersionInput struct {
@@ -5542,6 +6663,16 @@ type metadataGetPolicyVersionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetPolicyVersionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPolicyVersionInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful GetPolicyVersion request.
 type GetPolicyVersionOutput struct {
 	// Information about the policy version.
@@ -5558,6 +6689,16 @@ type metadataGetPolicyVersionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetPolicyVersionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPolicyVersionOutput) GoString() string {
+	return s.String()
+}
+
 type GetRoleInput struct {
 	// The name of the role to get information about.
 	RoleName *string `type:"string" required:"true"`
@@ -5567,6 +6708,16 @@ type GetRoleInput struct {
 
 type metadataGetRoleInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetRoleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetRoleInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetRole request.
@@ -5581,6 +6732,16 @@ type metadataGetRoleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetRoleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetRoleOutput) GoString() string {
+	return s.String()
+}
+
 type GetRolePolicyInput struct {
 	// The name of the policy document to get.
 	PolicyName *string `type:"string" required:"true"`
@@ -5593,6 +6754,16 @@ type GetRolePolicyInput struct {
 
 type metadataGetRolePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetRolePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetRolePolicyInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetRolePolicy request.
@@ -5613,6 +6784,16 @@ type metadataGetRolePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetRolePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetRolePolicyOutput) GoString() string {
+	return s.String()
+}
+
 type GetSAMLProviderInput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider to get information about.
 	SAMLProviderARN *string `locationName:"SAMLProviderArn" type:"string" required:"true"`
@@ -5622,6 +6803,16 @@ type GetSAMLProviderInput struct {
 
 type metadataGetSAMLProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetSAMLProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSAMLProviderInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetSAMLProvider request.
@@ -5642,6 +6833,16 @@ type metadataGetSAMLProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetSAMLProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSAMLProviderOutput) GoString() string {
+	return s.String()
+}
+
 type GetServerCertificateInput struct {
 	// The name of the server certificate you want to retrieve information about.
 	ServerCertificateName *string `type:"string" required:"true"`
@@ -5651,6 +6852,16 @@ type GetServerCertificateInput struct {
 
 type metadataGetServerCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetServerCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetServerCertificateInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetServerCertificate request.
@@ -5663,6 +6874,16 @@ type GetServerCertificateOutput struct {
 
 type metadataGetServerCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetServerCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetServerCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type GetUserInput struct {
@@ -5679,6 +6900,16 @@ type metadataGetUserInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetUserInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetUserInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful GetUser request.
 type GetUserOutput struct {
 	// Information about the user.
@@ -5689,6 +6920,16 @@ type GetUserOutput struct {
 
 type metadataGetUserOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetUserOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetUserOutput) GoString() string {
+	return s.String()
 }
 
 type GetUserPolicyInput struct {
@@ -5703,6 +6944,16 @@ type GetUserPolicyInput struct {
 
 type metadataGetUserPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetUserPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetUserPolicyInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful GetUserPolicy request.
@@ -5721,6 +6972,16 @@ type GetUserPolicyOutput struct {
 
 type metadataGetUserPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetUserPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetUserPolicyOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information about an IAM group entity.
@@ -5756,6 +7017,16 @@ type Group struct {
 
 type metadataGroup struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Group) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Group) GoString() string {
+	return s.String()
 }
 
 // Contains information about an IAM group, including all of the group's policies.
@@ -5798,6 +7069,16 @@ type GroupDetail struct {
 
 type metadataGroupDetail struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GroupDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GroupDetail) GoString() string {
+	return s.String()
 }
 
 // Contains information about an instance profile.
@@ -5844,6 +7125,16 @@ type metadataInstanceProfile struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s InstanceProfile) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceProfile) GoString() string {
+	return s.String()
+}
+
 type ListAccessKeysInput struct {
 	// Use this parameter only when paginating results, and only in a subsequent
 	// request after you've received a response where the results are truncated.
@@ -5864,6 +7155,16 @@ type ListAccessKeysInput struct {
 
 type metadataListAccessKeysInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAccessKeysInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAccessKeysInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful ListAccessKeys request.
@@ -5887,6 +7188,16 @@ type metadataListAccessKeysOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListAccessKeysOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAccessKeysOutput) GoString() string {
+	return s.String()
+}
+
 type ListAccountAliasesInput struct {
 	// Use this only when paginating results, and only in a subsequent request after
 	// you've received a response where the results are truncated. Set it to the
@@ -5904,6 +7215,16 @@ type ListAccountAliasesInput struct {
 
 type metadataListAccountAliasesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAccountAliasesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAccountAliasesInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful ListAccountAliases request.
@@ -5927,6 +7248,16 @@ type ListAccountAliasesOutput struct {
 
 type metadataListAccountAliasesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAccountAliasesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAccountAliasesOutput) GoString() string {
+	return s.String()
 }
 
 type ListAttachedGroupPoliciesInput struct {
@@ -5956,6 +7287,16 @@ type metadataListAttachedGroupPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListAttachedGroupPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAttachedGroupPoliciesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListAttachedGroupPolicies request.
 type ListAttachedGroupPoliciesOutput struct {
 	// A list of the attached policies.
@@ -5975,6 +7316,16 @@ type ListAttachedGroupPoliciesOutput struct {
 
 type metadataListAttachedGroupPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAttachedGroupPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAttachedGroupPoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type ListAttachedRolePoliciesInput struct {
@@ -6003,6 +7354,16 @@ type metadataListAttachedRolePoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListAttachedRolePoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAttachedRolePoliciesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListAttachedRolePolicies request.
 type ListAttachedRolePoliciesOutput struct {
 	// A list of the attached policies.
@@ -6022,6 +7383,16 @@ type ListAttachedRolePoliciesOutput struct {
 
 type metadataListAttachedRolePoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAttachedRolePoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAttachedRolePoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type ListAttachedUserPoliciesInput struct {
@@ -6050,6 +7421,16 @@ type metadataListAttachedUserPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListAttachedUserPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAttachedUserPoliciesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListAttachedUserPolicies request.
 type ListAttachedUserPoliciesOutput struct {
 	// A list of the attached policies.
@@ -6069,6 +7450,16 @@ type ListAttachedUserPoliciesOutput struct {
 
 type metadataListAttachedUserPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAttachedUserPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAttachedUserPoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type ListEntitiesForPolicyInput struct {
@@ -6108,6 +7499,16 @@ type metadataListEntitiesForPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListEntitiesForPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListEntitiesForPolicyInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListEntitiesForPolicy request.
 type ListEntitiesForPolicyOutput struct {
 	// A flag that indicates whether there are more entities to list. If your results
@@ -6135,6 +7536,16 @@ type metadataListEntitiesForPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListEntitiesForPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListEntitiesForPolicyOutput) GoString() string {
+	return s.String()
+}
+
 type ListGroupPoliciesInput struct {
 	// The name of the group to list policies for.
 	GroupName *string `type:"string" required:"true"`
@@ -6157,6 +7568,16 @@ type metadataListGroupPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListGroupPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGroupPoliciesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListGroupPolicies request.
 type ListGroupPoliciesOutput struct {
 	// A flag that indicates whether there are more policy names to list. If your
@@ -6176,6 +7597,16 @@ type ListGroupPoliciesOutput struct {
 
 type metadataListGroupPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListGroupPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGroupPoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type ListGroupsForUserInput struct {
@@ -6200,6 +7631,16 @@ type metadataListGroupsForUserInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListGroupsForUserInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGroupsForUserInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListGroupsForUser request.
 type ListGroupsForUserOutput struct {
 	// A list of groups.
@@ -6219,6 +7660,16 @@ type ListGroupsForUserOutput struct {
 
 type metadataListGroupsForUserOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListGroupsForUserOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGroupsForUserOutput) GoString() string {
+	return s.String()
 }
 
 type ListGroupsInput struct {
@@ -6247,6 +7698,16 @@ type metadataListGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListGroups request.
 type ListGroupsOutput struct {
 	// A list of groups.
@@ -6266,6 +7727,16 @@ type ListGroupsOutput struct {
 
 type metadataListGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type ListInstanceProfilesForRoleInput struct {
@@ -6291,6 +7762,16 @@ type metadataListInstanceProfilesForRoleInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListInstanceProfilesForRoleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInstanceProfilesForRoleInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListInstanceProfilesForRole request.
 type ListInstanceProfilesForRoleOutput struct {
 	// A list of instance profiles.
@@ -6311,6 +7792,16 @@ type ListInstanceProfilesForRoleOutput struct {
 
 type metadataListInstanceProfilesForRoleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListInstanceProfilesForRoleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInstanceProfilesForRoleOutput) GoString() string {
+	return s.String()
 }
 
 type ListInstanceProfilesInput struct {
@@ -6340,6 +7831,16 @@ type metadataListInstanceProfilesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListInstanceProfilesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInstanceProfilesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListInstanceProfiles request.
 type ListInstanceProfilesOutput struct {
 	// A list of instance profiles.
@@ -6360,6 +7861,16 @@ type ListInstanceProfilesOutput struct {
 
 type metadataListInstanceProfilesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListInstanceProfilesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListInstanceProfilesOutput) GoString() string {
+	return s.String()
 }
 
 type ListMFADevicesInput struct {
@@ -6384,6 +7895,16 @@ type metadataListMFADevicesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListMFADevicesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListMFADevicesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListMFADevices request.
 type ListMFADevicesOutput struct {
 	// A flag that indicates whether there are more MFA devices to list. If your
@@ -6405,12 +7926,32 @@ type metadataListMFADevicesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListMFADevicesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListMFADevicesOutput) GoString() string {
+	return s.String()
+}
+
 type ListOpenIDConnectProvidersInput struct {
 	metadataListOpenIDConnectProvidersInput `json:"-" xml:"-"`
 }
 
 type metadataListOpenIDConnectProvidersInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListOpenIDConnectProvidersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListOpenIDConnectProvidersInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful ListOpenIDConnectProviders request.
@@ -6423,6 +7964,16 @@ type ListOpenIDConnectProvidersOutput struct {
 
 type metadataListOpenIDConnectProvidersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListOpenIDConnectProvidersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListOpenIDConnectProvidersOutput) GoString() string {
+	return s.String()
 }
 
 type ListPoliciesInput struct {
@@ -6464,6 +8015,16 @@ type metadataListPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPoliciesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListPolicies request.
 type ListPoliciesOutput struct {
 	// A flag that indicates whether there are more policies to list. If your results
@@ -6483,6 +8044,16 @@ type ListPoliciesOutput struct {
 
 type metadataListPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type ListPolicyVersionsInput struct {
@@ -6512,6 +8083,16 @@ type metadataListPolicyVersionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPolicyVersionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPolicyVersionsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListPolicyVersions request.
 type ListPolicyVersionsOutput struct {
 	// A flag that indicates whether there are more policy versions to list. If
@@ -6538,6 +8119,16 @@ type metadataListPolicyVersionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPolicyVersionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPolicyVersionsOutput) GoString() string {
+	return s.String()
+}
+
 type ListRolePoliciesInput struct {
 	// Use this parameter only when paginating results, and only in a subsequent
 	// request after you've received a response where the results are truncated.
@@ -6560,6 +8151,16 @@ type metadataListRolePoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListRolePoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListRolePoliciesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListRolePolicies request.
 type ListRolePoliciesOutput struct {
 	// A flag that indicates whether there are more policy names to list. If your
@@ -6579,6 +8180,16 @@ type ListRolePoliciesOutput struct {
 
 type metadataListRolePoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListRolePoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListRolePoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type ListRolesInput struct {
@@ -6607,6 +8218,16 @@ type metadataListRolesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListRolesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListRolesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListRoles request.
 type ListRolesOutput struct {
 	// A flag that indicates whether there are more roles to list. If your results
@@ -6628,12 +8249,32 @@ type metadataListRolesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListRolesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListRolesOutput) GoString() string {
+	return s.String()
+}
+
 type ListSAMLProvidersInput struct {
 	metadataListSAMLProvidersInput `json:"-" xml:"-"`
 }
 
 type metadataListSAMLProvidersInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListSAMLProvidersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListSAMLProvidersInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful ListSAMLProviders request.
@@ -6646,6 +8287,16 @@ type ListSAMLProvidersOutput struct {
 
 type metadataListSAMLProvidersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListSAMLProvidersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListSAMLProvidersOutput) GoString() string {
+	return s.String()
 }
 
 type ListServerCertificatesInput struct {
@@ -6675,6 +8326,16 @@ type metadataListServerCertificatesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListServerCertificatesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListServerCertificatesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListServerCertificates request.
 type ListServerCertificatesOutput struct {
 	// A flag that indicates whether there are more server certificates to list.
@@ -6695,6 +8356,16 @@ type ListServerCertificatesOutput struct {
 
 type metadataListServerCertificatesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListServerCertificatesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListServerCertificatesOutput) GoString() string {
+	return s.String()
 }
 
 type ListSigningCertificatesInput struct {
@@ -6719,6 +8390,16 @@ type metadataListSigningCertificatesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListSigningCertificatesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListSigningCertificatesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListSigningCertificates request.
 type ListSigningCertificatesOutput struct {
 	// A list of the user's signing certificate information.
@@ -6738,6 +8419,16 @@ type ListSigningCertificatesOutput struct {
 
 type metadataListSigningCertificatesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListSigningCertificatesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListSigningCertificatesOutput) GoString() string {
+	return s.String()
 }
 
 type ListUserPoliciesInput struct {
@@ -6762,6 +8453,16 @@ type metadataListUserPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListUserPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListUserPoliciesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListUserPolicies request.
 type ListUserPoliciesOutput struct {
 	// A flag that indicates whether there are more policy names to list. If your
@@ -6781,6 +8482,16 @@ type ListUserPoliciesOutput struct {
 
 type metadataListUserPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListUserPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListUserPoliciesOutput) GoString() string {
+	return s.String()
 }
 
 type ListUsersInput struct {
@@ -6809,6 +8520,16 @@ type metadataListUsersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListUsersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListUsersInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListUsers request.
 type ListUsersOutput struct {
 	// A flag that indicates whether there are more user names to list. If your
@@ -6828,6 +8549,16 @@ type ListUsersOutput struct {
 
 type metadataListUsersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListUsersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListUsersOutput) GoString() string {
+	return s.String()
 }
 
 type ListVirtualMFADevicesInput struct {
@@ -6854,6 +8585,16 @@ type metadataListVirtualMFADevicesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListVirtualMFADevicesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVirtualMFADevicesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful ListVirtualMFADevices request.
 type ListVirtualMFADevicesOutput struct {
 	// A flag that indicates whether there are more items to list. If your results
@@ -6874,6 +8615,16 @@ type ListVirtualMFADevicesOutput struct {
 
 type metadataListVirtualMFADevicesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListVirtualMFADevicesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVirtualMFADevicesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the user name and password create date for a user.
@@ -6898,6 +8649,16 @@ type metadataLoginProfile struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LoginProfile) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoginProfile) GoString() string {
+	return s.String()
+}
+
 // Contains information about an MFA device.
 //
 // This data type is used as a response element in the ListMFADevices action.
@@ -6917,6 +8678,16 @@ type MFADevice struct {
 
 type metadataMFADevice struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MFADevice) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MFADevice) GoString() string {
+	return s.String()
 }
 
 // Contains information about a managed policy, including the policy's ARN,
@@ -6993,6 +8764,16 @@ type metadataManagedPolicyDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ManagedPolicyDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ManagedPolicyDetail) GoString() string {
+	return s.String()
+}
+
 // Contains the Amazon Resource Name (ARN) for an IAM OpenID Connect provider.
 type OpenIDConnectProviderListEntry struct {
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
@@ -7007,6 +8788,16 @@ type OpenIDConnectProviderListEntry struct {
 
 type metadataOpenIDConnectProviderListEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OpenIDConnectProviderListEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OpenIDConnectProviderListEntry) GoString() string {
+	return s.String()
 }
 
 // Contains information about the account password policy.
@@ -7052,6 +8843,16 @@ type PasswordPolicy struct {
 
 type metadataPasswordPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PasswordPolicy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PasswordPolicy) GoString() string {
+	return s.String()
 }
 
 // Contains information about a managed policy.
@@ -7121,6 +8922,16 @@ type metadataPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Policy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Policy) GoString() string {
+	return s.String()
+}
+
 // Contains information about an IAM policy, including the policy document.
 //
 // This data type is used as a response element in the GetAccountAuthorizationDetails
@@ -7137,6 +8948,16 @@ type PolicyDetail struct {
 
 type metadataPolicyDetail struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PolicyDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyDetail) GoString() string {
+	return s.String()
 }
 
 // Contains information about a group that a managed policy is attached to.
@@ -7158,6 +8979,16 @@ type metadataPolicyGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PolicyGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyGroup) GoString() string {
+	return s.String()
+}
+
 // Contains information about a role that a managed policy is attached to.
 //
 // This data type is used as a response element in the ListEntitiesForPolicy
@@ -7177,6 +9008,16 @@ type metadataPolicyRole struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PolicyRole) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyRole) GoString() string {
+	return s.String()
+}
+
 // Contains information about a user that a managed policy is attached to.
 //
 // This data type is used as a response element in the ListEntitiesForPolicy
@@ -7194,6 +9035,16 @@ type PolicyUser struct {
 
 type metadataPolicyUser struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PolicyUser) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyUser) GoString() string {
+	return s.String()
 }
 
 // Contains information about a version of a managed policy.
@@ -7233,6 +9084,16 @@ type metadataPolicyVersion struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PolicyVersion) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PolicyVersion) GoString() string {
+	return s.String()
+}
+
 type PutGroupPolicyInput struct {
 	// The name of the group to associate the policy with.
 	GroupName *string `type:"string" required:"true"`
@@ -7250,12 +9111,32 @@ type metadataPutGroupPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutGroupPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutGroupPolicyInput) GoString() string {
+	return s.String()
+}
+
 type PutGroupPolicyOutput struct {
 	metadataPutGroupPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutGroupPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutGroupPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutGroupPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type PutRolePolicyInput struct {
@@ -7275,12 +9156,32 @@ type metadataPutRolePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutRolePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRolePolicyInput) GoString() string {
+	return s.String()
+}
+
 type PutRolePolicyOutput struct {
 	metadataPutRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutRolePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutRolePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRolePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type PutUserPolicyInput struct {
@@ -7300,12 +9201,32 @@ type metadataPutUserPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutUserPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutUserPolicyInput) GoString() string {
+	return s.String()
+}
+
 type PutUserPolicyOutput struct {
 	metadataPutUserPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutUserPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutUserPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutUserPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type RemoveClientIDFromOpenIDConnectProviderInput struct {
@@ -7325,12 +9246,32 @@ type metadataRemoveClientIDFromOpenIDConnectProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveClientIDFromOpenIDConnectProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveClientIDFromOpenIDConnectProviderInput) GoString() string {
+	return s.String()
+}
+
 type RemoveClientIDFromOpenIDConnectProviderOutput struct {
 	metadataRemoveClientIDFromOpenIDConnectProviderOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveClientIDFromOpenIDConnectProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveClientIDFromOpenIDConnectProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveClientIDFromOpenIDConnectProviderOutput) GoString() string {
+	return s.String()
 }
 
 type RemoveRoleFromInstanceProfileInput struct {
@@ -7347,12 +9288,32 @@ type metadataRemoveRoleFromInstanceProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveRoleFromInstanceProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveRoleFromInstanceProfileInput) GoString() string {
+	return s.String()
+}
+
 type RemoveRoleFromInstanceProfileOutput struct {
 	metadataRemoveRoleFromInstanceProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveRoleFromInstanceProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveRoleFromInstanceProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveRoleFromInstanceProfileOutput) GoString() string {
+	return s.String()
 }
 
 type RemoveUserFromGroupInput struct {
@@ -7369,12 +9330,32 @@ type metadataRemoveUserFromGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveUserFromGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveUserFromGroupInput) GoString() string {
+	return s.String()
+}
+
 type RemoveUserFromGroupOutput struct {
 	metadataRemoveUserFromGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveUserFromGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveUserFromGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveUserFromGroupOutput) GoString() string {
+	return s.String()
 }
 
 type ResyncMFADeviceInput struct {
@@ -7397,12 +9378,32 @@ type metadataResyncMFADeviceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResyncMFADeviceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResyncMFADeviceInput) GoString() string {
+	return s.String()
+}
+
 type ResyncMFADeviceOutput struct {
 	metadataResyncMFADeviceOutput `json:"-" xml:"-"`
 }
 
 type metadataResyncMFADeviceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResyncMFADeviceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResyncMFADeviceOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information about an IAM role.
@@ -7445,6 +9446,16 @@ type Role struct {
 
 type metadataRole struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Role) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Role) GoString() string {
+	return s.String()
 }
 
 // Contains information about an IAM role, including all of the role's policies.
@@ -7497,6 +9508,16 @@ type metadataRoleDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RoleDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RoleDetail) GoString() string {
+	return s.String()
+}
+
 // Contains the list of SAML providers for this account.
 type SAMLProviderListEntry struct {
 	// The Amazon Resource Name (ARN) of the SAML provider.
@@ -7513,6 +9534,16 @@ type SAMLProviderListEntry struct {
 
 type metadataSAMLProviderListEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SAMLProviderListEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SAMLProviderListEntry) GoString() string {
+	return s.String()
 }
 
 // Contains information about a server certificate.
@@ -7535,6 +9566,16 @@ type ServerCertificate struct {
 
 type metadataServerCertificate struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ServerCertificate) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ServerCertificate) GoString() string {
+	return s.String()
 }
 
 // Contains information about a server certificate without its certificate body,
@@ -7575,6 +9616,16 @@ type metadataServerCertificateMetadata struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ServerCertificateMetadata) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ServerCertificateMetadata) GoString() string {
+	return s.String()
+}
+
 type SetDefaultPolicyVersionInput struct {
 	// The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources.
 	//
@@ -7597,12 +9648,32 @@ type metadataSetDefaultPolicyVersionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetDefaultPolicyVersionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetDefaultPolicyVersionInput) GoString() string {
+	return s.String()
+}
+
 type SetDefaultPolicyVersionOutput struct {
 	metadataSetDefaultPolicyVersionOutput `json:"-" xml:"-"`
 }
 
 type metadataSetDefaultPolicyVersionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetDefaultPolicyVersionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetDefaultPolicyVersionOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information about an X.509 signing certificate.
@@ -7633,6 +9704,16 @@ type metadataSigningCertificate struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SigningCertificate) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SigningCertificate) GoString() string {
+	return s.String()
+}
+
 type UpdateAccessKeyInput struct {
 	// The access key ID of the secret access key you want to update.
 	AccessKeyID *string `locationName:"AccessKeyId" type:"string" required:"true"`
@@ -7652,12 +9733,32 @@ type metadataUpdateAccessKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateAccessKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAccessKeyInput) GoString() string {
+	return s.String()
+}
+
 type UpdateAccessKeyOutput struct {
 	metadataUpdateAccessKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAccessKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateAccessKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAccessKeyOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateAccountPasswordPolicyInput struct {
@@ -7725,12 +9826,32 @@ type metadataUpdateAccountPasswordPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateAccountPasswordPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAccountPasswordPolicyInput) GoString() string {
+	return s.String()
+}
+
 type UpdateAccountPasswordPolicyOutput struct {
 	metadataUpdateAccountPasswordPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAccountPasswordPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateAccountPasswordPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAccountPasswordPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateAssumeRolePolicyInput struct {
@@ -7747,12 +9868,32 @@ type metadataUpdateAssumeRolePolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateAssumeRolePolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAssumeRolePolicyInput) GoString() string {
+	return s.String()
+}
+
 type UpdateAssumeRolePolicyOutput struct {
 	metadataUpdateAssumeRolePolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAssumeRolePolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateAssumeRolePolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAssumeRolePolicyOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateGroupInput struct {
@@ -7773,12 +9914,32 @@ type metadataUpdateGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGroupInput) GoString() string {
+	return s.String()
+}
+
 type UpdateGroupOutput struct {
 	metadataUpdateGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGroupOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateLoginProfileInput struct {
@@ -7798,12 +9959,32 @@ type metadataUpdateLoginProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateLoginProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateLoginProfileInput) GoString() string {
+	return s.String()
+}
+
 type UpdateLoginProfileOutput struct {
 	metadataUpdateLoginProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateLoginProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateLoginProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateLoginProfileOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateOpenIDConnectProviderThumbprintInput struct {
@@ -7823,12 +10004,32 @@ type metadataUpdateOpenIDConnectProviderThumbprintInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateOpenIDConnectProviderThumbprintInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateOpenIDConnectProviderThumbprintInput) GoString() string {
+	return s.String()
+}
+
 type UpdateOpenIDConnectProviderThumbprintOutput struct {
 	metadataUpdateOpenIDConnectProviderThumbprintOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateOpenIDConnectProviderThumbprintOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateOpenIDConnectProviderThumbprintOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateOpenIDConnectProviderThumbprintOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateSAMLProviderInput struct {
@@ -7849,6 +10050,16 @@ type metadataUpdateSAMLProviderInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateSAMLProviderInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSAMLProviderInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful UpdateSAMLProvider request.
 type UpdateSAMLProviderOutput struct {
 	// The Amazon Resource Name (ARN) of the SAML provider that was updated.
@@ -7859,6 +10070,16 @@ type UpdateSAMLProviderOutput struct {
 
 type metadataUpdateSAMLProviderOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateSAMLProviderOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSAMLProviderOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateServerCertificateInput struct {
@@ -7881,12 +10102,32 @@ type metadataUpdateServerCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateServerCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateServerCertificateInput) GoString() string {
+	return s.String()
+}
+
 type UpdateServerCertificateOutput struct {
 	metadataUpdateServerCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateServerCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateServerCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateServerCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateSigningCertificateInput struct {
@@ -7908,12 +10149,32 @@ type metadataUpdateSigningCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateSigningCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSigningCertificateInput) GoString() string {
+	return s.String()
+}
+
 type UpdateSigningCertificateOutput struct {
 	metadataUpdateSigningCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateSigningCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateSigningCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSigningCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateUserInput struct {
@@ -7936,12 +10197,32 @@ type metadataUpdateUserInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateUserInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateUserInput) GoString() string {
+	return s.String()
+}
+
 type UpdateUserOutput struct {
 	metadataUpdateUserOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateUserOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateUserOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateUserOutput) GoString() string {
+	return s.String()
 }
 
 type UploadServerCertificateInput struct {
@@ -7979,6 +10260,16 @@ type metadataUploadServerCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UploadServerCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadServerCertificateInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful UploadServerCertificate request.
 type UploadServerCertificateOutput struct {
 	// The meta information of the uploaded server certificate without its certificate
@@ -7990,6 +10281,16 @@ type UploadServerCertificateOutput struct {
 
 type metadataUploadServerCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UploadServerCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadServerCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type UploadSigningCertificateInput struct {
@@ -8006,6 +10307,16 @@ type metadataUploadSigningCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UploadSigningCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadSigningCertificateInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful UploadSigningCertificate request.
 type UploadSigningCertificateOutput struct {
 	// Information about the certificate.
@@ -8016,6 +10327,16 @@ type UploadSigningCertificateOutput struct {
 
 type metadataUploadSigningCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UploadSigningCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadSigningCertificateOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information about an IAM user entity.
@@ -8075,6 +10396,16 @@ type metadataUser struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s User) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s User) GoString() string {
+	return s.String()
+}
+
 // Contains information about an IAM user, including all the user's policies
 // and all the IAM groups the user is in.
 //
@@ -8121,6 +10452,16 @@ type metadataUserDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UserDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UserDetail) GoString() string {
+	return s.String()
+}
+
 // Contains information about a virtual MFA device.
 type VirtualMFADevice struct {
 	// The Base32 seed defined as specified in RFC3548 (http://www.ietf.org/rfc/rfc3548.txt).
@@ -8155,4 +10496,14 @@ type VirtualMFADevice struct {
 
 type metadataVirtualMFADevice struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VirtualMFADevice) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VirtualMFADevice) GoString() string {
+	return s.String()
 }

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -5,6 +5,7 @@ package kinesis
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddTagsToStream = "AddTagsToStream"
@@ -743,12 +744,32 @@ type metadataAddTagsToStreamInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddTagsToStreamInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToStreamInput) GoString() string {
+	return s.String()
+}
+
 type AddTagsToStreamOutput struct {
 	metadataAddTagsToStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToStreamOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddTagsToStreamOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToStreamOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input for CreateStream.
@@ -774,12 +795,32 @@ type metadataCreateStreamInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateStreamInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStreamInput) GoString() string {
+	return s.String()
+}
+
 type CreateStreamOutput struct {
 	metadataCreateStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateStreamOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateStreamOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStreamOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input for DeleteStream.
@@ -794,12 +835,32 @@ type metadataDeleteStreamInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteStreamInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteStreamInput) GoString() string {
+	return s.String()
+}
+
 type DeleteStreamOutput struct {
 	metadataDeleteStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStreamOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteStreamOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteStreamOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input for DescribeStream.
@@ -820,6 +881,16 @@ type metadataDescribeStreamInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStreamInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStreamInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output for DescribeStream.
 type DescribeStreamOutput struct {
 	// The current status of the stream, the stream ARN, an array of shard objects
@@ -831,6 +902,16 @@ type DescribeStreamOutput struct {
 
 type metadataDescribeStreamOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStreamOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStreamOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input for GetRecords.
@@ -849,6 +930,16 @@ type GetRecordsInput struct {
 
 type metadataGetRecordsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetRecordsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetRecordsInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output for GetRecords.
@@ -872,6 +963,16 @@ type GetRecordsOutput struct {
 
 type metadataGetRecordsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetRecordsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetRecordsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input for GetShardIterator.
@@ -907,6 +1008,16 @@ type metadataGetShardIteratorInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetShardIteratorInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetShardIteratorInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output for GetShardIterator.
 type GetShardIteratorOutput struct {
 	// The position in the shard from which to start reading data records sequentially.
@@ -919,6 +1030,16 @@ type GetShardIteratorOutput struct {
 
 type metadataGetShardIteratorOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetShardIteratorOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetShardIteratorOutput) GoString() string {
+	return s.String()
 }
 
 // The range of possible hash key values for the shard, which is a set of ordered
@@ -937,6 +1058,16 @@ type metadataHashKeyRange struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HashKeyRange) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HashKeyRange) GoString() string {
+	return s.String()
+}
+
 // Represents the input for ListStreams.
 type ListStreamsInput struct {
 	// The name of the stream to start the list with.
@@ -950,6 +1081,16 @@ type ListStreamsInput struct {
 
 type metadataListStreamsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListStreamsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStreamsInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output for ListStreams.
@@ -966,6 +1107,16 @@ type ListStreamsOutput struct {
 
 type metadataListStreamsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListStreamsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListStreamsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input for ListTagsForStream.
@@ -989,6 +1140,16 @@ type metadataListTagsForStreamInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListTagsForStreamInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForStreamInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output for ListTagsForStream.
 type ListTagsForStreamOutput struct {
 	// If set to true, more tags are available. To request additional tags, set
@@ -1004,6 +1165,16 @@ type ListTagsForStreamOutput struct {
 
 type metadataListTagsForStreamOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForStreamOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForStreamOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input for MergeShards.
@@ -1024,12 +1195,32 @@ type metadataMergeShardsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MergeShardsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MergeShardsInput) GoString() string {
+	return s.String()
+}
+
 type MergeShardsOutput struct {
 	metadataMergeShardsOutput `json:"-" xml:"-"`
 }
 
 type metadataMergeShardsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s MergeShardsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MergeShardsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the input for PutRecord.
@@ -1070,6 +1261,16 @@ type metadataPutRecordInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutRecordInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRecordInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output for PutRecord.
 type PutRecordOutput struct {
 	// The sequence number identifier that was assigned to the put data record.
@@ -1088,6 +1289,16 @@ type metadataPutRecordOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutRecordOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRecordOutput) GoString() string {
+	return s.String()
+}
+
 // A PutRecords request.
 type PutRecordsInput struct {
 	// The records associated with the request.
@@ -1101,6 +1312,16 @@ type PutRecordsInput struct {
 
 type metadataPutRecordsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutRecordsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRecordsInput) GoString() string {
+	return s.String()
 }
 
 // PutRecords results.
@@ -1120,6 +1341,16 @@ type PutRecordsOutput struct {
 
 type metadataPutRecordsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutRecordsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRecordsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the output for PutRecords.
@@ -1148,6 +1379,16 @@ type PutRecordsRequestEntry struct {
 
 type metadataPutRecordsRequestEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutRecordsRequestEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRecordsRequestEntry) GoString() string {
+	return s.String()
 }
 
 // Represents the result of an individual record from a PutRecords request.
@@ -1179,6 +1420,16 @@ type metadataPutRecordsResultEntry struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutRecordsResultEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutRecordsResultEntry) GoString() string {
+	return s.String()
+}
+
 // The unit of data of the Amazon Kinesis stream, which is composed of a sequence
 // number, a partition key, and a data blob.
 type Record struct {
@@ -1201,6 +1452,16 @@ type metadataRecord struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Record) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Record) GoString() string {
+	return s.String()
+}
+
 // Represents the input for RemoveTagsFromStream.
 type RemoveTagsFromStreamInput struct {
 	// The name of the stream.
@@ -1216,12 +1477,32 @@ type metadataRemoveTagsFromStreamInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveTagsFromStreamInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromStreamInput) GoString() string {
+	return s.String()
+}
+
 type RemoveTagsFromStreamOutput struct {
 	metadataRemoveTagsFromStreamOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromStreamOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveTagsFromStreamOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromStreamOutput) GoString() string {
+	return s.String()
 }
 
 // The range of possible sequence numbers for the shard.
@@ -1238,6 +1519,16 @@ type SequenceNumberRange struct {
 
 type metadataSequenceNumberRange struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SequenceNumberRange) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SequenceNumberRange) GoString() string {
+	return s.String()
 }
 
 // A uniquely identified group of data records in an Amazon Kinesis stream.
@@ -1265,6 +1556,16 @@ type metadataShard struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Shard) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Shard) GoString() string {
+	return s.String()
+}
+
 // Represents the input for SplitShard.
 type SplitShardInput struct {
 	// A hash key value for the starting hash key of one of the child shards created
@@ -1289,12 +1590,32 @@ type metadataSplitShardInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SplitShardInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SplitShardInput) GoString() string {
+	return s.String()
+}
+
 type SplitShardOutput struct {
 	metadataSplitShardOutput `json:"-" xml:"-"`
 }
 
 type metadataSplitShardOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SplitShardOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SplitShardOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the output for DescribeStream.
@@ -1332,6 +1653,16 @@ type metadataStreamDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StreamDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StreamDescription) GoString() string {
+	return s.String()
+}
+
 // Metadata assigned to the stream, consisting of a key-value pair.
 type Tag struct {
 	// A unique identifier for the tag. Maximum length: 128 characters. Valid characters:
@@ -1348,4 +1679,14 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateAlias = "CreateAlias"
@@ -894,6 +895,16 @@ type metadataAliasListEntry struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AliasListEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AliasListEntry) GoString() string {
+	return s.String()
+}
+
 type CreateAliasInput struct {
 	// String that contains the display name. The name must start with the word
 	// "alias" followed by a forward slash (alias/). Aliases that begin with "alias/AWS"
@@ -913,12 +924,32 @@ type metadataCreateAliasInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAliasInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAliasInput) GoString() string {
+	return s.String()
+}
+
 type CreateAliasOutput struct {
 	metadataCreateAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateAliasOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAliasOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAliasOutput) GoString() string {
+	return s.String()
 }
 
 type CreateGrantInput struct {
@@ -955,6 +986,16 @@ type metadataCreateGrantInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateGrantInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateGrantInput) GoString() string {
+	return s.String()
+}
+
 type CreateGrantOutput struct {
 	// Unique grant identifier. You can use the GrantId value to revoke a grant.
 	GrantID *string `locationName:"GrantId" type:"string"`
@@ -967,6 +1008,16 @@ type CreateGrantOutput struct {
 
 type metadataCreateGrantOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateGrantOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateGrantOutput) GoString() string {
+	return s.String()
 }
 
 type CreateKeyInput struct {
@@ -989,6 +1040,16 @@ type metadataCreateKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateKeyInput) GoString() string {
+	return s.String()
+}
+
 type CreateKeyOutput struct {
 	// Metadata associated with the key.
 	KeyMetadata *KeyMetadata `type:"structure"`
@@ -998,6 +1059,16 @@ type CreateKeyOutput struct {
 
 type metadataCreateKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateKeyOutput) GoString() string {
+	return s.String()
 }
 
 type DecryptInput struct {
@@ -1019,6 +1090,16 @@ type metadataDecryptInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DecryptInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DecryptInput) GoString() string {
+	return s.String()
+}
+
 type DecryptOutput struct {
 	// ARN of the key used to perform the decryption. This value is returned if
 	// no errors are encountered during the operation.
@@ -1035,6 +1116,16 @@ type metadataDecryptOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DecryptOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DecryptOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteAliasInput struct {
 	// The alias to be deleted. The name must start with the word "alias" followed
 	// by a forward slash (alias/). Aliases that begin with "alias/AWS" are reserved.
@@ -1047,12 +1138,32 @@ type metadataDeleteAliasInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAliasInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAliasInput) GoString() string {
+	return s.String()
+}
+
 type DeleteAliasOutput struct {
 	metadataDeleteAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAliasOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAliasOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAliasOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeKeyInput struct {
@@ -1071,6 +1182,16 @@ type metadataDescribeKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeKeyInput) GoString() string {
+	return s.String()
+}
+
 type DescribeKeyOutput struct {
 	// Metadata associated with the key.
 	KeyMetadata *KeyMetadata `type:"structure"`
@@ -1080,6 +1201,16 @@ type DescribeKeyOutput struct {
 
 type metadataDescribeKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeKeyOutput) GoString() string {
+	return s.String()
 }
 
 type DisableKeyInput struct {
@@ -1096,12 +1227,32 @@ type metadataDisableKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableKeyInput) GoString() string {
+	return s.String()
+}
+
 type DisableKeyOutput struct {
 	metadataDisableKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableKeyOutput) GoString() string {
+	return s.String()
 }
 
 type DisableKeyRotationInput struct {
@@ -1118,12 +1269,32 @@ type metadataDisableKeyRotationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableKeyRotationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableKeyRotationInput) GoString() string {
+	return s.String()
+}
+
 type DisableKeyRotationOutput struct {
 	metadataDisableKeyRotationOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableKeyRotationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableKeyRotationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableKeyRotationOutput) GoString() string {
+	return s.String()
 }
 
 type EnableKeyInput struct {
@@ -1140,12 +1311,32 @@ type metadataEnableKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableKeyInput) GoString() string {
+	return s.String()
+}
+
 type EnableKeyOutput struct {
 	metadataEnableKeyOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableKeyOutput) GoString() string {
+	return s.String()
 }
 
 type EnableKeyRotationInput struct {
@@ -1162,12 +1353,32 @@ type metadataEnableKeyRotationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableKeyRotationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableKeyRotationInput) GoString() string {
+	return s.String()
+}
+
 type EnableKeyRotationOutput struct {
 	metadataEnableKeyRotationOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableKeyRotationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableKeyRotationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableKeyRotationOutput) GoString() string {
+	return s.String()
 }
 
 type EncryptInput struct {
@@ -1198,6 +1409,16 @@ type metadataEncryptInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EncryptInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EncryptInput) GoString() string {
+	return s.String()
+}
+
 type EncryptOutput struct {
 	// The encrypted plaintext. If you are using the CLI, the value is Base64 encoded.
 	// Otherwise, it is not encoded.
@@ -1211,6 +1432,16 @@ type EncryptOutput struct {
 
 type metadataEncryptOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EncryptOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EncryptOutput) GoString() string {
+	return s.String()
 }
 
 type GenerateDataKeyInput struct {
@@ -1246,6 +1477,16 @@ type metadataGenerateDataKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GenerateDataKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenerateDataKeyInput) GoString() string {
+	return s.String()
+}
+
 type GenerateDataKeyOutput struct {
 	// Ciphertext that contains the encrypted data key. You must store the blob
 	// and enough information to reconstruct the encryption context so that the
@@ -1270,6 +1511,16 @@ type GenerateDataKeyOutput struct {
 
 type metadataGenerateDataKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GenerateDataKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenerateDataKeyOutput) GoString() string {
+	return s.String()
 }
 
 type GenerateDataKeyWithoutPlaintextInput struct {
@@ -1304,6 +1555,16 @@ type metadataGenerateDataKeyWithoutPlaintextInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GenerateDataKeyWithoutPlaintextInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenerateDataKeyWithoutPlaintextInput) GoString() string {
+	return s.String()
+}
+
 type GenerateDataKeyWithoutPlaintextOutput struct {
 	// Ciphertext that contains the wrapped data key. You must store the blob and
 	// encryption context so that the key can be used in a future decrypt operation.
@@ -1323,6 +1584,16 @@ type metadataGenerateDataKeyWithoutPlaintextOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GenerateDataKeyWithoutPlaintextOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenerateDataKeyWithoutPlaintextOutput) GoString() string {
+	return s.String()
+}
+
 type GenerateRandomInput struct {
 	// Integer that contains the number of bytes to generate. Common values are
 	// 128, 256, 512, 1024 and so on. The current limit is 1024 bytes.
@@ -1335,6 +1606,16 @@ type metadataGenerateRandomInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GenerateRandomInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenerateRandomInput) GoString() string {
+	return s.String()
+}
+
 type GenerateRandomOutput struct {
 	// Plaintext that contains the unpredictable byte string.
 	Plaintext []byte `type:"blob"`
@@ -1344,6 +1625,16 @@ type GenerateRandomOutput struct {
 
 type metadataGenerateRandomOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GenerateRandomOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GenerateRandomOutput) GoString() string {
+	return s.String()
 }
 
 type GetKeyPolicyInput struct {
@@ -1364,6 +1655,16 @@ type metadataGetKeyPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetKeyPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetKeyPolicyInput) GoString() string {
+	return s.String()
+}
+
 type GetKeyPolicyOutput struct {
 	// A policy document in JSON format.
 	Policy *string `type:"string"`
@@ -1373,6 +1674,16 @@ type GetKeyPolicyOutput struct {
 
 type metadataGetKeyPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetKeyPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetKeyPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type GetKeyRotationStatusInput struct {
@@ -1389,6 +1700,16 @@ type metadataGetKeyRotationStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetKeyRotationStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetKeyRotationStatusInput) GoString() string {
+	return s.String()
+}
+
 type GetKeyRotationStatusOutput struct {
 	// A Boolean value that specifies whether key rotation is enabled.
 	KeyRotationEnabled *bool `type:"boolean"`
@@ -1398,6 +1719,16 @@ type GetKeyRotationStatusOutput struct {
 
 type metadataGetKeyRotationStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetKeyRotationStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetKeyRotationStatusOutput) GoString() string {
+	return s.String()
 }
 
 // Contains constraints on the grant.
@@ -1414,6 +1745,16 @@ type GrantConstraints struct {
 
 type metadataGrantConstraints struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GrantConstraints) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GrantConstraints) GoString() string {
+	return s.String()
 }
 
 // Contains information about each entry in the grant list.
@@ -1446,6 +1787,16 @@ type metadataGrantListEntry struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GrantListEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GrantListEntry) GoString() string {
+	return s.String()
+}
+
 // Contains information about each entry in the key list.
 type KeyListEntry struct {
 	// ARN of the key.
@@ -1459,6 +1810,16 @@ type KeyListEntry struct {
 
 type metadataKeyListEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s KeyListEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s KeyListEntry) GoString() string {
+	return s.String()
 }
 
 // Contains metadata associated with a specific key.
@@ -1491,6 +1852,16 @@ type metadataKeyMetadata struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s KeyMetadata) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s KeyMetadata) GoString() string {
+	return s.String()
+}
+
 type ListAliasesInput struct {
 	// Specify this parameter when paginating results to indicate the maximum number
 	// of aliases you want in each response. If there are additional aliases beyond
@@ -1507,6 +1878,16 @@ type ListAliasesInput struct {
 
 type metadataListAliasesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAliasesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAliasesInput) GoString() string {
+	return s.String()
 }
 
 type ListAliasesOutput struct {
@@ -1527,6 +1908,16 @@ type ListAliasesOutput struct {
 
 type metadataListAliasesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAliasesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAliasesOutput) GoString() string {
+	return s.String()
 }
 
 type ListGrantsInput struct {
@@ -1554,6 +1945,16 @@ type metadataListGrantsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListGrantsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGrantsInput) GoString() string {
+	return s.String()
+}
+
 type ListGrantsOutput struct {
 	// A list of grants.
 	Grants []*GrantListEntry `type:"list"`
@@ -1572,6 +1973,16 @@ type ListGrantsOutput struct {
 
 type metadataListGrantsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListGrantsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGrantsOutput) GoString() string {
+	return s.String()
 }
 
 type ListKeyPoliciesInput struct {
@@ -1601,6 +2012,16 @@ type metadataListKeyPoliciesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListKeyPoliciesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListKeyPoliciesInput) GoString() string {
+	return s.String()
+}
+
 type ListKeyPoliciesOutput struct {
 	// If Truncated is true, this value is present and contains the value to use
 	// for the Marker request parameter in a subsequent pagination request.
@@ -1622,6 +2043,16 @@ type metadataListKeyPoliciesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListKeyPoliciesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListKeyPoliciesOutput) GoString() string {
+	return s.String()
+}
+
 type ListKeysInput struct {
 	// Specify this parameter only when paginating results to indicate the maximum
 	// number of keys you want listed in the response. If there are additional keys
@@ -1639,6 +2070,16 @@ type ListKeysInput struct {
 
 type metadataListKeysInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListKeysInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListKeysInput) GoString() string {
+	return s.String()
 }
 
 type ListKeysOutput struct {
@@ -1659,6 +2100,16 @@ type ListKeysOutput struct {
 
 type metadataListKeysOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListKeysOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListKeysOutput) GoString() string {
+	return s.String()
 }
 
 type PutKeyPolicyInput struct {
@@ -1682,12 +2133,32 @@ type metadataPutKeyPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutKeyPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutKeyPolicyInput) GoString() string {
+	return s.String()
+}
+
 type PutKeyPolicyOutput struct {
 	metadataPutKeyPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutKeyPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutKeyPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutKeyPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type ReEncryptInput struct {
@@ -1720,6 +2191,16 @@ type metadataReEncryptInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReEncryptInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReEncryptInput) GoString() string {
+	return s.String()
+}
+
 type ReEncryptOutput struct {
 	// The re-encrypted data. If you are using the CLI, the value is Base64 encoded.
 	// Otherwise, it is not encoded.
@@ -1736,6 +2217,16 @@ type ReEncryptOutput struct {
 
 type metadataReEncryptOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReEncryptOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReEncryptOutput) GoString() string {
+	return s.String()
 }
 
 type RetireGrantInput struct {
@@ -1759,12 +2250,32 @@ type metadataRetireGrantInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RetireGrantInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetireGrantInput) GoString() string {
+	return s.String()
+}
+
 type RetireGrantOutput struct {
 	metadataRetireGrantOutput `json:"-" xml:"-"`
 }
 
 type metadataRetireGrantOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RetireGrantOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetireGrantOutput) GoString() string {
+	return s.String()
 }
 
 type RevokeGrantInput struct {
@@ -1784,12 +2295,32 @@ type metadataRevokeGrantInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RevokeGrantInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeGrantInput) GoString() string {
+	return s.String()
+}
+
 type RevokeGrantOutput struct {
 	metadataRevokeGrantOutput `json:"-" xml:"-"`
 }
 
 type metadataRevokeGrantOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RevokeGrantOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeGrantOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateAliasInput struct {
@@ -1811,12 +2342,32 @@ type metadataUpdateAliasInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateAliasInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAliasInput) GoString() string {
+	return s.String()
+}
+
 type UpdateAliasOutput struct {
 	metadataUpdateAliasOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAliasOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateAliasOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAliasOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateKeyDescriptionInput struct {
@@ -1836,10 +2387,30 @@ type metadataUpdateKeyDescriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateKeyDescriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateKeyDescriptionInput) GoString() string {
+	return s.String()
+}
+
 type UpdateKeyDescriptionOutput struct {
 	metadataUpdateKeyDescriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateKeyDescriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateKeyDescriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateKeyDescriptionOutput) GoString() string {
+	return s.String()
 }

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddPermission = "AddPermission"
@@ -650,6 +651,16 @@ type metadataAddPermissionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddPermissionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddPermissionInput) GoString() string {
+	return s.String()
+}
+
 type AddPermissionOutput struct {
 	// The permission statement you specified in the request. The response returns
 	// the same as a string using "\" as an escape character in the JSON.
@@ -660,6 +671,16 @@ type AddPermissionOutput struct {
 
 type metadataAddPermissionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddPermissionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddPermissionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateEventSourceMappingInput struct {
@@ -699,6 +720,16 @@ type CreateEventSourceMappingInput struct {
 
 type metadataCreateEventSourceMappingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateEventSourceMappingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateEventSourceMappingInput) GoString() string {
+	return s.String()
 }
 
 type CreateFunctionInput struct {
@@ -755,6 +786,16 @@ type metadataCreateFunctionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateFunctionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateFunctionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteEventSourceMappingInput struct {
 	// The event source mapping ID.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
@@ -764,6 +805,16 @@ type DeleteEventSourceMappingInput struct {
 
 type metadataDeleteEventSourceMappingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteEventSourceMappingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEventSourceMappingInput) GoString() string {
+	return s.String()
 }
 
 type DeleteFunctionInput struct {
@@ -784,12 +835,32 @@ type metadataDeleteFunctionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteFunctionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteFunctionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteFunctionOutput struct {
 	metadataDeleteFunctionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteFunctionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteFunctionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteFunctionOutput) GoString() string {
+	return s.String()
 }
 
 // Describes mapping between an Amazon Kinesis stream and a Lambda function.
@@ -830,6 +901,16 @@ type metadataEventSourceMappingConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EventSourceMappingConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EventSourceMappingConfiguration) GoString() string {
+	return s.String()
+}
+
 // The code for the Lambda function.
 type FunctionCode struct {
 	// Amazon S3 bucket name where the .zip file containing your deployment package
@@ -855,6 +936,16 @@ type metadataFunctionCode struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FunctionCode) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FunctionCode) GoString() string {
+	return s.String()
+}
+
 // The object for the Lambda function location.
 type FunctionCodeLocation struct {
 	// The presigned URL you can use to download the function's .zip file that you
@@ -869,6 +960,16 @@ type FunctionCodeLocation struct {
 
 type metadataFunctionCodeLocation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s FunctionCodeLocation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FunctionCodeLocation) GoString() string {
+	return s.String()
 }
 
 // A complex type that describes function metadata.
@@ -914,6 +1015,16 @@ type metadataFunctionConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FunctionConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FunctionConfiguration) GoString() string {
+	return s.String()
+}
+
 type GetEventSourceMappingInput struct {
 	// The AWS Lambda assigned ID of the event source mapping.
 	UUID *string `location:"uri" locationName:"UUID" type:"string" required:"true"`
@@ -923,6 +1034,16 @@ type GetEventSourceMappingInput struct {
 
 type metadataGetEventSourceMappingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetEventSourceMappingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetEventSourceMappingInput) GoString() string {
+	return s.String()
 }
 
 type GetFunctionConfigurationInput struct {
@@ -944,6 +1065,16 @@ type metadataGetFunctionConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetFunctionConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetFunctionConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type GetFunctionInput struct {
 	// The Lambda function name.
 	//
@@ -962,6 +1093,16 @@ type metadataGetFunctionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetFunctionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetFunctionInput) GoString() string {
+	return s.String()
+}
+
 // This response contains the object for the Lambda function location (see API_FunctionCodeLocation
 type GetFunctionOutput struct {
 	// The object for the Lambda function location.
@@ -975,6 +1116,16 @@ type GetFunctionOutput struct {
 
 type metadataGetFunctionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetFunctionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetFunctionOutput) GoString() string {
+	return s.String()
 }
 
 type GetPolicyInput struct {
@@ -995,6 +1146,16 @@ type metadataGetPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPolicyInput) GoString() string {
+	return s.String()
+}
+
 type GetPolicyOutput struct {
 	// The access policy associated with the specified function. The response returns
 	// the same as a string using "\" as an escape character in the JSON.
@@ -1005,6 +1166,16 @@ type GetPolicyOutput struct {
 
 type metadataGetPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type InvokeAsyncInput struct {
@@ -1021,6 +1192,16 @@ type metadataInvokeAsyncInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"InvokeArgs"`
 }
 
+// String returns the string representation
+func (s InvokeAsyncInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InvokeAsyncInput) GoString() string {
+	return s.String()
+}
+
 // Upon success, it returns empty response. Otherwise, throws an exception.
 type InvokeAsyncOutput struct {
 	// It will be 202 upon success.
@@ -1031,6 +1212,16 @@ type InvokeAsyncOutput struct {
 
 type metadataInvokeAsyncOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InvokeAsyncOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InvokeAsyncOutput) GoString() string {
+	return s.String()
 }
 
 type InvokeInput struct {
@@ -1078,6 +1269,16 @@ type metadataInvokeInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Payload"`
 }
 
+// String returns the string representation
+func (s InvokeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InvokeInput) GoString() string {
+	return s.String()
+}
+
 // Upon success, returns an empty response. Otherwise, throws an exception.
 type InvokeOutput struct {
 	// Indicates whether an error occurred while executing the Lambda function.
@@ -1114,6 +1315,16 @@ type metadataInvokeOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Payload"`
 }
 
+// String returns the string representation
+func (s InvokeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InvokeOutput) GoString() string {
+	return s.String()
+}
+
 type ListEventSourceMappingsInput struct {
 	// The Amazon Resource Name (ARN) of the Amazon Kinesis stream.
 	EventSourceARN *string `location:"querystring" locationName:"EventSourceArn" type:"string"`
@@ -1144,6 +1355,16 @@ type metadataListEventSourceMappingsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListEventSourceMappingsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListEventSourceMappingsInput) GoString() string {
+	return s.String()
+}
+
 // Contains a list of event sources (see API_EventSourceMappingConfiguration)
 type ListEventSourceMappingsOutput struct {
 	// An array of EventSourceMappingConfiguration objects.
@@ -1157,6 +1378,16 @@ type ListEventSourceMappingsOutput struct {
 
 type metadataListEventSourceMappingsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListEventSourceMappingsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListEventSourceMappingsOutput) GoString() string {
+	return s.String()
 }
 
 type ListFunctionsInput struct {
@@ -1175,6 +1406,16 @@ type metadataListFunctionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListFunctionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListFunctionsInput) GoString() string {
+	return s.String()
+}
+
 // Contains a list of AWS Lambda function configurations (see FunctionConfiguration.
 type ListFunctionsOutput struct {
 	// A list of Lambda functions.
@@ -1188,6 +1429,16 @@ type ListFunctionsOutput struct {
 
 type metadataListFunctionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListFunctionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListFunctionsOutput) GoString() string {
+	return s.String()
 }
 
 type RemovePermissionInput struct {
@@ -1211,12 +1462,32 @@ type metadataRemovePermissionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemovePermissionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemovePermissionInput) GoString() string {
+	return s.String()
+}
+
 type RemovePermissionOutput struct {
 	metadataRemovePermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemovePermissionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemovePermissionOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateEventSourceMappingInput struct {
@@ -1246,6 +1517,16 @@ type UpdateEventSourceMappingInput struct {
 
 type metadataUpdateEventSourceMappingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateEventSourceMappingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateEventSourceMappingInput) GoString() string {
+	return s.String()
 }
 
 type UpdateFunctionCodeInput struct {
@@ -1278,6 +1559,16 @@ type UpdateFunctionCodeInput struct {
 
 type metadataUpdateFunctionCodeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateFunctionCodeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateFunctionCodeInput) GoString() string {
+	return s.String()
 }
 
 type UpdateFunctionConfigurationInput struct {
@@ -1321,4 +1612,14 @@ type UpdateFunctionConfigurationInput struct {
 
 type metadataUpdateFunctionConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateFunctionConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateFunctionConfigurationInput) GoString() string {
+	return s.String()
 }

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateBatchPrediction = "CreateBatchPrediction"
@@ -962,6 +963,16 @@ type metadataBatchPrediction struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BatchPrediction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchPrediction) GoString() string {
+	return s.String()
+}
+
 type CreateBatchPredictionInput struct {
 	// The ID of the DataSource that points to the group of observations to predict.
 	BatchPredictionDataSourceID *string `locationName:"BatchPredictionDataSourceId" type:"string" required:"true"`
@@ -992,6 +1003,16 @@ type metadataCreateBatchPredictionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateBatchPredictionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateBatchPredictionInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a CreateBatchPrediction operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1008,6 +1029,16 @@ type CreateBatchPredictionOutput struct {
 
 type metadataCreateBatchPredictionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateBatchPredictionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateBatchPredictionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDataSourceFromRDSInput struct {
@@ -1077,6 +1108,16 @@ type metadataCreateDataSourceFromRDSInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDataSourceFromRDSInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDataSourceFromRDSInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a CreateDataSourceFromRDS operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1096,6 +1137,16 @@ type CreateDataSourceFromRDSOutput struct {
 
 type metadataCreateDataSourceFromRDSOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDataSourceFromRDSOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDataSourceFromRDSOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDataSourceFromRedshiftInput struct {
@@ -1154,6 +1205,16 @@ type metadataCreateDataSourceFromRedshiftInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDataSourceFromRedshiftInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDataSourceFromRedshiftInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a CreateDataSourceFromRedshift operation, and is
 // an acknowledgement that Amazon ML received the request.
 //
@@ -1170,6 +1231,16 @@ type CreateDataSourceFromRedshiftOutput struct {
 
 type metadataCreateDataSourceFromRedshiftOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDataSourceFromRedshiftOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDataSourceFromRedshiftOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDataSourceFromS3Input struct {
@@ -1208,6 +1279,16 @@ type metadataCreateDataSourceFromS3Input struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDataSourceFromS3Input) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDataSourceFromS3Input) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a CreateDataSourceFromS3 operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1223,6 +1304,16 @@ type CreateDataSourceFromS3Output struct {
 
 type metadataCreateDataSourceFromS3Output struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDataSourceFromS3Output) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDataSourceFromS3Output) GoString() string {
+	return s.String()
 }
 
 type CreateEvaluationInput struct {
@@ -1249,6 +1340,16 @@ type metadataCreateEvaluationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateEvaluationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateEvaluationInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a CreateEvaluation operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1264,6 +1365,16 @@ type CreateEvaluationOutput struct {
 
 type metadataCreateEvaluationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateEvaluationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateEvaluationOutput) GoString() string {
+	return s.String()
 }
 
 type CreateMLModelInput struct {
@@ -1336,6 +1447,16 @@ type metadataCreateMLModelInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateMLModelInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateMLModelInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a CreateMLModel operation, and is an acknowledgement
 // that Amazon ML received the request.
 //
@@ -1353,6 +1474,16 @@ type metadataCreateMLModelOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateMLModelOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateMLModelOutput) GoString() string {
+	return s.String()
+}
+
 type CreateRealtimeEndpointInput struct {
 	// The ID assigned to the MLModel during creation.
 	MLModelID *string `locationName:"MLModelId" type:"string" required:"true"`
@@ -1362,6 +1493,16 @@ type CreateRealtimeEndpointInput struct {
 
 type metadataCreateRealtimeEndpointInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateRealtimeEndpointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateRealtimeEndpointInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of an CreateRealtimeEndpoint operation.
@@ -1383,6 +1524,16 @@ type CreateRealtimeEndpointOutput struct {
 
 type metadataCreateRealtimeEndpointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateRealtimeEndpointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateRealtimeEndpointOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of the GetDataSource operation.
@@ -1457,6 +1608,16 @@ type metadataDataSource struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DataSource) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DataSource) GoString() string {
+	return s.String()
+}
+
 type DeleteBatchPredictionInput struct {
 	// A user-supplied ID that uniquely identifies the BatchPrediction.
 	BatchPredictionID *string `locationName:"BatchPredictionId" type:"string" required:"true"`
@@ -1466,6 +1627,16 @@ type DeleteBatchPredictionInput struct {
 
 type metadataDeleteBatchPredictionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBatchPredictionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBatchPredictionInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a DeleteBatchPrediction operation.
@@ -1484,6 +1655,16 @@ type metadataDeleteBatchPredictionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBatchPredictionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBatchPredictionOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteDataSourceInput struct {
 	// A user-supplied ID that uniquely identifies the DataSource.
 	DataSourceID *string `locationName:"DataSourceId" type:"string" required:"true"`
@@ -1493,6 +1674,16 @@ type DeleteDataSourceInput struct {
 
 type metadataDeleteDataSourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDataSourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDataSourceInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a DeleteDataSource operation.
@@ -1508,6 +1699,16 @@ type metadataDeleteDataSourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDataSourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDataSourceOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteEvaluationInput struct {
 	// A user-supplied ID that uniquely identifies the Evaluation to delete.
 	EvaluationID *string `locationName:"EvaluationId" type:"string" required:"true"`
@@ -1517,6 +1718,16 @@ type DeleteEvaluationInput struct {
 
 type metadataDeleteEvaluationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteEvaluationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEvaluationInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a DeleteEvaluation operation. The output indicates
@@ -1536,6 +1747,16 @@ type metadataDeleteEvaluationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteEvaluationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEvaluationOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteMLModelInput struct {
 	// A user-supplied ID that uniquely identifies the MLModel.
 	MLModelID *string `locationName:"MLModelId" type:"string" required:"true"`
@@ -1545,6 +1766,16 @@ type DeleteMLModelInput struct {
 
 type metadataDeleteMLModelInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteMLModelInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMLModelInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a DeleteMLModel operation.
@@ -1563,6 +1794,16 @@ type metadataDeleteMLModelOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteMLModelOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMLModelOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteRealtimeEndpointInput struct {
 	// The ID assigned to the MLModel during creation.
 	MLModelID *string `locationName:"MLModelId" type:"string" required:"true"`
@@ -1572,6 +1813,16 @@ type DeleteRealtimeEndpointInput struct {
 
 type metadataDeleteRealtimeEndpointInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRealtimeEndpointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRealtimeEndpointInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of an DeleteRealtimeEndpoint operation.
@@ -1590,6 +1841,16 @@ type DeleteRealtimeEndpointOutput struct {
 
 type metadataDeleteRealtimeEndpointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteRealtimeEndpointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteRealtimeEndpointOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeBatchPredictionsInput struct {
@@ -1666,6 +1927,16 @@ type metadataDescribeBatchPredictionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeBatchPredictionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeBatchPredictionsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeBatchPredictions operation. The content
 // is essentially a list of BatchPredictions.
 type DescribeBatchPredictionsOutput struct {
@@ -1681,6 +1952,16 @@ type DescribeBatchPredictionsOutput struct {
 
 type metadataDescribeBatchPredictionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeBatchPredictionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeBatchPredictionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDataSourcesInput struct {
@@ -1752,6 +2033,16 @@ type metadataDescribeDataSourcesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDataSourcesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDataSourcesInput) GoString() string {
+	return s.String()
+}
+
 // Represents the query results from a DescribeDataSources operation. The content
 // is essentially a list of DataSource.
 type DescribeDataSourcesOutput struct {
@@ -1767,6 +2058,16 @@ type DescribeDataSourcesOutput struct {
 
 type metadataDescribeDataSourcesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDataSourcesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDataSourcesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeEvaluationsInput struct {
@@ -1840,6 +2141,16 @@ type metadataDescribeEvaluationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEvaluationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEvaluationsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the query results from a DescribeEvaluations operation. The content
 // is essentially a list of Evaluation.
 type DescribeEvaluationsOutput struct {
@@ -1855,6 +2166,16 @@ type DescribeEvaluationsOutput struct {
 
 type metadataDescribeEvaluationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEvaluationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEvaluationsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeMLModelsInput struct {
@@ -1931,6 +2252,16 @@ type metadataDescribeMLModelsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeMLModelsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMLModelsInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a DescribeMLModels operation. The content is essentially
 // a list of MLModel.
 type DescribeMLModelsOutput struct {
@@ -1946,6 +2277,16 @@ type DescribeMLModelsOutput struct {
 
 type metadataDescribeMLModelsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMLModelsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMLModelsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of GetEvaluation operation.
@@ -2020,6 +2361,16 @@ type metadataEvaluation struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Evaluation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Evaluation) GoString() string {
+	return s.String()
+}
+
 type GetBatchPredictionInput struct {
 	// An ID assigned to the BatchPrediction at creation.
 	BatchPredictionID *string `locationName:"BatchPredictionId" type:"string" required:"true"`
@@ -2029,6 +2380,16 @@ type GetBatchPredictionInput struct {
 
 type metadataGetBatchPredictionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBatchPredictionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBatchPredictionInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a GetBatchPrediction operation and describes a BatchPrediction.
@@ -2091,6 +2452,16 @@ type metadataGetBatchPredictionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBatchPredictionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBatchPredictionOutput) GoString() string {
+	return s.String()
+}
+
 type GetDataSourceInput struct {
 	// The ID assigned to the DataSource at creation.
 	DataSourceID *string `locationName:"DataSourceId" type:"string" required:"true"`
@@ -2107,6 +2478,16 @@ type GetDataSourceInput struct {
 
 type metadataGetDataSourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDataSourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDataSourceInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a GetDataSource operation and describes a DataSource.
@@ -2187,6 +2568,16 @@ type metadataGetDataSourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetDataSourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDataSourceOutput) GoString() string {
+	return s.String()
+}
+
 type GetEvaluationInput struct {
 	// The ID of the Evaluation to retrieve. The evaluation of each MLModel is recorded
 	// and cataloged. The ID provides the means to access the information.
@@ -2197,6 +2588,16 @@ type GetEvaluationInput struct {
 
 type metadataGetEvaluationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetEvaluationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetEvaluationInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a GetEvaluation operation and describes an Evaluation.
@@ -2271,6 +2672,16 @@ type metadataGetEvaluationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetEvaluationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetEvaluationOutput) GoString() string {
+	return s.String()
+}
+
 type GetMLModelInput struct {
 	// The ID assigned to the MLModel at creation.
 	MLModelID *string `locationName:"MLModelId" type:"string" required:"true"`
@@ -2287,6 +2698,16 @@ type GetMLModelInput struct {
 
 type metadataGetMLModelInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetMLModelInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetMLModelInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of a GetMLModel operation, and provides detailed information
@@ -2411,6 +2832,16 @@ type metadataGetMLModelOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetMLModelOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetMLModelOutput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of a GetMLModel operation.
 //
 // The content consists of the detailed metadata and the current status of
@@ -2522,6 +2953,16 @@ type metadataMLModel struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MLModel) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MLModel) GoString() string {
+	return s.String()
+}
+
 // Measurements of how well the MLModel performed on known observations. One
 // of the following metrics is returned, based on the type of the MLModel:
 //
@@ -2547,6 +2988,16 @@ type metadataPerformanceMetrics struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PerformanceMetrics) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PerformanceMetrics) GoString() string {
+	return s.String()
+}
+
 type PredictInput struct {
 	// A unique identifier of the MLModel.
 	MLModelID *string `locationName:"MLModelId" type:"string" required:"true"`
@@ -2561,6 +3012,16 @@ type PredictInput struct {
 
 type metadataPredictInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PredictInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PredictInput) GoString() string {
+	return s.String()
 }
 
 type PredictOutput struct {
@@ -2582,6 +3043,16 @@ type PredictOutput struct {
 
 type metadataPredictOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PredictOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PredictOutput) GoString() string {
+	return s.String()
 }
 
 // The output from a Predict operation:
@@ -2613,6 +3084,16 @@ type Prediction struct {
 
 type metadataPrediction struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Prediction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Prediction) GoString() string {
+	return s.String()
 }
 
 // The data specification of an Amazon Relational Database Service (Amazon RDS)
@@ -2675,6 +3156,16 @@ type metadataRDSDataSpec struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RDSDataSpec) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RDSDataSpec) GoString() string {
+	return s.String()
+}
+
 // The database details of an Amazon RDS database.
 type RDSDatabase struct {
 	// The name of a database hosted on an RDS DB instance.
@@ -2688,6 +3179,16 @@ type RDSDatabase struct {
 
 type metadataRDSDatabase struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RDSDatabase) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RDSDatabase) GoString() string {
+	return s.String()
 }
 
 // The database credentials to connect to a database on an RDS DB instance.
@@ -2707,6 +3208,16 @@ type RDSDatabaseCredentials struct {
 
 type metadataRDSDatabaseCredentials struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RDSDatabaseCredentials) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RDSDatabaseCredentials) GoString() string {
+	return s.String()
 }
 
 // The datasource details that are specific to Amazon RDS.
@@ -2747,6 +3258,16 @@ type metadataRDSMetadata struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RDSMetadata) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RDSMetadata) GoString() string {
+	return s.String()
+}
+
 // Describes the real-time endpoint information for an MLModel.
 type RealtimeEndpointInfo struct {
 	// The time that the request to create the real-time endpoint for the MLModel
@@ -2777,6 +3298,16 @@ type RealtimeEndpointInfo struct {
 
 type metadataRealtimeEndpointInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RealtimeEndpointInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RealtimeEndpointInfo) GoString() string {
+	return s.String()
 }
 
 // Describes the data specification of an Amazon Redshift DataSource.
@@ -2812,6 +3343,16 @@ type metadataRedshiftDataSpec struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RedshiftDataSpec) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RedshiftDataSpec) GoString() string {
+	return s.String()
+}
+
 // Describes the database details required to connect to an Amazon Redshift
 // database.
 type RedshiftDatabase struct {
@@ -2826,6 +3367,16 @@ type RedshiftDatabase struct {
 
 type metadataRedshiftDatabase struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RedshiftDatabase) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RedshiftDatabase) GoString() string {
+	return s.String()
 }
 
 // Describes the database credentials for connecting to a database on an Amazon
@@ -2848,6 +3399,16 @@ type RedshiftDatabaseCredentials struct {
 
 type metadataRedshiftDatabaseCredentials struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RedshiftDatabaseCredentials) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RedshiftDatabaseCredentials) GoString() string {
+	return s.String()
 }
 
 // Describes the DataSource details specific to Amazon Redshift.
@@ -2873,6 +3434,16 @@ type metadataRedshiftMetadata struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RedshiftMetadata) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RedshiftMetadata) GoString() string {
+	return s.String()
+}
+
 // Describes the data specification of a DataSource.
 type S3DataSpec struct {
 	// The location of the data file(s) used by a DataSource. The URI specifies
@@ -2896,6 +3467,16 @@ type metadataS3DataSpec struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s S3DataSpec) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s S3DataSpec) GoString() string {
+	return s.String()
+}
+
 type UpdateBatchPredictionInput struct {
 	// The ID assigned to the BatchPrediction during creation.
 	BatchPredictionID *string `locationName:"BatchPredictionId" type:"string" required:"true"`
@@ -2908,6 +3489,16 @@ type UpdateBatchPredictionInput struct {
 
 type metadataUpdateBatchPredictionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateBatchPredictionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateBatchPredictionInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of an UpdateBatchPrediction operation.
@@ -2925,6 +3516,16 @@ type metadataUpdateBatchPredictionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateBatchPredictionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateBatchPredictionOutput) GoString() string {
+	return s.String()
+}
+
 type UpdateDataSourceInput struct {
 	// The ID assigned to the DataSource during creation.
 	DataSourceID *string `locationName:"DataSourceId" type:"string" required:"true"`
@@ -2938,6 +3539,16 @@ type UpdateDataSourceInput struct {
 
 type metadataUpdateDataSourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateDataSourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDataSourceInput) GoString() string {
+	return s.String()
 }
 
 // Represents the output of an UpdateDataSource operation.
@@ -2955,6 +3566,16 @@ type metadataUpdateDataSourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateDataSourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDataSourceOutput) GoString() string {
+	return s.String()
+}
+
 type UpdateEvaluationInput struct {
 	// The ID assigned to the Evaluation during creation.
 	EvaluationID *string `locationName:"EvaluationId" type:"string" required:"true"`
@@ -2970,6 +3591,16 @@ type metadataUpdateEvaluationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateEvaluationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateEvaluationInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of an UpdateEvaluation operation.
 //
 // You can see the updated content by using the GetEvaluation operation.
@@ -2983,6 +3614,16 @@ type UpdateEvaluationOutput struct {
 
 type metadataUpdateEvaluationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateEvaluationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateEvaluationOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateMLModelInput struct {
@@ -3007,6 +3648,16 @@ type metadataUpdateMLModelInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateMLModelInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateMLModelInput) GoString() string {
+	return s.String()
+}
+
 // Represents the output of an UpdateMLModel operation.
 //
 // You can see the updated content by using the GetMLModel operation.
@@ -3020,4 +3671,14 @@ type UpdateMLModelOutput struct {
 
 type metadataUpdateMLModelOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateMLModelOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateMLModelOutput) GoString() string {
+	return s.String()
 }

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -5,6 +5,7 @@ package mobileanalytics
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opPutEvents = "PutEvents"
@@ -71,6 +72,16 @@ type metadataEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Event) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Event) GoString() string {
+	return s.String()
+}
+
 // A container for the data needed for a PutEvent operation
 type PutEventsInput struct {
 	// The client context including the client ID, app title, app version and package
@@ -90,12 +101,32 @@ type metadataPutEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutEventsInput) GoString() string {
+	return s.String()
+}
+
 type PutEventsOutput struct {
 	metadataPutEventsOutput `json:"-" xml:"-"`
 }
 
 type metadataPutEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutEventsOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the session. Session information is required on ALL events.
@@ -119,4 +150,14 @@ type Session struct {
 
 type metadataSession struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Session) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Session) GoString() string {
+	return s.String()
 }

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -5,6 +5,7 @@ package opsworks
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAssignInstance = "AssignInstance"
@@ -2248,6 +2249,16 @@ type metadataAgentVersion struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AgentVersion) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AgentVersion) GoString() string {
+	return s.String()
+}
+
 // A description of the app.
 type App struct {
 	// The app ID.
@@ -2310,6 +2321,16 @@ type metadataApp struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s App) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s App) GoString() string {
+	return s.String()
+}
+
 type AssignInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
@@ -2325,12 +2346,32 @@ type metadataAssignInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssignInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssignInstanceInput) GoString() string {
+	return s.String()
+}
+
 type AssignInstanceOutput struct {
 	metadataAssignInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataAssignInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssignInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssignInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type AssignVolumeInput struct {
@@ -2347,12 +2388,32 @@ type metadataAssignVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssignVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssignVolumeInput) GoString() string {
+	return s.String()
+}
+
 type AssignVolumeOutput struct {
 	metadataAssignVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataAssignVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssignVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssignVolumeOutput) GoString() string {
+	return s.String()
 }
 
 type AssociateElasticIPInput struct {
@@ -2369,12 +2430,32 @@ type metadataAssociateElasticIPInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssociateElasticIPInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateElasticIPInput) GoString() string {
+	return s.String()
+}
+
 type AssociateElasticIPOutput struct {
 	metadataAssociateElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataAssociateElasticIPOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociateElasticIPOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateElasticIPOutput) GoString() string {
+	return s.String()
 }
 
 type AttachElasticLoadBalancerInput struct {
@@ -2392,12 +2473,32 @@ type metadataAttachElasticLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AttachElasticLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachElasticLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
 type AttachElasticLoadBalancerOutput struct {
 	metadataAttachElasticLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataAttachElasticLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachElasticLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachElasticLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a load-based auto scaling upscaling or downscaling threshold configuration,
@@ -2447,6 +2548,16 @@ type metadataAutoScalingThresholds struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AutoScalingThresholds) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AutoScalingThresholds) GoString() string {
+	return s.String()
+}
+
 // Describes a block device mapping. This data type maps directly to the Amazon
 // EC2 BlockDeviceMapping (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html)
 // data type.
@@ -2473,6 +2584,16 @@ type metadataBlockDeviceMapping struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BlockDeviceMapping) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BlockDeviceMapping) GoString() string {
+	return s.String()
+}
+
 // Describes the Chef configuration.
 type ChefConfiguration struct {
 	// The Berkshelf version.
@@ -2486,6 +2607,16 @@ type ChefConfiguration struct {
 
 type metadataChefConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChefConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChefConfiguration) GoString() string {
+	return s.String()
 }
 
 type CloneStackInput struct {
@@ -2670,6 +2801,16 @@ type metadataCloneStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CloneStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CloneStackInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a CloneStack request.
 type CloneStackOutput struct {
 	// The cloned stack ID.
@@ -2680,6 +2821,16 @@ type CloneStackOutput struct {
 
 type metadataCloneStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CloneStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CloneStackOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a command.
@@ -2724,6 +2875,16 @@ type Command struct {
 
 type metadataCommand struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Command) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Command) GoString() string {
+	return s.String()
 }
 
 type CreateAppInput struct {
@@ -2788,6 +2949,16 @@ type metadataCreateAppInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAppInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAppInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a CreateApp request.
 type CreateAppOutput struct {
 	// The app ID.
@@ -2798,6 +2969,16 @@ type CreateAppOutput struct {
 
 type metadataCreateAppOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAppOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAppOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDeploymentInput struct {
@@ -2835,6 +3016,16 @@ type metadataCreateDeploymentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDeploymentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDeploymentInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a CreateDeployment request.
 type CreateDeploymentOutput struct {
 	// The deployment ID, which can be used with other requests to identify the
@@ -2846,6 +3037,16 @@ type CreateDeploymentOutput struct {
 
 type metadataCreateDeploymentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDeploymentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDeploymentOutput) GoString() string {
+	return s.String()
 }
 
 type CreateInstanceInput struct {
@@ -2952,6 +3153,16 @@ type metadataCreateInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInstanceInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a CreateInstance request.
 type CreateInstanceOutput struct {
 	// The instance ID.
@@ -2962,6 +3173,16 @@ type CreateInstanceOutput struct {
 
 type metadataCreateInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type CreateLayerInput struct {
@@ -3041,6 +3262,16 @@ type metadataCreateLayerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateLayerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLayerInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a CreateLayer request.
 type CreateLayerOutput struct {
 	// The layer ID.
@@ -3051,6 +3282,16 @@ type CreateLayerOutput struct {
 
 type metadataCreateLayerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateLayerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateLayerOutput) GoString() string {
+	return s.String()
 }
 
 type CreateStackInput struct {
@@ -3220,6 +3461,16 @@ type metadataCreateStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStackInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a CreateStack request.
 type CreateStackOutput struct {
 	// The stack ID, which is an opaque string that you use to identify the stack
@@ -3231,6 +3482,16 @@ type CreateStackOutput struct {
 
 type metadataCreateStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStackOutput) GoString() string {
+	return s.String()
 }
 
 type CreateUserProfileInput struct {
@@ -3258,6 +3519,16 @@ type metadataCreateUserProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateUserProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateUserProfileInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a CreateUserProfile request.
 type CreateUserProfileOutput struct {
 	// The user's IAM ARN.
@@ -3268,6 +3539,16 @@ type CreateUserProfileOutput struct {
 
 type metadataCreateUserProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateUserProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateUserProfileOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an app's data source.
@@ -3289,6 +3570,16 @@ type metadataDataSource struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DataSource) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DataSource) GoString() string {
+	return s.String()
+}
+
 type DeleteAppInput struct {
 	// The app ID.
 	AppID *string `locationName:"AppId" type:"string" required:"true"`
@@ -3300,12 +3591,32 @@ type metadataDeleteAppInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAppInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAppInput) GoString() string {
+	return s.String()
+}
+
 type DeleteAppOutput struct {
 	metadataDeleteAppOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAppOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAppOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAppOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteInstanceInput struct {
@@ -3325,12 +3636,32 @@ type metadataDeleteInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteInstanceInput) GoString() string {
+	return s.String()
+}
+
 type DeleteInstanceOutput struct {
 	metadataDeleteInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteLayerInput struct {
@@ -3344,12 +3675,32 @@ type metadataDeleteLayerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteLayerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLayerInput) GoString() string {
+	return s.String()
+}
+
 type DeleteLayerOutput struct {
 	metadataDeleteLayerOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteLayerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteLayerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteLayerOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteStackInput struct {
@@ -3363,12 +3714,32 @@ type metadataDeleteStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteStackInput) GoString() string {
+	return s.String()
+}
+
 type DeleteStackOutput struct {
 	metadataDeleteStackOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteStackOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteUserProfileInput struct {
@@ -3382,12 +3753,32 @@ type metadataDeleteUserProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteUserProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteUserProfileInput) GoString() string {
+	return s.String()
+}
+
 type DeleteUserProfileOutput struct {
 	metadataDeleteUserProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteUserProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteUserProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteUserProfileOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a deployment of a stack or app.
@@ -3445,6 +3836,16 @@ type metadataDeployment struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Deployment) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Deployment) GoString() string {
+	return s.String()
+}
+
 // Used to specify a stack or deployment command.
 type DeploymentCommand struct {
 	// The arguments of those commands that take arguments. It should be set to
@@ -3498,6 +3899,16 @@ type metadataDeploymentCommand struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeploymentCommand) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeploymentCommand) GoString() string {
+	return s.String()
+}
+
 type DeregisterElasticIPInput struct {
 	// The Elastic IP address.
 	ElasticIP *string `locationName:"ElasticIp" type:"string" required:"true"`
@@ -3509,12 +3920,32 @@ type metadataDeregisterElasticIPInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterElasticIPInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterElasticIPInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterElasticIPOutput struct {
 	metadataDeregisterElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterElasticIPOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterElasticIPOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterElasticIPOutput) GoString() string {
+	return s.String()
 }
 
 type DeregisterInstanceInput struct {
@@ -3528,12 +3959,32 @@ type metadataDeregisterInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterInstanceInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterInstanceOutput struct {
 	metadataDeregisterInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type DeregisterRDSDBInstanceInput struct {
@@ -3547,12 +3998,32 @@ type metadataDeregisterRDSDBInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterRDSDBInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterRDSDBInstanceInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterRDSDBInstanceOutput struct {
 	metadataDeregisterRDSDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterRDSDBInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterRDSDBInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterRDSDBInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type DeregisterVolumeInput struct {
@@ -3568,12 +4039,32 @@ type metadataDeregisterVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeregisterVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterVolumeInput) GoString() string {
+	return s.String()
+}
+
 type DeregisterVolumeOutput struct {
 	metadataDeregisterVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeregisterVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeregisterVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeregisterVolumeOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAgentVersionsInput struct {
@@ -3590,6 +4081,16 @@ type metadataDescribeAgentVersionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAgentVersionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAgentVersionsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeAgentVersions request.
 type DescribeAgentVersionsOutput struct {
 	// The agent versions for the specified stack or configuration manager. Note
@@ -3602,6 +4103,16 @@ type DescribeAgentVersionsOutput struct {
 
 type metadataDescribeAgentVersionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAgentVersionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAgentVersionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAppsInput struct {
@@ -3621,6 +4132,16 @@ type metadataDescribeAppsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAppsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAppsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeApps request.
 type DescribeAppsOutput struct {
 	// An array of App objects that describe the specified apps.
@@ -3631,6 +4152,16 @@ type DescribeAppsOutput struct {
 
 type metadataDescribeAppsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAppsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAppsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeCommandsInput struct {
@@ -3654,6 +4185,16 @@ type metadataDescribeCommandsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCommandsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCommandsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeCommands request.
 type DescribeCommandsOutput struct {
 	// An array of Command objects that describe each of the specified commands.
@@ -3664,6 +4205,16 @@ type DescribeCommandsOutput struct {
 
 type metadataDescribeCommandsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCommandsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCommandsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDeploymentsInput struct {
@@ -3687,6 +4238,16 @@ type metadataDescribeDeploymentsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDeploymentsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDeploymentsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeDeployments request.
 type DescribeDeploymentsOutput struct {
 	// An array of Deployment objects that describe the deployments.
@@ -3697,6 +4258,16 @@ type DescribeDeploymentsOutput struct {
 
 type metadataDescribeDeploymentsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDeploymentsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDeploymentsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeElasticIPsInput struct {
@@ -3720,6 +4291,16 @@ type metadataDescribeElasticIPsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeElasticIPsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeElasticIPsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeElasticIps request.
 type DescribeElasticIPsOutput struct {
 	// An ElasticIps object that describes the specified Elastic IP addresses.
@@ -3730,6 +4311,16 @@ type DescribeElasticIPsOutput struct {
 
 type metadataDescribeElasticIPsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeElasticIPsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeElasticIPsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeElasticLoadBalancersInput struct {
@@ -3747,6 +4338,16 @@ type metadataDescribeElasticLoadBalancersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeElasticLoadBalancersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeElasticLoadBalancersInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeElasticLoadBalancers request.
 type DescribeElasticLoadBalancersOutput struct {
 	// A list of ElasticLoadBalancer objects that describe the specified Elastic
@@ -3758,6 +4359,16 @@ type DescribeElasticLoadBalancersOutput struct {
 
 type metadataDescribeElasticLoadBalancersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeElasticLoadBalancersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeElasticLoadBalancersOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeInstancesInput struct {
@@ -3781,6 +4392,16 @@ type metadataDescribeInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeInstances request.
 type DescribeInstancesOutput struct {
 	// An array of Instance objects that describe the instances.
@@ -3791,6 +4412,16 @@ type DescribeInstancesOutput struct {
 
 type metadataDescribeInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeLayersInput struct {
@@ -3809,6 +4440,16 @@ type metadataDescribeLayersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLayersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLayersInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeLayers request.
 type DescribeLayersOutput struct {
 	// An array of Layer objects that describe the layers.
@@ -3821,6 +4462,16 @@ type metadataDescribeLayersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLayersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLayersOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeLoadBasedAutoScalingInput struct {
 	// An array of layer IDs.
 	LayerIDs []*string `locationName:"LayerIds" type:"list" required:"true"`
@@ -3830,6 +4481,16 @@ type DescribeLoadBasedAutoScalingInput struct {
 
 type metadataDescribeLoadBasedAutoScalingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLoadBasedAutoScalingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBasedAutoScalingInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a DescribeLoadBasedAutoScaling request.
@@ -3845,12 +4506,32 @@ type metadataDescribeLoadBasedAutoScalingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeLoadBasedAutoScalingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoadBasedAutoScalingOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeMyUserProfileInput struct {
 	metadataDescribeMyUserProfileInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeMyUserProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMyUserProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMyUserProfileInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a DescribeMyUserProfile request.
@@ -3863,6 +4544,16 @@ type DescribeMyUserProfileOutput struct {
 
 type metadataDescribeMyUserProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMyUserProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMyUserProfileOutput) GoString() string {
+	return s.String()
 }
 
 type DescribePermissionsInput struct {
@@ -3878,6 +4569,16 @@ type DescribePermissionsInput struct {
 
 type metadataDescribePermissionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribePermissionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePermissionsInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a DescribePermissions request.
@@ -3897,6 +4598,16 @@ type DescribePermissionsOutput struct {
 
 type metadataDescribePermissionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribePermissionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePermissionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeRAIDArraysInput struct {
@@ -3919,6 +4630,16 @@ type metadataDescribeRAIDArraysInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeRAIDArraysInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRAIDArraysInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeRaidArrays request.
 type DescribeRAIDArraysOutput struct {
 	// A RaidArrays object that describes the specified RAID arrays.
@@ -3929,6 +4650,16 @@ type DescribeRAIDArraysOutput struct {
 
 type metadataDescribeRAIDArraysOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeRAIDArraysOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRAIDArraysOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeRDSDBInstancesInput struct {
@@ -3946,6 +4677,16 @@ type metadataDescribeRDSDBInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeRDSDBInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRDSDBInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeRdsDbInstances request.
 type DescribeRDSDBInstancesOutput struct {
 	// An a array of RdsDbInstance objects that describe the instances.
@@ -3956,6 +4697,16 @@ type DescribeRDSDBInstancesOutput struct {
 
 type metadataDescribeRDSDBInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeRDSDBInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeRDSDBInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeServiceErrorsInput struct {
@@ -3979,6 +4730,16 @@ type metadataDescribeServiceErrorsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeServiceErrorsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeServiceErrorsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeServiceErrors request.
 type DescribeServiceErrorsOutput struct {
 	// An array of ServiceError objects that describe the specified service errors.
@@ -3991,6 +4752,16 @@ type metadataDescribeServiceErrorsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeServiceErrorsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeServiceErrorsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeStackProvisioningParametersInput struct {
 	// The stack ID
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
@@ -4000,6 +4771,16 @@ type DescribeStackProvisioningParametersInput struct {
 
 type metadataDescribeStackProvisioningParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStackProvisioningParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackProvisioningParametersInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a DescribeStackProvisioningParameters request.
@@ -4017,6 +4798,16 @@ type metadataDescribeStackProvisioningParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStackProvisioningParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackProvisioningParametersOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeStackSummaryInput struct {
 	// The stack ID.
 	StackID *string `locationName:"StackId" type:"string" required:"true"`
@@ -4026,6 +4817,16 @@ type DescribeStackSummaryInput struct {
 
 type metadataDescribeStackSummaryInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStackSummaryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackSummaryInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a DescribeStackSummary request.
@@ -4040,6 +4841,16 @@ type metadataDescribeStackSummaryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStackSummaryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStackSummaryOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeStacksInput struct {
 	// An array of stack IDs that specify the stacks to be described. If you omit
 	// this parameter, DescribeStacks returns a description of every stack.
@@ -4050,6 +4861,16 @@ type DescribeStacksInput struct {
 
 type metadataDescribeStacksInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStacksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStacksInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a DescribeStacks request.
@@ -4064,6 +4885,16 @@ type metadataDescribeStacksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStacksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStacksOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeTimeBasedAutoScalingInput struct {
 	// An array of instance IDs.
 	InstanceIDs []*string `locationName:"InstanceIds" type:"list" required:"true"`
@@ -4073,6 +4904,16 @@ type DescribeTimeBasedAutoScalingInput struct {
 
 type metadataDescribeTimeBasedAutoScalingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTimeBasedAutoScalingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTimeBasedAutoScalingInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a DescribeTimeBasedAutoScaling request.
@@ -4088,6 +4929,16 @@ type metadataDescribeTimeBasedAutoScalingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTimeBasedAutoScalingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTimeBasedAutoScalingOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeUserProfilesInput struct {
 	// An array of IAM user ARNs that identify the users to be described.
 	IAMUserARNs []*string `locationName:"IamUserArns" type:"list"`
@@ -4097,6 +4948,16 @@ type DescribeUserProfilesInput struct {
 
 type metadataDescribeUserProfilesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeUserProfilesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeUserProfilesInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a DescribeUserProfiles request.
@@ -4109,6 +4970,16 @@ type DescribeUserProfilesOutput struct {
 
 type metadataDescribeUserProfilesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeUserProfilesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeUserProfilesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeVolumesInput struct {
@@ -4135,6 +5006,16 @@ type metadataDescribeVolumesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVolumesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVolumesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a DescribeVolumes request.
 type DescribeVolumesOutput struct {
 	// An array of volume IDs.
@@ -4145,6 +5026,16 @@ type DescribeVolumesOutput struct {
 
 type metadataDescribeVolumesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeVolumesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVolumesOutput) GoString() string {
+	return s.String()
 }
 
 type DetachElasticLoadBalancerInput struct {
@@ -4162,12 +5053,32 @@ type metadataDetachElasticLoadBalancerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DetachElasticLoadBalancerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachElasticLoadBalancerInput) GoString() string {
+	return s.String()
+}
+
 type DetachElasticLoadBalancerOutput struct {
 	metadataDetachElasticLoadBalancerOutput `json:"-" xml:"-"`
 }
 
 type metadataDetachElasticLoadBalancerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DetachElasticLoadBalancerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DetachElasticLoadBalancerOutput) GoString() string {
+	return s.String()
 }
 
 type DisassociateElasticIPInput struct {
@@ -4181,12 +5092,32 @@ type metadataDisassociateElasticIPInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisassociateElasticIPInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateElasticIPInput) GoString() string {
+	return s.String()
+}
+
 type DisassociateElasticIPOutput struct {
 	metadataDisassociateElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataDisassociateElasticIPOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisassociateElasticIPOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateElasticIPOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an Amazon EBS volume. This data type maps directly to the Amazon
@@ -4217,6 +5148,16 @@ type metadataEBSBlockDevice struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EBSBlockDevice) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EBSBlockDevice) GoString() string {
+	return s.String()
+}
+
 // Describes an Elastic IP address.
 type ElasticIP struct {
 	// The domain.
@@ -4239,6 +5180,16 @@ type ElasticIP struct {
 
 type metadataElasticIP struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ElasticIP) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ElasticIP) GoString() string {
+	return s.String()
 }
 
 // Describes an Elastic Load Balancing instance.
@@ -4278,6 +5229,16 @@ type metadataElasticLoadBalancer struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ElasticLoadBalancer) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ElasticLoadBalancer) GoString() string {
+	return s.String()
+}
+
 // Represents an app's environment variable.
 type EnvironmentVariable struct {
 	// (Required) The environment variable's name, which can consist of up to 64
@@ -4304,6 +5265,16 @@ type metadataEnvironmentVariable struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnvironmentVariable) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnvironmentVariable) GoString() string {
+	return s.String()
+}
+
 type GetHostnameSuggestionInput struct {
 	// The layer ID.
 	LayerID *string `locationName:"LayerId" type:"string" required:"true"`
@@ -4313,6 +5284,16 @@ type GetHostnameSuggestionInput struct {
 
 type metadataGetHostnameSuggestionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetHostnameSuggestionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHostnameSuggestionInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a GetHostnameSuggestion request.
@@ -4328,6 +5309,16 @@ type GetHostnameSuggestionOutput struct {
 
 type metadataGetHostnameSuggestionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetHostnameSuggestionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHostnameSuggestionOutput) GoString() string {
+	return s.String()
 }
 
 type GrantAccessInput struct {
@@ -4347,6 +5338,16 @@ type metadataGrantAccessInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GrantAccessInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GrantAccessInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a GrantAccess request.
 type GrantAccessOutput struct {
 	// A TemporaryCredential object that contains the data needed to log in to the
@@ -4358,6 +5359,16 @@ type GrantAccessOutput struct {
 
 type metadataGrantAccessOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GrantAccessOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GrantAccessOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an instance.
@@ -4497,6 +5508,16 @@ type metadataInstance struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Instance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Instance) GoString() string {
+	return s.String()
+}
+
 // Contains a description of an Amazon EC2 instance from the Amazon EC2 metadata
 // service. For more information, see Instance Metadata and User Data (http://docs.aws.amazon.com/sdkfornet/latest/apidocs/Index.html).
 type InstanceIdentity struct {
@@ -4511,6 +5532,16 @@ type InstanceIdentity struct {
 
 type metadataInstanceIdentity struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstanceIdentity) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstanceIdentity) GoString() string {
+	return s.String()
 }
 
 // Describes how many instances a stack has for each status.
@@ -4577,6 +5608,16 @@ type InstancesCount struct {
 
 type metadataInstancesCount struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s InstancesCount) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s InstancesCount) GoString() string {
+	return s.String()
 }
 
 // Describes a layer.
@@ -4672,6 +5713,16 @@ type metadataLayer struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Layer) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Layer) GoString() string {
+	return s.String()
+}
+
 // Specifies the lifecycle event configuration
 type LifecycleEventConfiguration struct {
 	// A ShutdownEventConfiguration object that specifies the Shutdown event configuration.
@@ -4682,6 +5733,16 @@ type LifecycleEventConfiguration struct {
 
 type metadataLifecycleEventConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LifecycleEventConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LifecycleEventConfiguration) GoString() string {
+	return s.String()
 }
 
 // Describes a layer's load-based auto scaling configuration.
@@ -4705,6 +5766,16 @@ type LoadBasedAutoScalingConfiguration struct {
 
 type metadataLoadBasedAutoScalingConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LoadBasedAutoScalingConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoadBasedAutoScalingConfiguration) GoString() string {
+	return s.String()
 }
 
 // Describes stack or user permissions.
@@ -4733,6 +5804,16 @@ type Permission struct {
 
 type metadataPermission struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Permission) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Permission) GoString() string {
+	return s.String()
 }
 
 // Describes an instance's RAID array.
@@ -4784,6 +5865,16 @@ type metadataRAIDArray struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RAIDArray) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RAIDArray) GoString() string {
+	return s.String()
+}
+
 // Describes an Amazon RDS instance.
 type RDSDBInstance struct {
 	// The instance's address.
@@ -4822,6 +5913,16 @@ type metadataRDSDBInstance struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RDSDBInstance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RDSDBInstance) GoString() string {
+	return s.String()
+}
+
 type RebootInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
@@ -4833,12 +5934,32 @@ type metadataRebootInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebootInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootInstanceInput) GoString() string {
+	return s.String()
+}
+
 type RebootInstanceOutput struct {
 	metadataRebootInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataRebootInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebootInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // AWS OpsWorks supports five lifecycle events: setup, configuration, deploy,
@@ -4875,6 +5996,16 @@ type metadataRecipes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Recipes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Recipes) GoString() string {
+	return s.String()
+}
+
 type RegisterElasticIPInput struct {
 	// The Elastic IP address.
 	ElasticIP *string `locationName:"ElasticIp" type:"string" required:"true"`
@@ -4889,6 +6020,16 @@ type metadataRegisterElasticIPInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterElasticIPInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterElasticIPInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a RegisterElasticIp request.
 type RegisterElasticIPOutput struct {
 	// The Elastic IP address.
@@ -4899,6 +6040,16 @@ type RegisterElasticIPOutput struct {
 
 type metadataRegisterElasticIPOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterElasticIPOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterElasticIPOutput) GoString() string {
+	return s.String()
 }
 
 type RegisterInstanceInput struct {
@@ -4931,6 +6082,16 @@ type metadataRegisterInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterInstanceInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a RegisterInstanceResult request.
 type RegisterInstanceOutput struct {
 	// The registered instance's AWS OpsWorks ID.
@@ -4941,6 +6102,16 @@ type RegisterInstanceOutput struct {
 
 type metadataRegisterInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type RegisterRDSDBInstanceInput struct {
@@ -4963,12 +6134,32 @@ type metadataRegisterRDSDBInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterRDSDBInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterRDSDBInstanceInput) GoString() string {
+	return s.String()
+}
+
 type RegisterRDSDBInstanceOutput struct {
 	metadataRegisterRDSDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterRDSDBInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterRDSDBInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterRDSDBInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type RegisterVolumeInput struct {
@@ -4985,6 +6176,16 @@ type metadataRegisterVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterVolumeInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a RegisterVolume request.
 type RegisterVolumeOutput struct {
 	// The volume ID.
@@ -4995,6 +6196,16 @@ type RegisterVolumeOutput struct {
 
 type metadataRegisterVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterVolumeOutput) GoString() string {
+	return s.String()
 }
 
 // A registered instance's reported operating system.
@@ -5013,6 +6224,16 @@ type ReportedOs struct {
 
 type metadataReportedOs struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReportedOs) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReportedOs) GoString() string {
+	return s.String()
 }
 
 // Describes an app's SSL configuration.
@@ -5034,6 +6255,16 @@ type metadataSSLConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SSLConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SSLConfiguration) GoString() string {
+	return s.String()
+}
+
 // Describes a user's SSH information.
 type SelfUserProfile struct {
 	// The user's IAM ARN.
@@ -5053,6 +6284,16 @@ type SelfUserProfile struct {
 
 type metadataSelfUserProfile struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SelfUserProfile) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SelfUserProfile) GoString() string {
+	return s.String()
 }
 
 // Describes an AWS OpsWorks service error.
@@ -5082,6 +6323,16 @@ type metadataServiceError struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ServiceError) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ServiceError) GoString() string {
+	return s.String()
+}
+
 type SetLoadBasedAutoScalingInput struct {
 	// An AutoScalingThresholds object with the downscaling threshold configuration.
 	// If the load falls below these thresholds for a specified amount of time,
@@ -5106,12 +6357,32 @@ type metadataSetLoadBasedAutoScalingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetLoadBasedAutoScalingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetLoadBasedAutoScalingInput) GoString() string {
+	return s.String()
+}
+
 type SetLoadBasedAutoScalingOutput struct {
 	metadataSetLoadBasedAutoScalingOutput `json:"-" xml:"-"`
 }
 
 type metadataSetLoadBasedAutoScalingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetLoadBasedAutoScalingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetLoadBasedAutoScalingOutput) GoString() string {
+	return s.String()
 }
 
 type SetPermissionInput struct {
@@ -5141,12 +6412,32 @@ type metadataSetPermissionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetPermissionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetPermissionInput) GoString() string {
+	return s.String()
+}
+
 type SetPermissionOutput struct {
 	metadataSetPermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataSetPermissionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetPermissionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetPermissionOutput) GoString() string {
+	return s.String()
 }
 
 type SetTimeBasedAutoScalingInput struct {
@@ -5163,12 +6454,32 @@ type metadataSetTimeBasedAutoScalingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetTimeBasedAutoScalingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetTimeBasedAutoScalingInput) GoString() string {
+	return s.String()
+}
+
 type SetTimeBasedAutoScalingOutput struct {
 	metadataSetTimeBasedAutoScalingOutput `json:"-" xml:"-"`
 }
 
 type metadataSetTimeBasedAutoScalingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetTimeBasedAutoScalingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetTimeBasedAutoScalingOutput) GoString() string {
+	return s.String()
 }
 
 // The Shutdown event configuration.
@@ -5186,6 +6497,16 @@ type ShutdownEventConfiguration struct {
 
 type metadataShutdownEventConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ShutdownEventConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ShutdownEventConfiguration) GoString() string {
+	return s.String()
 }
 
 // Contains the information required to retrieve an app or cookbook from a repository.
@@ -5232,6 +6553,16 @@ type Source struct {
 
 type metadataSource struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Source) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Source) GoString() string {
+	return s.String()
 }
 
 // Describes a stack.
@@ -5330,6 +6661,16 @@ type metadataStack struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Stack) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Stack) GoString() string {
+	return s.String()
+}
+
 // Describes the configuration manager.
 type StackConfigurationManager struct {
 	// The name. This parameter must be set to "Chef".
@@ -5344,6 +6685,16 @@ type StackConfigurationManager struct {
 
 type metadataStackConfigurationManager struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StackConfigurationManager) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StackConfigurationManager) GoString() string {
+	return s.String()
 }
 
 // Summarizes the number of layers, instances, and apps in a stack.
@@ -5373,6 +6724,16 @@ type metadataStackSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StackSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StackSummary) GoString() string {
+	return s.String()
+}
+
 type StartInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
@@ -5384,12 +6745,32 @@ type metadataStartInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartInstanceInput) GoString() string {
+	return s.String()
+}
+
 type StartInstanceOutput struct {
 	metadataStartInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataStartInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type StartStackInput struct {
@@ -5403,12 +6784,32 @@ type metadataStartStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartStackInput) GoString() string {
+	return s.String()
+}
+
 type StartStackOutput struct {
 	metadataStartStackOutput `json:"-" xml:"-"`
 }
 
 type metadataStartStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartStackOutput) GoString() string {
+	return s.String()
 }
 
 type StopInstanceInput struct {
@@ -5422,12 +6823,32 @@ type metadataStopInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StopInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopInstanceInput) GoString() string {
+	return s.String()
+}
+
 type StopInstanceOutput struct {
 	metadataStopInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataStopInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type StopStackInput struct {
@@ -5441,12 +6862,32 @@ type metadataStopStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StopStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopStackInput) GoString() string {
+	return s.String()
+}
+
 type StopStackOutput struct {
 	metadataStopStackOutput `json:"-" xml:"-"`
 }
 
 type metadataStopStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StopStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StopStackOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the data needed by RDP clients such as the Microsoft Remote Desktop
@@ -5474,6 +6915,16 @@ type metadataTemporaryCredential struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TemporaryCredential) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TemporaryCredential) GoString() string {
+	return s.String()
+}
+
 // Describes an instance's time-based auto scaling configuration.
 type TimeBasedAutoScalingConfiguration struct {
 	// A WeeklyAutoScalingSchedule object with the instance schedule.
@@ -5489,6 +6940,16 @@ type metadataTimeBasedAutoScalingConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TimeBasedAutoScalingConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TimeBasedAutoScalingConfiguration) GoString() string {
+	return s.String()
+}
+
 type UnassignInstanceInput struct {
 	// The instance ID.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
@@ -5500,12 +6961,32 @@ type metadataUnassignInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnassignInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnassignInstanceInput) GoString() string {
+	return s.String()
+}
+
 type UnassignInstanceOutput struct {
 	metadataUnassignInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataUnassignInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnassignInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnassignInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type UnassignVolumeInput struct {
@@ -5519,12 +7000,32 @@ type metadataUnassignVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnassignVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnassignVolumeInput) GoString() string {
+	return s.String()
+}
+
 type UnassignVolumeOutput struct {
 	metadataUnassignVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataUnassignVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnassignVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnassignVolumeOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateAppInput struct {
@@ -5582,12 +7083,32 @@ type metadataUpdateAppInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateAppInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAppInput) GoString() string {
+	return s.String()
+}
+
 type UpdateAppOutput struct {
 	metadataUpdateAppOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateAppOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateAppOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAppOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateElasticIPInput struct {
@@ -5604,12 +7125,32 @@ type metadataUpdateElasticIPInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateElasticIPInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateElasticIPInput) GoString() string {
+	return s.String()
+}
+
 type UpdateElasticIPOutput struct {
 	metadataUpdateElasticIPOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateElasticIPOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateElasticIPOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateElasticIPOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateInstanceInput struct {
@@ -5699,12 +7240,32 @@ type metadataUpdateInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateInstanceInput) GoString() string {
+	return s.String()
+}
+
 type UpdateInstanceOutput struct {
 	metadataUpdateInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateLayerInput struct {
@@ -5777,12 +7338,32 @@ type metadataUpdateLayerInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateLayerInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateLayerInput) GoString() string {
+	return s.String()
+}
+
 type UpdateLayerOutput struct {
 	metadataUpdateLayerOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateLayerOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateLayerOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateLayerOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateMyUserProfileInput struct {
@@ -5796,12 +7377,32 @@ type metadataUpdateMyUserProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateMyUserProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateMyUserProfileInput) GoString() string {
+	return s.String()
+}
+
 type UpdateMyUserProfileOutput struct {
 	metadataUpdateMyUserProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateMyUserProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateMyUserProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateMyUserProfileOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateRDSDBInstanceInput struct {
@@ -5821,12 +7422,32 @@ type metadataUpdateRDSDBInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateRDSDBInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRDSDBInstanceInput) GoString() string {
+	return s.String()
+}
+
 type UpdateRDSDBInstanceOutput struct {
 	metadataUpdateRDSDBInstanceOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateRDSDBInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateRDSDBInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateRDSDBInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateStackInput struct {
@@ -5973,12 +7594,32 @@ type metadataUpdateStackInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateStackInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateStackInput) GoString() string {
+	return s.String()
+}
+
 type UpdateStackOutput struct {
 	metadataUpdateStackOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateStackOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateStackOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateStackOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateUserProfileInput struct {
@@ -6006,12 +7647,32 @@ type metadataUpdateUserProfileInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateUserProfileInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateUserProfileInput) GoString() string {
+	return s.String()
+}
+
 type UpdateUserProfileOutput struct {
 	metadataUpdateUserProfileOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateUserProfileOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateUserProfileOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateUserProfileOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateVolumeInput struct {
@@ -6031,12 +7692,32 @@ type metadataUpdateVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateVolumeInput) GoString() string {
+	return s.String()
+}
+
 type UpdateVolumeOutput struct {
 	metadataUpdateVolumeOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateVolumeOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a user's SSH information.
@@ -6062,6 +7743,16 @@ type UserProfile struct {
 
 type metadataUserProfile struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UserProfile) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UserProfile) GoString() string {
+	return s.String()
 }
 
 // Describes an instance's Amazon EBS volume.
@@ -6114,6 +7805,16 @@ type metadataVolume struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Volume) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Volume) GoString() string {
+	return s.String()
+}
+
 // Describes an Amazon EBS volume configuration.
 type VolumeConfiguration struct {
 	// For PIOPS volumes, the IOPS per disk.
@@ -6142,6 +7843,16 @@ type VolumeConfiguration struct {
 
 type metadataVolumeConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeConfiguration) GoString() string {
+	return s.String()
 }
 
 // Describes a time-based instance's auto scaling schedule. The schedule consists
@@ -6185,4 +7896,14 @@ type WeeklyAutoScalingSchedule struct {
 
 type metadataWeeklyAutoScalingSchedule struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WeeklyAutoScalingSchedule) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WeeklyAutoScalingSchedule) GoString() string {
+	return s.String()
 }

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddSourceIdentifierToSubscription = "AddSourceIdentifierToSubscription"
@@ -2001,6 +2002,16 @@ type metadataAccountQuota struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AccountQuota) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccountQuota) GoString() string {
+	return s.String()
+}
+
 type AddSourceIdentifierToSubscriptionInput struct {
 	// The identifier of the event source to be added. An identifier must begin
 	// with a letter and must contain only ASCII letters, digits, and hyphens; it
@@ -2026,6 +2037,16 @@ type metadataAddSourceIdentifierToSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddSourceIdentifierToSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddSourceIdentifierToSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type AddSourceIdentifierToSubscriptionOutput struct {
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
@@ -2036,6 +2057,16 @@ type AddSourceIdentifierToSubscriptionOutput struct {
 
 type metadataAddSourceIdentifierToSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddSourceIdentifierToSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddSourceIdentifierToSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type AddTagsToResourceInput struct {
@@ -2054,12 +2085,32 @@ type metadataAddTagsToResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddTagsToResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToResourceInput) GoString() string {
+	return s.String()
+}
+
 type AddTagsToResourceOutput struct {
 	metadataAddTagsToResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataAddTagsToResourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddTagsToResourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddTagsToResourceOutput) GoString() string {
+	return s.String()
 }
 
 type ApplyPendingMaintenanceActionInput struct {
@@ -2086,6 +2137,16 @@ type metadataApplyPendingMaintenanceActionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ApplyPendingMaintenanceActionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplyPendingMaintenanceActionInput) GoString() string {
+	return s.String()
+}
+
 type ApplyPendingMaintenanceActionOutput struct {
 	// Describes the pending maintenance actions for a resource.
 	ResourcePendingMaintenanceActions *ResourcePendingMaintenanceActions `type:"structure"`
@@ -2095,6 +2156,16 @@ type ApplyPendingMaintenanceActionOutput struct {
 
 type metadataApplyPendingMaintenanceActionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ApplyPendingMaintenanceActionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ApplyPendingMaintenanceActionOutput) GoString() string {
+	return s.String()
 }
 
 type AuthorizeDBSecurityGroupIngressInput struct {
@@ -2128,6 +2199,16 @@ type metadataAuthorizeDBSecurityGroupIngressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AuthorizeDBSecurityGroupIngressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeDBSecurityGroupIngressInput) GoString() string {
+	return s.String()
+}
+
 type AuthorizeDBSecurityGroupIngressOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -2143,6 +2224,16 @@ type metadataAuthorizeDBSecurityGroupIngressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AuthorizeDBSecurityGroupIngressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeDBSecurityGroupIngressOutput) GoString() string {
+	return s.String()
+}
+
 // Contains Availability Zone information.
 //
 //  This data type is used as an element in the following data type: OrderableDBInstanceOption
@@ -2155,6 +2246,16 @@ type AvailabilityZone struct {
 
 type metadataAvailabilityZone struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AvailabilityZone) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AvailabilityZone) GoString() string {
+	return s.String()
 }
 
 // A CA certificate for an AWS account.
@@ -2181,6 +2282,16 @@ type metadataCertificate struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Certificate) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Certificate) GoString() string {
+	return s.String()
+}
+
 // This data type is used as a response element in the action DescribeDBEngineVersions.
 type CharacterSet struct {
 	// The description of the character set.
@@ -2194,6 +2305,16 @@ type CharacterSet struct {
 
 type metadataCharacterSet struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CharacterSet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CharacterSet) GoString() string {
+	return s.String()
 }
 
 type CopyDBParameterGroupInput struct {
@@ -2230,6 +2351,16 @@ type metadataCopyDBParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopyDBParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyDBParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type CopyDBParameterGroupOutput struct {
 	// Contains the result of a successful invocation of the CreateDBParameterGroup
 	// action.
@@ -2243,6 +2374,16 @@ type CopyDBParameterGroupOutput struct {
 
 type metadataCopyDBParameterGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CopyDBParameterGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyDBParameterGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CopyDBSnapshotInput struct {
@@ -2279,6 +2420,16 @@ type metadataCopyDBSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopyDBSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyDBSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type CopyDBSnapshotOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -2291,6 +2442,16 @@ type CopyDBSnapshotOutput struct {
 
 type metadataCopyDBSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CopyDBSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyDBSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 type CopyOptionGroupInput struct {
@@ -2326,6 +2487,16 @@ type metadataCopyOptionGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopyOptionGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyOptionGroupInput) GoString() string {
+	return s.String()
+}
+
 type CopyOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
@@ -2334,6 +2505,16 @@ type CopyOptionGroupOutput struct {
 
 type metadataCopyOptionGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CopyOptionGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyOptionGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDBInstanceInput struct {
@@ -2791,6 +2972,16 @@ type metadataCreateDBInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDBInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBInstanceInput) GoString() string {
+	return s.String()
+}
+
 type CreateDBInstanceOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -2803,6 +2994,16 @@ type CreateDBInstanceOutput struct {
 
 type metadataCreateDBInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDBInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDBInstanceReadReplicaInput struct {
@@ -2913,6 +3114,16 @@ type metadataCreateDBInstanceReadReplicaInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDBInstanceReadReplicaInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBInstanceReadReplicaInput) GoString() string {
+	return s.String()
+}
+
 type CreateDBInstanceReadReplicaOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -2925,6 +3136,16 @@ type CreateDBInstanceReadReplicaOutput struct {
 
 type metadataCreateDBInstanceReadReplicaOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDBInstanceReadReplicaOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBInstanceReadReplicaOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDBParameterGroupInput struct {
@@ -2956,6 +3177,16 @@ type metadataCreateDBParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDBParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateDBParameterGroupOutput struct {
 	// Contains the result of a successful invocation of the CreateDBParameterGroup
 	// action.
@@ -2969,6 +3200,16 @@ type CreateDBParameterGroupOutput struct {
 
 type metadataCreateDBParameterGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDBParameterGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBParameterGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDBSecurityGroupInput struct {
@@ -2994,6 +3235,16 @@ type metadataCreateDBSecurityGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDBSecurityGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateDBSecurityGroupOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -3007,6 +3258,16 @@ type CreateDBSecurityGroupOutput struct {
 
 type metadataCreateDBSecurityGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDBSecurityGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBSecurityGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDBSnapshotInput struct {
@@ -3037,6 +3298,16 @@ type metadataCreateDBSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDBSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type CreateDBSnapshotOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -3049,6 +3320,16 @@ type CreateDBSnapshotOutput struct {
 
 type metadataCreateDBSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDBSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDBSubnetGroupInput struct {
@@ -3076,6 +3357,16 @@ type metadataCreateDBSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDBSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateDBSubnetGroupOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -3089,6 +3380,16 @@ type CreateDBSubnetGroupOutput struct {
 
 type metadataCreateDBSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDBSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDBSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateEventSubscriptionInput struct {
@@ -3146,6 +3447,16 @@ type metadataCreateEventSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateEventSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type CreateEventSubscriptionOutput struct {
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
@@ -3156,6 +3467,16 @@ type CreateEventSubscriptionOutput struct {
 
 type metadataCreateEventSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateEventSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateEventSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateOptionGroupInput struct {
@@ -3189,6 +3510,16 @@ type metadataCreateOptionGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateOptionGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateOptionGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
@@ -3197,6 +3528,16 @@ type CreateOptionGroupOutput struct {
 
 type metadataCreateOptionGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateOptionGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateOptionGroupOutput) GoString() string {
+	return s.String()
 }
 
 // This data type is used as a response element in the action DescribeDBEngineVersions.
@@ -3229,6 +3570,16 @@ type DBEngineVersion struct {
 
 type metadataDBEngineVersion struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DBEngineVersion) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBEngineVersion) GoString() string {
+	return s.String()
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -3399,6 +3750,16 @@ type metadataDBInstance struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DBInstance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBInstance) GoString() string {
+	return s.String()
+}
+
 // Provides a list of status information for a DB instance.
 type DBInstanceStatusInfo struct {
 	// Details of the error if there is an error for the instance. If the instance
@@ -3421,6 +3782,16 @@ type DBInstanceStatusInfo struct {
 
 type metadataDBInstanceStatusInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DBInstanceStatusInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBInstanceStatusInfo) GoString() string {
+	return s.String()
 }
 
 // Contains the result of a successful invocation of the CreateDBParameterGroup
@@ -3446,6 +3817,16 @@ type metadataDBParameterGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DBParameterGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBParameterGroup) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the ModifyDBParameterGroup
 // or ResetDBParameterGroup action.
 type DBParameterGroupNameMessage struct {
@@ -3457,6 +3838,16 @@ type DBParameterGroupNameMessage struct {
 
 type metadataDBParameterGroupNameMessage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DBParameterGroupNameMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBParameterGroupNameMessage) GoString() string {
+	return s.String()
 }
 
 // The status of the DB parameter group.
@@ -3477,6 +3868,16 @@ type DBParameterGroupStatus struct {
 
 type metadataDBParameterGroupStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DBParameterGroupStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBParameterGroupStatus) GoString() string {
+	return s.String()
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -3510,6 +3911,16 @@ type metadataDBSecurityGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DBSecurityGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBSecurityGroup) GoString() string {
+	return s.String()
+}
+
 // This data type is used as a response element in the following actions:
 //
 //   ModifyDBInstance   RebootDBInstance   RestoreDBInstanceFromDBSnapshot
@@ -3526,6 +3937,16 @@ type DBSecurityGroupMembership struct {
 
 type metadataDBSecurityGroupMembership struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DBSecurityGroupMembership) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBSecurityGroupMembership) GoString() string {
+	return s.String()
 }
 
 // Contains the result of a successful invocation of the following actions:
@@ -3610,6 +4031,16 @@ type metadataDBSnapshot struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DBSnapshot) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBSnapshot) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the following actions:
 //
 //   CreateDBSubnetGroup   ModifyDBSubnetGroup   DescribeDBSubnetGroups   DeleteDBSubnetGroup
@@ -3636,6 +4067,16 @@ type DBSubnetGroup struct {
 
 type metadataDBSubnetGroup struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DBSubnetGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DBSubnetGroup) GoString() string {
+	return s.String()
 }
 
 type DeleteDBInstanceInput struct {
@@ -3676,6 +4117,16 @@ type metadataDeleteDBInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDBInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBInstanceInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDBInstanceOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -3688,6 +4139,16 @@ type DeleteDBInstanceOutput struct {
 
 type metadataDeleteDBInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDBInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteDBParameterGroupInput struct {
@@ -3706,12 +4167,32 @@ type metadataDeleteDBParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDBParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDBParameterGroupOutput struct {
 	metadataDeleteDBParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBParameterGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDBParameterGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBParameterGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteDBSecurityGroupInput struct {
@@ -3731,12 +4212,32 @@ type metadataDeleteDBSecurityGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDBSecurityGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDBSecurityGroupOutput struct {
 	metadataDeleteDBSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBSecurityGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDBSecurityGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBSecurityGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteDBSnapshotInput struct {
@@ -3753,6 +4254,16 @@ type metadataDeleteDBSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDBSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDBSnapshotOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -3765,6 +4276,16 @@ type DeleteDBSnapshotOutput struct {
 
 type metadataDeleteDBSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDBSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteDBSubnetGroupInput struct {
@@ -3783,12 +4304,32 @@ type metadataDeleteDBSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDBSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDBSubnetGroupOutput struct {
 	metadataDeleteDBSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDBSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDBSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDBSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteEventSubscriptionInput struct {
@@ -3802,6 +4343,16 @@ type metadataDeleteEventSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteEventSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteEventSubscriptionOutput struct {
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
@@ -3812,6 +4363,16 @@ type DeleteEventSubscriptionOutput struct {
 
 type metadataDeleteEventSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteEventSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEventSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteOptionGroupInput struct {
@@ -3827,6 +4388,16 @@ type metadataDeleteOptionGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteOptionGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteOptionGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteOptionGroupOutput struct {
 	metadataDeleteOptionGroupOutput `json:"-" xml:"-"`
 }
@@ -3835,12 +4406,32 @@ type metadataDeleteOptionGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteOptionGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteOptionGroupOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeAccountAttributesInput struct {
 	metadataDescribeAccountAttributesInput `json:"-" xml:"-"`
 }
 
 type metadataDescribeAccountAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAccountAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountAttributesInput) GoString() string {
+	return s.String()
 }
 
 // Data returned by the DescribeAccountAttributes action.
@@ -3854,6 +4445,16 @@ type DescribeAccountAttributesOutput struct {
 
 type metadataDescribeAccountAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAccountAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountAttributesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeCertificatesInput struct {
@@ -3891,6 +4492,16 @@ type metadataDescribeCertificatesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCertificatesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCertificatesInput) GoString() string {
+	return s.String()
+}
+
 // Data returned by the DescribeCertificates action.
 type DescribeCertificatesOutput struct {
 	// The list of Certificate objects for the AWS account.
@@ -3906,6 +4517,16 @@ type DescribeCertificatesOutput struct {
 
 type metadataDescribeCertificatesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCertificatesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCertificatesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDBEngineVersionsInput struct {
@@ -3958,6 +4579,16 @@ type metadataDescribeDBEngineVersionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBEngineVersionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBEngineVersionsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeDBEngineVersions
 // action.
 type DescribeDBEngineVersionsOutput struct {
@@ -3974,6 +4605,16 @@ type DescribeDBEngineVersionsOutput struct {
 
 type metadataDescribeDBEngineVersionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDBEngineVersionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBEngineVersionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDBInstancesInput struct {
@@ -4011,6 +4652,16 @@ type metadataDescribeDBInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBInstancesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeDBInstances
 // action.
 type DescribeDBInstancesOutput struct {
@@ -4029,6 +4680,16 @@ type metadataDescribeDBInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBInstancesOutput) GoString() string {
+	return s.String()
+}
+
 // This data type is used as a response element to DescribeDBLogFiles.
 type DescribeDBLogFilesDetails struct {
 	// A POSIX timestamp when the last log entry was written.
@@ -4045,6 +4706,16 @@ type DescribeDBLogFilesDetails struct {
 
 type metadataDescribeDBLogFilesDetails struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDBLogFilesDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBLogFilesDetails) GoString() string {
+	return s.String()
 }
 
 type DescribeDBLogFilesInput struct {
@@ -4088,6 +4759,16 @@ type metadataDescribeDBLogFilesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBLogFilesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBLogFilesInput) GoString() string {
+	return s.String()
+}
+
 // The response from a call to DescribeDBLogFiles.
 type DescribeDBLogFilesOutput struct {
 	// The DB log files returned.
@@ -4101,6 +4782,16 @@ type DescribeDBLogFilesOutput struct {
 
 type metadataDescribeDBLogFilesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDBLogFilesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBLogFilesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDBParameterGroupsInput struct {
@@ -4136,6 +4827,16 @@ type metadataDescribeDBParameterGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBParameterGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBParameterGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeDBParameterGroups
 // action.
 type DescribeDBParameterGroupsOutput struct {
@@ -4152,6 +4853,16 @@ type DescribeDBParameterGroupsOutput struct {
 
 type metadataDescribeDBParameterGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDBParameterGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBParameterGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDBParametersInput struct {
@@ -4194,6 +4905,16 @@ type metadataDescribeDBParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBParametersInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeDBParameters
 // action.
 type DescribeDBParametersOutput struct {
@@ -4210,6 +4931,16 @@ type DescribeDBParametersOutput struct {
 
 type metadataDescribeDBParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDBParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBParametersOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDBSecurityGroupsInput struct {
@@ -4240,6 +4971,16 @@ type metadataDescribeDBSecurityGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBSecurityGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBSecurityGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeDBSecurityGroups
 // action.
 type DescribeDBSecurityGroupsOutput struct {
@@ -4256,6 +4997,16 @@ type DescribeDBSecurityGroupsOutput struct {
 
 type metadataDescribeDBSecurityGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDBSecurityGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBSecurityGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDBSnapshotsInput struct {
@@ -4309,6 +5060,16 @@ type metadataDescribeDBSnapshotsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBSnapshotsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBSnapshotsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeDBSnapshots
 // action.
 type DescribeDBSnapshotsOutput struct {
@@ -4325,6 +5086,16 @@ type DescribeDBSnapshotsOutput struct {
 
 type metadataDescribeDBSnapshotsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDBSnapshotsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBSnapshotsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDBSubnetGroupsInput struct {
@@ -4355,6 +5126,16 @@ type metadataDescribeDBSubnetGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDBSubnetGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBSubnetGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeDBSubnetGroups
 // action.
 type DescribeDBSubnetGroupsOutput struct {
@@ -4371,6 +5152,16 @@ type DescribeDBSubnetGroupsOutput struct {
 
 type metadataDescribeDBSubnetGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDBSubnetGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDBSubnetGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeEngineDefaultParametersInput struct {
@@ -4401,6 +5192,16 @@ type metadataDescribeEngineDefaultParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEngineDefaultParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEngineDefaultParametersInput) GoString() string {
+	return s.String()
+}
+
 type DescribeEngineDefaultParametersOutput struct {
 	// Contains the result of a successful invocation of the DescribeEngineDefaultParameters
 	// action.
@@ -4411,6 +5212,16 @@ type DescribeEngineDefaultParametersOutput struct {
 
 type metadataDescribeEngineDefaultParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEngineDefaultParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEngineDefaultParametersOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeEventCategoriesInput struct {
@@ -4429,6 +5240,16 @@ type metadataDescribeEventCategoriesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEventCategoriesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventCategoriesInput) GoString() string {
+	return s.String()
+}
+
 // Data returned from the DescribeEventCategories action.
 type DescribeEventCategoriesOutput struct {
 	// A list of EventCategoriesMap data types.
@@ -4439,6 +5260,16 @@ type DescribeEventCategoriesOutput struct {
 
 type metadataDescribeEventCategoriesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventCategoriesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventCategoriesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeEventSubscriptionsInput struct {
@@ -4469,6 +5300,16 @@ type metadataDescribeEventSubscriptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEventSubscriptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventSubscriptionsInput) GoString() string {
+	return s.String()
+}
+
 // Data returned by the DescribeEventSubscriptions action.
 type DescribeEventSubscriptionsOutput struct {
 	// A list of EventSubscriptions data types.
@@ -4484,6 +5325,16 @@ type DescribeEventSubscriptionsOutput struct {
 
 type metadataDescribeEventSubscriptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventSubscriptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventSubscriptionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeEventsInput struct {
@@ -4551,6 +5402,16 @@ type metadataDescribeEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeEvents action.
 type DescribeEventsOutput struct {
 	// A list of Event instances.
@@ -4566,6 +5427,16 @@ type DescribeEventsOutput struct {
 
 type metadataDescribeEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeOptionGroupOptionsInput struct {
@@ -4601,6 +5472,16 @@ type metadataDescribeOptionGroupOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeOptionGroupOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOptionGroupOptionsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeOptionGroupOptionsOutput struct {
 	// An optional pagination token provided by a previous request. If this parameter
 	// is specified, the response includes only records beyond the marker, up to
@@ -4615,6 +5496,16 @@ type DescribeOptionGroupOptionsOutput struct {
 
 type metadataDescribeOptionGroupOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeOptionGroupOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOptionGroupOptionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeOptionGroupsInput struct {
@@ -4655,6 +5546,16 @@ type metadataDescribeOptionGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeOptionGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOptionGroupsInput) GoString() string {
+	return s.String()
+}
+
 // List of option groups.
 type DescribeOptionGroupsOutput struct {
 	// An optional pagination token provided by a previous request. If this parameter
@@ -4670,6 +5571,16 @@ type DescribeOptionGroupsOutput struct {
 
 type metadataDescribeOptionGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeOptionGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOptionGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeOrderableDBInstanceOptionsInput struct {
@@ -4716,6 +5627,16 @@ type metadataDescribeOrderableDBInstanceOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeOrderableDBInstanceOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOrderableDBInstanceOptionsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeOrderableDBInstanceOptions
 // action.
 type DescribeOrderableDBInstanceOptionsOutput struct {
@@ -4733,6 +5654,16 @@ type DescribeOrderableDBInstanceOptionsOutput struct {
 
 type metadataDescribeOrderableDBInstanceOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeOrderableDBInstanceOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOrderableDBInstanceOptionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribePendingMaintenanceActionsInput struct {
@@ -4770,6 +5701,16 @@ type metadataDescribePendingMaintenanceActionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribePendingMaintenanceActionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePendingMaintenanceActionsInput) GoString() string {
+	return s.String()
+}
+
 // Data returned from the DescribePendingMaintenanceActions action.
 type DescribePendingMaintenanceActionsOutput struct {
 	// An optional pagination token provided by a previous DescribePendingMaintenanceActions
@@ -4785,6 +5726,16 @@ type DescribePendingMaintenanceActionsOutput struct {
 
 type metadataDescribePendingMaintenanceActionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribePendingMaintenanceActionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribePendingMaintenanceActionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeReservedDBInstancesInput struct {
@@ -4844,6 +5795,16 @@ type metadataDescribeReservedDBInstancesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedDBInstancesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedDBInstancesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeReservedDBInstancesOfferingsInput struct {
 	// The DB instance class filter value. Specify this parameter to show only the
 	// available offerings matching the specified DB instance class.
@@ -4899,6 +5860,16 @@ type metadataDescribeReservedDBInstancesOfferingsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedDBInstancesOfferingsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedDBInstancesOfferingsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeReservedDBInstancesOfferings
 // action.
 type DescribeReservedDBInstancesOfferingsOutput struct {
@@ -4917,6 +5888,16 @@ type metadataDescribeReservedDBInstancesOfferingsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedDBInstancesOfferingsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedDBInstancesOfferingsOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the result of a successful invocation of the DescribeReservedDBInstances
 // action.
 type DescribeReservedDBInstancesOutput struct {
@@ -4933,6 +5914,16 @@ type DescribeReservedDBInstancesOutput struct {
 
 type metadataDescribeReservedDBInstancesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeReservedDBInstancesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedDBInstancesOutput) GoString() string {
+	return s.String()
 }
 
 type DownloadDBLogFilePortionInput struct {
@@ -4980,6 +5971,16 @@ type metadataDownloadDBLogFilePortionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DownloadDBLogFilePortionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DownloadDBLogFilePortionInput) GoString() string {
+	return s.String()
+}
+
 // This data type is used as a response element to DownloadDBLogFilePortion.
 type DownloadDBLogFilePortionOutput struct {
 	// Boolean value that if true, indicates there is more data to be downloaded.
@@ -4997,6 +5998,16 @@ type DownloadDBLogFilePortionOutput struct {
 
 type metadataDownloadDBLogFilePortionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DownloadDBLogFilePortionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DownloadDBLogFilePortionOutput) GoString() string {
+	return s.String()
 }
 
 // This data type is used as a response element in the following actions:
@@ -5024,6 +6035,16 @@ type metadataEC2SecurityGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EC2SecurityGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EC2SecurityGroup) GoString() string {
+	return s.String()
+}
+
 // This data type is used as a response element in the following actions:
 //
 //   CreateDBInstance   DescribeDBInstances   DeleteDBInstance
@@ -5039,6 +6060,16 @@ type Endpoint struct {
 
 type metadataEndpoint struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Endpoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Endpoint) GoString() string {
+	return s.String()
 }
 
 // Contains the result of a successful invocation of the DescribeEngineDefaultParameters
@@ -5061,6 +6092,16 @@ type EngineDefaults struct {
 
 type metadataEngineDefaults struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EngineDefaults) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EngineDefaults) GoString() string {
+	return s.String()
 }
 
 // This data type is used as a response element in the DescribeEvents action.
@@ -5087,6 +6128,16 @@ type metadataEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Event) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Event) GoString() string {
+	return s.String()
+}
+
 // Contains the results of a successful invocation of the DescribeEventCategories
 // action.
 type EventCategoriesMap struct {
@@ -5101,6 +6152,16 @@ type EventCategoriesMap struct {
 
 type metadataEventCategoriesMap struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EventCategoriesMap) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EventCategoriesMap) GoString() string {
+	return s.String()
 }
 
 // Contains the results of a successful invocation of the DescribeEventSubscriptions
@@ -5150,6 +6211,16 @@ type metadataEventSubscription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EventSubscription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EventSubscription) GoString() string {
+	return s.String()
+}
+
 type Filter struct {
 	// This parameter is not currently supported.
 	Name *string `type:"string" required:"true"`
@@ -5162,6 +6233,16 @@ type Filter struct {
 
 type metadataFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Filter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Filter) GoString() string {
+	return s.String()
 }
 
 // This data type is used as a response element in the DescribeDBSecurityGroups
@@ -5181,6 +6262,16 @@ type metadataIPRange struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s IPRange) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IPRange) GoString() string {
+	return s.String()
+}
+
 type ListTagsForResourceInput struct {
 	// This parameter is not currently supported.
 	Filters []*Filter `locationNameList:"Filter" type:"list"`
@@ -5197,6 +6288,16 @@ type metadataListTagsForResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListTagsForResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceInput) GoString() string {
+	return s.String()
+}
+
 type ListTagsForResourceOutput struct {
 	// List of tags returned by the ListTagsForResource operation.
 	TagList []*Tag `locationNameList:"Tag" type:"list"`
@@ -5206,6 +6307,16 @@ type ListTagsForResourceOutput struct {
 
 type metadataListTagsForResourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForResourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyDBInstanceInput struct {
@@ -5529,6 +6640,16 @@ type metadataModifyDBInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyDBInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyDBInstanceInput) GoString() string {
+	return s.String()
+}
+
 type ModifyDBInstanceOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -5541,6 +6662,16 @@ type ModifyDBInstanceOutput struct {
 
 type metadataModifyDBInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyDBInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyDBInstanceOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyDBParameterGroupInput struct {
@@ -5572,6 +6703,16 @@ type metadataModifyDBParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyDBParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyDBParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type ModifyDBSubnetGroupInput struct {
 	// The description for the DB subnet group.
 	DBSubnetGroupDescription *string `type:"string"`
@@ -5594,6 +6735,16 @@ type metadataModifyDBSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyDBSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyDBSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type ModifyDBSubnetGroupOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -5607,6 +6758,16 @@ type ModifyDBSubnetGroupOutput struct {
 
 type metadataModifyDBSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyDBSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyDBSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyEventSubscriptionInput struct {
@@ -5643,6 +6804,16 @@ type metadataModifyEventSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyEventSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type ModifyEventSubscriptionOutput struct {
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
@@ -5653,6 +6824,16 @@ type ModifyEventSubscriptionOutput struct {
 
 type metadataModifyEventSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyEventSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyEventSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyOptionGroupInput struct {
@@ -5681,6 +6862,16 @@ type metadataModifyOptionGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyOptionGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyOptionGroupInput) GoString() string {
+	return s.String()
+}
+
 type ModifyOptionGroupOutput struct {
 	OptionGroup *OptionGroup `type:"structure"`
 
@@ -5689,6 +6880,16 @@ type ModifyOptionGroupOutput struct {
 
 type metadataModifyOptionGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyOptionGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyOptionGroupOutput) GoString() string {
+	return s.String()
 }
 
 // Option details.
@@ -5726,6 +6927,16 @@ type metadataOption struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Option) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Option) GoString() string {
+	return s.String()
+}
+
 // A list of all available options
 type OptionConfiguration struct {
 	// A list of DBSecurityGroupMemebrship name strings used for this option.
@@ -5748,6 +6959,16 @@ type OptionConfiguration struct {
 
 type metadataOptionConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OptionConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionConfiguration) GoString() string {
+	return s.String()
 }
 
 type OptionGroup struct {
@@ -5785,6 +7006,16 @@ type metadataOptionGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s OptionGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionGroup) GoString() string {
+	return s.String()
+}
+
 // Provides information on the option groups the DB instance is a member of.
 type OptionGroupMembership struct {
 	// The name of the option group that the instance belongs to.
@@ -5799,6 +7030,16 @@ type OptionGroupMembership struct {
 
 type metadataOptionGroupMembership struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OptionGroupMembership) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionGroupMembership) GoString() string {
+	return s.String()
 }
 
 // Available option.
@@ -5849,6 +7090,16 @@ type metadataOptionGroupOption struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s OptionGroupOption) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionGroupOption) GoString() string {
+	return s.String()
+}
+
 // Option group option settings are used to display settings available for each
 // option with their default values and other information. These values are
 // used with the DescribeOptionGroupOptions action.
@@ -5877,6 +7128,16 @@ type OptionGroupOptionSetting struct {
 
 type metadataOptionGroupOptionSetting struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OptionGroupOptionSetting) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionGroupOptionSetting) GoString() string {
+	return s.String()
 }
 
 // Option settings are the actual settings being applied or configured for that
@@ -5917,6 +7178,16 @@ type OptionSetting struct {
 
 type metadataOptionSetting struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OptionSetting) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OptionSetting) GoString() string {
+	return s.String()
 }
 
 // Contains a list of available options for a DB instance
@@ -5964,6 +7235,16 @@ type metadataOrderableDBInstanceOption struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s OrderableDBInstanceOption) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OrderableDBInstanceOption) GoString() string {
+	return s.String()
+}
+
 // This data type is used as a request parameter in the ModifyDBParameterGroup
 // and ResetDBParameterGroup actions.
 //
@@ -6009,6 +7290,16 @@ type metadataParameter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Parameter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Parameter) GoString() string {
+	return s.String()
+}
+
 // Provides information about a pending maintenance action for a resource.
 type PendingMaintenanceAction struct {
 	// The type of pending maintenance action that is available for the resource.
@@ -6044,6 +7335,16 @@ type PendingMaintenanceAction struct {
 
 type metadataPendingMaintenanceAction struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PendingMaintenanceAction) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PendingMaintenanceAction) GoString() string {
+	return s.String()
 }
 
 // This data type is used as a response element in the ModifyDBInstance action.
@@ -6093,6 +7394,16 @@ type metadataPendingModifiedValues struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PendingModifiedValues) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PendingModifiedValues) GoString() string {
+	return s.String()
+}
+
 type PromoteReadReplicaInput struct {
 	// The number of days to retain automated backups. Setting this parameter to
 	// a positive number enables backups. Setting this parameter to 0 disables automated
@@ -6134,6 +7445,16 @@ type metadataPromoteReadReplicaInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PromoteReadReplicaInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PromoteReadReplicaInput) GoString() string {
+	return s.String()
+}
+
 type PromoteReadReplicaOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -6146,6 +7467,16 @@ type PromoteReadReplicaOutput struct {
 
 type metadataPromoteReadReplicaOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PromoteReadReplicaOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PromoteReadReplicaOutput) GoString() string {
+	return s.String()
 }
 
 type PurchaseReservedDBInstancesOfferingInput struct {
@@ -6174,6 +7505,16 @@ type metadataPurchaseReservedDBInstancesOfferingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PurchaseReservedDBInstancesOfferingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedDBInstancesOfferingInput) GoString() string {
+	return s.String()
+}
+
 type PurchaseReservedDBInstancesOfferingOutput struct {
 	// This data type is used as a response element in the DescribeReservedDBInstances
 	// and PurchaseReservedDBInstancesOffering actions.
@@ -6184,6 +7525,16 @@ type PurchaseReservedDBInstancesOfferingOutput struct {
 
 type metadataPurchaseReservedDBInstancesOfferingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PurchaseReservedDBInstancesOfferingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedDBInstancesOfferingOutput) GoString() string {
+	return s.String()
 }
 
 type RebootDBInstanceInput struct {
@@ -6208,6 +7559,16 @@ type metadataRebootDBInstanceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebootDBInstanceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootDBInstanceInput) GoString() string {
+	return s.String()
+}
+
 type RebootDBInstanceOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -6220,6 +7581,16 @@ type RebootDBInstanceOutput struct {
 
 type metadataRebootDBInstanceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebootDBInstanceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootDBInstanceOutput) GoString() string {
+	return s.String()
 }
 
 // This data type is used as a response element in the DescribeReservedDBInstances
@@ -6238,6 +7609,16 @@ type metadataRecurringCharge struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecurringCharge) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecurringCharge) GoString() string {
+	return s.String()
+}
+
 type RemoveSourceIdentifierFromSubscriptionInput struct {
 	// The source identifier to be removed from the subscription, such as the DB
 	// instance identifier for a DB instance or the name of a security group.
@@ -6254,6 +7635,16 @@ type metadataRemoveSourceIdentifierFromSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveSourceIdentifierFromSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveSourceIdentifierFromSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type RemoveSourceIdentifierFromSubscriptionOutput struct {
 	// Contains the results of a successful invocation of the DescribeEventSubscriptions
 	// action.
@@ -6264,6 +7655,16 @@ type RemoveSourceIdentifierFromSubscriptionOutput struct {
 
 type metadataRemoveSourceIdentifierFromSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveSourceIdentifierFromSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveSourceIdentifierFromSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type RemoveTagsFromResourceInput struct {
@@ -6282,12 +7683,32 @@ type metadataRemoveTagsFromResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemoveTagsFromResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromResourceInput) GoString() string {
+	return s.String()
+}
+
 type RemoveTagsFromResourceOutput struct {
 	metadataRemoveTagsFromResourceOutput `json:"-" xml:"-"`
 }
 
 type metadataRemoveTagsFromResourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemoveTagsFromResourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemoveTagsFromResourceOutput) GoString() string {
+	return s.String()
 }
 
 // This data type is used as a response element in the DescribeReservedDBInstances
@@ -6342,6 +7763,16 @@ type metadataReservedDBInstance struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedDBInstance) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedDBInstance) GoString() string {
+	return s.String()
+}
+
 // This data type is used as a response element in the DescribeReservedDBInstancesOfferings
 // action.
 type ReservedDBInstancesOffering struct {
@@ -6380,6 +7811,16 @@ type ReservedDBInstancesOffering struct {
 
 type metadataReservedDBInstancesOffering struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReservedDBInstancesOffering) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedDBInstancesOffering) GoString() string {
+	return s.String()
 }
 
 type ResetDBParameterGroupInput struct {
@@ -6422,6 +7863,16 @@ type metadataResetDBParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResetDBParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetDBParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 // Describes the pending maintenance actions for a resource.
 type ResourcePendingMaintenanceActions struct {
 	// A list that provides details about the pending maintenance actions for the
@@ -6436,6 +7887,16 @@ type ResourcePendingMaintenanceActions struct {
 
 type metadataResourcePendingMaintenanceActions struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResourcePendingMaintenanceActions) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResourcePendingMaintenanceActions) GoString() string {
+	return s.String()
 }
 
 type RestoreDBInstanceFromDBSnapshotInput struct {
@@ -6579,6 +8040,16 @@ type metadataRestoreDBInstanceFromDBSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RestoreDBInstanceFromDBSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreDBInstanceFromDBSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type RestoreDBInstanceFromDBSnapshotOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -6591,6 +8062,16 @@ type RestoreDBInstanceFromDBSnapshotOutput struct {
 
 type metadataRestoreDBInstanceFromDBSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RestoreDBInstanceFromDBSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreDBInstanceFromDBSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 type RestoreDBInstanceToPointInTimeInput struct {
@@ -6749,6 +8230,16 @@ type metadataRestoreDBInstanceToPointInTimeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RestoreDBInstanceToPointInTimeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreDBInstanceToPointInTimeInput) GoString() string {
+	return s.String()
+}
+
 type RestoreDBInstanceToPointInTimeOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -6761,6 +8252,16 @@ type RestoreDBInstanceToPointInTimeOutput struct {
 
 type metadataRestoreDBInstanceToPointInTimeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RestoreDBInstanceToPointInTimeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreDBInstanceToPointInTimeOutput) GoString() string {
+	return s.String()
 }
 
 type RevokeDBSecurityGroupIngressInput struct {
@@ -6796,6 +8297,16 @@ type metadataRevokeDBSecurityGroupIngressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RevokeDBSecurityGroupIngressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeDBSecurityGroupIngressInput) GoString() string {
+	return s.String()
+}
+
 type RevokeDBSecurityGroupIngressOutput struct {
 	// Contains the result of a successful invocation of the following actions:
 	//
@@ -6809,6 +8320,16 @@ type RevokeDBSecurityGroupIngressOutput struct {
 
 type metadataRevokeDBSecurityGroupIngressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RevokeDBSecurityGroupIngressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeDBSecurityGroupIngressOutput) GoString() string {
+	return s.String()
 }
 
 // This data type is used as a response element in the DescribeDBSubnetGroups
@@ -6832,6 +8353,16 @@ type metadataSubnet struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Subnet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Subnet) GoString() string {
+	return s.String()
+}
+
 // Metadata assigned to an Amazon RDS resource consisting of a key-value pair.
 type Tag struct {
 	// A key is the required name of the tag. The string value can be from 1 to
@@ -6853,6 +8384,16 @@ type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
 // This data type is used as a response element for queries on VPC security
 // group membership.
 type VPCSecurityGroupMembership struct {
@@ -6867,4 +8408,14 @@ type VPCSecurityGroupMembership struct {
 
 type metadataVPCSecurityGroupMembership struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPCSecurityGroupMembership) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPCSecurityGroupMembership) GoString() string {
+	return s.String()
 }

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAuthorizeClusterSecurityGroupIngress = "AuthorizeClusterSecurityGroupIngress"
@@ -2188,6 +2189,16 @@ type metadataAccountWithRestoreAccess struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AccountWithRestoreAccess) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccountWithRestoreAccess) GoString() string {
+	return s.String()
+}
+
 // ???
 type AuthorizeClusterSecurityGroupIngressInput struct {
 	// The IP range to be added the Amazon Redshift security group.
@@ -2213,6 +2224,16 @@ type metadataAuthorizeClusterSecurityGroupIngressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AuthorizeClusterSecurityGroupIngressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeClusterSecurityGroupIngressInput) GoString() string {
+	return s.String()
+}
+
 type AuthorizeClusterSecurityGroupIngressOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
@@ -2222,6 +2243,16 @@ type AuthorizeClusterSecurityGroupIngressOutput struct {
 
 type metadataAuthorizeClusterSecurityGroupIngressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AuthorizeClusterSecurityGroupIngressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeClusterSecurityGroupIngressOutput) GoString() string {
+	return s.String()
 }
 
 type AuthorizeSnapshotAccessInput struct {
@@ -2244,6 +2275,16 @@ type metadataAuthorizeSnapshotAccessInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AuthorizeSnapshotAccessInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeSnapshotAccessInput) GoString() string {
+	return s.String()
+}
+
 type AuthorizeSnapshotAccessOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
@@ -2253,6 +2294,16 @@ type AuthorizeSnapshotAccessOutput struct {
 
 type metadataAuthorizeSnapshotAccessOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AuthorizeSnapshotAccessOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AuthorizeSnapshotAccessOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an availability zone.
@@ -2265,6 +2316,16 @@ type AvailabilityZone struct {
 
 type metadataAvailabilityZone struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AvailabilityZone) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AvailabilityZone) GoString() string {
+	return s.String()
 }
 
 // Describes a cluster.
@@ -2391,6 +2452,16 @@ type metadataCluster struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Cluster) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Cluster) GoString() string {
+	return s.String()
+}
+
 // The identifier of a node in a cluster.
 type ClusterNode struct {
 	// Whether the node is a leader node or a compute node.
@@ -2407,6 +2478,16 @@ type ClusterNode struct {
 
 type metadataClusterNode struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterNode) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterNode) GoString() string {
+	return s.String()
 }
 
 // Describes a parameter group.
@@ -2431,6 +2512,16 @@ type metadataClusterParameterGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ClusterParameterGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterParameterGroup) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the ModifyClusterParameterGroup and ResetClusterParameterGroup
 // actions and indicate the parameter group involved and the status of the operation
 // on the parameter group.
@@ -2448,6 +2539,16 @@ type ClusterParameterGroupNameMessage struct {
 
 type metadataClusterParameterGroupNameMessage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterParameterGroupNameMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterParameterGroupNameMessage) GoString() string {
+	return s.String()
 }
 
 // Describes the status of a parameter group.
@@ -2470,6 +2571,16 @@ type ClusterParameterGroupStatus struct {
 
 type metadataClusterParameterGroupStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterParameterGroupStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterParameterGroupStatus) GoString() string {
+	return s.String()
 }
 
 // Describes the status of a parameter group.
@@ -2503,6 +2614,16 @@ type metadataClusterParameterStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ClusterParameterStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterParameterStatus) GoString() string {
+	return s.String()
+}
+
 // Describes a security group.
 type ClusterSecurityGroup struct {
 	// The name of the cluster security group to which the operation was applied.
@@ -2529,6 +2650,16 @@ type metadataClusterSecurityGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ClusterSecurityGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterSecurityGroup) GoString() string {
+	return s.String()
+}
+
 // Describes a security group.
 type ClusterSecurityGroupMembership struct {
 	// The name of the cluster security group.
@@ -2542,6 +2673,16 @@ type ClusterSecurityGroupMembership struct {
 
 type metadataClusterSecurityGroupMembership struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterSecurityGroupMembership) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterSecurityGroupMembership) GoString() string {
+	return s.String()
 }
 
 // Returns the destination region and retention period that are configured for
@@ -2563,6 +2704,16 @@ type ClusterSnapshotCopyStatus struct {
 
 type metadataClusterSnapshotCopyStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterSnapshotCopyStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterSnapshotCopyStatus) GoString() string {
+	return s.String()
 }
 
 // Describes a subnet group.
@@ -2593,6 +2744,16 @@ type metadataClusterSubnetGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ClusterSubnetGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterSubnetGroup) GoString() string {
+	return s.String()
+}
+
 // Describes a cluster version, including the parameter group family and description
 // of the version.
 type ClusterVersion struct {
@@ -2610,6 +2771,16 @@ type ClusterVersion struct {
 
 type metadataClusterVersion struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ClusterVersion) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ClusterVersion) GoString() string {
+	return s.String()
 }
 
 type CopyClusterSnapshotInput struct {
@@ -2646,6 +2817,16 @@ type metadataCopyClusterSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopyClusterSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyClusterSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type CopyClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
@@ -2655,6 +2836,16 @@ type CopyClusterSnapshotOutput struct {
 
 type metadataCopyClusterSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CopyClusterSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyClusterSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 type CreateClusterInput struct {
@@ -2878,6 +3069,16 @@ type metadataCreateClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterInput) GoString() string {
+	return s.String()
+}
+
 type CreateClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -2887,6 +3088,16 @@ type CreateClusterOutput struct {
 
 type metadataCreateClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterOutput) GoString() string {
+	return s.String()
 }
 
 type CreateClusterParameterGroupInput struct {
@@ -2924,6 +3135,16 @@ type metadataCreateClusterParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateClusterParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateClusterParameterGroupOutput struct {
 	// Describes a parameter group.
 	ClusterParameterGroup *ClusterParameterGroup `type:"structure"`
@@ -2933,6 +3154,16 @@ type CreateClusterParameterGroupOutput struct {
 
 type metadataCreateClusterParameterGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateClusterParameterGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterParameterGroupOutput) GoString() string {
+	return s.String()
 }
 
 // ???
@@ -2960,6 +3191,16 @@ type metadataCreateClusterSecurityGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateClusterSecurityGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateClusterSecurityGroupOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
@@ -2969,6 +3210,16 @@ type CreateClusterSecurityGroupOutput struct {
 
 type metadataCreateClusterSecurityGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateClusterSecurityGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterSecurityGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateClusterSnapshotInput struct {
@@ -2995,6 +3246,16 @@ type metadataCreateClusterSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateClusterSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type CreateClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
@@ -3004,6 +3265,16 @@ type CreateClusterSnapshotOutput struct {
 
 type metadataCreateClusterSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateClusterSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 type CreateClusterSubnetGroupInput struct {
@@ -3034,6 +3305,16 @@ type metadataCreateClusterSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateClusterSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type CreateClusterSubnetGroupOutput struct {
 	// Describes a subnet group.
 	ClusterSubnetGroup *ClusterSubnetGroup `type:"structure"`
@@ -3043,6 +3324,16 @@ type CreateClusterSubnetGroupOutput struct {
 
 type metadataCreateClusterSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateClusterSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateClusterSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 type CreateEventSubscriptionInput struct {
@@ -3107,6 +3398,16 @@ type metadataCreateEventSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateEventSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type CreateEventSubscriptionOutput struct {
 	EventSubscription *EventSubscription `type:"structure"`
 
@@ -3115,6 +3416,16 @@ type CreateEventSubscriptionOutput struct {
 
 type metadataCreateEventSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateEventSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateEventSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type CreateHSMClientCertificateInput struct {
@@ -3132,6 +3443,16 @@ type metadataCreateHSMClientCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateHSMClientCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHSMClientCertificateInput) GoString() string {
+	return s.String()
+}
+
 type CreateHSMClientCertificateOutput struct {
 	// Returns information about an HSM client certificate. The certificate is stored
 	// in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift
@@ -3143,6 +3464,16 @@ type CreateHSMClientCertificateOutput struct {
 
 type metadataCreateHSMClientCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateHSMClientCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHSMClientCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type CreateHSMConfigurationInput struct {
@@ -3176,6 +3507,16 @@ type metadataCreateHSMConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateHSMConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHSMConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type CreateHSMConfigurationOutput struct {
 	// Returns information about an HSM configuration, which is an object that describes
 	// to Amazon Redshift clusters the information they require to connect to an
@@ -3187,6 +3528,16 @@ type CreateHSMConfigurationOutput struct {
 
 type metadataCreateHSMConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateHSMConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHSMConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 // The result of the CreateSnapshotCopyGrant action.
@@ -3216,6 +3567,16 @@ type metadataCreateSnapshotCopyGrantInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSnapshotCopyGrantInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotCopyGrantInput) GoString() string {
+	return s.String()
+}
+
 type CreateSnapshotCopyGrantOutput struct {
 	// The snapshot copy grant that grants Amazon Redshift permission to encrypt
 	// copied snapshots with the specified customer master key (CMK) from AWS KMS
@@ -3231,6 +3592,16 @@ type CreateSnapshotCopyGrantOutput struct {
 
 type metadataCreateSnapshotCopyGrantOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSnapshotCopyGrantOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotCopyGrantOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the output from the CreateTags action.
@@ -3253,12 +3624,32 @@ type metadataCreateTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTagsInput) GoString() string {
+	return s.String()
+}
+
 type CreateTagsOutput struct {
 	metadataCreateTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataCreateTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTagsOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the default cluster parameters for a parameter group family.
@@ -3282,6 +3673,16 @@ type DefaultClusterParameters struct {
 
 type metadataDefaultClusterParameters struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DefaultClusterParameters) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefaultClusterParameters) GoString() string {
+	return s.String()
 }
 
 type DeleteClusterInput struct {
@@ -3319,6 +3720,16 @@ type metadataDeleteClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterInput) GoString() string {
+	return s.String()
+}
+
 type DeleteClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -3328,6 +3739,16 @@ type DeleteClusterOutput struct {
 
 type metadataDeleteClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteClusterParameterGroupInput struct {
@@ -3346,12 +3767,32 @@ type metadataDeleteClusterParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteClusterParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteClusterParameterGroupOutput struct {
 	metadataDeleteClusterParameterGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterParameterGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteClusterParameterGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterParameterGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteClusterSecurityGroupInput struct {
@@ -3365,12 +3806,32 @@ type metadataDeleteClusterSecurityGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteClusterSecurityGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterSecurityGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteClusterSecurityGroupOutput struct {
 	metadataDeleteClusterSecurityGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterSecurityGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteClusterSecurityGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterSecurityGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteClusterSnapshotInput struct {
@@ -3394,6 +3855,16 @@ type metadataDeleteClusterSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteClusterSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type DeleteClusterSnapshotOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
@@ -3403,6 +3874,16 @@ type DeleteClusterSnapshotOutput struct {
 
 type metadataDeleteClusterSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteClusterSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteClusterSubnetGroupInput struct {
@@ -3416,12 +3897,32 @@ type metadataDeleteClusterSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteClusterSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type DeleteClusterSubnetGroupOutput struct {
 	metadataDeleteClusterSubnetGroupOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteClusterSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteClusterSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteClusterSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteEventSubscriptionInput struct {
@@ -3435,12 +3936,32 @@ type metadataDeleteEventSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteEventSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type DeleteEventSubscriptionOutput struct {
 	metadataDeleteEventSubscriptionOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEventSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteEventSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEventSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteHSMClientCertificateInput struct {
@@ -3454,12 +3975,32 @@ type metadataDeleteHSMClientCertificateInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteHSMClientCertificateInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHSMClientCertificateInput) GoString() string {
+	return s.String()
+}
+
 type DeleteHSMClientCertificateOutput struct {
 	metadataDeleteHSMClientCertificateOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHSMClientCertificateOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteHSMClientCertificateOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHSMClientCertificateOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteHSMConfigurationInput struct {
@@ -3473,12 +4014,32 @@ type metadataDeleteHSMConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteHSMConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHSMConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type DeleteHSMConfigurationOutput struct {
 	metadataDeleteHSMConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteHSMConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteHSMConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHSMConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 // The result of the DeleteSnapshotCopyGrant action.
@@ -3493,12 +4054,32 @@ type metadataDeleteSnapshotCopyGrantInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSnapshotCopyGrantInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotCopyGrantInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSnapshotCopyGrantOutput struct {
 	metadataDeleteSnapshotCopyGrantOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteSnapshotCopyGrantOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSnapshotCopyGrantOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotCopyGrantOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the output from the DeleteTags action.
@@ -3517,12 +4098,32 @@ type metadataDeleteTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteTagsOutput struct {
 	metadataDeleteTagsOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeClusterParameterGroupsInput struct {
@@ -3571,6 +4172,16 @@ type metadataDescribeClusterParameterGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClusterParameterGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterParameterGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeClusterParameterGroups action.
 type DescribeClusterParameterGroupsOutput struct {
 	// A value that indicates the starting point for the next set of response records
@@ -3589,6 +4200,16 @@ type DescribeClusterParameterGroupsOutput struct {
 
 type metadataDescribeClusterParameterGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClusterParameterGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterParameterGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeClusterParametersInput struct {
@@ -3629,6 +4250,16 @@ type metadataDescribeClusterParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClusterParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterParametersInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeClusterParameters action.
 type DescribeClusterParametersOutput struct {
 	// A value that indicates the starting point for the next set of response records
@@ -3647,6 +4278,16 @@ type DescribeClusterParametersOutput struct {
 
 type metadataDescribeClusterParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClusterParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterParametersOutput) GoString() string {
+	return s.String()
 }
 
 // ???
@@ -3702,6 +4343,16 @@ type metadataDescribeClusterSecurityGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClusterSecurityGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterSecurityGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeClusterSecurityGroups action.
 type DescribeClusterSecurityGroupsOutput struct {
 	// A list of ClusterSecurityGroup instances.
@@ -3719,6 +4370,16 @@ type DescribeClusterSecurityGroupsOutput struct {
 
 type metadataDescribeClusterSecurityGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClusterSecurityGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterSecurityGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeClusterSnapshotsInput struct {
@@ -3795,6 +4456,16 @@ type metadataDescribeClusterSnapshotsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClusterSnapshotsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterSnapshotsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeClusterSnapshots action.
 type DescribeClusterSnapshotsOutput struct {
 	// A value that indicates the starting point for the next set of response records
@@ -3812,6 +4483,16 @@ type DescribeClusterSnapshotsOutput struct {
 
 type metadataDescribeClusterSnapshotsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClusterSnapshotsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterSnapshotsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeClusterSubnetGroupsInput struct {
@@ -3859,6 +4540,16 @@ type metadataDescribeClusterSubnetGroupsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClusterSubnetGroupsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterSubnetGroupsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeClusterSubnetGroups action.
 type DescribeClusterSubnetGroupsOutput struct {
 	// A list of ClusterSubnetGroup instances.
@@ -3876,6 +4567,16 @@ type DescribeClusterSubnetGroupsOutput struct {
 
 type metadataDescribeClusterSubnetGroupsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClusterSubnetGroupsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterSubnetGroupsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeClusterVersionsInput struct {
@@ -3916,6 +4617,16 @@ type metadataDescribeClusterVersionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClusterVersionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterVersionsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeClusterVersions action.
 type DescribeClusterVersionsOutput struct {
 	// A list of Version elements.
@@ -3933,6 +4644,16 @@ type DescribeClusterVersionsOutput struct {
 
 type metadataDescribeClusterVersionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClusterVersionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClusterVersionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeClustersInput struct {
@@ -3985,6 +4706,16 @@ type metadataDescribeClustersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeClustersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClustersInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeClusters action.
 type DescribeClustersOutput struct {
 	// A list of Cluster objects, where each object describes one cluster.
@@ -4002,6 +4733,16 @@ type DescribeClustersOutput struct {
 
 type metadataDescribeClustersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeClustersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeClustersOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDefaultClusterParametersInput struct {
@@ -4033,6 +4774,16 @@ type metadataDescribeDefaultClusterParametersInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDefaultClusterParametersInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDefaultClusterParametersInput) GoString() string {
+	return s.String()
+}
+
 type DescribeDefaultClusterParametersOutput struct {
 	// Describes the default cluster parameters for a parameter group family.
 	DefaultClusterParameters *DefaultClusterParameters `type:"structure"`
@@ -4042,6 +4793,16 @@ type DescribeDefaultClusterParametersOutput struct {
 
 type metadataDescribeDefaultClusterParametersOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDefaultClusterParametersOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDefaultClusterParametersOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeEventCategoriesInput struct {
@@ -4058,6 +4819,16 @@ type metadataDescribeEventCategoriesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEventCategoriesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventCategoriesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeEventCategoriesOutput struct {
 	// A list of event categories descriptions.
 	EventCategoriesMapList []*EventCategoriesMap `locationNameList:"EventCategoriesMap" type:"list"`
@@ -4067,6 +4838,16 @@ type DescribeEventCategoriesOutput struct {
 
 type metadataDescribeEventCategoriesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventCategoriesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventCategoriesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeEventSubscriptionsInput struct {
@@ -4098,6 +4879,16 @@ type metadataDescribeEventSubscriptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEventSubscriptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventSubscriptionsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeEventSubscriptionsOutput struct {
 	// A list of event subscriptions.
 	EventSubscriptionsList []*EventSubscription `locationNameList:"EventSubscription" type:"list"`
@@ -4114,6 +4905,16 @@ type DescribeEventSubscriptionsOutput struct {
 
 type metadataDescribeEventSubscriptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventSubscriptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventSubscriptionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeEventsInput struct {
@@ -4189,6 +4990,16 @@ type metadataDescribeEventsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeEventsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeEvents action.
 type DescribeEventsOutput struct {
 	// A list of Event instances.
@@ -4206,6 +5017,16 @@ type DescribeEventsOutput struct {
 
 type metadataDescribeEventsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeEventsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeEventsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeHSMClientCertificatesInput struct {
@@ -4255,6 +5076,16 @@ type metadataDescribeHSMClientCertificatesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeHSMClientCertificatesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeHSMClientCertificatesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeHSMClientCertificatesOutput struct {
 	// A list of the identifiers for one or more HSM client certificates used by
 	// Amazon Redshift clusters to store and retrieve database encryption keys in
@@ -4273,6 +5104,16 @@ type DescribeHSMClientCertificatesOutput struct {
 
 type metadataDescribeHSMClientCertificatesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeHSMClientCertificatesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeHSMClientCertificatesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeHSMConfigurationsInput struct {
@@ -4322,6 +5163,16 @@ type metadataDescribeHSMConfigurationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeHSMConfigurationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeHSMConfigurationsInput) GoString() string {
+	return s.String()
+}
+
 type DescribeHSMConfigurationsOutput struct {
 	// A list of Amazon Redshift HSM configurations.
 	HSMConfigurations []*HSMConfiguration `locationName:"HsmConfigurations" locationNameList:"HsmConfiguration" type:"list"`
@@ -4340,6 +5191,16 @@ type metadataDescribeHSMConfigurationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeHSMConfigurationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeHSMConfigurationsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeLoggingStatusInput struct {
 	// The identifier of the cluster to get the logging status from.
 	//
@@ -4351,6 +5212,16 @@ type DescribeLoggingStatusInput struct {
 
 type metadataDescribeLoggingStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeLoggingStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeLoggingStatusInput) GoString() string {
+	return s.String()
 }
 
 type DescribeOrderableClusterOptionsInput struct {
@@ -4391,6 +5262,16 @@ type metadataDescribeOrderableClusterOptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeOrderableClusterOptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOrderableClusterOptionsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeOrderableClusterOptions action.
 type DescribeOrderableClusterOptionsOutput struct {
 	// A value that indicates the starting point for the next set of response records
@@ -4409,6 +5290,16 @@ type DescribeOrderableClusterOptionsOutput struct {
 
 type metadataDescribeOrderableClusterOptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeOrderableClusterOptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeOrderableClusterOptionsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeReservedNodeOfferingsInput struct {
@@ -4440,6 +5331,16 @@ type metadataDescribeReservedNodeOfferingsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedNodeOfferingsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedNodeOfferingsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeReservedNodeOfferings action.
 type DescribeReservedNodeOfferingsOutput struct {
 	// A value that indicates the starting point for the next set of response records
@@ -4457,6 +5358,16 @@ type DescribeReservedNodeOfferingsOutput struct {
 
 type metadataDescribeReservedNodeOfferingsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeReservedNodeOfferingsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedNodeOfferingsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeReservedNodesInput struct {
@@ -4487,6 +5398,16 @@ type metadataDescribeReservedNodesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedNodesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedNodesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeReservedNodes action.
 type DescribeReservedNodesOutput struct {
 	// A value that indicates the starting point for the next set of response records
@@ -4506,6 +5427,16 @@ type metadataDescribeReservedNodesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeReservedNodesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeReservedNodesOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeResizeInput struct {
 	// The unique identifier of a cluster whose resize progress you are requesting.
 	// This parameter is case-sensitive.
@@ -4519,6 +5450,16 @@ type DescribeResizeInput struct {
 
 type metadataDescribeResizeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeResizeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeResizeInput) GoString() string {
+	return s.String()
 }
 
 // Describes the result of a cluster resize operation.
@@ -4589,6 +5530,16 @@ type metadataDescribeResizeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeResizeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeResizeOutput) GoString() string {
+	return s.String()
+}
+
 // The result of the DescribeSnapshotCopyGrants action.
 type DescribeSnapshotCopyGrantsInput struct {
 	// An optional parameter that specifies the starting point to return a set of
@@ -4638,6 +5589,16 @@ type metadataDescribeSnapshotCopyGrantsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSnapshotCopyGrantsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotCopyGrantsInput) GoString() string {
+	return s.String()
+}
+
 // The result of the snapshot copy grant.
 type DescribeSnapshotCopyGrantsOutput struct {
 	// An optional parameter that specifies the starting point to return a set of
@@ -4659,6 +5620,16 @@ type DescribeSnapshotCopyGrantsOutput struct {
 
 type metadataDescribeSnapshotCopyGrantsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSnapshotCopyGrantsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotCopyGrantsOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the output from the DescribeTags action.
@@ -4713,6 +5684,16 @@ type metadataDescribeTagsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTagsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsInput) GoString() string {
+	return s.String()
+}
+
 // Contains the output from the DescribeTags action.
 type DescribeTagsOutput struct {
 	// A value that indicates the starting point for the next set of response records
@@ -4732,6 +5713,16 @@ type metadataDescribeTagsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTagsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTagsOutput) GoString() string {
+	return s.String()
+}
+
 type DisableLoggingInput struct {
 	// The identifier of the cluster on which logging is to be stopped.
 	//
@@ -4743,6 +5734,16 @@ type DisableLoggingInput struct {
 
 type metadataDisableLoggingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableLoggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableLoggingInput) GoString() string {
+	return s.String()
 }
 
 type DisableSnapshotCopyInput struct {
@@ -4760,6 +5761,16 @@ type metadataDisableSnapshotCopyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableSnapshotCopyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableSnapshotCopyInput) GoString() string {
+	return s.String()
+}
+
 type DisableSnapshotCopyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -4769,6 +5780,16 @@ type DisableSnapshotCopyOutput struct {
 
 type metadataDisableSnapshotCopyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableSnapshotCopyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableSnapshotCopyOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an Amazon EC2 security group.
@@ -4793,6 +5814,16 @@ type metadataEC2SecurityGroup struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EC2SecurityGroup) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EC2SecurityGroup) GoString() string {
+	return s.String()
+}
+
 // Describes the status of the elastic IP (EIP) address.
 type ElasticIPStatus struct {
 	// The elastic IP (EIP) address for the cluster.
@@ -4806,6 +5837,16 @@ type ElasticIPStatus struct {
 
 type metadataElasticIPStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ElasticIPStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ElasticIPStatus) GoString() string {
+	return s.String()
 }
 
 type EnableLoggingInput struct {
@@ -4836,6 +5877,16 @@ type EnableLoggingInput struct {
 
 type metadataEnableLoggingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableLoggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableLoggingInput) GoString() string {
+	return s.String()
 }
 
 type EnableSnapshotCopyInput struct {
@@ -4871,6 +5922,16 @@ type metadataEnableSnapshotCopyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableSnapshotCopyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableSnapshotCopyInput) GoString() string {
+	return s.String()
+}
+
 type EnableSnapshotCopyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -4880,6 +5941,16 @@ type EnableSnapshotCopyOutput struct {
 
 type metadataEnableSnapshotCopyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableSnapshotCopyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableSnapshotCopyOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a connection endpoint.
@@ -4895,6 +5966,16 @@ type Endpoint struct {
 
 type metadataEndpoint struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Endpoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Endpoint) GoString() string {
+	return s.String()
 }
 
 // Describes an event.
@@ -4931,6 +6012,16 @@ type metadataEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Event) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Event) GoString() string {
+	return s.String()
+}
+
 type EventCategoriesMap struct {
 	// The events in the event category.
 	Events []*EventInfoMap `locationNameList:"EventInfoMap" type:"list"`
@@ -4944,6 +6035,16 @@ type EventCategoriesMap struct {
 
 type metadataEventCategoriesMap struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EventCategoriesMap) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EventCategoriesMap) GoString() string {
+	return s.String()
 }
 
 type EventInfoMap struct {
@@ -4966,6 +6067,16 @@ type EventInfoMap struct {
 
 type metadataEventInfoMap struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EventInfoMap) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EventInfoMap) GoString() string {
+	return s.String()
 }
 
 type EventSubscription struct {
@@ -5027,6 +6138,16 @@ type metadataEventSubscription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EventSubscription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EventSubscription) GoString() string {
+	return s.String()
+}
+
 // Returns information about an HSM client certificate. The certificate is stored
 // in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift
 // cluster to encrypt data files.
@@ -5046,6 +6167,16 @@ type HSMClientCertificate struct {
 
 type metadataHSMClientCertificate struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HSMClientCertificate) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HSMClientCertificate) GoString() string {
+	return s.String()
 }
 
 // Returns information about an HSM configuration, which is an object that describes
@@ -5075,6 +6206,16 @@ type metadataHSMConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HSMConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HSMConfiguration) GoString() string {
+	return s.String()
+}
+
 type HSMStatus struct {
 	// Specifies the name of the HSM client certificate the Amazon Redshift cluster
 	// uses to retrieve the data encryption keys stored in an HSM.
@@ -5097,6 +6238,16 @@ type metadataHSMStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HSMStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HSMStatus) GoString() string {
+	return s.String()
+}
+
 // Describes an IP range used in a security group.
 type IPRange struct {
 	// The IP range in Classless Inter-Domain Routing (CIDR) notation.
@@ -5113,6 +6264,16 @@ type IPRange struct {
 
 type metadataIPRange struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IPRange) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IPRange) GoString() string {
+	return s.String()
 }
 
 // Describes the status of logging for a cluster.
@@ -5140,6 +6301,16 @@ type LoggingStatus struct {
 
 type metadataLoggingStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LoggingStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoggingStatus) GoString() string {
+	return s.String()
 }
 
 type ModifyClusterInput struct {
@@ -5305,6 +6476,16 @@ type metadataModifyClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyClusterInput) GoString() string {
+	return s.String()
+}
+
 type ModifyClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -5314,6 +6495,16 @@ type ModifyClusterOutput struct {
 
 type metadataModifyClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyClusterOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyClusterParameterGroupInput struct {
@@ -5337,6 +6528,16 @@ type metadataModifyClusterParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyClusterParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyClusterParameterGroupInput) GoString() string {
+	return s.String()
+}
+
 type ModifyClusterSubnetGroupInput struct {
 	// The name of the subnet group to be modified.
 	ClusterSubnetGroupName *string `type:"string" required:"true"`
@@ -5355,6 +6556,16 @@ type metadataModifyClusterSubnetGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyClusterSubnetGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyClusterSubnetGroupInput) GoString() string {
+	return s.String()
+}
+
 type ModifyClusterSubnetGroupOutput struct {
 	// Describes a subnet group.
 	ClusterSubnetGroup *ClusterSubnetGroup `type:"structure"`
@@ -5364,6 +6575,16 @@ type ModifyClusterSubnetGroupOutput struct {
 
 type metadataModifyClusterSubnetGroupOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyClusterSubnetGroupOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyClusterSubnetGroupOutput) GoString() string {
+	return s.String()
 }
 
 type ModifyEventSubscriptionInput struct {
@@ -5418,6 +6639,16 @@ type metadataModifyEventSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifyEventSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyEventSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 type ModifyEventSubscriptionOutput struct {
 	EventSubscription *EventSubscription `type:"structure"`
 
@@ -5426,6 +6657,16 @@ type ModifyEventSubscriptionOutput struct {
 
 type metadataModifyEventSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifyEventSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifyEventSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 type ModifySnapshotCopyRetentionPeriodInput struct {
@@ -5454,6 +6695,16 @@ type metadataModifySnapshotCopyRetentionPeriodInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ModifySnapshotCopyRetentionPeriodInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifySnapshotCopyRetentionPeriodInput) GoString() string {
+	return s.String()
+}
+
 type ModifySnapshotCopyRetentionPeriodOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -5463,6 +6714,16 @@ type ModifySnapshotCopyRetentionPeriodOutput struct {
 
 type metadataModifySnapshotCopyRetentionPeriodOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ModifySnapshotCopyRetentionPeriodOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ModifySnapshotCopyRetentionPeriodOutput) GoString() string {
+	return s.String()
 }
 
 // Describes an orderable cluster option.
@@ -5484,6 +6745,16 @@ type OrderableClusterOption struct {
 
 type metadataOrderableClusterOption struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OrderableClusterOption) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OrderableClusterOption) GoString() string {
+	return s.String()
 }
 
 // Describes a parameter in a cluster parameter group.
@@ -5523,6 +6794,16 @@ type metadataParameter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Parameter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Parameter) GoString() string {
+	return s.String()
+}
+
 // Describes cluster attributes that are in a pending state. A change to one
 // or more the attributes was requested and is in progress or will be applied.
 type PendingModifiedValues struct {
@@ -5554,6 +6835,16 @@ type metadataPendingModifiedValues struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PendingModifiedValues) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PendingModifiedValues) GoString() string {
+	return s.String()
+}
+
 type PurchaseReservedNodeOfferingInput struct {
 	// The number of reserved nodes you want to purchase.
 	//
@@ -5570,6 +6861,16 @@ type metadataPurchaseReservedNodeOfferingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PurchaseReservedNodeOfferingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedNodeOfferingInput) GoString() string {
+	return s.String()
+}
+
 type PurchaseReservedNodeOfferingOutput struct {
 	// Describes a reserved node. You can call the DescribeReservedNodeOfferings
 	// API to obtain the available reserved node offerings.
@@ -5580,6 +6881,16 @@ type PurchaseReservedNodeOfferingOutput struct {
 
 type metadataPurchaseReservedNodeOfferingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PurchaseReservedNodeOfferingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseReservedNodeOfferingOutput) GoString() string {
+	return s.String()
 }
 
 type RebootClusterInput struct {
@@ -5593,6 +6904,16 @@ type metadataRebootClusterInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebootClusterInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootClusterInput) GoString() string {
+	return s.String()
+}
+
 type RebootClusterOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -5602,6 +6923,16 @@ type RebootClusterOutput struct {
 
 type metadataRebootClusterOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebootClusterOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootClusterOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a recurring charge.
@@ -5618,6 +6949,16 @@ type RecurringCharge struct {
 
 type metadataRecurringCharge struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RecurringCharge) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecurringCharge) GoString() string {
+	return s.String()
 }
 
 // Describes a reserved node. You can call the DescribeReservedNodeOfferings
@@ -5675,6 +7016,16 @@ type metadataReservedNode struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedNode) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedNode) GoString() string {
+	return s.String()
+}
+
 // Describes a reserved node offering.
 type ReservedNodeOffering struct {
 	// The currency code for the compute nodes offering.
@@ -5713,6 +7064,16 @@ type metadataReservedNodeOffering struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReservedNodeOffering) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReservedNodeOffering) GoString() string {
+	return s.String()
+}
+
 type ResetClusterParameterGroupInput struct {
 	// The name of the cluster parameter group to be reset.
 	ParameterGroupName *string `type:"string" required:"true"`
@@ -5734,6 +7095,16 @@ type ResetClusterParameterGroupInput struct {
 
 type metadataResetClusterParameterGroupInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResetClusterParameterGroupInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetClusterParameterGroupInput) GoString() string {
+	return s.String()
 }
 
 type RestoreFromClusterSnapshotInput struct {
@@ -5879,6 +7250,16 @@ type metadataRestoreFromClusterSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RestoreFromClusterSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreFromClusterSnapshotInput) GoString() string {
+	return s.String()
+}
+
 type RestoreFromClusterSnapshotOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -5888,6 +7269,16 @@ type RestoreFromClusterSnapshotOutput struct {
 
 type metadataRestoreFromClusterSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RestoreFromClusterSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreFromClusterSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the status of a cluster restore action. Returns null if the cluster
@@ -5922,6 +7313,16 @@ type metadataRestoreStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RestoreStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreStatus) GoString() string {
+	return s.String()
+}
+
 // ???
 type RevokeClusterSecurityGroupIngressInput struct {
 	// The IP range for which to revoke access. This range must be a valid Classless
@@ -5952,6 +7353,16 @@ type metadataRevokeClusterSecurityGroupIngressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RevokeClusterSecurityGroupIngressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeClusterSecurityGroupIngressInput) GoString() string {
+	return s.String()
+}
+
 type RevokeClusterSecurityGroupIngressOutput struct {
 	// Describes a security group.
 	ClusterSecurityGroup *ClusterSecurityGroup `type:"structure"`
@@ -5961,6 +7372,16 @@ type RevokeClusterSecurityGroupIngressOutput struct {
 
 type metadataRevokeClusterSecurityGroupIngressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RevokeClusterSecurityGroupIngressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeClusterSecurityGroupIngressOutput) GoString() string {
+	return s.String()
 }
 
 type RevokeSnapshotAccessInput struct {
@@ -5983,6 +7404,16 @@ type metadataRevokeSnapshotAccessInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RevokeSnapshotAccessInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeSnapshotAccessInput) GoString() string {
+	return s.String()
+}
+
 type RevokeSnapshotAccessOutput struct {
 	// Describes a snapshot.
 	Snapshot *Snapshot `type:"structure"`
@@ -5992,6 +7423,16 @@ type RevokeSnapshotAccessOutput struct {
 
 type metadataRevokeSnapshotAccessOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RevokeSnapshotAccessOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RevokeSnapshotAccessOutput) GoString() string {
+	return s.String()
 }
 
 type RotateEncryptionKeyInput struct {
@@ -6008,6 +7449,16 @@ type metadataRotateEncryptionKeyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RotateEncryptionKeyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RotateEncryptionKeyInput) GoString() string {
+	return s.String()
+}
+
 type RotateEncryptionKeyOutput struct {
 	// Describes a cluster.
 	Cluster *Cluster `type:"structure"`
@@ -6017,6 +7468,16 @@ type RotateEncryptionKeyOutput struct {
 
 type metadataRotateEncryptionKeyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RotateEncryptionKeyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RotateEncryptionKeyOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a snapshot.
@@ -6128,6 +7589,16 @@ type metadataSnapshot struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Snapshot) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Snapshot) GoString() string {
+	return s.String()
+}
+
 // The snapshot copy grant that grants Amazon Redshift permission to encrypt
 // copied snapshots with the specified customer master key (CMK) from AWS KMS
 // in the destination region.
@@ -6153,6 +7624,16 @@ type metadataSnapshotCopyGrant struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SnapshotCopyGrant) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SnapshotCopyGrant) GoString() string {
+	return s.String()
+}
+
 // Describes a subnet.
 type Subnet struct {
 	// Describes an availability zone.
@@ -6171,6 +7652,16 @@ type metadataSubnet struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Subnet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Subnet) GoString() string {
+	return s.String()
+}
+
 // A tag consisting of a name/value pair for a resource.
 type Tag struct {
 	// The key, or name, for the resource tag.
@@ -6184,6 +7675,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // A tag and its associated resource.
@@ -6211,6 +7712,16 @@ type metadataTaggedResource struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TaggedResource) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TaggedResource) GoString() string {
+	return s.String()
+}
+
 // Describes the members of a VPC security group.
 type VPCSecurityGroupMembership struct {
 	Status *string `type:"string"`
@@ -6222,4 +7733,14 @@ type VPCSecurityGroupMembership struct {
 
 type metadataVPCSecurityGroupMembership struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPCSecurityGroupMembership) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPCSecurityGroupMembership) GoString() string {
+	return s.String()
 }

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAssociateVPCWithHostedZone = "AssociateVPCWithHostedZone"
@@ -1124,6 +1125,16 @@ type metadataAliasTarget struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AliasTarget) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AliasTarget) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains information about the request to associate a
 // VPC with an hosted zone.
 type AssociateVPCWithHostedZoneInput struct {
@@ -1146,6 +1157,16 @@ type metadataAssociateVPCWithHostedZoneInput struct {
 	SDKShapeTraits bool `locationName:"AssociateVPCWithHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s AssociateVPCWithHostedZoneInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateVPCWithHostedZoneInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing the response information for the request.
 type AssociateVPCWithHostedZoneOutput struct {
 	// A complex type that contains the ID, the status, and the date and time of
@@ -1157,6 +1178,16 @@ type AssociateVPCWithHostedZoneOutput struct {
 
 type metadataAssociateVPCWithHostedZoneOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociateVPCWithHostedZoneOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociateVPCWithHostedZoneOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the information for each change in a change
@@ -1177,6 +1208,16 @@ type metadataChange struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Change) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Change) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains an optional comment and the changes that you
 // want to make with a change batch request.
 type ChangeBatch struct {
@@ -1192,6 +1233,16 @@ type ChangeBatch struct {
 
 type metadataChangeBatch struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChangeBatch) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeBatch) GoString() string {
+	return s.String()
 }
 
 // A complex type that describes change information about changes made to your
@@ -1230,6 +1281,16 @@ type metadataChangeInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ChangeInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeInfo) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains a change batch.
 type ChangeResourceRecordSetsInput struct {
 	// A complex type that contains an optional comment and the Changes element.
@@ -1246,6 +1307,16 @@ type metadataChangeResourceRecordSetsInput struct {
 	SDKShapeTraits bool `locationName:"ChangeResourceRecordSetsRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s ChangeResourceRecordSetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeResourceRecordSetsInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing the response for the request.
 type ChangeResourceRecordSetsOutput struct {
 	// A complex type that contains information about changes made to your hosted
@@ -1260,6 +1331,16 @@ type ChangeResourceRecordSetsOutput struct {
 
 type metadataChangeResourceRecordSetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChangeResourceRecordSetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeResourceRecordSetsOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type containing information about a request to add, change, or
@@ -1289,6 +1370,16 @@ type metadataChangeTagsForResourceInput struct {
 	SDKShapeTraits bool `locationName:"ChangeTagsForResourceRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s ChangeTagsForResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeTagsForResourceInput) GoString() string {
+	return s.String()
+}
+
 // Empty response for the request.
 type ChangeTagsForResourceOutput struct {
 	metadataChangeTagsForResourceOutput `json:"-" xml:"-"`
@@ -1296,6 +1387,16 @@ type ChangeTagsForResourceOutput struct {
 
 type metadataChangeTagsForResourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChangeTagsForResourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeTagsForResourceOutput) GoString() string {
+	return s.String()
 }
 
 // >A complex type that contains information about the request to create a health
@@ -1321,6 +1422,16 @@ type metadataCreateHealthCheckInput struct {
 	SDKShapeTraits bool `locationName:"CreateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s CreateHealthCheckInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHealthCheckInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing the response information for the new health check.
 type CreateHealthCheckOutput struct {
 	// A complex type that contains identifying information about the health check.
@@ -1334,6 +1445,16 @@ type CreateHealthCheckOutput struct {
 
 type metadataCreateHealthCheckOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateHealthCheckOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHealthCheckOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the request to create a hosted
@@ -1378,6 +1499,16 @@ type metadataCreateHostedZoneInput struct {
 	SDKShapeTraits bool `locationName:"CreateHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s CreateHostedZoneInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHostedZoneInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing the response information for the new hosted zone.
 type CreateHostedZoneOutput struct {
 	// A complex type that contains information about the request to create a hosted
@@ -1403,6 +1534,16 @@ type metadataCreateHostedZoneOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateHostedZoneOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateHostedZoneOutput) GoString() string {
+	return s.String()
+}
+
 type CreateReusableDelegationSetInput struct {
 	// A unique string that identifies the request and that allows failed CreateReusableDelegationSet
 	// requests to be retried without the risk of executing the operation twice.
@@ -1425,6 +1566,16 @@ type metadataCreateReusableDelegationSetInput struct {
 	SDKShapeTraits bool `locationName:"CreateReusableDelegationSetRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s CreateReusableDelegationSetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateReusableDelegationSetInput) GoString() string {
+	return s.String()
+}
+
 type CreateReusableDelegationSetOutput struct {
 	// A complex type that contains name server information.
 	DelegationSet *DelegationSet `type:"structure" required:"true"`
@@ -1437,6 +1588,16 @@ type CreateReusableDelegationSetOutput struct {
 
 type metadataCreateReusableDelegationSetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateReusableDelegationSetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateReusableDelegationSetOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains name server information.
@@ -1457,6 +1618,16 @@ type metadataDelegationSet struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DelegationSet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DelegationSet) GoString() string {
+	return s.String()
+}
+
 // A complex type containing the request information for delete health check.
 type DeleteHealthCheckInput struct {
 	// The ID of the health check to delete.
@@ -1469,6 +1640,16 @@ type metadataDeleteHealthCheckInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteHealthCheckInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHealthCheckInput) GoString() string {
+	return s.String()
+}
+
 // Empty response for the request.
 type DeleteHealthCheckOutput struct {
 	metadataDeleteHealthCheckOutput `json:"-" xml:"-"`
@@ -1476,6 +1657,16 @@ type DeleteHealthCheckOutput struct {
 
 type metadataDeleteHealthCheckOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteHealthCheckOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHealthCheckOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the hosted zone that you want
@@ -1491,6 +1682,16 @@ type metadataDeleteHostedZoneInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteHostedZoneInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHostedZoneInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing the response information for the request.
 type DeleteHostedZoneOutput struct {
 	// A complex type that contains the ID, the status, and the date and time of
@@ -1502,6 +1703,16 @@ type DeleteHostedZoneOutput struct {
 
 type metadataDeleteHostedZoneOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteHostedZoneOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteHostedZoneOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type containing the information for the delete request.
@@ -1516,6 +1727,16 @@ type metadataDeleteReusableDelegationSetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteReusableDelegationSetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteReusableDelegationSetInput) GoString() string {
+	return s.String()
+}
+
 // Empty response for the request.
 type DeleteReusableDelegationSetOutput struct {
 	metadataDeleteReusableDelegationSetOutput `json:"-" xml:"-"`
@@ -1523,6 +1744,16 @@ type DeleteReusableDelegationSetOutput struct {
 
 type metadataDeleteReusableDelegationSetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteReusableDelegationSetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteReusableDelegationSetOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the request to disassociate
@@ -1546,6 +1777,16 @@ type metadataDisassociateVPCFromHostedZoneInput struct {
 	SDKShapeTraits bool `locationName:"DisassociateVPCFromHostedZoneRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s DisassociateVPCFromHostedZoneInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateVPCFromHostedZoneInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing the response information for the request.
 type DisassociateVPCFromHostedZoneOutput struct {
 	// A complex type that contains the ID, the status, and the date and time of
@@ -1557,6 +1798,16 @@ type DisassociateVPCFromHostedZoneOutput struct {
 
 type metadataDisassociateVPCFromHostedZoneOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisassociateVPCFromHostedZoneOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisassociateVPCFromHostedZoneOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about a geo location.
@@ -1589,6 +1840,16 @@ type GeoLocation struct {
 
 type metadataGeoLocation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GeoLocation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GeoLocation) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about a GeoLocation.
@@ -1627,6 +1888,16 @@ type metadataGeoLocationDetails struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GeoLocationDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GeoLocationDetails) GoString() string {
+	return s.String()
+}
+
 // The input for a GetChange request.
 type GetChangeInput struct {
 	// The ID of the change batch request. The value that you specify here is the
@@ -1639,6 +1910,16 @@ type GetChangeInput struct {
 
 type metadataGetChangeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetChangeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetChangeInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the ChangeInfo element.
@@ -1655,6 +1936,16 @@ type metadataGetChangeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetChangeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetChangeOutput) GoString() string {
+	return s.String()
+}
+
 // Empty request.
 type GetCheckerIPRangesInput struct {
 	metadataGetCheckerIPRangesInput `json:"-" xml:"-"`
@@ -1662,6 +1953,16 @@ type GetCheckerIPRangesInput struct {
 
 type metadataGetCheckerIPRangesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCheckerIPRangesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCheckerIPRangesInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the CheckerIpRanges element.
@@ -1675,6 +1976,16 @@ type GetCheckerIPRangesOutput struct {
 
 type metadataGetCheckerIPRangesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetCheckerIPRangesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetCheckerIPRangesOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the request to get a geo location.
@@ -1709,6 +2020,16 @@ type metadataGetGeoLocationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetGeoLocationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetGeoLocationInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing information about the specified geo location.
 type GetGeoLocationOutput struct {
 	// A complex type that contains the information about the specified geo location.
@@ -1721,6 +2042,16 @@ type metadataGetGeoLocationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetGeoLocationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetGeoLocationOutput) GoString() string {
+	return s.String()
+}
+
 // To retrieve a count of all your health checks, send a GET request to the
 // 2013-04-01/healthcheckcount resource.
 type GetHealthCheckCountInput struct {
@@ -1729,6 +2060,16 @@ type GetHealthCheckCountInput struct {
 
 type metadataGetHealthCheckCountInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetHealthCheckCountInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHealthCheckCountInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the count of health checks associated with the
@@ -1744,6 +2085,16 @@ type metadataGetHealthCheckCountOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetHealthCheckCountOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHealthCheckCountOutput) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains information about the request to get a health
 // check.
 type GetHealthCheckInput struct {
@@ -1755,6 +2106,16 @@ type GetHealthCheckInput struct {
 
 type metadataGetHealthCheckInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetHealthCheckInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHealthCheckInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the request to get the most
@@ -1771,6 +2132,16 @@ type metadataGetHealthCheckLastFailureReasonInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetHealthCheckLastFailureReasonInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHealthCheckLastFailureReasonInput) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains information about the most recent failure for
 // the specified health check.
 type GetHealthCheckLastFailureReasonOutput struct {
@@ -1785,6 +2156,16 @@ type metadataGetHealthCheckLastFailureReasonOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetHealthCheckLastFailureReasonOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHealthCheckLastFailureReasonOutput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing information about the specified health check.
 type GetHealthCheckOutput struct {
 	// A complex type that contains the information about the specified health check.
@@ -1795,6 +2176,16 @@ type GetHealthCheckOutput struct {
 
 type metadataGetHealthCheckOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetHealthCheckOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHealthCheckOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the request to get health
@@ -1811,6 +2202,16 @@ type metadataGetHealthCheckStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetHealthCheckStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHealthCheckStatusInput) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains information about the status of the specified
 // health check.
 type GetHealthCheckStatusOutput struct {
@@ -1825,6 +2226,16 @@ type metadataGetHealthCheckStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetHealthCheckStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHealthCheckStatusOutput) GoString() string {
+	return s.String()
+}
+
 // To retrieve a count of all your hosted zones, send a GET request to the 2013-04-01/hostedzonecount
 // resource.
 type GetHostedZoneCountInput struct {
@@ -1833,6 +2244,16 @@ type GetHostedZoneCountInput struct {
 
 type metadataGetHostedZoneCountInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetHostedZoneCountInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHostedZoneCountInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the count of hosted zones associated with the
@@ -1848,6 +2269,16 @@ type metadataGetHostedZoneCountOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetHostedZoneCountOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHostedZoneCountOutput) GoString() string {
+	return s.String()
+}
+
 // The input for a GetHostedZone request.
 type GetHostedZoneInput struct {
 	// The ID of the hosted zone for which you want to get a list of the name servers
@@ -1859,6 +2290,16 @@ type GetHostedZoneInput struct {
 
 type metadataGetHostedZoneInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetHostedZoneInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHostedZoneInput) GoString() string {
+	return s.String()
 }
 
 // A complex type containing information about the specified hosted zone.
@@ -1881,6 +2322,16 @@ type metadataGetHostedZoneOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetHostedZoneOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetHostedZoneOutput) GoString() string {
+	return s.String()
+}
+
 // The input for a GetReusableDelegationSet request.
 type GetReusableDelegationSetInput struct {
 	// The ID of the reusable delegation set for which you want to get a list of
@@ -1892,6 +2343,16 @@ type GetReusableDelegationSetInput struct {
 
 type metadataGetReusableDelegationSetInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetReusableDelegationSetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetReusableDelegationSetInput) GoString() string {
+	return s.String()
 }
 
 // A complex type containing information about the specified reusable delegation
@@ -1906,6 +2367,16 @@ type GetReusableDelegationSetOutput struct {
 
 type metadataGetReusableDelegationSetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetReusableDelegationSetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetReusableDelegationSetOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains identifying information about the health check.
@@ -1929,6 +2400,16 @@ type HealthCheck struct {
 
 type metadataHealthCheck struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HealthCheck) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HealthCheck) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the health check configuration.
@@ -1980,6 +2461,16 @@ type metadataHealthCheckConfig struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HealthCheckConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HealthCheckConfig) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains the IP address of a Route 53 health checker
 // and the reason for the health check status.
 type HealthCheckObservation struct {
@@ -1995,6 +2486,16 @@ type HealthCheckObservation struct {
 
 type metadataHealthCheckObservation struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HealthCheckObservation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HealthCheckObservation) GoString() string {
+	return s.String()
 }
 
 // A complex type that contain information about the specified hosted zone.
@@ -2028,6 +2529,16 @@ type metadataHostedZone struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HostedZone) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HostedZone) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains an optional comment about your hosted zone.
 // If you don't want to specify a comment, you can omit the HostedZoneConfig
 // and Comment elements from the XML document.
@@ -2046,6 +2557,16 @@ type HostedZoneConfig struct {
 
 type metadataHostedZoneConfig struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HostedZoneConfig) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HostedZoneConfig) GoString() string {
+	return s.String()
 }
 
 // The input for a ListGeoLocations request.
@@ -2082,6 +2603,16 @@ type ListGeoLocationsInput struct {
 
 type metadataListGeoLocationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListGeoLocationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGeoLocationsInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the geo locations that are
@@ -2126,6 +2657,16 @@ type metadataListGeoLocationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListGeoLocationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGeoLocationsOutput) GoString() string {
+	return s.String()
+}
+
 // To retrieve a list of your health checks, send a GET request to the 2013-04-01/healthcheck
 // resource. The response to this request includes a HealthChecks element with
 // zero or more HealthCheck child elements. By default, the list of health checks
@@ -2149,6 +2690,16 @@ type ListHealthChecksInput struct {
 
 type metadataListHealthChecksInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListHealthChecksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHealthChecksInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the response for the request.
@@ -2188,6 +2739,16 @@ type metadataListHealthChecksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListHealthChecksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHealthChecksOutput) GoString() string {
+	return s.String()
+}
+
 // To retrieve a list of your hosted zones in lexicographic order, send a GET
 // request to the 2013-04-01/hostedzonesbyname resource. The response to this
 // request includes a HostedZones element with zero or more HostedZone child
@@ -2222,6 +2783,16 @@ type ListHostedZonesByNameInput struct {
 
 type metadataListHostedZonesByNameInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListHostedZonesByNameInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHostedZonesByNameInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the response for the request.
@@ -2272,6 +2843,16 @@ type metadataListHostedZonesByNameOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListHostedZonesByNameOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHostedZonesByNameOutput) GoString() string {
+	return s.String()
+}
+
 // To retrieve a list of your hosted zones, send a GET request to the 2013-04-01/hostedzone
 // resource. The response to this request includes a HostedZones element with
 // zero or more HostedZone child elements. By default, the list of hosted zones
@@ -2300,6 +2881,16 @@ type ListHostedZonesInput struct {
 
 type metadataListHostedZonesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListHostedZonesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHostedZonesInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the response for the request.
@@ -2337,6 +2928,16 @@ type ListHostedZonesOutput struct {
 
 type metadataListHostedZonesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListHostedZonesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListHostedZonesOutput) GoString() string {
+	return s.String()
 }
 
 // The input for a ListResourceRecordSets request.
@@ -2377,6 +2978,16 @@ type ListResourceRecordSetsInput struct {
 
 type metadataListResourceRecordSetsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListResourceRecordSetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListResourceRecordSetsInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the resource record sets that
@@ -2420,6 +3031,16 @@ type metadataListResourceRecordSetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListResourceRecordSetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListResourceRecordSetsOutput) GoString() string {
+	return s.String()
+}
+
 // To retrieve a list of your reusable delegation sets, send a GET request to
 // the 2013-04-01/delegationset resource. The response to this request includes
 // a DelegationSets element with zero or more DelegationSet child elements.
@@ -2445,6 +3066,16 @@ type ListReusableDelegationSetsInput struct {
 
 type metadataListReusableDelegationSetsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListReusableDelegationSetsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListReusableDelegationSetsInput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the response for the request.
@@ -2486,6 +3117,16 @@ type metadataListReusableDelegationSetsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListReusableDelegationSetsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListReusableDelegationSetsOutput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing information about a request for a list of the tags
 // that are associated with an individual resource.
 type ListTagsForResourceInput struct {
@@ -2506,6 +3147,16 @@ type metadataListTagsForResourceInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListTagsForResourceInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing tags for the specified resource.
 type ListTagsForResourceOutput struct {
 	// A ResourceTagSet containing tags associated with the specified resource.
@@ -2516,6 +3167,16 @@ type ListTagsForResourceOutput struct {
 
 type metadataListTagsForResourceOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForResourceOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourceOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type containing information about a request for a list of the tags
@@ -2539,6 +3200,16 @@ type metadataListTagsForResourcesInput struct {
 	SDKShapeTraits bool `locationName:"ListTagsForResourcesRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s ListTagsForResourcesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourcesInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing tags for the specified resources.
 type ListTagsForResourcesOutput struct {
 	// A list of ResourceTagSets containing tags associated with the specified resources.
@@ -2549,6 +3220,16 @@ type ListTagsForResourcesOutput struct {
 
 type metadataListTagsForResourcesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForResourcesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForResourcesOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains the value of the Value element for the current
@@ -2562,6 +3243,16 @@ type ResourceRecord struct {
 
 type metadataResourceRecord struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResourceRecord) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResourceRecord) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the current resource record
@@ -2635,6 +3326,16 @@ type metadataResourceRecordSet struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResourceRecordSet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResourceRecordSet) GoString() string {
+	return s.String()
+}
+
 // A complex type containing a resource and its associated tags.
 type ResourceTagSet struct {
 	// The ID for the specified resource.
@@ -2657,6 +3358,16 @@ type metadataResourceTagSet struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResourceTagSet) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResourceTagSet) GoString() string {
+	return s.String()
+}
+
 // A complex type that contains information about the health check status for
 // the current observation.
 type StatusReport struct {
@@ -2676,6 +3387,16 @@ type metadataStatusReport struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StatusReport) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StatusReport) GoString() string {
+	return s.String()
+}
+
 // A single tag containing a key and value.
 type Tag struct {
 	// The key for a Tag.
@@ -2689,6 +3410,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // >A complex type that contains information about the request to update a health
@@ -2753,6 +3484,16 @@ type metadataUpdateHealthCheckInput struct {
 	SDKShapeTraits bool `locationName:"UpdateHealthCheckRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s UpdateHealthCheckInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateHealthCheckInput) GoString() string {
+	return s.String()
+}
+
 type UpdateHealthCheckOutput struct {
 	// A complex type that contains identifying information about the health check.
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
@@ -2762,6 +3503,16 @@ type UpdateHealthCheckOutput struct {
 
 type metadataUpdateHealthCheckOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateHealthCheckOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateHealthCheckOutput) GoString() string {
+	return s.String()
 }
 
 // A complex type that contains information about the request to update a hosted
@@ -2780,6 +3531,16 @@ type metadataUpdateHostedZoneCommentInput struct {
 	SDKShapeTraits bool `locationName:"UpdateHostedZoneCommentRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 }
 
+// String returns the string representation
+func (s UpdateHostedZoneCommentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateHostedZoneCommentInput) GoString() string {
+	return s.String()
+}
+
 // A complex type containing information about the specified hosted zone after
 // the update.
 type UpdateHostedZoneCommentOutput struct {
@@ -2793,6 +3554,16 @@ type metadataUpdateHostedZoneCommentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateHostedZoneCommentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateHostedZoneCommentOutput) GoString() string {
+	return s.String()
+}
+
 type VPC struct {
 	// A VPC ID
 	VPCID *string `locationName:"VPCId" type:"string"`
@@ -2804,4 +3575,14 @@ type VPC struct {
 
 type metadataVPC struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VPC) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VPC) GoString() string {
+	return s.String()
 }

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCheckDomainAvailability = "CheckDomainAvailability"
@@ -652,6 +653,16 @@ type metadataCheckDomainAvailabilityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CheckDomainAvailabilityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CheckDomainAvailabilityInput) GoString() string {
+	return s.String()
+}
+
 // The CheckDomainAvailability response includes the following elements.
 type CheckDomainAvailabilityOutput struct {
 	// Whether the domain name is available for registering.
@@ -679,6 +690,16 @@ type CheckDomainAvailabilityOutput struct {
 
 type metadataCheckDomainAvailabilityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CheckDomainAvailabilityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CheckDomainAvailabilityOutput) GoString() string {
+	return s.String()
 }
 
 // ContactDetail includes the following elements.
@@ -880,6 +901,16 @@ type metadataContactDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ContactDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ContactDetail) GoString() string {
+	return s.String()
+}
+
 // The DeleteTagsForDomainRequest includes the following elements.
 type DeleteTagsForDomainInput struct {
 	// The domain for which you want to delete one or more tags.
@@ -917,12 +948,32 @@ type metadataDeleteTagsForDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTagsForDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsForDomainInput) GoString() string {
+	return s.String()
+}
+
 type DeleteTagsForDomainOutput struct {
 	metadataDeleteTagsForDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTagsForDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTagsForDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTagsForDomainOutput) GoString() string {
+	return s.String()
 }
 
 type DisableDomainAutoRenewInput struct {
@@ -935,12 +986,32 @@ type metadataDisableDomainAutoRenewInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableDomainAutoRenewInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableDomainAutoRenewInput) GoString() string {
+	return s.String()
+}
+
 type DisableDomainAutoRenewOutput struct {
 	metadataDisableDomainAutoRenewOutput `json:"-" xml:"-"`
 }
 
 type metadataDisableDomainAutoRenewOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableDomainAutoRenewOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableDomainAutoRenewOutput) GoString() string {
+	return s.String()
 }
 
 // The DisableDomainTransferLock request includes the following element.
@@ -965,6 +1036,16 @@ type metadataDisableDomainTransferLockInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableDomainTransferLockInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableDomainTransferLockInput) GoString() string {
+	return s.String()
+}
+
 // The DisableDomainTransferLock response includes the following element.
 type DisableDomainTransferLockOutput struct {
 	// Identifier for tracking the progress of the request. To use this ID to query
@@ -982,6 +1063,16 @@ type DisableDomainTransferLockOutput struct {
 
 type metadataDisableDomainTransferLockOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableDomainTransferLockOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableDomainTransferLockOutput) GoString() string {
+	return s.String()
 }
 
 type DomainSummary struct {
@@ -1017,6 +1108,16 @@ type metadataDomainSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DomainSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DomainSummary) GoString() string {
+	return s.String()
+}
+
 type EnableDomainAutoRenewInput struct {
 	DomainName *string `type:"string" required:"true"`
 
@@ -1027,12 +1128,32 @@ type metadataEnableDomainAutoRenewInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableDomainAutoRenewInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableDomainAutoRenewInput) GoString() string {
+	return s.String()
+}
+
 type EnableDomainAutoRenewOutput struct {
 	metadataEnableDomainAutoRenewOutput `json:"-" xml:"-"`
 }
 
 type metadataEnableDomainAutoRenewOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableDomainAutoRenewOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableDomainAutoRenewOutput) GoString() string {
+	return s.String()
 }
 
 // The EnableDomainTransferLock request includes the following element.
@@ -1057,6 +1178,16 @@ type metadataEnableDomainTransferLockInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s EnableDomainTransferLockInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableDomainTransferLockInput) GoString() string {
+	return s.String()
+}
+
 // The EnableDomainTransferLock response includes the following elements.
 type EnableDomainTransferLockOutput struct {
 	// Identifier for tracking the progress of the request. To use this ID to query
@@ -1074,6 +1205,16 @@ type EnableDomainTransferLockOutput struct {
 
 type metadataEnableDomainTransferLockOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s EnableDomainTransferLockOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s EnableDomainTransferLockOutput) GoString() string {
+	return s.String()
 }
 
 // ExtraParam includes the following elements.
@@ -1116,6 +1257,16 @@ type metadataExtraParam struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ExtraParam) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExtraParam) GoString() string {
+	return s.String()
+}
+
 // The GetDomainDetail request includes the following element.
 type GetDomainDetailInput struct {
 	// The name of a domain.
@@ -1136,6 +1287,16 @@ type GetDomainDetailInput struct {
 
 type metadataGetDomainDetailInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDomainDetailInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDomainDetailInput) GoString() string {
+	return s.String()
 }
 
 // The GetDomainDetail response includes the following elements.
@@ -1284,6 +1445,16 @@ type metadataGetDomainDetailOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetDomainDetailOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDomainDetailOutput) GoString() string {
+	return s.String()
+}
+
 // The GetOperationDetail request includes the following element.
 type GetOperationDetailInput struct {
 	// The identifier for the operation for which you want to get the status. Amazon
@@ -1301,6 +1472,16 @@ type GetOperationDetailInput struct {
 
 type metadataGetOperationDetailInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetOperationDetailInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOperationDetailInput) GoString() string {
+	return s.String()
 }
 
 // The GetOperationDetail response includes the following elements.
@@ -1340,6 +1521,16 @@ type metadataGetOperationDetailOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetOperationDetailOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetOperationDetailOutput) GoString() string {
+	return s.String()
+}
+
 // The ListDomains request includes the following elements.
 type ListDomainsInput struct {
 	// For an initial request for a list of domains, omit this element. If the number
@@ -1376,6 +1567,16 @@ type metadataListDomainsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDomainsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDomainsInput) GoString() string {
+	return s.String()
+}
+
 // The ListDomains response includes the following elements.
 type ListDomainsOutput struct {
 	// A summary of domains.
@@ -1399,6 +1600,16 @@ type ListDomainsOutput struct {
 
 type metadataListDomainsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDomainsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDomainsOutput) GoString() string {
+	return s.String()
 }
 
 // The ListOperations request includes the following elements.
@@ -1435,6 +1646,16 @@ type metadataListOperationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListOperationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListOperationsInput) GoString() string {
+	return s.String()
+}
+
 // The ListOperations response includes the following elements.
 type ListOperationsOutput struct {
 	// If there are more operations than you specified for MaxItems in the request,
@@ -1460,6 +1681,16 @@ type metadataListOperationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListOperationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListOperationsOutput) GoString() string {
+	return s.String()
+}
+
 // The ListTagsForDomainRequest includes the following elements.
 type ListTagsForDomainInput struct {
 	// The domain for which you want to get a list of tags.
@@ -1470,6 +1701,16 @@ type ListTagsForDomainInput struct {
 
 type metadataListTagsForDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForDomainInput) GoString() string {
+	return s.String()
 }
 
 // The ListTagsForDomain response includes the following elements.
@@ -1498,6 +1739,16 @@ type ListTagsForDomainOutput struct {
 
 type metadataListTagsForDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTagsForDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTagsForDomainOutput) GoString() string {
+	return s.String()
 }
 
 // Nameserver includes the following elements.
@@ -1530,6 +1781,16 @@ type metadataNameserver struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Nameserver) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Nameserver) GoString() string {
+	return s.String()
+}
+
 // OperationSummary includes the following elements.
 type OperationSummary struct {
 	// Identifier returned to track the requested action.
@@ -1558,6 +1819,16 @@ type OperationSummary struct {
 
 type metadataOperationSummary struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s OperationSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s OperationSummary) GoString() string {
+	return s.String()
 }
 
 // The RegisterDomain request includes the following elements.
@@ -1684,6 +1955,16 @@ type metadataRegisterDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterDomainInput) GoString() string {
+	return s.String()
+}
+
 // The RegisterDomain response includes the following element.
 type RegisterDomainOutput struct {
 	// Identifier for tracking the progress of the request. To use this ID to query
@@ -1701,6 +1982,16 @@ type RegisterDomainOutput struct {
 
 type metadataRegisterDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterDomainOutput) GoString() string {
+	return s.String()
 }
 
 // The RetrieveDomainAuthCode request includes the following element.
@@ -1725,6 +2016,16 @@ type metadataRetrieveDomainAuthCodeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RetrieveDomainAuthCodeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetrieveDomainAuthCodeInput) GoString() string {
+	return s.String()
+}
+
 // The RetrieveDomainAuthCode response includes the following element.
 type RetrieveDomainAuthCodeOutput struct {
 	// The authorization code for the domain.
@@ -1737,6 +2038,16 @@ type RetrieveDomainAuthCodeOutput struct {
 
 type metadataRetrieveDomainAuthCodeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RetrieveDomainAuthCodeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetrieveDomainAuthCodeOutput) GoString() string {
+	return s.String()
 }
 
 // Each tag includes the following elements.
@@ -1772,6 +2083,16 @@ type Tag struct {
 
 type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
 }
 
 // The TransferDomain request includes the following elements.
@@ -1915,6 +2236,16 @@ type metadataTransferDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TransferDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TransferDomainInput) GoString() string {
+	return s.String()
+}
+
 // The TranserDomain response includes the following element.
 type TransferDomainOutput struct {
 	// Identifier for tracking the progress of the request. To use this ID to query
@@ -1932,6 +2263,16 @@ type TransferDomainOutput struct {
 
 type metadataTransferDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TransferDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TransferDomainOutput) GoString() string {
+	return s.String()
 }
 
 // The UpdateDomainContact request includes the following elements.
@@ -1989,6 +2330,16 @@ type metadataUpdateDomainContactInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateDomainContactInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDomainContactInput) GoString() string {
+	return s.String()
+}
+
 // The UpdateDomainContact response includes the following element.
 type UpdateDomainContactOutput struct {
 	// Identifier for tracking the progress of the request. To use this ID to query
@@ -2006,6 +2357,16 @@ type UpdateDomainContactOutput struct {
 
 type metadataUpdateDomainContactOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateDomainContactOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDomainContactOutput) GoString() string {
+	return s.String()
 }
 
 // The UpdateDomainContactPrivacy request includes the following elements.
@@ -2072,6 +2433,16 @@ type metadataUpdateDomainContactPrivacyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateDomainContactPrivacyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDomainContactPrivacyInput) GoString() string {
+	return s.String()
+}
+
 // The UpdateDomainContactPrivacy response includes the following element.
 type UpdateDomainContactPrivacyOutput struct {
 	// Identifier for tracking the progress of the request. To use this ID to query
@@ -2089,6 +2460,16 @@ type UpdateDomainContactPrivacyOutput struct {
 
 type metadataUpdateDomainContactPrivacyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateDomainContactPrivacyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDomainContactPrivacyOutput) GoString() string {
+	return s.String()
 }
 
 // The UpdateDomainNameserver request includes the following elements.
@@ -2125,6 +2506,16 @@ type metadataUpdateDomainNameserversInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateDomainNameserversInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDomainNameserversInput) GoString() string {
+	return s.String()
+}
+
 // The UpdateDomainNameservers response includes the following element.
 type UpdateDomainNameserversOutput struct {
 	// Identifier for tracking the progress of the request. To use this ID to query
@@ -2142,6 +2533,16 @@ type UpdateDomainNameserversOutput struct {
 
 type metadataUpdateDomainNameserversOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateDomainNameserversOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateDomainNameserversOutput) GoString() string {
+	return s.String()
 }
 
 // The UpdateTagsForDomainRequest includes the following elements.
@@ -2210,10 +2611,30 @@ type metadataUpdateTagsForDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateTagsForDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTagsForDomainInput) GoString() string {
+	return s.String()
+}
+
 type UpdateTagsForDomainOutput struct {
 	metadataUpdateTagsForDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataUpdateTagsForDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateTagsForDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateTagsForDomainOutput) GoString() string {
+	return s.String()
 }

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAbortMultipartUpload = "AbortMultipartUpload"
@@ -1575,6 +1576,16 @@ type metadataAbortMultipartUploadInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AbortMultipartUploadInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AbortMultipartUploadInput) GoString() string {
+	return s.String()
+}
+
 type AbortMultipartUploadOutput struct {
 	// If present, indicates that the requester was successfully charged for the
 	// request.
@@ -1585,6 +1596,16 @@ type AbortMultipartUploadOutput struct {
 
 type metadataAbortMultipartUploadOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AbortMultipartUploadOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AbortMultipartUploadOutput) GoString() string {
+	return s.String()
 }
 
 type AccessControlPolicy struct {
@@ -1598,6 +1619,16 @@ type AccessControlPolicy struct {
 
 type metadataAccessControlPolicy struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AccessControlPolicy) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AccessControlPolicy) GoString() string {
+	return s.String()
 }
 
 type Bucket struct {
@@ -1614,6 +1645,16 @@ type metadataBucket struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Bucket) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Bucket) GoString() string {
+	return s.String()
+}
+
 type BucketLoggingStatus struct {
 	LoggingEnabled *LoggingEnabled `type:"structure"`
 
@@ -1624,6 +1665,16 @@ type metadataBucketLoggingStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BucketLoggingStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BucketLoggingStatus) GoString() string {
+	return s.String()
+}
+
 type CORSConfiguration struct {
 	CORSRules []*CORSRule `locationName:"CORSRule" type:"list" flattened:"true"`
 
@@ -1632,6 +1683,16 @@ type CORSConfiguration struct {
 
 type metadataCORSConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CORSConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CORSConfiguration) GoString() string {
+	return s.String()
 }
 
 type CORSRule struct {
@@ -1661,6 +1722,16 @@ type metadataCORSRule struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CORSRule) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CORSRule) GoString() string {
+	return s.String()
+}
+
 type CloudFunctionConfiguration struct {
 	CloudFunction *string `type:"string"`
 
@@ -1682,6 +1753,16 @@ type metadataCloudFunctionConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CloudFunctionConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CloudFunctionConfiguration) GoString() string {
+	return s.String()
+}
+
 type CommonPrefix struct {
 	Prefix *string `type:"string"`
 
@@ -1690,6 +1771,16 @@ type CommonPrefix struct {
 
 type metadataCommonPrefix struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CommonPrefix) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CommonPrefix) GoString() string {
+	return s.String()
 }
 
 type CompleteMultipartUploadInput struct {
@@ -1712,6 +1803,16 @@ type CompleteMultipartUploadInput struct {
 
 type metadataCompleteMultipartUploadInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"MultipartUpload"`
+}
+
+// String returns the string representation
+func (s CompleteMultipartUploadInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompleteMultipartUploadInput) GoString() string {
+	return s.String()
 }
 
 type CompleteMultipartUploadOutput struct {
@@ -1750,6 +1851,16 @@ type metadataCompleteMultipartUploadOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CompleteMultipartUploadOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompleteMultipartUploadOutput) GoString() string {
+	return s.String()
+}
+
 type CompletedMultipartUpload struct {
 	Parts []*CompletedPart `locationName:"Part" type:"list" flattened:"true"`
 
@@ -1758,6 +1869,16 @@ type CompletedMultipartUpload struct {
 
 type metadataCompletedMultipartUpload struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CompletedMultipartUpload) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompletedMultipartUpload) GoString() string {
+	return s.String()
 }
 
 type CompletedPart struct {
@@ -1773,6 +1894,16 @@ type CompletedPart struct {
 
 type metadataCompletedPart struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CompletedPart) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompletedPart) GoString() string {
+	return s.String()
 }
 
 type Condition struct {
@@ -1797,6 +1928,16 @@ type Condition struct {
 
 type metadataCondition struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Condition) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Condition) GoString() string {
+	return s.String()
 }
 
 type CopyObjectInput struct {
@@ -1922,6 +2063,16 @@ type metadataCopyObjectInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopyObjectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyObjectInput) GoString() string {
+	return s.String()
+}
+
 type CopyObjectOutput struct {
 	CopyObjectResult *CopyObjectResult `type:"structure"`
 
@@ -1959,6 +2110,16 @@ type metadataCopyObjectOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CopyObjectResult"`
 }
 
+// String returns the string representation
+func (s CopyObjectOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyObjectOutput) GoString() string {
+	return s.String()
+}
+
 type CopyObjectResult struct {
 	ETag *string `type:"string"`
 
@@ -1969,6 +2130,16 @@ type CopyObjectResult struct {
 
 type metadataCopyObjectResult struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CopyObjectResult) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyObjectResult) GoString() string {
+	return s.String()
 }
 
 type CopyPartResult struct {
@@ -1985,6 +2156,16 @@ type metadataCopyPartResult struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CopyPartResult) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CopyPartResult) GoString() string {
+	return s.String()
+}
+
 type CreateBucketConfiguration struct {
 	// Specifies the region where the bucket will be created. If you don't specify
 	// a region, the bucket will be created in US Standard.
@@ -1995,6 +2176,16 @@ type CreateBucketConfiguration struct {
 
 type metadataCreateBucketConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateBucketConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateBucketConfiguration) GoString() string {
+	return s.String()
 }
 
 type CreateBucketInput struct {
@@ -2028,6 +2219,16 @@ type metadataCreateBucketInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CreateBucketConfiguration"`
 }
 
+// String returns the string representation
+func (s CreateBucketInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateBucketInput) GoString() string {
+	return s.String()
+}
+
 type CreateBucketOutput struct {
 	Location *string `location:"header" locationName:"Location" type:"string"`
 
@@ -2036,6 +2237,16 @@ type CreateBucketOutput struct {
 
 type metadataCreateBucketOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateBucketOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateBucketOutput) GoString() string {
+	return s.String()
 }
 
 type CreateMultipartUploadInput struct {
@@ -2127,6 +2338,16 @@ type metadataCreateMultipartUploadInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateMultipartUploadInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateMultipartUploadInput) GoString() string {
+	return s.String()
+}
+
 type CreateMultipartUploadOutput struct {
 	// Name of the bucket to which the multipart upload was initiated.
 	Bucket *string `locationName:"Bucket" type:"string"`
@@ -2166,6 +2387,16 @@ type metadataCreateMultipartUploadOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateMultipartUploadOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateMultipartUploadOutput) GoString() string {
+	return s.String()
+}
+
 type Delete struct {
 	Objects []*ObjectIdentifier `locationName:"Object" type:"list" flattened:"true" required:"true"`
 
@@ -2180,6 +2411,16 @@ type metadataDelete struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Delete) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Delete) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketCORSInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2190,12 +2431,32 @@ type metadataDeleteBucketCORSInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBucketCORSInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketCORSInput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketCORSOutput struct {
 	metadataDeleteBucketCORSOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketCORSOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketCORSOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketCORSOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteBucketInput struct {
@@ -2208,6 +2469,16 @@ type metadataDeleteBucketInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBucketInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketInput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketLifecycleInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2218,6 +2489,16 @@ type metadataDeleteBucketLifecycleInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBucketLifecycleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketLifecycleInput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketLifecycleOutput struct {
 	metadataDeleteBucketLifecycleOutput `json:"-" xml:"-"`
 }
@@ -2226,12 +2507,32 @@ type metadataDeleteBucketLifecycleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBucketLifecycleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketLifecycleOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketOutput struct {
 	metadataDeleteBucketOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteBucketPolicyInput struct {
@@ -2244,12 +2545,32 @@ type metadataDeleteBucketPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBucketPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketPolicyInput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketPolicyOutput struct {
 	metadataDeleteBucketPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteBucketReplicationInput struct {
@@ -2262,12 +2583,32 @@ type metadataDeleteBucketReplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBucketReplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketReplicationInput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketReplicationOutput struct {
 	metadataDeleteBucketReplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketReplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketReplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketReplicationOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteBucketTaggingInput struct {
@@ -2280,12 +2621,32 @@ type metadataDeleteBucketTaggingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBucketTaggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketTaggingInput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketTaggingOutput struct {
 	metadataDeleteBucketTaggingOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketTaggingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketTaggingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketTaggingOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteBucketWebsiteInput struct {
@@ -2298,12 +2659,32 @@ type metadataDeleteBucketWebsiteInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBucketWebsiteInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketWebsiteInput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketWebsiteOutput struct {
 	metadataDeleteBucketWebsiteOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteBucketWebsiteOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketWebsiteOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketWebsiteOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteMarkerEntry struct {
@@ -2327,6 +2708,16 @@ type DeleteMarkerEntry struct {
 
 type metadataDeleteMarkerEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteMarkerEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMarkerEntry) GoString() string {
+	return s.String()
 }
 
 type DeleteObjectInput struct {
@@ -2354,6 +2745,16 @@ type metadataDeleteObjectInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteObjectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteObjectInput) GoString() string {
+	return s.String()
+}
+
 type DeleteObjectOutput struct {
 	// Specifies whether the versioned object that was permanently deleted was (true)
 	// or was not (false) a delete marker.
@@ -2372,6 +2773,16 @@ type DeleteObjectOutput struct {
 
 type metadataDeleteObjectOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteObjectOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteObjectOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteObjectsInput struct {
@@ -2396,6 +2807,16 @@ type metadataDeleteObjectsInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Delete"`
 }
 
+// String returns the string representation
+func (s DeleteObjectsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteObjectsInput) GoString() string {
+	return s.String()
+}
+
 type DeleteObjectsOutput struct {
 	Deleted []*DeletedObject `type:"list" flattened:"true"`
 
@@ -2410,6 +2831,16 @@ type DeleteObjectsOutput struct {
 
 type metadataDeleteObjectsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteObjectsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteObjectsOutput) GoString() string {
+	return s.String()
 }
 
 type DeletedObject struct {
@@ -2428,6 +2859,16 @@ type metadataDeletedObject struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletedObject) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletedObject) GoString() string {
+	return s.String()
+}
+
 type Destination struct {
 	// Amazon resource name (ARN) of the bucket where you want Amazon S3 to store
 	// replicas of the object identified by the rule.
@@ -2438,6 +2879,16 @@ type Destination struct {
 
 type metadataDestination struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Destination) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Destination) GoString() string {
+	return s.String()
 }
 
 type Error struct {
@@ -2456,6 +2907,16 @@ type metadataError struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Error) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Error) GoString() string {
+	return s.String()
+}
+
 type ErrorDocument struct {
 	// The object key name to use when a 4XX class error occurs.
 	Key *string `type:"string" required:"true"`
@@ -2467,6 +2928,16 @@ type metadataErrorDocument struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ErrorDocument) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ErrorDocument) GoString() string {
+	return s.String()
+}
+
 type GetBucketACLInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2475,6 +2946,16 @@ type GetBucketACLInput struct {
 
 type metadataGetBucketACLInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketACLInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketACLInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketACLOutput struct {
@@ -2490,6 +2971,16 @@ type metadataGetBucketACLOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketACLOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketACLOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketCORSInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2498,6 +2989,16 @@ type GetBucketCORSInput struct {
 
 type metadataGetBucketCORSInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketCORSInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketCORSInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketCORSOutput struct {
@@ -2510,6 +3011,16 @@ type metadataGetBucketCORSOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketCORSOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketCORSOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketLifecycleInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2518,6 +3029,16 @@ type GetBucketLifecycleInput struct {
 
 type metadataGetBucketLifecycleInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketLifecycleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketLifecycleInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketLifecycleOutput struct {
@@ -2530,6 +3051,16 @@ type metadataGetBucketLifecycleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketLifecycleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketLifecycleOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketLocationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2538,6 +3069,16 @@ type GetBucketLocationInput struct {
 
 type metadataGetBucketLocationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketLocationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketLocationInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketLocationOutput struct {
@@ -2550,6 +3091,16 @@ type metadataGetBucketLocationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketLocationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketLocationOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketLoggingInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2560,6 +3111,16 @@ type metadataGetBucketLoggingInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketLoggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketLoggingInput) GoString() string {
+	return s.String()
+}
+
 type GetBucketLoggingOutput struct {
 	LoggingEnabled *LoggingEnabled `type:"structure"`
 
@@ -2568,6 +3129,16 @@ type GetBucketLoggingOutput struct {
 
 type metadataGetBucketLoggingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketLoggingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketLoggingOutput) GoString() string {
+	return s.String()
 }
 
 type GetBucketNotificationConfigurationRequest struct {
@@ -2581,6 +3152,16 @@ type metadataGetBucketNotificationConfigurationRequest struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketNotificationConfigurationRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketNotificationConfigurationRequest) GoString() string {
+	return s.String()
+}
+
 type GetBucketPolicyInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2589,6 +3170,16 @@ type GetBucketPolicyInput struct {
 
 type metadataGetBucketPolicyInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketPolicyInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketPolicyOutput struct {
@@ -2602,6 +3193,16 @@ type metadataGetBucketPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Policy"`
 }
 
+// String returns the string representation
+func (s GetBucketPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketPolicyOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketReplicationInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2610,6 +3211,16 @@ type GetBucketReplicationInput struct {
 
 type metadataGetBucketReplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketReplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketReplicationInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketReplicationOutput struct {
@@ -2624,6 +3235,16 @@ type metadataGetBucketReplicationOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"ReplicationConfiguration"`
 }
 
+// String returns the string representation
+func (s GetBucketReplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketReplicationOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketRequestPaymentInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2632,6 +3253,16 @@ type GetBucketRequestPaymentInput struct {
 
 type metadataGetBucketRequestPaymentInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketRequestPaymentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketRequestPaymentInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketRequestPaymentOutput struct {
@@ -2645,6 +3276,16 @@ type metadataGetBucketRequestPaymentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketRequestPaymentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketRequestPaymentOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketTaggingInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2653,6 +3294,16 @@ type GetBucketTaggingInput struct {
 
 type metadataGetBucketTaggingInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketTaggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketTaggingInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketTaggingOutput struct {
@@ -2665,6 +3316,16 @@ type metadataGetBucketTaggingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketTaggingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketTaggingOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketVersioningInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2673,6 +3334,16 @@ type GetBucketVersioningInput struct {
 
 type metadataGetBucketVersioningInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketVersioningInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketVersioningInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketVersioningOutput struct {
@@ -2691,6 +3362,16 @@ type metadataGetBucketVersioningOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetBucketVersioningOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketVersioningOutput) GoString() string {
+	return s.String()
+}
+
 type GetBucketWebsiteInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2699,6 +3380,16 @@ type GetBucketWebsiteInput struct {
 
 type metadataGetBucketWebsiteInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketWebsiteInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketWebsiteInput) GoString() string {
+	return s.String()
 }
 
 type GetBucketWebsiteOutput struct {
@@ -2715,6 +3406,16 @@ type GetBucketWebsiteOutput struct {
 
 type metadataGetBucketWebsiteOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketWebsiteOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketWebsiteOutput) GoString() string {
+	return s.String()
 }
 
 type GetObjectACLInput struct {
@@ -2738,6 +3439,16 @@ type metadataGetObjectACLInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetObjectACLInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetObjectACLInput) GoString() string {
+	return s.String()
+}
+
 type GetObjectACLOutput struct {
 	// A list of grants.
 	Grants []*Grant `locationName:"AccessControlList" locationNameList:"Grant" type:"list"`
@@ -2753,6 +3464,16 @@ type GetObjectACLOutput struct {
 
 type metadataGetObjectACLOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetObjectACLOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetObjectACLOutput) GoString() string {
+	return s.String()
 }
 
 type GetObjectInput struct {
@@ -2827,6 +3548,16 @@ type GetObjectInput struct {
 
 type metadataGetObjectInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetObjectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetObjectInput) GoString() string {
+	return s.String()
 }
 
 type GetObjectOutput struct {
@@ -2930,6 +3661,16 @@ type metadataGetObjectOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Body"`
 }
 
+// String returns the string representation
+func (s GetObjectOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetObjectOutput) GoString() string {
+	return s.String()
+}
+
 type GetObjectTorrentInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -2948,6 +3689,16 @@ type metadataGetObjectTorrentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetObjectTorrentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetObjectTorrentInput) GoString() string {
+	return s.String()
+}
+
 type GetObjectTorrentOutput struct {
 	Body io.ReadCloser `type:"blob"`
 
@@ -2962,6 +3713,16 @@ type metadataGetObjectTorrentOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Body"`
 }
 
+// String returns the string representation
+func (s GetObjectTorrentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetObjectTorrentOutput) GoString() string {
+	return s.String()
+}
+
 type Grant struct {
 	Grantee *Grantee `type:"structure"`
 
@@ -2973,6 +3734,16 @@ type Grant struct {
 
 type metadataGrant struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Grant) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Grant) GoString() string {
+	return s.String()
 }
 
 type Grantee struct {
@@ -2998,6 +3769,16 @@ type metadataGrantee struct {
 	SDKShapeTraits bool `type:"structure" xmlPrefix:"xsi" xmlURI:"http://www.w3.org/2001/XMLSchema-instance"`
 }
 
+// String returns the string representation
+func (s Grantee) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Grantee) GoString() string {
+	return s.String()
+}
+
 type HeadBucketInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -3008,12 +3789,32 @@ type metadataHeadBucketInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HeadBucketInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HeadBucketInput) GoString() string {
+	return s.String()
+}
+
 type HeadBucketOutput struct {
 	metadataHeadBucketOutput `json:"-" xml:"-"`
 }
 
 type metadataHeadBucketOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HeadBucketOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HeadBucketOutput) GoString() string {
+	return s.String()
 }
 
 type HeadObjectInput struct {
@@ -3070,6 +3871,16 @@ type HeadObjectInput struct {
 
 type metadataHeadObjectInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s HeadObjectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HeadObjectInput) GoString() string {
+	return s.String()
 }
 
 type HeadObjectOutput struct {
@@ -3167,6 +3978,16 @@ type metadataHeadObjectOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HeadObjectOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HeadObjectOutput) GoString() string {
+	return s.String()
+}
+
 type IndexDocument struct {
 	// A suffix that is appended to a request that is for a directory on the website
 	// endpoint (e.g. if the suffix is index.html and you make a request to samplebucket/images/
@@ -3179,6 +4000,16 @@ type IndexDocument struct {
 
 type metadataIndexDocument struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IndexDocument) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IndexDocument) GoString() string {
+	return s.String()
 }
 
 type Initiator struct {
@@ -3194,6 +4025,16 @@ type Initiator struct {
 
 type metadataInitiator struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Initiator) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Initiator) GoString() string {
+	return s.String()
 }
 
 // Container for specifying the AWS Lambda notification configuration.
@@ -3215,6 +4056,16 @@ type metadataLambdaFunctionConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LambdaFunctionConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LambdaFunctionConfiguration) GoString() string {
+	return s.String()
+}
+
 type LifecycleConfiguration struct {
 	Rules []*LifecycleRule `locationName:"Rule" type:"list" flattened:"true" required:"true"`
 
@@ -3223,6 +4074,16 @@ type LifecycleConfiguration struct {
 
 type metadataLifecycleConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LifecycleConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LifecycleConfiguration) GoString() string {
+	return s.String()
 }
 
 type LifecycleExpiration struct {
@@ -3239,6 +4100,16 @@ type LifecycleExpiration struct {
 
 type metadataLifecycleExpiration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LifecycleExpiration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LifecycleExpiration) GoString() string {
+	return s.String()
 }
 
 type LifecycleRule struct {
@@ -3277,12 +4148,32 @@ type metadataLifecycleRule struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s LifecycleRule) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LifecycleRule) GoString() string {
+	return s.String()
+}
+
 type ListBucketsInput struct {
 	metadataListBucketsInput `json:"-" xml:"-"`
 }
 
 type metadataListBucketsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListBucketsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListBucketsInput) GoString() string {
+	return s.String()
 }
 
 type ListBucketsOutput struct {
@@ -3295,6 +4186,16 @@ type ListBucketsOutput struct {
 
 type metadataListBucketsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListBucketsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListBucketsOutput) GoString() string {
+	return s.String()
 }
 
 type ListMultipartUploadsInput struct {
@@ -3334,6 +4235,16 @@ type ListMultipartUploadsInput struct {
 
 type metadataListMultipartUploadsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListMultipartUploadsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListMultipartUploadsInput) GoString() string {
+	return s.String()
 }
 
 type ListMultipartUploadsOutput struct {
@@ -3384,6 +4295,16 @@ type metadataListMultipartUploadsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListMultipartUploadsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListMultipartUploadsOutput) GoString() string {
+	return s.String()
+}
+
 type ListObjectVersionsInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -3416,6 +4337,16 @@ type ListObjectVersionsInput struct {
 
 type metadataListObjectVersionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListObjectVersionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListObjectVersionsInput) GoString() string {
+	return s.String()
 }
 
 type ListObjectVersionsOutput struct {
@@ -3461,6 +4392,16 @@ type metadataListObjectVersionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListObjectVersionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListObjectVersionsOutput) GoString() string {
+	return s.String()
+}
+
 type ListObjectsInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -3490,6 +4431,16 @@ type ListObjectsInput struct {
 
 type metadataListObjectsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListObjectsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListObjectsInput) GoString() string {
+	return s.String()
 }
 
 type ListObjectsOutput struct {
@@ -3530,6 +4481,16 @@ type metadataListObjectsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListObjectsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListObjectsOutput) GoString() string {
+	return s.String()
+}
+
 type ListPartsInput struct {
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
@@ -3556,6 +4517,16 @@ type ListPartsInput struct {
 
 type metadataListPartsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListPartsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPartsInput) GoString() string {
+	return s.String()
 }
 
 type ListPartsOutput struct {
@@ -3603,6 +4574,16 @@ type metadataListPartsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPartsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPartsOutput) GoString() string {
+	return s.String()
+}
+
 type LoggingEnabled struct {
 	// Specifies the bucket where you want Amazon S3 to store server access logs.
 	// You can have your logs delivered to any bucket that you own, including the
@@ -3623,6 +4604,16 @@ type LoggingEnabled struct {
 
 type metadataLoggingEnabled struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s LoggingEnabled) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s LoggingEnabled) GoString() string {
+	return s.String()
 }
 
 type MultipartUpload struct {
@@ -3650,6 +4641,16 @@ type metadataMultipartUpload struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MultipartUpload) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MultipartUpload) GoString() string {
+	return s.String()
+}
+
 // Specifies when noncurrent object versions expire. Upon expiration, Amazon
 // S3 permanently deletes the noncurrent object versions. You set this lifecycle
 // configuration action on a bucket that has versioning enabled (or suspended)
@@ -3668,6 +4669,16 @@ type NoncurrentVersionExpiration struct {
 
 type metadataNoncurrentVersionExpiration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NoncurrentVersionExpiration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NoncurrentVersionExpiration) GoString() string {
+	return s.String()
 }
 
 // Container for the transition rule that describes when noncurrent objects
@@ -3693,6 +4704,16 @@ type metadataNoncurrentVersionTransition struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NoncurrentVersionTransition) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NoncurrentVersionTransition) GoString() string {
+	return s.String()
+}
+
 // Container for specifying the notification configuration of the bucket. If
 // this element is empty, notifications are turned off on the bucket.
 type NotificationConfiguration struct {
@@ -3709,6 +4730,16 @@ type metadataNotificationConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NotificationConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NotificationConfiguration) GoString() string {
+	return s.String()
+}
+
 type NotificationConfigurationDeprecated struct {
 	CloudFunctionConfiguration *CloudFunctionConfiguration `type:"structure"`
 
@@ -3721,6 +4752,16 @@ type NotificationConfigurationDeprecated struct {
 
 type metadataNotificationConfigurationDeprecated struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s NotificationConfigurationDeprecated) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NotificationConfigurationDeprecated) GoString() string {
+	return s.String()
 }
 
 type Object struct {
@@ -3744,6 +4785,16 @@ type metadataObject struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Object) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Object) GoString() string {
+	return s.String()
+}
+
 type ObjectIdentifier struct {
 	// Key name of the object to delete.
 	Key *string `type:"string" required:"true"`
@@ -3756,6 +4807,16 @@ type ObjectIdentifier struct {
 
 type metadataObjectIdentifier struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ObjectIdentifier) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ObjectIdentifier) GoString() string {
+	return s.String()
 }
 
 type ObjectVersion struct {
@@ -3789,6 +4850,16 @@ type metadataObjectVersion struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ObjectVersion) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ObjectVersion) GoString() string {
+	return s.String()
+}
+
 type Owner struct {
 	DisplayName *string `type:"string"`
 
@@ -3799,6 +4870,16 @@ type Owner struct {
 
 type metadataOwner struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Owner) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Owner) GoString() string {
+	return s.String()
 }
 
 type Part struct {
@@ -3820,6 +4901,16 @@ type Part struct {
 
 type metadataPart struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Part) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Part) GoString() string {
+	return s.String()
 }
 
 type PutBucketACLInput struct {
@@ -3853,12 +4944,32 @@ type metadataPutBucketACLInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"AccessControlPolicy"`
 }
 
+// String returns the string representation
+func (s PutBucketACLInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketACLInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketACLOutput struct {
 	metadataPutBucketACLOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketACLOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketACLOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketACLOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketCORSInput struct {
@@ -3873,12 +4984,32 @@ type metadataPutBucketCORSInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CORSConfiguration"`
 }
 
+// String returns the string representation
+func (s PutBucketCORSInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketCORSInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketCORSOutput struct {
 	metadataPutBucketCORSOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketCORSOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketCORSOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketCORSOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketLifecycleInput struct {
@@ -3893,12 +5024,32 @@ type metadataPutBucketLifecycleInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"LifecycleConfiguration"`
 }
 
+// String returns the string representation
+func (s PutBucketLifecycleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketLifecycleInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketLifecycleOutput struct {
 	metadataPutBucketLifecycleOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketLifecycleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketLifecycleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketLifecycleOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketLoggingInput struct {
@@ -3913,12 +5064,32 @@ type metadataPutBucketLoggingInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"BucketLoggingStatus"`
 }
 
+// String returns the string representation
+func (s PutBucketLoggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketLoggingInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketLoggingOutput struct {
 	metadataPutBucketLoggingOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketLoggingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketLoggingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketLoggingOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketNotificationConfigurationInput struct {
@@ -3935,12 +5106,32 @@ type metadataPutBucketNotificationConfigurationInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"NotificationConfiguration"`
 }
 
+// String returns the string representation
+func (s PutBucketNotificationConfigurationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketNotificationConfigurationInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketNotificationConfigurationOutput struct {
 	metadataPutBucketNotificationConfigurationOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketNotificationConfigurationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketNotificationConfigurationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketNotificationConfigurationOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketNotificationInput struct {
@@ -3955,12 +5146,32 @@ type metadataPutBucketNotificationInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"NotificationConfiguration"`
 }
 
+// String returns the string representation
+func (s PutBucketNotificationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketNotificationInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketNotificationOutput struct {
 	metadataPutBucketNotificationOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketNotificationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketNotificationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketNotificationOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketPolicyInput struct {
@@ -3976,12 +5187,32 @@ type metadataPutBucketPolicyInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Policy"`
 }
 
+// String returns the string representation
+func (s PutBucketPolicyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketPolicyInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketPolicyOutput struct {
 	metadataPutBucketPolicyOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketPolicyOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketPolicyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketPolicyOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketReplicationInput struct {
@@ -3998,12 +5229,32 @@ type metadataPutBucketReplicationInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"ReplicationConfiguration"`
 }
 
+// String returns the string representation
+func (s PutBucketReplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketReplicationInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketReplicationOutput struct {
 	metadataPutBucketReplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketReplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketReplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketReplicationOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketRequestPaymentInput struct {
@@ -4018,12 +5269,32 @@ type metadataPutBucketRequestPaymentInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"RequestPaymentConfiguration"`
 }
 
+// String returns the string representation
+func (s PutBucketRequestPaymentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketRequestPaymentInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketRequestPaymentOutput struct {
 	metadataPutBucketRequestPaymentOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketRequestPaymentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketRequestPaymentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketRequestPaymentOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketTaggingInput struct {
@@ -4038,12 +5309,32 @@ type metadataPutBucketTaggingInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Tagging"`
 }
 
+// String returns the string representation
+func (s PutBucketTaggingInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketTaggingInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketTaggingOutput struct {
 	metadataPutBucketTaggingOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketTaggingOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketTaggingOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketTaggingOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketVersioningInput struct {
@@ -4062,12 +5353,32 @@ type metadataPutBucketVersioningInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"VersioningConfiguration"`
 }
 
+// String returns the string representation
+func (s PutBucketVersioningInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketVersioningInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketVersioningOutput struct {
 	metadataPutBucketVersioningOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketVersioningOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketVersioningOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketVersioningOutput) GoString() string {
+	return s.String()
 }
 
 type PutBucketWebsiteInput struct {
@@ -4082,12 +5393,32 @@ type metadataPutBucketWebsiteInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"WebsiteConfiguration"`
 }
 
+// String returns the string representation
+func (s PutBucketWebsiteInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketWebsiteInput) GoString() string {
+	return s.String()
+}
+
 type PutBucketWebsiteOutput struct {
 	metadataPutBucketWebsiteOutput `json:"-" xml:"-"`
 }
 
 type metadataPutBucketWebsiteOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketWebsiteOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketWebsiteOutput) GoString() string {
+	return s.String()
 }
 
 type PutObjectACLInput struct {
@@ -4129,6 +5460,16 @@ type metadataPutObjectACLInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"AccessControlPolicy"`
 }
 
+// String returns the string representation
+func (s PutObjectACLInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutObjectACLInput) GoString() string {
+	return s.String()
+}
+
 type PutObjectACLOutput struct {
 	// If present, indicates that the requester was successfully charged for the
 	// request.
@@ -4139,6 +5480,16 @@ type PutObjectACLOutput struct {
 
 type metadataPutObjectACLOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutObjectACLOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutObjectACLOutput) GoString() string {
+	return s.String()
 }
 
 type PutObjectInput struct {
@@ -4237,6 +5588,16 @@ type metadataPutObjectInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Body"`
 }
 
+// String returns the string representation
+func (s PutObjectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutObjectInput) GoString() string {
+	return s.String()
+}
+
 type PutObjectOutput struct {
 	// Entity tag for the uploaded object.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
@@ -4277,6 +5638,16 @@ type metadataPutObjectOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PutObjectOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PutObjectOutput) GoString() string {
+	return s.String()
+}
+
 // Container for specifying an configuration when you want Amazon S3 to publish
 // events to an Amazon Simple Queue Service (Amazon SQS) queue.
 type QueueConfiguration struct {
@@ -4297,6 +5668,16 @@ type metadataQueueConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s QueueConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s QueueConfiguration) GoString() string {
+	return s.String()
+}
+
 type QueueConfigurationDeprecated struct {
 	// Bucket event for which to send notifications.
 	Event *string `type:"string"`
@@ -4314,6 +5695,16 @@ type QueueConfigurationDeprecated struct {
 
 type metadataQueueConfigurationDeprecated struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s QueueConfigurationDeprecated) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s QueueConfigurationDeprecated) GoString() string {
+	return s.String()
 }
 
 type Redirect struct {
@@ -4348,6 +5739,16 @@ type metadataRedirect struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Redirect) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Redirect) GoString() string {
+	return s.String()
+}
+
 type RedirectAllRequestsTo struct {
 	// Name of the host where requests will be redirected.
 	HostName *string `type:"string" required:"true"`
@@ -4361,6 +5762,16 @@ type RedirectAllRequestsTo struct {
 
 type metadataRedirectAllRequestsTo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RedirectAllRequestsTo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RedirectAllRequestsTo) GoString() string {
+	return s.String()
 }
 
 // Container for replication rules. You can add as many as 1,000 rules. Total
@@ -4379,6 +5790,16 @@ type ReplicationConfiguration struct {
 
 type metadataReplicationConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReplicationConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplicationConfiguration) GoString() string {
+	return s.String()
 }
 
 type ReplicationRule struct {
@@ -4402,6 +5823,16 @@ type metadataReplicationRule struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReplicationRule) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReplicationRule) GoString() string {
+	return s.String()
+}
+
 type RequestPaymentConfiguration struct {
 	// Specifies who pays for the download and request fees.
 	Payer *string `type:"string" required:"true"`
@@ -4411,6 +5842,16 @@ type RequestPaymentConfiguration struct {
 
 type metadataRequestPaymentConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RequestPaymentConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestPaymentConfiguration) GoString() string {
+	return s.String()
 }
 
 type RestoreObjectInput struct {
@@ -4435,6 +5876,16 @@ type metadataRestoreObjectInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"RestoreRequest"`
 }
 
+// String returns the string representation
+func (s RestoreObjectInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreObjectInput) GoString() string {
+	return s.String()
+}
+
 type RestoreObjectOutput struct {
 	// If present, indicates that the requester was successfully charged for the
 	// request.
@@ -4447,6 +5898,16 @@ type metadataRestoreObjectOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RestoreObjectOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreObjectOutput) GoString() string {
+	return s.String()
+}
+
 type RestoreRequest struct {
 	// Lifetime of the active copy in days
 	Days *int64 `type:"integer" required:"true"`
@@ -4456,6 +5917,16 @@ type RestoreRequest struct {
 
 type metadataRestoreRequest struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RestoreRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RestoreRequest) GoString() string {
+	return s.String()
 }
 
 type RoutingRule struct {
@@ -4477,6 +5948,16 @@ type metadataRoutingRule struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RoutingRule) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RoutingRule) GoString() string {
+	return s.String()
+}
+
 type Tag struct {
 	// Name of the tag.
 	Key *string `type:"string" required:"true"`
@@ -4491,6 +5972,16 @@ type metadataTag struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Tag) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tag) GoString() string {
+	return s.String()
+}
+
 type Tagging struct {
 	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
 
@@ -4499,6 +5990,16 @@ type Tagging struct {
 
 type metadataTagging struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tagging) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tagging) GoString() string {
+	return s.String()
 }
 
 type TargetGrant struct {
@@ -4512,6 +6013,16 @@ type TargetGrant struct {
 
 type metadataTargetGrant struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TargetGrant) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TargetGrant) GoString() string {
+	return s.String()
 }
 
 // Container for specifying the configuration when you want Amazon S3 to publish
@@ -4532,6 +6043,16 @@ type TopicConfiguration struct {
 
 type metadataTopicConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TopicConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TopicConfiguration) GoString() string {
+	return s.String()
 }
 
 type TopicConfigurationDeprecated struct {
@@ -4555,6 +6076,16 @@ type metadataTopicConfigurationDeprecated struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TopicConfigurationDeprecated) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TopicConfigurationDeprecated) GoString() string {
+	return s.String()
+}
+
 type Transition struct {
 	// Indicates at what date the object is to be moved or deleted. Should be in
 	// GMT ISO 8601 Format.
@@ -4572,6 +6103,16 @@ type Transition struct {
 
 type metadataTransition struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Transition) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Transition) GoString() string {
+	return s.String()
 }
 
 type UploadPartCopyInput struct {
@@ -4652,6 +6193,16 @@ type metadataUploadPartCopyInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UploadPartCopyInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadPartCopyInput) GoString() string {
+	return s.String()
+}
+
 type UploadPartCopyOutput struct {
 	CopyPartResult *CopyPartResult `type:"structure"`
 
@@ -4686,6 +6237,16 @@ type UploadPartCopyOutput struct {
 
 type metadataUploadPartCopyOutput struct {
 	SDKShapeTraits bool `type:"structure" payload:"CopyPartResult"`
+}
+
+// String returns the string representation
+func (s UploadPartCopyOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadPartCopyOutput) GoString() string {
+	return s.String()
 }
 
 type UploadPartInput struct {
@@ -4735,6 +6296,16 @@ type metadataUploadPartInput struct {
 	SDKShapeTraits bool `type:"structure" payload:"Body"`
 }
 
+// String returns the string representation
+func (s UploadPartInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadPartInput) GoString() string {
+	return s.String()
+}
+
 type UploadPartOutput struct {
 	// Entity tag for the uploaded object.
 	ETag *string `location:"header" locationName:"ETag" type:"string"`
@@ -4768,6 +6339,16 @@ type metadataUploadPartOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UploadPartOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UploadPartOutput) GoString() string {
+	return s.String()
+}
+
 type VersioningConfiguration struct {
 	// Specifies whether MFA delete is enabled in the bucket versioning configuration.
 	// This element is only returned if the bucket has been configured with MFA
@@ -4784,6 +6365,16 @@ type metadataVersioningConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VersioningConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VersioningConfiguration) GoString() string {
+	return s.String()
+}
+
 type WebsiteConfiguration struct {
 	ErrorDocument *ErrorDocument `type:"structure"`
 
@@ -4798,4 +6389,14 @@ type WebsiteConfiguration struct {
 
 type metadataWebsiteConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WebsiteConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WebsiteConfiguration) GoString() string {
+	return s.String()
 }

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opDeleteIdentity = "DeleteIdentity"
@@ -677,6 +678,16 @@ type metadataBody struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Body) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Body) GoString() string {
+	return s.String()
+}
+
 // Represents textual data, plus an optional character set specification.
 //
 // By default, the text must be 7-bit ASCII, due to the constraints of the
@@ -696,6 +707,16 @@ type metadataContent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Content) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Content) GoString() string {
+	return s.String()
+}
+
 // Represents a request instructing the service to delete an identity from the
 // list of identities for the AWS Account.
 type DeleteIdentityInput struct {
@@ -709,6 +730,16 @@ type metadataDeleteIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteIdentityInput) GoString() string {
+	return s.String()
+}
+
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type DeleteIdentityOutput struct {
@@ -717,6 +748,16 @@ type DeleteIdentityOutput struct {
 
 type metadataDeleteIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteIdentityOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a request instructing the service to delete an address from the
@@ -732,12 +773,32 @@ type metadataDeleteVerifiedEmailAddressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVerifiedEmailAddressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVerifiedEmailAddressInput) GoString() string {
+	return s.String()
+}
+
 type DeleteVerifiedEmailAddressOutput struct {
 	metadataDeleteVerifiedEmailAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteVerifiedEmailAddressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteVerifiedEmailAddressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVerifiedEmailAddressOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the destination of the message, consisting of To:, CC:, and BCC:
@@ -764,6 +825,16 @@ type metadataDestination struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Destination) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Destination) GoString() string {
+	return s.String()
+}
+
 // Given a list of verified identities, describes their DKIM attributes. The
 // DKIM attributes of an email address identity includes whether DKIM signing
 // is individually enabled or disabled for that address. The DKIM attributes
@@ -782,6 +853,16 @@ type metadataGetIdentityDKIMAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetIdentityDKIMAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityDKIMAttributesInput) GoString() string {
+	return s.String()
+}
+
 // Represents a list of all the DKIM attributes for the specified identity.
 type GetIdentityDKIMAttributesOutput struct {
 	// The DKIM attributes for an email address or a domain.
@@ -794,6 +875,16 @@ type metadataGetIdentityDKIMAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetIdentityDKIMAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityDKIMAttributesOutput) GoString() string {
+	return s.String()
+}
+
 type GetIdentityNotificationAttributesInput struct {
 	// A list of one or more identities.
 	Identities []*string `type:"list" required:"true"`
@@ -803,6 +894,16 @@ type GetIdentityNotificationAttributesInput struct {
 
 type metadataGetIdentityNotificationAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetIdentityNotificationAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityNotificationAttributesInput) GoString() string {
+	return s.String()
 }
 
 // Describes whether an identity has Amazon Simple Notification Service (Amazon
@@ -820,6 +921,16 @@ type metadataGetIdentityNotificationAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetIdentityNotificationAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityNotificationAttributesOutput) GoString() string {
+	return s.String()
+}
+
 // Represents a request instructing the service to provide the verification
 // attributes for a list of identities.
 type GetIdentityVerificationAttributesInput struct {
@@ -831,6 +942,16 @@ type GetIdentityVerificationAttributesInput struct {
 
 type metadataGetIdentityVerificationAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetIdentityVerificationAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityVerificationAttributesInput) GoString() string {
+	return s.String()
 }
 
 // Represents the verification attributes for a list of identities.
@@ -845,12 +966,32 @@ type metadataGetIdentityVerificationAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetIdentityVerificationAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetIdentityVerificationAttributesOutput) GoString() string {
+	return s.String()
+}
+
 type GetSendQuotaInput struct {
 	metadataGetSendQuotaInput `json:"-" xml:"-"`
 }
 
 type metadataGetSendQuotaInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetSendQuotaInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSendQuotaInput) GoString() string {
+	return s.String()
 }
 
 // Represents the user's current activity limits returned from a successful
@@ -877,12 +1018,32 @@ type metadataGetSendQuotaOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetSendQuotaOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSendQuotaOutput) GoString() string {
+	return s.String()
+}
+
 type GetSendStatisticsInput struct {
 	metadataGetSendStatisticsInput `json:"-" xml:"-"`
 }
 
 type metadataGetSendStatisticsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetSendStatisticsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSendStatisticsInput) GoString() string {
+	return s.String()
 }
 
 // Represents a list of SendDataPoint items returned from a successful GetSendStatistics
@@ -897,6 +1058,16 @@ type GetSendStatisticsOutput struct {
 
 type metadataGetSendStatisticsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetSendStatisticsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSendStatisticsOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the DKIM attributes of a verified email address or a domain.
@@ -926,6 +1097,16 @@ type IdentityDKIMAttributes struct {
 
 type metadataIdentityDKIMAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IdentityDKIMAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IdentityDKIMAttributes) GoString() string {
+	return s.String()
 }
 
 // Represents the notification attributes of an identity, including whether
@@ -958,6 +1139,16 @@ type metadataIdentityNotificationAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s IdentityNotificationAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IdentityNotificationAttributes) GoString() string {
+	return s.String()
+}
+
 // Represents the verification attributes of a single identity.
 type IdentityVerificationAttributes struct {
 	// The verification status of the identity: "Pending", "Success", "Failed",
@@ -972,6 +1163,16 @@ type IdentityVerificationAttributes struct {
 
 type metadataIdentityVerificationAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s IdentityVerificationAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s IdentityVerificationAttributes) GoString() string {
+	return s.String()
 }
 
 // Represents a request instructing the service to list all identities for the
@@ -994,6 +1195,16 @@ type metadataListIdentitiesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListIdentitiesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListIdentitiesInput) GoString() string {
+	return s.String()
+}
+
 // Represents a list of all verified identities for the AWS Account.
 type ListIdentitiesOutput struct {
 	// A list of identities.
@@ -1009,12 +1220,32 @@ type metadataListIdentitiesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListIdentitiesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListIdentitiesOutput) GoString() string {
+	return s.String()
+}
+
 type ListVerifiedEmailAddressesInput struct {
 	metadataListVerifiedEmailAddressesInput `json:"-" xml:"-"`
 }
 
 type metadataListVerifiedEmailAddressesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListVerifiedEmailAddressesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVerifiedEmailAddressesInput) GoString() string {
+	return s.String()
 }
 
 // Represents a list of all the email addresses verified for the current user.
@@ -1027,6 +1258,16 @@ type ListVerifiedEmailAddressesOutput struct {
 
 type metadataListVerifiedEmailAddressesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListVerifiedEmailAddressesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVerifiedEmailAddressesOutput) GoString() string {
+	return s.String()
 }
 
 // Represents the message to be sent, composed of a subject and a body.
@@ -1045,6 +1286,16 @@ type metadataMessage struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Message) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Message) GoString() string {
+	return s.String()
+}
+
 // Represents the raw data of the message.
 type RawMessage struct {
 	// The raw data of the message. The client must ensure that the message format
@@ -1061,6 +1312,16 @@ type RawMessage struct {
 
 type metadataRawMessage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RawMessage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RawMessage) GoString() string {
+	return s.String()
 }
 
 // Represents sending statistics data. Each SendDataPoint contains statistics
@@ -1086,6 +1347,16 @@ type SendDataPoint struct {
 
 type metadataSendDataPoint struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SendDataPoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendDataPoint) GoString() string {
+	return s.String()
 }
 
 // Represents a request instructing the service to send a single email message.
@@ -1128,6 +1399,16 @@ type metadataSendEmailInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SendEmailInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendEmailInput) GoString() string {
+	return s.String()
+}
+
 // Represents a unique message ID returned from a successful SendEmail request.
 type SendEmailOutput struct {
 	// The unique message identifier returned from the SendEmail action.
@@ -1138,6 +1419,16 @@ type SendEmailOutput struct {
 
 type metadataSendEmailOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SendEmailOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendEmailOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a request instructing the service to send a raw email message.
@@ -1182,6 +1473,16 @@ type metadataSendRawEmailInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SendRawEmailInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendRawEmailInput) GoString() string {
+	return s.String()
+}
+
 // Represents a unique message ID returned from a successful SendRawEmail request.
 type SendRawEmailOutput struct {
 	// The unique message identifier returned from the SendRawEmail action.
@@ -1192,6 +1493,16 @@ type SendRawEmailOutput struct {
 
 type metadataSendRawEmailOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SendRawEmailOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendRawEmailOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a request instructing the service to enable or disable DKIM signing
@@ -1211,6 +1522,16 @@ type metadataSetIdentityDKIMEnabledInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetIdentityDKIMEnabledInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityDKIMEnabledInput) GoString() string {
+	return s.String()
+}
+
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityDKIMEnabledOutput struct {
@@ -1219,6 +1540,16 @@ type SetIdentityDKIMEnabledOutput struct {
 
 type metadataSetIdentityDKIMEnabledOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetIdentityDKIMEnabledOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityDKIMEnabledOutput) GoString() string {
+	return s.String()
 }
 
 type SetIdentityFeedbackForwardingEnabledInput struct {
@@ -1241,6 +1572,16 @@ type metadataSetIdentityFeedbackForwardingEnabledInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetIdentityFeedbackForwardingEnabledInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityFeedbackForwardingEnabledInput) GoString() string {
+	return s.String()
+}
+
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityFeedbackForwardingEnabledOutput struct {
@@ -1249,6 +1590,16 @@ type SetIdentityFeedbackForwardingEnabledOutput struct {
 
 type metadataSetIdentityFeedbackForwardingEnabledOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetIdentityFeedbackForwardingEnabledOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityFeedbackForwardingEnabledOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a request to set or clear an identity's notification topic.
@@ -1273,6 +1624,16 @@ type metadataSetIdentityNotificationTopicInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetIdentityNotificationTopicInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityNotificationTopicInput) GoString() string {
+	return s.String()
+}
+
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type SetIdentityNotificationTopicOutput struct {
@@ -1281,6 +1642,16 @@ type SetIdentityNotificationTopicOutput struct {
 
 type metadataSetIdentityNotificationTopicOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetIdentityNotificationTopicOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetIdentityNotificationTopicOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a request instructing the service to begin DKIM verification for
@@ -1294,6 +1665,16 @@ type VerifyDomainDKIMInput struct {
 
 type metadataVerifyDomainDKIMInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VerifyDomainDKIMInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VerifyDomainDKIMInput) GoString() string {
+	return s.String()
 }
 
 // Represents the DNS records that must be published in the domain name's DNS
@@ -1319,6 +1700,16 @@ type metadataVerifyDomainDKIMOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VerifyDomainDKIMOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VerifyDomainDKIMOutput) GoString() string {
+	return s.String()
+}
+
 // Represents a request instructing the service to begin domain verification.
 type VerifyDomainIdentityInput struct {
 	// The domain to be verified.
@@ -1329,6 +1720,16 @@ type VerifyDomainIdentityInput struct {
 
 type metadataVerifyDomainIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VerifyDomainIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VerifyDomainIdentityInput) GoString() string {
+	return s.String()
 }
 
 // Represents a token used for domain ownership verification.
@@ -1344,6 +1745,16 @@ type metadataVerifyDomainIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VerifyDomainIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VerifyDomainIdentityOutput) GoString() string {
+	return s.String()
+}
+
 // Represents a request instructing the service to begin email address verification.
 type VerifyEmailAddressInput struct {
 	// The email address to be verified.
@@ -1356,12 +1767,32 @@ type metadataVerifyEmailAddressInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VerifyEmailAddressInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VerifyEmailAddressInput) GoString() string {
+	return s.String()
+}
+
 type VerifyEmailAddressOutput struct {
 	metadataVerifyEmailAddressOutput `json:"-" xml:"-"`
 }
 
 type metadataVerifyEmailAddressOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VerifyEmailAddressOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VerifyEmailAddressOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a request instructing the service to begin email address verification.
@@ -1376,6 +1807,16 @@ type metadataVerifyEmailIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VerifyEmailIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VerifyEmailIdentityInput) GoString() string {
+	return s.String()
+}
+
 // An empty element. Receiving this element indicates that the request completed
 // successfully.
 type VerifyEmailIdentityOutput struct {
@@ -1384,4 +1825,14 @@ type VerifyEmailIdentityOutput struct {
 
 type metadataVerifyEmailIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VerifyEmailIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VerifyEmailIdentityOutput) GoString() string {
+	return s.String()
 }

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -5,6 +5,7 @@ package sns
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddPermission = "AddPermission"
@@ -859,12 +860,32 @@ type metadataAddPermissionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddPermissionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddPermissionInput) GoString() string {
+	return s.String()
+}
+
 type AddPermissionOutput struct {
 	metadataAddPermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataAddPermissionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddPermissionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddPermissionOutput) GoString() string {
+	return s.String()
 }
 
 // Input for ConfirmSubscription action.
@@ -888,6 +909,16 @@ type metadataConfirmSubscriptionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ConfirmSubscriptionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmSubscriptionInput) GoString() string {
+	return s.String()
+}
+
 // Response for ConfirmSubscriptions action.
 type ConfirmSubscriptionOutput struct {
 	// The ARN of the created subscription.
@@ -898,6 +929,16 @@ type ConfirmSubscriptionOutput struct {
 
 type metadataConfirmSubscriptionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ConfirmSubscriptionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ConfirmSubscriptionOutput) GoString() string {
+	return s.String()
 }
 
 // Input for CreatePlatformApplication action.
@@ -921,6 +962,16 @@ type metadataCreatePlatformApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePlatformApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePlatformApplicationInput) GoString() string {
+	return s.String()
+}
+
 // Response from CreatePlatformApplication action.
 type CreatePlatformApplicationOutput struct {
 	// PlatformApplicationArn is returned.
@@ -931,6 +982,16 @@ type CreatePlatformApplicationOutput struct {
 
 type metadataCreatePlatformApplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreatePlatformApplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePlatformApplicationOutput) GoString() string {
+	return s.String()
 }
 
 // Input for CreatePlatformEndpoint action.
@@ -960,6 +1021,16 @@ type metadataCreatePlatformEndpointInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreatePlatformEndpointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePlatformEndpointInput) GoString() string {
+	return s.String()
+}
+
 // Response from CreateEndpoint action.
 type CreatePlatformEndpointOutput struct {
 	// EndpointArn returned from CreateEndpoint action.
@@ -970,6 +1041,16 @@ type CreatePlatformEndpointOutput struct {
 
 type metadataCreatePlatformEndpointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreatePlatformEndpointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreatePlatformEndpointOutput) GoString() string {
+	return s.String()
 }
 
 // Input for CreateTopic action.
@@ -988,6 +1069,16 @@ type metadataCreateTopicInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTopicInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTopicInput) GoString() string {
+	return s.String()
+}
+
 // Response from CreateTopic action.
 type CreateTopicOutput struct {
 	// The Amazon Resource Name (ARN) assigned to the created topic.
@@ -998,6 +1089,16 @@ type CreateTopicOutput struct {
 
 type metadataCreateTopicOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTopicOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTopicOutput) GoString() string {
+	return s.String()
 }
 
 // Input for DeleteEndpoint action.
@@ -1012,12 +1113,32 @@ type metadataDeleteEndpointInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteEndpointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEndpointInput) GoString() string {
+	return s.String()
+}
+
 type DeleteEndpointOutput struct {
 	metadataDeleteEndpointOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteEndpointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteEndpointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteEndpointOutput) GoString() string {
+	return s.String()
 }
 
 // Input for DeletePlatformApplication action.
@@ -1032,12 +1153,32 @@ type metadataDeletePlatformApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeletePlatformApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePlatformApplicationInput) GoString() string {
+	return s.String()
+}
+
 type DeletePlatformApplicationOutput struct {
 	metadataDeletePlatformApplicationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeletePlatformApplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeletePlatformApplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeletePlatformApplicationOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteTopicInput struct {
@@ -1051,12 +1192,32 @@ type metadataDeleteTopicInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTopicInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTopicInput) GoString() string {
+	return s.String()
+}
+
 type DeleteTopicOutput struct {
 	metadataDeleteTopicOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteTopicOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTopicOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTopicOutput) GoString() string {
+	return s.String()
 }
 
 // Endpoint for mobile app and device.
@@ -1074,6 +1235,16 @@ type metadataEndpoint struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Endpoint) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Endpoint) GoString() string {
+	return s.String()
+}
+
 // Input for GetEndpointAttributes action.
 type GetEndpointAttributesInput struct {
 	// EndpointArn for GetEndpointAttributes input.
@@ -1084,6 +1255,16 @@ type GetEndpointAttributesInput struct {
 
 type metadataGetEndpointAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetEndpointAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetEndpointAttributesInput) GoString() string {
+	return s.String()
 }
 
 // Response from GetEndpointAttributes of the EndpointArn.
@@ -1108,6 +1289,16 @@ type metadataGetEndpointAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetEndpointAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetEndpointAttributesOutput) GoString() string {
+	return s.String()
+}
+
 // Input for GetPlatformApplicationAttributes action.
 type GetPlatformApplicationAttributesInput struct {
 	// PlatformApplicationArn for GetPlatformApplicationAttributesInput.
@@ -1118,6 +1309,16 @@ type GetPlatformApplicationAttributesInput struct {
 
 type metadataGetPlatformApplicationAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetPlatformApplicationAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPlatformApplicationAttributesInput) GoString() string {
+	return s.String()
 }
 
 // Response for GetPlatformApplicationAttributes action.
@@ -1140,6 +1341,16 @@ type metadataGetPlatformApplicationAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetPlatformApplicationAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetPlatformApplicationAttributesOutput) GoString() string {
+	return s.String()
+}
+
 // Input for GetSubscriptionAttributes.
 type GetSubscriptionAttributesInput struct {
 	// The ARN of the subscription whose properties you want to get.
@@ -1150,6 +1361,16 @@ type GetSubscriptionAttributesInput struct {
 
 type metadataGetSubscriptionAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetSubscriptionAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSubscriptionAttributesInput) GoString() string {
+	return s.String()
 }
 
 // Response for GetSubscriptionAttributes action.
@@ -1173,6 +1394,16 @@ type metadataGetSubscriptionAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetSubscriptionAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSubscriptionAttributesOutput) GoString() string {
+	return s.String()
+}
+
 // Input for GetTopicAttributes action.
 type GetTopicAttributesInput struct {
 	// The ARN of the topic whose properties you want to get.
@@ -1183,6 +1414,16 @@ type GetTopicAttributesInput struct {
 
 type metadataGetTopicAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetTopicAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetTopicAttributesInput) GoString() string {
+	return s.String()
 }
 
 // Response for GetTopicAttributes action.
@@ -1208,6 +1449,16 @@ type metadataGetTopicAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetTopicAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetTopicAttributesOutput) GoString() string {
+	return s.String()
+}
+
 // Input for ListEndpointsByPlatformApplication action.
 type ListEndpointsByPlatformApplicationInput struct {
 	// NextToken string is used when calling ListEndpointsByPlatformApplication
@@ -1223,6 +1474,16 @@ type ListEndpointsByPlatformApplicationInput struct {
 
 type metadataListEndpointsByPlatformApplicationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListEndpointsByPlatformApplicationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListEndpointsByPlatformApplicationInput) GoString() string {
+	return s.String()
 }
 
 // Response for ListEndpointsByPlatformApplication action.
@@ -1241,6 +1502,16 @@ type metadataListEndpointsByPlatformApplicationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListEndpointsByPlatformApplicationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListEndpointsByPlatformApplicationOutput) GoString() string {
+	return s.String()
+}
+
 // Input for ListPlatformApplications action.
 type ListPlatformApplicationsInput struct {
 	// NextToken string is used when calling ListPlatformApplications action to
@@ -1252,6 +1523,16 @@ type ListPlatformApplicationsInput struct {
 
 type metadataListPlatformApplicationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListPlatformApplicationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPlatformApplicationsInput) GoString() string {
+	return s.String()
 }
 
 // Response for ListPlatformApplications action.
@@ -1270,6 +1551,16 @@ type metadataListPlatformApplicationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListPlatformApplicationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListPlatformApplicationsOutput) GoString() string {
+	return s.String()
+}
+
 // Input for ListSubscriptionsByTopic action.
 type ListSubscriptionsByTopicInput struct {
 	// Token returned by the previous ListSubscriptionsByTopic request.
@@ -1283,6 +1574,16 @@ type ListSubscriptionsByTopicInput struct {
 
 type metadataListSubscriptionsByTopicInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListSubscriptionsByTopicInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListSubscriptionsByTopicInput) GoString() string {
+	return s.String()
 }
 
 // Response for ListSubscriptionsByTopic action.
@@ -1301,6 +1602,16 @@ type metadataListSubscriptionsByTopicOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListSubscriptionsByTopicOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListSubscriptionsByTopicOutput) GoString() string {
+	return s.String()
+}
+
 // Input for ListSubscriptions action.
 type ListSubscriptionsInput struct {
 	// Token returned by the previous ListSubscriptions request.
@@ -1311,6 +1622,16 @@ type ListSubscriptionsInput struct {
 
 type metadataListSubscriptionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListSubscriptionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListSubscriptionsInput) GoString() string {
+	return s.String()
 }
 
 // Response for ListSubscriptions action
@@ -1329,6 +1650,16 @@ type metadataListSubscriptionsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListSubscriptionsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListSubscriptionsOutput) GoString() string {
+	return s.String()
+}
+
 type ListTopicsInput struct {
 	// Token returned by the previous ListTopics request.
 	NextToken *string `type:"string"`
@@ -1338,6 +1669,16 @@ type ListTopicsInput struct {
 
 type metadataListTopicsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTopicsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTopicsInput) GoString() string {
+	return s.String()
 }
 
 // Response for ListTopics action.
@@ -1354,6 +1695,16 @@ type ListTopicsOutput struct {
 
 type metadataListTopicsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListTopicsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListTopicsOutput) GoString() string {
+	return s.String()
 }
 
 // The user-specified message attribute value. For string data types, the value
@@ -1385,6 +1736,16 @@ type metadataMessageAttributeValue struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MessageAttributeValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MessageAttributeValue) GoString() string {
+	return s.String()
+}
+
 // Platform application object.
 type PlatformApplication struct {
 	// Attributes for platform application object.
@@ -1398,6 +1759,16 @@ type PlatformApplication struct {
 
 type metadataPlatformApplication struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PlatformApplication) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PlatformApplication) GoString() string {
+	return s.String()
 }
 
 // Input for Publish action.
@@ -1471,6 +1842,16 @@ type metadataPublishInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PublishInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PublishInput) GoString() string {
+	return s.String()
+}
+
 // Response for Publish action.
 type PublishOutput struct {
 	// Unique identifier assigned to the published message.
@@ -1483,6 +1864,16 @@ type PublishOutput struct {
 
 type metadataPublishOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PublishOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PublishOutput) GoString() string {
+	return s.String()
 }
 
 // Input for RemovePermission action.
@@ -1500,12 +1891,32 @@ type metadataRemovePermissionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemovePermissionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemovePermissionInput) GoString() string {
+	return s.String()
+}
+
 type RemovePermissionOutput struct {
 	metadataRemovePermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemovePermissionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemovePermissionOutput) GoString() string {
+	return s.String()
 }
 
 // Input for SetEndpointAttributes action.
@@ -1533,12 +1944,32 @@ type metadataSetEndpointAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetEndpointAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetEndpointAttributesInput) GoString() string {
+	return s.String()
+}
+
 type SetEndpointAttributesOutput struct {
 	metadataSetEndpointAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetEndpointAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetEndpointAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetEndpointAttributesOutput) GoString() string {
+	return s.String()
 }
 
 // Input for SetPlatformApplicationAttributes action.
@@ -1570,12 +2001,32 @@ type metadataSetPlatformApplicationAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetPlatformApplicationAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetPlatformApplicationAttributesInput) GoString() string {
+	return s.String()
+}
+
 type SetPlatformApplicationAttributesOutput struct {
 	metadataSetPlatformApplicationAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetPlatformApplicationAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetPlatformApplicationAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetPlatformApplicationAttributesOutput) GoString() string {
+	return s.String()
 }
 
 // Input for SetSubscriptionAttributes action.
@@ -1599,12 +2050,32 @@ type metadataSetSubscriptionAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetSubscriptionAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetSubscriptionAttributesInput) GoString() string {
+	return s.String()
+}
+
 type SetSubscriptionAttributesOutput struct {
 	metadataSetSubscriptionAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetSubscriptionAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetSubscriptionAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetSubscriptionAttributesOutput) GoString() string {
+	return s.String()
 }
 
 // Input for SetTopicAttributes action.
@@ -1628,12 +2099,32 @@ type metadataSetTopicAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetTopicAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetTopicAttributesInput) GoString() string {
+	return s.String()
+}
+
 type SetTopicAttributesOutput struct {
 	metadataSetTopicAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetTopicAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetTopicAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetTopicAttributesOutput) GoString() string {
+	return s.String()
 }
 
 // Input for Subscribe action.
@@ -1669,6 +2160,16 @@ type metadataSubscribeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SubscribeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubscribeInput) GoString() string {
+	return s.String()
+}
+
 // Response for Subscribe action.
 type SubscribeOutput struct {
 	// The ARN of the subscription, if the service was able to create a subscription
@@ -1680,6 +2181,16 @@ type SubscribeOutput struct {
 
 type metadataSubscribeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SubscribeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SubscribeOutput) GoString() string {
+	return s.String()
 }
 
 // A wrapper type for the attributes of an Amazon SNS subscription.
@@ -1706,6 +2217,16 @@ type metadataSubscription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Subscription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Subscription) GoString() string {
+	return s.String()
+}
+
 // A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a
 // topic's attributes, use GetTopicAttributes.
 type Topic struct {
@@ -1717,6 +2238,16 @@ type Topic struct {
 
 type metadataTopic struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Topic) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Topic) GoString() string {
+	return s.String()
 }
 
 // Input for Unsubscribe action.
@@ -1731,10 +2262,30 @@ type metadataUnsubscribeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UnsubscribeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnsubscribeInput) GoString() string {
+	return s.String()
+}
+
 type UnsubscribeOutput struct {
 	metadataUnsubscribeOutput `json:"-" xml:"-"`
 }
 
 type metadataUnsubscribeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UnsubscribeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UnsubscribeOutput) GoString() string {
+	return s.String()
 }

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -5,6 +5,7 @@ package sqs
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddPermission = "AddPermission"
@@ -769,12 +770,32 @@ type metadataAddPermissionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddPermissionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddPermissionInput) GoString() string {
+	return s.String()
+}
+
 type AddPermissionOutput struct {
 	metadataAddPermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataAddPermissionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddPermissionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddPermissionOutput) GoString() string {
+	return s.String()
 }
 
 // This is used in the responses of batch API to give a detailed description
@@ -799,6 +820,16 @@ type metadataBatchResultErrorEntry struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s BatchResultErrorEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s BatchResultErrorEntry) GoString() string {
+	return s.String()
+}
+
 type ChangeMessageVisibilityBatchInput struct {
 	// A list of receipt handles of the messages for which the visibility timeout
 	// must be changed.
@@ -812,6 +843,16 @@ type ChangeMessageVisibilityBatchInput struct {
 
 type metadataChangeMessageVisibilityBatchInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChangeMessageVisibilityBatchInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeMessageVisibilityBatchInput) GoString() string {
+	return s.String()
 }
 
 // For each message in the batch, the response contains a ChangeMessageVisibilityBatchResultEntry
@@ -829,6 +870,16 @@ type ChangeMessageVisibilityBatchOutput struct {
 
 type metadataChangeMessageVisibilityBatchOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChangeMessageVisibilityBatchOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeMessageVisibilityBatchOutput) GoString() string {
+	return s.String()
 }
 
 // Encloses a receipt handle and an entry id for each message in ChangeMessageVisibilityBatch.
@@ -862,6 +913,16 @@ type metadataChangeMessageVisibilityBatchRequestEntry struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ChangeMessageVisibilityBatchRequestEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeMessageVisibilityBatchRequestEntry) GoString() string {
+	return s.String()
+}
+
 // Encloses the id of an entry in ChangeMessageVisibilityBatch.
 type ChangeMessageVisibilityBatchResultEntry struct {
 	// Represents a message whose visibility timeout has been changed successfully.
@@ -872,6 +933,16 @@ type ChangeMessageVisibilityBatchResultEntry struct {
 
 type metadataChangeMessageVisibilityBatchResultEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChangeMessageVisibilityBatchResultEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeMessageVisibilityBatchResultEntry) GoString() string {
+	return s.String()
 }
 
 type ChangeMessageVisibilityInput struct {
@@ -893,12 +964,32 @@ type metadataChangeMessageVisibilityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ChangeMessageVisibilityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeMessageVisibilityInput) GoString() string {
+	return s.String()
+}
+
 type ChangeMessageVisibilityOutput struct {
 	metadataChangeMessageVisibilityOutput `json:"-" xml:"-"`
 }
 
 type metadataChangeMessageVisibilityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChangeMessageVisibilityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChangeMessageVisibilityOutput) GoString() string {
+	return s.String()
 }
 
 type CreateQueueInput struct {
@@ -936,6 +1027,16 @@ type metadataCreateQueueInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateQueueInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateQueueInput) GoString() string {
+	return s.String()
+}
+
 // Returns the QueueUrl element of the created queue.
 type CreateQueueOutput struct {
 	// The URL for the created Amazon SQS queue.
@@ -946,6 +1047,16 @@ type CreateQueueOutput struct {
 
 type metadataCreateQueueOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateQueueOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateQueueOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteMessageBatchInput struct {
@@ -960,6 +1071,16 @@ type DeleteMessageBatchInput struct {
 
 type metadataDeleteMessageBatchInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteMessageBatchInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMessageBatchInput) GoString() string {
+	return s.String()
 }
 
 // For each message in the batch, the response contains a DeleteMessageBatchResultEntry
@@ -979,6 +1100,16 @@ type metadataDeleteMessageBatchOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteMessageBatchOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMessageBatchOutput) GoString() string {
+	return s.String()
+}
+
 // Encloses a receipt handle and an identifier for it.
 type DeleteMessageBatchRequestEntry struct {
 	// An identifier for this particular receipt handle. This is used to communicate
@@ -996,6 +1127,16 @@ type metadataDeleteMessageBatchRequestEntry struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteMessageBatchRequestEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMessageBatchRequestEntry) GoString() string {
+	return s.String()
+}
+
 // Encloses the id an entry in DeleteMessageBatch.
 type DeleteMessageBatchResultEntry struct {
 	// Represents a successfully deleted message.
@@ -1006,6 +1147,16 @@ type DeleteMessageBatchResultEntry struct {
 
 type metadataDeleteMessageBatchResultEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteMessageBatchResultEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMessageBatchResultEntry) GoString() string {
+	return s.String()
 }
 
 type DeleteMessageInput struct {
@@ -1022,12 +1173,32 @@ type metadataDeleteMessageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteMessageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMessageInput) GoString() string {
+	return s.String()
+}
+
 type DeleteMessageOutput struct {
 	metadataDeleteMessageOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteMessageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteMessageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteMessageOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteQueueInput struct {
@@ -1041,12 +1212,32 @@ type metadataDeleteQueueInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteQueueInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteQueueInput) GoString() string {
+	return s.String()
+}
+
 type DeleteQueueOutput struct {
 	metadataDeleteQueueOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteQueueOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteQueueOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteQueueOutput) GoString() string {
+	return s.String()
 }
 
 type GetQueueAttributesInput struct {
@@ -1063,6 +1254,16 @@ type metadataGetQueueAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetQueueAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetQueueAttributesInput) GoString() string {
+	return s.String()
+}
+
 // A list of returned queue attributes.
 type GetQueueAttributesOutput struct {
 	// A map of attributes to the respective values.
@@ -1073,6 +1274,16 @@ type GetQueueAttributesOutput struct {
 
 type metadataGetQueueAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetQueueAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetQueueAttributesOutput) GoString() string {
+	return s.String()
 }
 
 type GetQueueURLInput struct {
@@ -1090,6 +1301,16 @@ type metadataGetQueueURLInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetQueueURLInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetQueueURLInput) GoString() string {
+	return s.String()
+}
+
 // For more information, see Responses (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html)
 // in the Amazon SQS Developer Guide.
 type GetQueueURLOutput struct {
@@ -1103,6 +1324,16 @@ type metadataGetQueueURLOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetQueueURLOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetQueueURLOutput) GoString() string {
+	return s.String()
+}
+
 type ListDeadLetterSourceQueuesInput struct {
 	// The queue URL of a dead letter queue.
 	QueueURL *string `locationName:"QueueUrl" type:"string" required:"true"`
@@ -1112,6 +1343,16 @@ type ListDeadLetterSourceQueuesInput struct {
 
 type metadataListDeadLetterSourceQueuesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDeadLetterSourceQueuesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeadLetterSourceQueuesInput) GoString() string {
+	return s.String()
 }
 
 // A list of your dead letter source queues.
@@ -1127,6 +1368,16 @@ type metadataListDeadLetterSourceQueuesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDeadLetterSourceQueuesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDeadLetterSourceQueuesOutput) GoString() string {
+	return s.String()
+}
+
 type ListQueuesInput struct {
 	// A string to use for filtering the list results. Only those queues whose name
 	// begins with the specified string are returned.
@@ -1139,6 +1390,16 @@ type metadataListQueuesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListQueuesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListQueuesInput) GoString() string {
+	return s.String()
+}
+
 // A list of your queues.
 type ListQueuesOutput struct {
 	// A list of queue URLs, up to 1000 entries.
@@ -1149,6 +1410,16 @@ type ListQueuesOutput struct {
 
 type metadataListQueuesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListQueuesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListQueuesOutput) GoString() string {
+	return s.String()
 }
 
 // An Amazon SQS message.
@@ -1191,6 +1462,16 @@ type metadataMessage struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Message) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Message) GoString() string {
+	return s.String()
+}
+
 // The user-specified message attribute value. For string data types, the value
 // attribute has the same restrictions on the content as the message body. For
 // more information, see SendMessage (http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html).
@@ -1226,6 +1507,16 @@ type metadataMessageAttributeValue struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MessageAttributeValue) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MessageAttributeValue) GoString() string {
+	return s.String()
+}
+
 type PurgeQueueInput struct {
 	// The queue URL of the queue to delete the messages from when using the PurgeQueue
 	// API.
@@ -1238,12 +1529,32 @@ type metadataPurgeQueueInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PurgeQueueInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurgeQueueInput) GoString() string {
+	return s.String()
+}
+
 type PurgeQueueOutput struct {
 	metadataPurgeQueueOutput `json:"-" xml:"-"`
 }
 
 type metadataPurgeQueueOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PurgeQueueOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PurgeQueueOutput) GoString() string {
+	return s.String()
 }
 
 type ReceiveMessageInput struct {
@@ -1302,6 +1613,16 @@ type metadataReceiveMessageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ReceiveMessageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReceiveMessageInput) GoString() string {
+	return s.String()
+}
+
 // A list of received messages.
 type ReceiveMessageOutput struct {
 	// A list of messages.
@@ -1312,6 +1633,16 @@ type ReceiveMessageOutput struct {
 
 type metadataReceiveMessageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ReceiveMessageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ReceiveMessageOutput) GoString() string {
+	return s.String()
 }
 
 type RemovePermissionInput struct {
@@ -1329,12 +1660,32 @@ type metadataRemovePermissionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RemovePermissionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemovePermissionInput) GoString() string {
+	return s.String()
+}
+
 type RemovePermissionOutput struct {
 	metadataRemovePermissionOutput `json:"-" xml:"-"`
 }
 
 type metadataRemovePermissionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RemovePermissionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RemovePermissionOutput) GoString() string {
+	return s.String()
 }
 
 type SendMessageBatchInput struct {
@@ -1349,6 +1700,16 @@ type SendMessageBatchInput struct {
 
 type metadataSendMessageBatchInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SendMessageBatchInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendMessageBatchInput) GoString() string {
+	return s.String()
 }
 
 // For each message in the batch, the response contains a SendMessageBatchResultEntry
@@ -1367,6 +1728,16 @@ type SendMessageBatchOutput struct {
 
 type metadataSendMessageBatchOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SendMessageBatchOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendMessageBatchOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the details of a single Amazon SQS message along with a Id.
@@ -1391,6 +1762,16 @@ type SendMessageBatchRequestEntry struct {
 
 type metadataSendMessageBatchRequestEntry struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SendMessageBatchRequestEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendMessageBatchRequestEntry) GoString() string {
+	return s.String()
 }
 
 // Encloses a message ID for successfully enqueued message of a SendMessageBatch.
@@ -1420,6 +1801,16 @@ type metadataSendMessageBatchResultEntry struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SendMessageBatchResultEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendMessageBatchResultEntry) GoString() string {
+	return s.String()
+}
+
 type SendMessageInput struct {
 	// The number of seconds (0 to 900 - 15 minutes) to delay a specific message.
 	// Messages with a positive DelaySeconds value become available for processing
@@ -1443,6 +1834,16 @@ type SendMessageInput struct {
 
 type metadataSendMessageInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SendMessageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendMessageInput) GoString() string {
+	return s.String()
 }
 
 // The MD5OfMessageBody and MessageId elements.
@@ -1469,6 +1870,16 @@ type SendMessageOutput struct {
 
 type metadataSendMessageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SendMessageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SendMessageOutput) GoString() string {
+	return s.String()
 }
 
 type SetQueueAttributesInput struct {
@@ -1508,10 +1919,30 @@ type metadataSetQueueAttributesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SetQueueAttributesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetQueueAttributesInput) GoString() string {
+	return s.String()
+}
+
 type SetQueueAttributesOutput struct {
 	metadataSetQueueAttributesOutput `json:"-" xml:"-"`
 }
 
 type metadataSetQueueAttributesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SetQueueAttributesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SetQueueAttributesOutput) GoString() string {
+	return s.String()
 }

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateAssociation = "CreateAssociation"
@@ -350,6 +351,16 @@ type metadataAssociation struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Association) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Association) GoString() string {
+	return s.String()
+}
+
 // Describes an association.
 type AssociationDescription struct {
 	// The date when the association was made.
@@ -371,6 +382,16 @@ type metadataAssociationDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssociationDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociationDescription) GoString() string {
+	return s.String()
+}
+
 // Describes a filter.
 type AssociationFilter struct {
 	// The name of the filter.
@@ -384,6 +405,16 @@ type AssociationFilter struct {
 
 type metadataAssociationFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssociationFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociationFilter) GoString() string {
+	return s.String()
 }
 
 // Describes an association status.
@@ -407,6 +438,16 @@ type metadataAssociationStatus struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssociationStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssociationStatus) GoString() string {
+	return s.String()
+}
+
 type CreateAssociationBatchInput struct {
 	// One or more associations.
 	Entries []*CreateAssociationBatchRequestEntry `locationNameList:"entries" type:"list" required:"true"`
@@ -416,6 +457,16 @@ type CreateAssociationBatchInput struct {
 
 type metadataCreateAssociationBatchInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAssociationBatchInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAssociationBatchInput) GoString() string {
+	return s.String()
 }
 
 type CreateAssociationBatchOutput struct {
@@ -430,6 +481,16 @@ type CreateAssociationBatchOutput struct {
 
 type metadataCreateAssociationBatchOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAssociationBatchOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAssociationBatchOutput) GoString() string {
+	return s.String()
 }
 
 // Describes the association of a configuration document and an instance.
@@ -447,6 +508,16 @@ type metadataCreateAssociationBatchRequestEntry struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAssociationBatchRequestEntry) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAssociationBatchRequestEntry) GoString() string {
+	return s.String()
+}
+
 type CreateAssociationInput struct {
 	// The ID of the instance.
 	InstanceID *string `locationName:"InstanceId" type:"string" required:"true"`
@@ -461,6 +532,16 @@ type metadataCreateAssociationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateAssociationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAssociationInput) GoString() string {
+	return s.String()
+}
+
 type CreateAssociationOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
@@ -470,6 +551,16 @@ type CreateAssociationOutput struct {
 
 type metadataCreateAssociationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateAssociationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateAssociationOutput) GoString() string {
+	return s.String()
 }
 
 type CreateDocumentInput struct {
@@ -487,6 +578,16 @@ type metadataCreateDocumentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateDocumentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDocumentInput) GoString() string {
+	return s.String()
+}
+
 type CreateDocumentOutput struct {
 	// Information about the configuration document.
 	DocumentDescription *DocumentDescription `type:"structure"`
@@ -496,6 +597,16 @@ type CreateDocumentOutput struct {
 
 type metadataCreateDocumentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateDocumentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateDocumentOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteAssociationInput struct {
@@ -512,12 +623,32 @@ type metadataDeleteAssociationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteAssociationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAssociationInput) GoString() string {
+	return s.String()
+}
+
 type DeleteAssociationOutput struct {
 	metadataDeleteAssociationOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteAssociationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteAssociationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteAssociationOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteDocumentInput struct {
@@ -531,12 +662,32 @@ type metadataDeleteDocumentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteDocumentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDocumentInput) GoString() string {
+	return s.String()
+}
+
 type DeleteDocumentOutput struct {
 	metadataDeleteDocumentOutput `json:"-" xml:"-"`
 }
 
 type metadataDeleteDocumentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteDocumentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteDocumentOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeAssociationInput struct {
@@ -553,6 +704,16 @@ type metadataDescribeAssociationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeAssociationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAssociationInput) GoString() string {
+	return s.String()
+}
+
 type DescribeAssociationOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
@@ -562,6 +723,16 @@ type DescribeAssociationOutput struct {
 
 type metadataDescribeAssociationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAssociationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAssociationOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeDocumentInput struct {
@@ -575,6 +746,16 @@ type metadataDescribeDocumentInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDocumentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDocumentInput) GoString() string {
+	return s.String()
+}
+
 type DescribeDocumentOutput struct {
 	// Information about the configuration document.
 	Document *DocumentDescription `type:"structure"`
@@ -584,6 +765,16 @@ type DescribeDocumentOutput struct {
 
 type metadataDescribeDocumentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDocumentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDocumentOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a configuration document.
@@ -607,6 +798,16 @@ type metadataDocumentDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DocumentDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DocumentDescription) GoString() string {
+	return s.String()
+}
+
 // Describes a filter.
 type DocumentFilter struct {
 	// The name of the filter.
@@ -622,6 +823,16 @@ type metadataDocumentFilter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DocumentFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DocumentFilter) GoString() string {
+	return s.String()
+}
+
 // Describes the name of a configuration document.
 type DocumentIdentifier struct {
 	// The name of the configuration document.
@@ -632,6 +843,16 @@ type DocumentIdentifier struct {
 
 type metadataDocumentIdentifier struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DocumentIdentifier) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DocumentIdentifier) GoString() string {
+	return s.String()
 }
 
 // Describes a failed association.
@@ -652,6 +873,16 @@ type metadataFailedCreateAssociation struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FailedCreateAssociation) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FailedCreateAssociation) GoString() string {
+	return s.String()
+}
+
 type GetDocumentInput struct {
 	// The name of the configuration document.
 	Name *string `type:"string" required:"true"`
@@ -661,6 +892,16 @@ type GetDocumentInput struct {
 
 type metadataGetDocumentInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDocumentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDocumentInput) GoString() string {
+	return s.String()
 }
 
 type GetDocumentOutput struct {
@@ -675,6 +916,16 @@ type GetDocumentOutput struct {
 
 type metadataGetDocumentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetDocumentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetDocumentOutput) GoString() string {
+	return s.String()
 }
 
 type ListAssociationsInput struct {
@@ -697,6 +948,16 @@ type metadataListAssociationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListAssociationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAssociationsInput) GoString() string {
+	return s.String()
+}
+
 type ListAssociationsOutput struct {
 	// The associations.
 	Associations []*Association `locationNameList:"Association" type:"list"`
@@ -710,6 +971,16 @@ type ListAssociationsOutput struct {
 
 type metadataListAssociationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListAssociationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListAssociationsOutput) GoString() string {
+	return s.String()
 }
 
 type ListDocumentsInput struct {
@@ -732,6 +1003,16 @@ type metadataListDocumentsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDocumentsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDocumentsInput) GoString() string {
+	return s.String()
+}
+
 type ListDocumentsOutput struct {
 	// The names of the configuration documents.
 	DocumentIdentifiers []*DocumentIdentifier `locationNameList:"DocumentIdentifier" type:"list"`
@@ -745,6 +1026,16 @@ type ListDocumentsOutput struct {
 
 type metadataListDocumentsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDocumentsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDocumentsOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateAssociationStatusInput struct {
@@ -764,6 +1055,16 @@ type metadataUpdateAssociationStatusInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateAssociationStatusInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAssociationStatusInput) GoString() string {
+	return s.String()
+}
+
 type UpdateAssociationStatusOutput struct {
 	// Information about the association.
 	AssociationDescription *AssociationDescription `type:"structure"`
@@ -773,4 +1074,14 @@ type UpdateAssociationStatusOutput struct {
 
 type metadataUpdateAssociationStatusOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateAssociationStatusOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateAssociationStatusOutput) GoString() string {
+	return s.String()
 }

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opActivateGateway = "ActivateGateway"
@@ -1825,6 +1826,16 @@ type metadataActivateGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActivateGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivateGatewayInput) GoString() string {
+	return s.String()
+}
+
 // AWS Storage Gateway returns the Amazon Resource Name (ARN) of the activated
 // gateway. It is a string made of information such as your account, gateway
 // name, and region. This ARN is used to reference the gateway in other API
@@ -1841,6 +1852,16 @@ type metadataActivateGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActivateGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivateGatewayOutput) GoString() string {
+	return s.String()
+}
+
 type AddCacheInput struct {
 	DiskIDs []*string `locationName:"DiskIds" type:"list" required:"true"`
 
@@ -1855,6 +1876,16 @@ type metadataAddCacheInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddCacheInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddCacheInput) GoString() string {
+	return s.String()
+}
+
 type AddCacheOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -1865,6 +1896,16 @@ type AddCacheOutput struct {
 
 type metadataAddCacheOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddCacheOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddCacheOutput) GoString() string {
+	return s.String()
 }
 
 type AddUploadBufferInput struct {
@@ -1881,6 +1922,16 @@ type metadataAddUploadBufferInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddUploadBufferInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddUploadBufferInput) GoString() string {
+	return s.String()
+}
+
 type AddUploadBufferOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -1891,6 +1942,16 @@ type AddUploadBufferOutput struct {
 
 type metadataAddUploadBufferOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddUploadBufferOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddUploadBufferOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing one or more of the following fields:
@@ -1913,6 +1974,16 @@ type metadataAddWorkingStorageInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddWorkingStorageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddWorkingStorageInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway for which working storage was
 // configured.
 type AddWorkingStorageOutput struct {
@@ -1925,6 +1996,16 @@ type AddWorkingStorageOutput struct {
 
 type metadataAddWorkingStorageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddWorkingStorageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddWorkingStorageOutput) GoString() string {
+	return s.String()
 }
 
 type CachediSCSIVolume struct {
@@ -1952,6 +2033,16 @@ type metadataCachediSCSIVolume struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CachediSCSIVolume) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CachediSCSIVolume) GoString() string {
+	return s.String()
+}
+
 // CancelArchivalInput
 type CancelArchivalInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -1969,6 +2060,16 @@ type metadataCancelArchivalInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelArchivalInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelArchivalInput) GoString() string {
+	return s.String()
+}
+
 // CancelArchivalOutput
 type CancelArchivalOutput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape for which archiving was
@@ -1980,6 +2081,16 @@ type CancelArchivalOutput struct {
 
 type metadataCancelArchivalOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelArchivalOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelArchivalOutput) GoString() string {
+	return s.String()
 }
 
 // CancelRetrievalInput
@@ -1999,6 +2110,16 @@ type metadataCancelRetrievalInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelRetrievalInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelRetrievalInput) GoString() string {
+	return s.String()
+}
+
 // CancelRetrievalOutput
 type CancelRetrievalOutput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape for which retrieval was
@@ -2010,6 +2131,16 @@ type CancelRetrievalOutput struct {
 
 type metadataCancelRetrievalOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelRetrievalOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelRetrievalOutput) GoString() string {
+	return s.String()
 }
 
 // Describes Challenge-Handshake Authentication Protocol (CHAP) information
@@ -2039,6 +2170,16 @@ type metadataChapInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ChapInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChapInfo) GoString() string {
+	return s.String()
+}
+
 type CreateCachediSCSIVolumeInput struct {
 	ClientToken *string `type:"string" required:"true"`
 
@@ -2061,6 +2202,16 @@ type metadataCreateCachediSCSIVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateCachediSCSIVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCachediSCSIVolumeInput) GoString() string {
+	return s.String()
+}
+
 type CreateCachediSCSIVolumeOutput struct {
 	TargetARN *string `type:"string"`
 
@@ -2071,6 +2222,16 @@ type CreateCachediSCSIVolumeOutput struct {
 
 type metadataCreateCachediSCSIVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateCachediSCSIVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCachediSCSIVolumeOutput) GoString() string {
+	return s.String()
 }
 
 type CreateSnapshotFromVolumeRecoveryPointInput struct {
@@ -2085,6 +2246,16 @@ type metadataCreateSnapshotFromVolumeRecoveryPointInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSnapshotFromVolumeRecoveryPointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotFromVolumeRecoveryPointInput) GoString() string {
+	return s.String()
+}
+
 type CreateSnapshotFromVolumeRecoveryPointOutput struct {
 	SnapshotID *string `locationName:"SnapshotId" type:"string"`
 
@@ -2097,6 +2268,16 @@ type CreateSnapshotFromVolumeRecoveryPointOutput struct {
 
 type metadataCreateSnapshotFromVolumeRecoveryPointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSnapshotFromVolumeRecoveryPointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotFromVolumeRecoveryPointOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing one or more of the following fields:
@@ -2119,6 +2300,16 @@ type metadataCreateSnapshotInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateSnapshotInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the following fields:
 type CreateSnapshotOutput struct {
 	// The snapshot ID that is used to refer to the snapshot in future operations
@@ -2134,6 +2325,16 @@ type CreateSnapshotOutput struct {
 
 type metadataCreateSnapshotOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateSnapshotOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateSnapshotOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing one or more of the following fields:
@@ -2184,6 +2385,16 @@ type metadataCreateStorediSCSIVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateStorediSCSIVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStorediSCSIVolumeInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the following fields:
 type CreateStorediSCSIVolumeOutput struct {
 	// he Amazon Resource Name (ARN) of the volume target that includes the iSCSI
@@ -2201,6 +2412,16 @@ type CreateStorediSCSIVolumeOutput struct {
 
 type metadataCreateStorediSCSIVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateStorediSCSIVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateStorediSCSIVolumeOutput) GoString() string {
+	return s.String()
 }
 
 // CreateTapesInput
@@ -2238,6 +2459,16 @@ type metadataCreateTapesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateTapesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTapesInput) GoString() string {
+	return s.String()
+}
+
 // CreateTapeOutput
 type CreateTapesOutput struct {
 	// A list of unique Amazon Resource Named (ARN) the represents the virtual tapes
@@ -2249,6 +2480,16 @@ type CreateTapesOutput struct {
 
 type metadataCreateTapesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateTapesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateTapesOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteBandwidthRateLimitInput struct {
@@ -2265,6 +2506,16 @@ type metadataDeleteBandwidthRateLimitInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteBandwidthRateLimitInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBandwidthRateLimitInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway whose bandwidth rate information
 // was deleted.
 type DeleteBandwidthRateLimitOutput struct {
@@ -2277,6 +2528,16 @@ type DeleteBandwidthRateLimitOutput struct {
 
 type metadataDeleteBandwidthRateLimitOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBandwidthRateLimitOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBandwidthRateLimitOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing one or more of the following fields:
@@ -2297,6 +2558,16 @@ type metadataDeleteChapCredentialsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteChapCredentialsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteChapCredentialsInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the following fields:
 type DeleteChapCredentialsOutput struct {
 	// The iSCSI initiator that connects to the target.
@@ -2312,6 +2583,16 @@ type metadataDeleteChapCredentialsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteChapCredentialsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteChapCredentialsOutput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the id of the gateway to delete.
 type DeleteGatewayInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -2323,6 +2604,16 @@ type DeleteGatewayInput struct {
 
 type metadataDeleteGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteGatewayInput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the id of the deleted gateway.
@@ -2338,6 +2629,16 @@ type metadataDeleteGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteGatewayOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteSnapshotScheduleInput struct {
 	VolumeARN *string `type:"string" required:"true"`
 
@@ -2348,6 +2649,16 @@ type metadataDeleteSnapshotScheduleInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteSnapshotScheduleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotScheduleInput) GoString() string {
+	return s.String()
+}
+
 type DeleteSnapshotScheduleOutput struct {
 	VolumeARN *string `type:"string"`
 
@@ -2356,6 +2667,16 @@ type DeleteSnapshotScheduleOutput struct {
 
 type metadataDeleteSnapshotScheduleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteSnapshotScheduleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteSnapshotScheduleOutput) GoString() string {
+	return s.String()
 }
 
 // DeleteTapeArchiveInput
@@ -2371,6 +2692,16 @@ type metadataDeleteTapeArchiveInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTapeArchiveInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTapeArchiveInput) GoString() string {
+	return s.String()
+}
+
 // DeleteTapeArchiveOutput
 type DeleteTapeArchiveOutput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape that was deleted from
@@ -2382,6 +2713,16 @@ type DeleteTapeArchiveOutput struct {
 
 type metadataDeleteTapeArchiveOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTapeArchiveOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTapeArchiveOutput) GoString() string {
+	return s.String()
 }
 
 // DeleteTapeInput
@@ -2401,6 +2742,16 @@ type metadataDeleteTapeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteTapeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTapeInput) GoString() string {
+	return s.String()
+}
+
 // DeleteTapeOutput
 type DeleteTapeOutput struct {
 	// The Amazon Resource Name (ARN) of the deleted virtual tape.
@@ -2411,6 +2762,16 @@ type DeleteTapeOutput struct {
 
 type metadataDeleteTapeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteTapeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteTapeOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the DeleteVolumeInput$VolumeARN to delete.
@@ -2426,6 +2787,16 @@ type metadataDeleteVolumeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVolumeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVolumeInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the storage volume that was deleted
 type DeleteVolumeOutput struct {
 	// The Amazon Resource Name (ARN) of the storage volume that was deleted. It
@@ -2439,6 +2810,16 @@ type metadataDeleteVolumeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeleteVolumeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeleteVolumeOutput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway.
 type DescribeBandwidthRateLimitInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -2450,6 +2831,16 @@ type DescribeBandwidthRateLimitInput struct {
 
 type metadataDescribeBandwidthRateLimitInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeBandwidthRateLimitInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeBandwidthRateLimitInput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the following fields:
@@ -2473,6 +2864,16 @@ type metadataDescribeBandwidthRateLimitOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeBandwidthRateLimitOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeBandwidthRateLimitOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeCacheInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -2483,6 +2884,16 @@ type DescribeCacheInput struct {
 
 type metadataDescribeCacheInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCacheInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheInput) GoString() string {
+	return s.String()
 }
 
 type DescribeCacheOutput struct {
@@ -2509,6 +2920,16 @@ type metadataDescribeCacheOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCacheOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCacheOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeCachediSCSIVolumesInput struct {
 	VolumeARNs []*string `type:"list" required:"true"`
 
@@ -2517,6 +2938,16 @@ type DescribeCachediSCSIVolumesInput struct {
 
 type metadataDescribeCachediSCSIVolumesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCachediSCSIVolumesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCachediSCSIVolumesInput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the following fields:
@@ -2532,6 +2963,16 @@ type metadataDescribeCachediSCSIVolumesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCachediSCSIVolumesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCachediSCSIVolumesOutput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the Amazon Resource Name (ARN) of the iSCSI volume
 // target.
 type DescribeChapCredentialsInput struct {
@@ -2544,6 +2985,16 @@ type DescribeChapCredentialsInput struct {
 
 type metadataDescribeChapCredentialsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeChapCredentialsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeChapCredentialsInput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing a .
@@ -2572,6 +3023,16 @@ type metadataDescribeChapCredentialsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeChapCredentialsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeChapCredentialsOutput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the id of the gateway.
 type DescribeGatewayInformationInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -2583,6 +3044,16 @@ type DescribeGatewayInformationInput struct {
 
 type metadataDescribeGatewayInformationInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeGatewayInformationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeGatewayInformationInput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the following fields:
@@ -2624,6 +3095,16 @@ type metadataDescribeGatewayInformationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeGatewayInformationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeGatewayInformationOutput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway.
 type DescribeMaintenanceStartTimeInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -2635,6 +3116,16 @@ type DescribeMaintenanceStartTimeInput struct {
 
 type metadataDescribeMaintenanceStartTimeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeMaintenanceStartTimeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMaintenanceStartTimeInput) GoString() string {
+	return s.String()
 }
 
 type DescribeMaintenanceStartTimeOutput struct {
@@ -2657,6 +3148,16 @@ type metadataDescribeMaintenanceStartTimeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeMaintenanceStartTimeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeMaintenanceStartTimeOutput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the DescribeSnapshotScheduleInput$VolumeARN of the
 // volume.
 type DescribeSnapshotScheduleInput struct {
@@ -2669,6 +3170,16 @@ type DescribeSnapshotScheduleInput struct {
 
 type metadataDescribeSnapshotScheduleInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeSnapshotScheduleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotScheduleInput) GoString() string {
+	return s.String()
 }
 
 type DescribeSnapshotScheduleOutput struct {
@@ -2689,6 +3200,16 @@ type metadataDescribeSnapshotScheduleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSnapshotScheduleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSnapshotScheduleOutput) GoString() string {
+	return s.String()
+}
+
 // A JSON Object containing a list of DescribeStorediSCSIVolumesInput$VolumeARNs.
 type DescribeStorediSCSIVolumesInput struct {
 	// An array of strings where each string represents the Amazon Resource Name
@@ -2703,6 +3224,16 @@ type metadataDescribeStorediSCSIVolumesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeStorediSCSIVolumesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStorediSCSIVolumesInput) GoString() string {
+	return s.String()
+}
+
 type DescribeStorediSCSIVolumesOutput struct {
 	StorediSCSIVolumes []*StorediSCSIVolume `type:"list"`
 
@@ -2711,6 +3242,16 @@ type DescribeStorediSCSIVolumesOutput struct {
 
 type metadataDescribeStorediSCSIVolumesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeStorediSCSIVolumesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeStorediSCSIVolumesOutput) GoString() string {
+	return s.String()
 }
 
 // DescribeTapeArchivesInput
@@ -2732,6 +3273,16 @@ type DescribeTapeArchivesInput struct {
 
 type metadataDescribeTapeArchivesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTapeArchivesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTapeArchivesInput) GoString() string {
+	return s.String()
 }
 
 // DescribeTapeArchivesOutput
@@ -2756,6 +3307,16 @@ type metadataDescribeTapeArchivesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTapeArchivesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTapeArchivesOutput) GoString() string {
+	return s.String()
+}
+
 // DescribeTapeRecoveryPointsInput
 type DescribeTapeRecoveryPointsInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -2775,6 +3336,16 @@ type DescribeTapeRecoveryPointsInput struct {
 
 type metadataDescribeTapeRecoveryPointsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTapeRecoveryPointsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTapeRecoveryPointsInput) GoString() string {
+	return s.String()
 }
 
 // DescribeTapeRecoveryPointsOutput
@@ -2799,6 +3370,16 @@ type DescribeTapeRecoveryPointsOutput struct {
 
 type metadataDescribeTapeRecoveryPointsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTapeRecoveryPointsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTapeRecoveryPointsOutput) GoString() string {
+	return s.String()
 }
 
 // DescribeTapesInput
@@ -2832,6 +3413,16 @@ type metadataDescribeTapesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTapesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTapesInput) GoString() string {
+	return s.String()
+}
+
 // DescribeTapesOutput
 type DescribeTapesOutput struct {
 	// An opaque string which can be used as part of a subsequent DescribeTapes
@@ -2851,6 +3442,16 @@ type metadataDescribeTapesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTapesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTapesOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeUploadBufferInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -2861,6 +3462,16 @@ type DescribeUploadBufferInput struct {
 
 type metadataDescribeUploadBufferInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeUploadBufferInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeUploadBufferInput) GoString() string {
+	return s.String()
 }
 
 type DescribeUploadBufferOutput struct {
@@ -2879,6 +3490,16 @@ type DescribeUploadBufferOutput struct {
 
 type metadataDescribeUploadBufferOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeUploadBufferOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeUploadBufferOutput) GoString() string {
+	return s.String()
 }
 
 // DescribeVTLDevicesInput
@@ -2910,6 +3531,16 @@ type metadataDescribeVTLDevicesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVTLDevicesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVTLDevicesInput) GoString() string {
+	return s.String()
+}
+
 // DescribeVTLDevicesOutput
 type DescribeVTLDevicesOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -2933,6 +3564,16 @@ type metadataDescribeVTLDevicesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeVTLDevicesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeVTLDevicesOutput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway.
 type DescribeWorkingStorageInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -2944,6 +3585,16 @@ type DescribeWorkingStorageInput struct {
 
 type metadataDescribeWorkingStorageInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeWorkingStorageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkingStorageInput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the following fields:
@@ -2973,6 +3624,16 @@ type metadataDescribeWorkingStorageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeWorkingStorageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkingStorageOutput) GoString() string {
+	return s.String()
+}
+
 // Lists iSCSI information about a VTL device.
 type DeviceiSCSIAttributes struct {
 	// Indicates whether mutual CHAP is enabled for the iSCSI target.
@@ -2995,6 +3656,16 @@ type metadataDeviceiSCSIAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeviceiSCSIAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeviceiSCSIAttributes) GoString() string {
+	return s.String()
+}
+
 // DisableGatewayInput
 type DisableGatewayInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -3008,6 +3679,16 @@ type metadataDisableGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DisableGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableGatewayInput) GoString() string {
+	return s.String()
+}
+
 // DisableGatewayOutput
 type DisableGatewayOutput struct {
 	// The unique Amazon Resource Name of the disabled gateway.
@@ -3018,6 +3699,16 @@ type DisableGatewayOutput struct {
 
 type metadataDisableGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DisableGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DisableGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type Disk struct {
@@ -3042,6 +3733,16 @@ type metadataDisk struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Disk) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Disk) GoString() string {
+	return s.String()
+}
+
 // Provides additional information about an error that was returned by the service
 // as an or. See the errorCode and errorDetails members for more information
 // about the error.
@@ -3059,6 +3760,16 @@ type metadataError struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Error) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Error) GoString() string {
+	return s.String()
+}
+
 type GatewayInfo struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -3073,6 +3784,16 @@ type GatewayInfo struct {
 
 type metadataGatewayInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GatewayInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GatewayInfo) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing zero or more of the following fields:
@@ -3094,6 +3815,16 @@ type metadataListGatewaysInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListGatewaysInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGatewaysInput) GoString() string {
+	return s.String()
+}
+
 type ListGatewaysOutput struct {
 	Gateways []*GatewayInfo `type:"list"`
 
@@ -3104,6 +3835,16 @@ type ListGatewaysOutput struct {
 
 type metadataListGatewaysOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListGatewaysOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListGatewaysOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the of the gateway.
@@ -3117,6 +3858,16 @@ type ListLocalDisksInput struct {
 
 type metadataListLocalDisksInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListLocalDisksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListLocalDisksInput) GoString() string {
+	return s.String()
 }
 
 type ListLocalDisksOutput struct {
@@ -3133,6 +3884,16 @@ type metadataListLocalDisksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListLocalDisksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListLocalDisksOutput) GoString() string {
+	return s.String()
+}
+
 // ListVolumeInitiatorsInput
 type ListVolumeInitiatorsInput struct {
 	// The Amazon Resource Name (ARN) of the volume. Use the ListVolumes operation
@@ -3144,6 +3905,16 @@ type ListVolumeInitiatorsInput struct {
 
 type metadataListVolumeInitiatorsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListVolumeInitiatorsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVolumeInitiatorsInput) GoString() string {
+	return s.String()
 }
 
 // ListVolumeInitiatorsOutput
@@ -3159,6 +3930,16 @@ type metadataListVolumeInitiatorsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListVolumeInitiatorsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVolumeInitiatorsOutput) GoString() string {
+	return s.String()
+}
+
 type ListVolumeRecoveryPointsInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -3169,6 +3950,16 @@ type ListVolumeRecoveryPointsInput struct {
 
 type metadataListVolumeRecoveryPointsInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListVolumeRecoveryPointsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVolumeRecoveryPointsInput) GoString() string {
+	return s.String()
 }
 
 type ListVolumeRecoveryPointsOutput struct {
@@ -3183,6 +3974,16 @@ type ListVolumeRecoveryPointsOutput struct {
 
 type metadataListVolumeRecoveryPointsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListVolumeRecoveryPointsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVolumeRecoveryPointsOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object that contains one or more of the following fields:
@@ -3209,6 +4010,16 @@ type metadataListVolumesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListVolumesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVolumesInput) GoString() string {
+	return s.String()
+}
+
 type ListVolumesOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -3223,6 +4034,16 @@ type ListVolumesOutput struct {
 
 type metadataListVolumesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListVolumesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListVolumesOutput) GoString() string {
+	return s.String()
 }
 
 // Describes a gateway's network interface.
@@ -3246,6 +4067,16 @@ type metadataNetworkInterface struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s NetworkInterface) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s NetworkInterface) GoString() string {
+	return s.String()
+}
+
 type ResetCacheInput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -3258,6 +4089,16 @@ type metadataResetCacheInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ResetCacheInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetCacheInput) GoString() string {
+	return s.String()
+}
+
 type ResetCacheOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
 	// to return a list of gateways for your account and region.
@@ -3268,6 +4109,16 @@ type ResetCacheOutput struct {
 
 type metadataResetCacheOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResetCacheOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResetCacheOutput) GoString() string {
+	return s.String()
 }
 
 // RetrieveTapeArchiveInput
@@ -3291,6 +4142,16 @@ type metadataRetrieveTapeArchiveInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RetrieveTapeArchiveInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetrieveTapeArchiveInput) GoString() string {
+	return s.String()
+}
+
 // RetrieveTapeArchiveOutput
 type RetrieveTapeArchiveOutput struct {
 	// The Amazon Resource Name (ARN) of the retrieved virtual tape.
@@ -3301,6 +4162,16 @@ type RetrieveTapeArchiveOutput struct {
 
 type metadataRetrieveTapeArchiveOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RetrieveTapeArchiveOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetrieveTapeArchiveOutput) GoString() string {
+	return s.String()
 }
 
 // RetrieveTapeRecoveryPointInput
@@ -3320,6 +4191,16 @@ type metadataRetrieveTapeRecoveryPointInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RetrieveTapeRecoveryPointInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetrieveTapeRecoveryPointInput) GoString() string {
+	return s.String()
+}
+
 // RetrieveTapeRecoveryPointOutput
 type RetrieveTapeRecoveryPointOutput struct {
 	// The Amazon Resource Name (ARN) of the virtual tape for which the recovery
@@ -3331,6 +4212,16 @@ type RetrieveTapeRecoveryPointOutput struct {
 
 type metadataRetrieveTapeRecoveryPointOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RetrieveTapeRecoveryPointOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RetrieveTapeRecoveryPointOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the of the gateway to shut down.
@@ -3346,6 +4237,16 @@ type metadataShutdownGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ShutdownGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ShutdownGatewayInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway that was shut down.
 type ShutdownGatewayOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -3357,6 +4258,16 @@ type ShutdownGatewayOutput struct {
 
 type metadataShutdownGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ShutdownGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ShutdownGatewayOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the of the gateway to start.
@@ -3372,6 +4283,16 @@ type metadataStartGatewayInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartGatewayInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartGatewayInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway that was restarted.
 type StartGatewayOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -3383,6 +4304,16 @@ type StartGatewayOutput struct {
 
 type metadataStartGatewayOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartGatewayOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartGatewayOutput) GoString() string {
+	return s.String()
 }
 
 type StorediSCSIVolume struct {
@@ -3414,6 +4345,16 @@ type metadataStorediSCSIVolume struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StorediSCSIVolume) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StorediSCSIVolume) GoString() string {
+	return s.String()
+}
+
 // Describes a virtual tape object.
 type Tape struct {
 	// For archiving virtual tapes, indicates how much data remains to be uploaded
@@ -3443,6 +4384,16 @@ type Tape struct {
 
 type metadataTape struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Tape) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Tape) GoString() string {
+	return s.String()
 }
 
 // Represents a virtual tape that is archived in the virtual tape shelf (VTS).
@@ -3478,6 +4429,16 @@ type metadataTapeArchive struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TapeArchive) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TapeArchive) GoString() string {
+	return s.String()
+}
+
 // Describes a recovery point.
 type TapeRecoveryPointInfo struct {
 	// The Amazon Resource Name (ARN) of the virtual tape.
@@ -3502,6 +4463,16 @@ type metadataTapeRecoveryPointInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TapeRecoveryPointInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TapeRecoveryPointInfo) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing one or more of the following fields:
 //
 //   UpdateBandwidthRateLimitInput$AverageDownloadRateLimitInBitsPerSec   UpdateBandwidthRateLimitInput$AverageUploadRateLimitInBitsPerSec
@@ -3523,6 +4494,16 @@ type metadataUpdateBandwidthRateLimitInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateBandwidthRateLimitInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateBandwidthRateLimitInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway whose throttle information was
 // updated.
 type UpdateBandwidthRateLimitOutput struct {
@@ -3535,6 +4516,16 @@ type UpdateBandwidthRateLimitOutput struct {
 
 type metadataUpdateBandwidthRateLimitOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateBandwidthRateLimitOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateBandwidthRateLimitOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing one or more of the following fields:
@@ -3570,6 +4561,16 @@ type metadataUpdateChapCredentialsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateChapCredentialsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateChapCredentialsInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the following fields:
 type UpdateChapCredentialsOutput struct {
 	// The iSCSI initiator that connects to the target. This is the same initiator
@@ -3585,6 +4586,16 @@ type UpdateChapCredentialsOutput struct {
 
 type metadataUpdateChapCredentialsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateChapCredentialsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateChapCredentialsOutput) GoString() string {
+	return s.String()
 }
 
 type UpdateGatewayInformationInput struct {
@@ -3605,6 +4616,16 @@ type metadataUpdateGatewayInformationInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateGatewayInformationInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGatewayInformationInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway that was updated.
 type UpdateGatewayInformationOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -3616,6 +4637,16 @@ type UpdateGatewayInformationOutput struct {
 
 type metadataUpdateGatewayInformationOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateGatewayInformationOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGatewayInformationOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the of the gateway to update.
@@ -3631,6 +4662,16 @@ type metadataUpdateGatewaySoftwareNowInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateGatewaySoftwareNowInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGatewaySoftwareNowInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway that was updated.
 type UpdateGatewaySoftwareNowOutput struct {
 	// The Amazon Resource Name (ARN) of the gateway. Use the ListGateways operation
@@ -3642,6 +4683,16 @@ type UpdateGatewaySoftwareNowOutput struct {
 
 type metadataUpdateGatewaySoftwareNowOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateGatewaySoftwareNowOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateGatewaySoftwareNowOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing the following fields:
@@ -3673,6 +4724,16 @@ type metadataUpdateMaintenanceStartTimeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateMaintenanceStartTimeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateMaintenanceStartTimeInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the gateway whose maintenance start time
 // is updated.
 type UpdateMaintenanceStartTimeOutput struct {
@@ -3685,6 +4746,16 @@ type UpdateMaintenanceStartTimeOutput struct {
 
 type metadataUpdateMaintenanceStartTimeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateMaintenanceStartTimeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateMaintenanceStartTimeOutput) GoString() string {
+	return s.String()
 }
 
 // A JSON object containing one or more of the following fields:
@@ -3714,6 +4785,16 @@ type metadataUpdateSnapshotScheduleInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateSnapshotScheduleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSnapshotScheduleInput) GoString() string {
+	return s.String()
+}
+
 // A JSON object containing the of the updated storage volume.
 type UpdateSnapshotScheduleOutput struct {
 	VolumeARN *string `type:"string"`
@@ -3723,6 +4804,16 @@ type UpdateSnapshotScheduleOutput struct {
 
 type metadataUpdateSnapshotScheduleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateSnapshotScheduleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateSnapshotScheduleOutput) GoString() string {
+	return s.String()
 }
 
 // UpdateVTLDeviceTypeInput
@@ -3742,6 +4833,16 @@ type metadataUpdateVTLDeviceTypeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s UpdateVTLDeviceTypeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateVTLDeviceTypeInput) GoString() string {
+	return s.String()
+}
+
 // UpdateVTLDeviceTypeOutput
 type UpdateVTLDeviceTypeOutput struct {
 	// The Amazon Resource Name (ARN) of the medium changer you have selected.
@@ -3752,6 +4853,16 @@ type UpdateVTLDeviceTypeOutput struct {
 
 type metadataUpdateVTLDeviceTypeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UpdateVTLDeviceTypeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UpdateVTLDeviceTypeOutput) GoString() string {
+	return s.String()
 }
 
 // Represents a device object associated with a gateway-VTL.
@@ -3776,6 +4887,16 @@ type metadataVTLDevice struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s VTLDevice) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VTLDevice) GoString() string {
+	return s.String()
+}
+
 type VolumeInfo struct {
 	VolumeARN *string `type:"string"`
 
@@ -3786,6 +4907,16 @@ type VolumeInfo struct {
 
 type metadataVolumeInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeInfo) GoString() string {
+	return s.String()
 }
 
 type VolumeRecoveryPointInfo struct {
@@ -3802,6 +4933,16 @@ type VolumeRecoveryPointInfo struct {
 
 type metadataVolumeRecoveryPointInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeRecoveryPointInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeRecoveryPointInfo) GoString() string {
+	return s.String()
 }
 
 // Lists iSCSI information about a volume.
@@ -3826,4 +4967,14 @@ type VolumeiSCSIAttributes struct {
 
 type metadataVolumeiSCSIAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s VolumeiSCSIAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s VolumeiSCSIAttributes) GoString() string {
+	return s.String()
 }

--- a/service/sts/api.go
+++ b/service/sts/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAssumeRole = "AssumeRole"
@@ -525,6 +526,16 @@ type metadataAssumeRoleInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssumeRoleInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssumeRoleInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful AssumeRole request, including temporary
 // AWS credentials that can be used to make AWS requests.
 type AssumeRoleOutput struct {
@@ -549,6 +560,16 @@ type AssumeRoleOutput struct {
 
 type metadataAssumeRoleOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssumeRoleOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssumeRoleOutput) GoString() string {
+	return s.String()
 }
 
 type AssumeRoleWithSAMLInput struct {
@@ -597,6 +618,16 @@ type AssumeRoleWithSAMLInput struct {
 
 type metadataAssumeRoleWithSAMLInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssumeRoleWithSAMLInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssumeRoleWithSAMLInput) GoString() string {
+	return s.String()
 }
 
 // Contains the response to a successful AssumeRoleWithSAML request, including
@@ -652,6 +683,16 @@ type metadataAssumeRoleWithSAMLOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssumeRoleWithSAMLOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssumeRoleWithSAMLOutput) GoString() string {
+	return s.String()
+}
+
 type AssumeRoleWithWebIdentityInput struct {
 	// The duration, in seconds, of the role session. The value can range from 900
 	// seconds (15 minutes) to 3600 seconds (1 hour). By default, the value is set
@@ -703,6 +744,16 @@ type metadataAssumeRoleWithWebIdentityInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssumeRoleWithWebIdentityInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssumeRoleWithWebIdentityInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful AssumeRoleWithWebIdentity request,
 // including temporary AWS credentials that can be used to make AWS requests.
 type AssumeRoleWithWebIdentityOutput struct {
@@ -748,6 +799,16 @@ type metadataAssumeRoleWithWebIdentityOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AssumeRoleWithWebIdentityOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssumeRoleWithWebIdentityOutput) GoString() string {
+	return s.String()
+}
+
 // The identifiers for the temporary security credentials that the operation
 // returns.
 type AssumedRoleUser struct {
@@ -767,6 +828,16 @@ type AssumedRoleUser struct {
 
 type metadataAssumedRoleUser struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AssumedRoleUser) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AssumedRoleUser) GoString() string {
+	return s.String()
 }
 
 // AWS credentials for API authentication.
@@ -790,6 +861,16 @@ type metadataCredentials struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Credentials) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Credentials) GoString() string {
+	return s.String()
+}
+
 type DecodeAuthorizationMessageInput struct {
 	// The encoded message that was returned with the response.
 	EncodedMessage *string `type:"string" required:"true"`
@@ -799,6 +880,16 @@ type DecodeAuthorizationMessageInput struct {
 
 type metadataDecodeAuthorizationMessageInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DecodeAuthorizationMessageInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DecodeAuthorizationMessageInput) GoString() string {
+	return s.String()
 }
 
 // A document that contains additional information about the authorization status
@@ -814,6 +905,16 @@ type DecodeAuthorizationMessageOutput struct {
 
 type metadataDecodeAuthorizationMessageOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DecodeAuthorizationMessageOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DecodeAuthorizationMessageOutput) GoString() string {
+	return s.String()
 }
 
 // Identifiers for the federated user that is associated with the credentials.
@@ -833,6 +934,16 @@ type FederatedUser struct {
 
 type metadataFederatedUser struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s FederatedUser) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FederatedUser) GoString() string {
+	return s.String()
 }
 
 type GetFederationTokenInput struct {
@@ -878,6 +989,16 @@ type metadataGetFederationTokenInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetFederationTokenInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetFederationTokenInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful GetFederationToken request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type GetFederationTokenOutput struct {
@@ -900,6 +1021,16 @@ type GetFederationTokenOutput struct {
 
 type metadataGetFederationTokenOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetFederationTokenOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetFederationTokenOutput) GoString() string {
+	return s.String()
 }
 
 type GetSessionTokenInput struct {
@@ -934,6 +1065,16 @@ type metadataGetSessionTokenInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetSessionTokenInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSessionTokenInput) GoString() string {
+	return s.String()
+}
+
 // Contains the response to a successful GetSessionToken request, including
 // temporary AWS credentials that can be used to make AWS requests.
 type GetSessionTokenOutput struct {
@@ -945,4 +1086,14 @@ type GetSessionTokenOutput struct {
 
 type metadataGetSessionTokenOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetSessionTokenOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetSessionTokenOutput) GoString() string {
+	return s.String()
 }

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -5,6 +5,7 @@ package support
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opAddAttachmentsToSet = "AddAttachmentsToSet"
@@ -539,6 +540,16 @@ type metadataAddAttachmentsToSetInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddAttachmentsToSetInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddAttachmentsToSetInput) GoString() string {
+	return s.String()
+}
+
 // The ID and expiry time of the attachment set returned by the AddAttachmentsToSet
 // operation.
 type AddAttachmentsToSetOutput struct {
@@ -556,6 +567,16 @@ type AddAttachmentsToSetOutput struct {
 
 type metadataAddAttachmentsToSetOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddAttachmentsToSetOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddAttachmentsToSetOutput) GoString() string {
+	return s.String()
 }
 
 // To be written.
@@ -582,6 +603,16 @@ type metadataAddCommunicationToCaseInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s AddCommunicationToCaseInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddCommunicationToCaseInput) GoString() string {
+	return s.String()
+}
+
 // The result of the AddCommunicationToCase operation.
 type AddCommunicationToCaseOutput struct {
 	// True if AddCommunicationToCase succeeds. Otherwise, returns an error.
@@ -592,6 +623,16 @@ type AddCommunicationToCaseOutput struct {
 
 type metadataAddCommunicationToCaseOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AddCommunicationToCaseOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AddCommunicationToCaseOutput) GoString() string {
+	return s.String()
 }
 
 // An attachment to a case communication. The attachment consists of the file
@@ -610,6 +651,16 @@ type metadataAttachment struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Attachment) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Attachment) GoString() string {
+	return s.String()
+}
+
 // The file name and ID of an attachment to a case communication. You can use
 // the ID to retrieve the attachment with the DescribeAttachment operation.
 type AttachmentDetails struct {
@@ -624,6 +675,16 @@ type AttachmentDetails struct {
 
 type metadataAttachmentDetails struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s AttachmentDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s AttachmentDetails) GoString() string {
+	return s.String()
 }
 
 // A JSON-formatted object that contains the metadata for a support case. It
@@ -697,6 +758,16 @@ type metadataCaseDetails struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CaseDetails) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CaseDetails) GoString() string {
+	return s.String()
+}
+
 // A JSON-formatted name/value pair that represents the category name and category
 // code of the problem, selected from the DescribeServices response for each
 // AWS service.
@@ -712,6 +783,16 @@ type Category struct {
 
 type metadataCategory struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Category) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Category) GoString() string {
+	return s.String()
 }
 
 // A communication associated with an AWS Support case. The communication consists
@@ -739,6 +820,16 @@ type Communication struct {
 
 type metadataCommunication struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s Communication) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Communication) GoString() string {
+	return s.String()
 }
 
 type CreateCaseInput struct {
@@ -785,6 +876,16 @@ type metadataCreateCaseInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateCaseInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCaseInput) GoString() string {
+	return s.String()
+}
+
 // The AWS Support case ID returned by a successful completion of the CreateCase
 // operation.
 type CreateCaseOutput struct {
@@ -799,6 +900,16 @@ type metadataCreateCaseOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CreateCaseOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateCaseOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeAttachmentInput struct {
 	// The ID of the attachment to return. Attachment IDs are returned by the DescribeCommunications
 	// operation.
@@ -809,6 +920,16 @@ type DescribeAttachmentInput struct {
 
 type metadataDescribeAttachmentInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAttachmentInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAttachmentInput) GoString() string {
+	return s.String()
 }
 
 // The content and file name of the attachment returned by the DescribeAttachment
@@ -822,6 +943,16 @@ type DescribeAttachmentOutput struct {
 
 type metadataDescribeAttachmentOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeAttachmentOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAttachmentOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeCasesInput struct {
@@ -866,6 +997,16 @@ type metadataDescribeCasesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCasesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCasesInput) GoString() string {
+	return s.String()
+}
+
 // Returns an array of CaseDetails objects and a NextToken that defines a point
 // for pagination in the result set.
 type DescribeCasesOutput struct {
@@ -880,6 +1021,16 @@ type DescribeCasesOutput struct {
 
 type metadataDescribeCasesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCasesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCasesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeCommunicationsInput struct {
@@ -908,6 +1059,16 @@ type metadataDescribeCommunicationsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeCommunicationsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCommunicationsInput) GoString() string {
+	return s.String()
+}
+
 // The communications returned by the DescribeCommunications operation.
 type DescribeCommunicationsOutput struct {
 	// The communications for the case.
@@ -921,6 +1082,16 @@ type DescribeCommunicationsOutput struct {
 
 type metadataDescribeCommunicationsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeCommunicationsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeCommunicationsOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeServicesInput struct {
@@ -939,6 +1110,16 @@ type metadataDescribeServicesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeServicesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeServicesInput) GoString() string {
+	return s.String()
+}
+
 // The list of AWS services returned by the DescribeServices operation.
 type DescribeServicesOutput struct {
 	// A JSON-formatted list of AWS services.
@@ -949,6 +1130,16 @@ type DescribeServicesOutput struct {
 
 type metadataDescribeServicesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeServicesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeServicesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeSeverityLevelsInput struct {
@@ -964,6 +1155,16 @@ type metadataDescribeSeverityLevelsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSeverityLevelsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSeverityLevelsInput) GoString() string {
+	return s.String()
+}
+
 // The list of severity levels returned by the DescribeSeverityLevels operation.
 type DescribeSeverityLevelsOutput struct {
 	// The available severity levels for the support case. Available severity levels
@@ -977,6 +1178,16 @@ type metadataDescribeSeverityLevelsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeSeverityLevelsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeSeverityLevelsOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeTrustedAdvisorCheckRefreshStatusesInput struct {
 	// The IDs of the Trusted Advisor checks.
 	CheckIDs []*string `locationName:"checkIds" type:"list" required:"true"`
@@ -986,6 +1197,16 @@ type DescribeTrustedAdvisorCheckRefreshStatusesInput struct {
 
 type metadataDescribeTrustedAdvisorCheckRefreshStatusesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTrustedAdvisorCheckRefreshStatusesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrustedAdvisorCheckRefreshStatusesInput) GoString() string {
+	return s.String()
 }
 
 // The statuses of the Trusted Advisor checks returned by the DescribeTrustedAdvisorCheckRefreshStatuses
@@ -999,6 +1220,16 @@ type DescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
 
 type metadataDescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTrustedAdvisorCheckRefreshStatusesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrustedAdvisorCheckRefreshStatusesOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeTrustedAdvisorCheckResultInput struct {
@@ -1017,6 +1248,16 @@ type metadataDescribeTrustedAdvisorCheckResultInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTrustedAdvisorCheckResultInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrustedAdvisorCheckResultInput) GoString() string {
+	return s.String()
+}
+
 // The result of the Trusted Advisor check returned by the DescribeTrustedAdvisorCheckResult
 // operation.
 type DescribeTrustedAdvisorCheckResultOutput struct {
@@ -1030,6 +1271,16 @@ type metadataDescribeTrustedAdvisorCheckResultOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTrustedAdvisorCheckResultOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrustedAdvisorCheckResultOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeTrustedAdvisorCheckSummariesInput struct {
 	// The IDs of the Trusted Advisor checks.
 	CheckIDs []*string `locationName:"checkIds" type:"list" required:"true"`
@@ -1039,6 +1290,16 @@ type DescribeTrustedAdvisorCheckSummariesInput struct {
 
 type metadataDescribeTrustedAdvisorCheckSummariesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTrustedAdvisorCheckSummariesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrustedAdvisorCheckSummariesInput) GoString() string {
+	return s.String()
 }
 
 // The summaries of the Trusted Advisor checks returned by the DescribeTrustedAdvisorCheckSummaries
@@ -1054,6 +1315,16 @@ type metadataDescribeTrustedAdvisorCheckSummariesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTrustedAdvisorCheckSummariesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrustedAdvisorCheckSummariesOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeTrustedAdvisorChecksInput struct {
 	// The ISO 639-1 code for the language in which AWS provides support. AWS Support
 	// currently supports English ("en") and Japanese ("ja"). Language parameters
@@ -1067,6 +1338,16 @@ type metadataDescribeTrustedAdvisorChecksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeTrustedAdvisorChecksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrustedAdvisorChecksInput) GoString() string {
+	return s.String()
+}
+
 // Information about the Trusted Advisor checks returned by the DescribeTrustedAdvisorChecks
 // operation.
 type DescribeTrustedAdvisorChecksOutput struct {
@@ -1078,6 +1359,16 @@ type DescribeTrustedAdvisorChecksOutput struct {
 
 type metadataDescribeTrustedAdvisorChecksOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeTrustedAdvisorChecksOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeTrustedAdvisorChecksOutput) GoString() string {
+	return s.String()
 }
 
 // The five most recent communications associated with the case.
@@ -1095,6 +1386,16 @@ type metadataRecentCaseCommunications struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecentCaseCommunications) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecentCaseCommunications) GoString() string {
+	return s.String()
+}
+
 type RefreshTrustedAdvisorCheckInput struct {
 	// The unique identifier for the Trusted Advisor check.
 	CheckID *string `locationName:"checkId" type:"string" required:"true"`
@@ -1104,6 +1405,16 @@ type RefreshTrustedAdvisorCheckInput struct {
 
 type metadataRefreshTrustedAdvisorCheckInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RefreshTrustedAdvisorCheckInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RefreshTrustedAdvisorCheckInput) GoString() string {
+	return s.String()
 }
 
 // The current refresh status of a Trusted Advisor check.
@@ -1119,6 +1430,16 @@ type metadataRefreshTrustedAdvisorCheckOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RefreshTrustedAdvisorCheckOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RefreshTrustedAdvisorCheckOutput) GoString() string {
+	return s.String()
+}
+
 type ResolveCaseInput struct {
 	// The AWS Support case ID requested or returned in the call. The case ID is
 	// an alphanumeric string formatted as shown in this example: case-12345678910-2013-c4c1d2bf33c5cf47
@@ -1129,6 +1450,16 @@ type ResolveCaseInput struct {
 
 type metadataResolveCaseInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResolveCaseInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResolveCaseInput) GoString() string {
+	return s.String()
 }
 
 // The status of the case returned by the ResolveCase operation.
@@ -1144,6 +1475,16 @@ type ResolveCaseOutput struct {
 
 type metadataResolveCaseOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ResolveCaseOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ResolveCaseOutput) GoString() string {
+	return s.String()
 }
 
 // Information about an AWS service returned by the DescribeServices operation.
@@ -1168,6 +1509,16 @@ type metadataService struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Service) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Service) GoString() string {
+	return s.String()
+}
+
 // A code and name pair that represent a severity level that can be applied
 // to a support case.
 type SeverityLevel struct {
@@ -1185,6 +1536,16 @@ type metadataSeverityLevel struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SeverityLevel) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SeverityLevel) GoString() string {
+	return s.String()
+}
+
 // The container for summary information that relates to the category of the
 // Trusted Advisor check.
 type TrustedAdvisorCategorySpecificSummary struct {
@@ -1197,6 +1558,16 @@ type TrustedAdvisorCategorySpecificSummary struct {
 
 type metadataTrustedAdvisorCategorySpecificSummary struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TrustedAdvisorCategorySpecificSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedAdvisorCategorySpecificSummary) GoString() string {
+	return s.String()
 }
 
 // The description and metadata for a Trusted Advisor check.
@@ -1228,6 +1599,16 @@ type metadataTrustedAdvisorCheckDescription struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TrustedAdvisorCheckDescription) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedAdvisorCheckDescription) GoString() string {
+	return s.String()
+}
+
 // The refresh status of a Trusted Advisor check.
 type TrustedAdvisorCheckRefreshStatus struct {
 	// The unique identifier for the Trusted Advisor check.
@@ -1246,6 +1627,16 @@ type TrustedAdvisorCheckRefreshStatus struct {
 
 type metadataTrustedAdvisorCheckRefreshStatus struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TrustedAdvisorCheckRefreshStatus) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedAdvisorCheckRefreshStatus) GoString() string {
+	return s.String()
 }
 
 // The results of a Trusted Advisor check returned by DescribeTrustedAdvisorCheckResult.
@@ -1276,6 +1667,16 @@ type TrustedAdvisorCheckResult struct {
 
 type metadataTrustedAdvisorCheckResult struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TrustedAdvisorCheckResult) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedAdvisorCheckResult) GoString() string {
+	return s.String()
 }
 
 // A summary of a Trusted Advisor check result, including the alert status,
@@ -1309,6 +1710,16 @@ type metadataTrustedAdvisorCheckSummary struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TrustedAdvisorCheckSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedAdvisorCheckSummary) GoString() string {
+	return s.String()
+}
+
 // The estimated cost savings that might be realized if the recommended actions
 // are taken.
 type TrustedAdvisorCostOptimizingSummary struct {
@@ -1325,6 +1736,16 @@ type TrustedAdvisorCostOptimizingSummary struct {
 
 type metadataTrustedAdvisorCostOptimizingSummary struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TrustedAdvisorCostOptimizingSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedAdvisorCostOptimizingSummary) GoString() string {
+	return s.String()
 }
 
 // Contains information about a resource identified by a Trusted Advisor check.
@@ -1356,6 +1777,16 @@ type metadataTrustedAdvisorResourceDetail struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TrustedAdvisorResourceDetail) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedAdvisorResourceDetail) GoString() string {
+	return s.String()
+}
+
 // Details about AWS resources that were analyzed in a call to Trusted Advisor
 // DescribeTrustedAdvisorCheckSummaries.
 type TrustedAdvisorResourcesSummary struct {
@@ -1379,4 +1810,14 @@ type TrustedAdvisorResourcesSummary struct {
 
 type metadataTrustedAdvisorResourcesSummary struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TrustedAdvisorResourcesSummary) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TrustedAdvisorResourcesSummary) GoString() string {
+	return s.String()
 }

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCountClosedWorkflowExecutions = "CountClosedWorkflowExecutions"
@@ -1592,6 +1593,16 @@ type metadataActivityTaskCancelRequestedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActivityTaskCancelRequestedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTaskCancelRequestedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the ActivityTaskCanceled event.
 type ActivityTaskCanceledEventAttributes struct {
 	// Details of the cancellation (if any).
@@ -1619,6 +1630,16 @@ type metadataActivityTaskCanceledEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActivityTaskCanceledEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTaskCanceledEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the ActivityTaskCompleted event.
 type ActivityTaskCompletedEventAttributes struct {
 	// The results of the activity task (if any).
@@ -1639,6 +1660,16 @@ type ActivityTaskCompletedEventAttributes struct {
 
 type metadataActivityTaskCompletedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ActivityTaskCompletedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTaskCompletedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ActivityTaskFailed event.
@@ -1664,6 +1695,16 @@ type ActivityTaskFailedEventAttributes struct {
 
 type metadataActivityTaskFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ActivityTaskFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTaskFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ActivityTaskScheduled event.
@@ -1726,6 +1767,16 @@ type metadataActivityTaskScheduledEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActivityTaskScheduledEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTaskScheduledEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the ActivityTaskStarted event.
 type ActivityTaskStartedEventAttributes struct {
 	// Identity of the worker that was assigned this task. This aids diagnostics
@@ -1742,6 +1793,16 @@ type ActivityTaskStartedEventAttributes struct {
 
 type metadataActivityTaskStartedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ActivityTaskStartedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTaskStartedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ActivityTaskTimedOut event.
@@ -1770,6 +1831,16 @@ type metadataActivityTaskTimedOutEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActivityTaskTimedOutEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTaskTimedOutEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Represents an activity type.
 type ActivityType struct {
 	// The name of this activity.
@@ -1789,6 +1860,16 @@ type ActivityType struct {
 
 type metadataActivityType struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ActivityType) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityType) GoString() string {
+	return s.String()
 }
 
 // Configuration settings registered with the activity type.
@@ -1857,6 +1938,16 @@ type metadataActivityTypeConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ActivityTypeConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTypeConfiguration) GoString() string {
+	return s.String()
+}
+
 // Detailed information about an activity type.
 type ActivityTypeInfo struct {
 	// The ActivityType type structure representing the activity type.
@@ -1879,6 +1970,16 @@ type ActivityTypeInfo struct {
 
 type metadataActivityTypeInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ActivityTypeInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ActivityTypeInfo) GoString() string {
+	return s.String()
 }
 
 // Provides details of the CancelTimer decision.
@@ -1907,6 +2008,16 @@ type metadataCancelTimerDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelTimerDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelTimerDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the CancelTimerFailed event.
 type CancelTimerFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -1931,6 +2042,16 @@ type CancelTimerFailedEventAttributes struct {
 
 type metadataCancelTimerFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelTimerFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelTimerFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the CancelWorkflowExecution decision.
@@ -1959,6 +2080,16 @@ type metadataCancelWorkflowExecutionDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CancelWorkflowExecutionDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelWorkflowExecutionDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the CancelWorkflowExecutionFailed event.
 type CancelWorkflowExecutionFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -1980,6 +2111,16 @@ type CancelWorkflowExecutionFailedEventAttributes struct {
 
 type metadataCancelWorkflowExecutionFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CancelWorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CancelWorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provide details of the ChildWorkflowExecutionCanceled event.
@@ -2011,6 +2152,16 @@ type metadataChildWorkflowExecutionCanceledEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ChildWorkflowExecutionCanceledEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChildWorkflowExecutionCanceledEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the ChildWorkflowExecutionCompleted event.
 type ChildWorkflowExecutionCompletedEventAttributes struct {
 	// The id of the StartChildWorkflowExecutionInitiated event corresponding to
@@ -2038,6 +2189,16 @@ type ChildWorkflowExecutionCompletedEventAttributes struct {
 
 type metadataChildWorkflowExecutionCompletedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChildWorkflowExecutionCompletedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChildWorkflowExecutionCompletedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ChildWorkflowExecutionFailed event.
@@ -2072,6 +2233,16 @@ type metadataChildWorkflowExecutionFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ChildWorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChildWorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the ChildWorkflowExecutionStarted event.
 type ChildWorkflowExecutionStartedEventAttributes struct {
 	// The id of the StartChildWorkflowExecutionInitiated event corresponding to
@@ -2091,6 +2262,16 @@ type ChildWorkflowExecutionStartedEventAttributes struct {
 
 type metadataChildWorkflowExecutionStartedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChildWorkflowExecutionStartedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChildWorkflowExecutionStartedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ChildWorkflowExecutionTerminated event.
@@ -2117,6 +2298,16 @@ type ChildWorkflowExecutionTerminatedEventAttributes struct {
 
 type metadataChildWorkflowExecutionTerminatedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ChildWorkflowExecutionTerminatedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChildWorkflowExecutionTerminatedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ChildWorkflowExecutionTimedOut event.
@@ -2149,6 +2340,16 @@ type metadataChildWorkflowExecutionTimedOutEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ChildWorkflowExecutionTimedOutEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ChildWorkflowExecutionTimedOutEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Used to filter the closed workflow executions in visibility APIs by their
 // close status.
 type CloseStatusFilter struct {
@@ -2161,6 +2362,16 @@ type CloseStatusFilter struct {
 
 type metadataCloseStatusFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CloseStatusFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CloseStatusFilter) GoString() string {
+	return s.String()
 }
 
 // Provides details of the CompleteWorkflowExecution decision.
@@ -2190,6 +2401,16 @@ type metadataCompleteWorkflowExecutionDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CompleteWorkflowExecutionDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompleteWorkflowExecutionDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the CompleteWorkflowExecutionFailed event.
 type CompleteWorkflowExecutionFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -2211,6 +2432,16 @@ type CompleteWorkflowExecutionFailedEventAttributes struct {
 
 type metadataCompleteWorkflowExecutionFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CompleteWorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CompleteWorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ContinueAsNewWorkflowExecution decision.
@@ -2308,6 +2539,16 @@ type metadataContinueAsNewWorkflowExecutionDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ContinueAsNewWorkflowExecutionDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ContinueAsNewWorkflowExecutionDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the ContinueAsNewWorkflowExecutionFailed event.
 type ContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -2329,6 +2570,16 @@ type ContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 
 type metadataContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ContinueAsNewWorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ContinueAsNewWorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 type CountClosedWorkflowExecutionsInput struct {
@@ -2383,6 +2634,16 @@ type metadataCountClosedWorkflowExecutionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CountClosedWorkflowExecutionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CountClosedWorkflowExecutionsInput) GoString() string {
+	return s.String()
+}
+
 type CountOpenWorkflowExecutionsInput struct {
 	// The name of the domain containing the workflow executions to count.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -2418,6 +2679,16 @@ type metadataCountOpenWorkflowExecutionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CountOpenWorkflowExecutionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CountOpenWorkflowExecutionsInput) GoString() string {
+	return s.String()
+}
+
 type CountPendingActivityTasksInput struct {
 	// The name of the domain that contains the task list.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -2432,6 +2703,16 @@ type metadataCountPendingActivityTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s CountPendingActivityTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CountPendingActivityTasksInput) GoString() string {
+	return s.String()
+}
+
 type CountPendingDecisionTasksInput struct {
 	// The name of the domain that contains the task list.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -2444,6 +2725,16 @@ type CountPendingDecisionTasksInput struct {
 
 type metadataCountPendingDecisionTasksInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CountPendingDecisionTasksInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CountPendingDecisionTasksInput) GoString() string {
+	return s.String()
 }
 
 // Specifies a decision made by the decider. A decision can be one of these
@@ -2608,6 +2899,16 @@ type metadataDecision struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Decision) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Decision) GoString() string {
+	return s.String()
+}
+
 // Provides details of the DecisionTaskCompleted event.
 type DecisionTaskCompletedEventAttributes struct {
 	// User defined context for the workflow execution.
@@ -2628,6 +2929,16 @@ type DecisionTaskCompletedEventAttributes struct {
 
 type metadataDecisionTaskCompletedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DecisionTaskCompletedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DecisionTaskCompletedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details about the DecisionTaskScheduled event.
@@ -2659,6 +2970,16 @@ type metadataDecisionTaskScheduledEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DecisionTaskScheduledEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DecisionTaskScheduledEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the DecisionTaskStarted event.
 type DecisionTaskStartedEventAttributes struct {
 	// Identity of the decider making the request. This enables diagnostic tracing
@@ -2675,6 +2996,16 @@ type DecisionTaskStartedEventAttributes struct {
 
 type metadataDecisionTaskStartedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DecisionTaskStartedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DecisionTaskStartedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the DecisionTaskTimedOut event.
@@ -2699,6 +3030,16 @@ type metadataDecisionTaskTimedOutEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DecisionTaskTimedOutEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DecisionTaskTimedOutEventAttributes) GoString() string {
+	return s.String()
+}
+
 type DeprecateActivityTypeInput struct {
 	// The activity type to deprecate.
 	ActivityType *ActivityType `locationName:"activityType" type:"structure" required:"true"`
@@ -2713,12 +3054,32 @@ type metadataDeprecateActivityTypeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeprecateActivityTypeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeprecateActivityTypeInput) GoString() string {
+	return s.String()
+}
+
 type DeprecateActivityTypeOutput struct {
 	metadataDeprecateActivityTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateActivityTypeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeprecateActivityTypeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeprecateActivityTypeOutput) GoString() string {
+	return s.String()
 }
 
 type DeprecateDomainInput struct {
@@ -2732,12 +3093,32 @@ type metadataDeprecateDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeprecateDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeprecateDomainInput) GoString() string {
+	return s.String()
+}
+
 type DeprecateDomainOutput struct {
 	metadataDeprecateDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeprecateDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeprecateDomainOutput) GoString() string {
+	return s.String()
 }
 
 type DeprecateWorkflowTypeInput struct {
@@ -2754,12 +3135,32 @@ type metadataDeprecateWorkflowTypeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DeprecateWorkflowTypeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeprecateWorkflowTypeInput) GoString() string {
+	return s.String()
+}
+
 type DeprecateWorkflowTypeOutput struct {
 	metadataDeprecateWorkflowTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataDeprecateWorkflowTypeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeprecateWorkflowTypeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DeprecateWorkflowTypeOutput) GoString() string {
+	return s.String()
 }
 
 type DescribeActivityTypeInput struct {
@@ -2775,6 +3176,16 @@ type DescribeActivityTypeInput struct {
 
 type metadataDescribeActivityTypeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeActivityTypeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeActivityTypeInput) GoString() string {
+	return s.String()
 }
 
 // Detailed information about an activity type.
@@ -2800,6 +3211,16 @@ type metadataDescribeActivityTypeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeActivityTypeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeActivityTypeOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeDomainInput struct {
 	// The name of the domain to describe.
 	Name *string `locationName:"name" type:"string" required:"true"`
@@ -2809,6 +3230,16 @@ type DescribeDomainInput struct {
 
 type metadataDescribeDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDomainInput) GoString() string {
+	return s.String()
 }
 
 // Contains details of a domain.
@@ -2826,6 +3257,16 @@ type metadataDescribeDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeDomainOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeWorkflowExecutionInput struct {
 	// The name of the domain containing the workflow execution.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -2838,6 +3279,16 @@ type DescribeWorkflowExecutionInput struct {
 
 type metadataDescribeWorkflowExecutionInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeWorkflowExecutionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkflowExecutionInput) GoString() string {
+	return s.String()
 }
 
 // Contains details about a workflow execution.
@@ -2870,6 +3321,16 @@ type metadataDescribeWorkflowExecutionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeWorkflowExecutionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkflowExecutionOutput) GoString() string {
+	return s.String()
+}
+
 type DescribeWorkflowTypeInput struct {
 	// The name of the domain in which this workflow type is registered.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -2882,6 +3343,16 @@ type DescribeWorkflowTypeInput struct {
 
 type metadataDescribeWorkflowTypeInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeWorkflowTypeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkflowTypeInput) GoString() string {
+	return s.String()
 }
 
 // Contains details about a workflow type.
@@ -2907,6 +3378,16 @@ type metadataDescribeWorkflowTypeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeWorkflowTypeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkflowTypeOutput) GoString() string {
+	return s.String()
+}
+
 // Contains the configuration settings of a domain.
 type DomainConfiguration struct {
 	// The retention period for workflow executions in this domain.
@@ -2917,6 +3398,16 @@ type DomainConfiguration struct {
 
 type metadataDomainConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DomainConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DomainConfiguration) GoString() string {
+	return s.String()
 }
 
 // Contains general information about a domain.
@@ -2942,6 +3433,16 @@ type metadataDomainInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DomainInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DomainInfo) GoString() string {
+	return s.String()
+}
+
 // Used to filter the workflow executions in visibility APIs by various time-based
 // rules. Each parameter, if specified, defines a rule that must be satisfied
 // by each returned query result. The parameter values are in the Unix Time
@@ -2959,6 +3460,16 @@ type ExecutionTimeFilter struct {
 
 type metadataExecutionTimeFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ExecutionTimeFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExecutionTimeFilter) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ExternalWorkflowExecutionCancelRequested event.
@@ -2979,6 +3490,16 @@ type metadataExternalWorkflowExecutionCancelRequestedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ExternalWorkflowExecutionCancelRequestedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExternalWorkflowExecutionCancelRequestedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the ExternalWorkflowExecutionSignaled event.
 type ExternalWorkflowExecutionSignaledEventAttributes struct {
 	// The id of the SignalExternalWorkflowExecutionInitiated event corresponding
@@ -2995,6 +3516,16 @@ type ExternalWorkflowExecutionSignaledEventAttributes struct {
 
 type metadataExternalWorkflowExecutionSignaledEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ExternalWorkflowExecutionSignaledEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ExternalWorkflowExecutionSignaledEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the FailWorkflowExecution decision.
@@ -3026,6 +3557,16 @@ type metadataFailWorkflowExecutionDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FailWorkflowExecutionDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FailWorkflowExecutionDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the FailWorkflowExecutionFailed event.
 type FailWorkflowExecutionFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -3047,6 +3588,16 @@ type FailWorkflowExecutionFailedEventAttributes struct {
 
 type metadataFailWorkflowExecutionFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s FailWorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FailWorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 type GetWorkflowExecutionHistoryInput struct {
@@ -3084,6 +3635,16 @@ type metadataGetWorkflowExecutionHistoryInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s GetWorkflowExecutionHistoryInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetWorkflowExecutionHistoryInput) GoString() string {
+	return s.String()
+}
+
 // Paginated representation of a workflow history for a workflow execution.
 // This is the up to date, complete and authoritative record of the events related
 // to all tasks and events in the life of the workflow execution.
@@ -3104,6 +3665,16 @@ type GetWorkflowExecutionHistoryOutput struct {
 
 type metadataGetWorkflowExecutionHistoryOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetWorkflowExecutionHistoryOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s GetWorkflowExecutionHistoryOutput) GoString() string {
+	return s.String()
 }
 
 // Event within a workflow execution. A history event can be one of these types:
@@ -3408,6 +3979,16 @@ type metadataHistoryEvent struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s HistoryEvent) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s HistoryEvent) GoString() string {
+	return s.String()
+}
+
 type ListActivityTypesInput struct {
 	// The name of the domain in which the activity types have been registered.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -3446,6 +4027,16 @@ type metadataListActivityTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListActivityTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListActivityTypesInput) GoString() string {
+	return s.String()
+}
+
 // Contains a paginated list of activity type information structures.
 type ListActivityTypesOutput struct {
 	// If a NextPageToken was returned by a previous call, there are more results
@@ -3464,6 +4055,16 @@ type ListActivityTypesOutput struct {
 
 type metadataListActivityTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListActivityTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListActivityTypesOutput) GoString() string {
+	return s.String()
 }
 
 type ListClosedWorkflowExecutionsInput struct {
@@ -3543,6 +4144,16 @@ type metadataListClosedWorkflowExecutionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListClosedWorkflowExecutionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListClosedWorkflowExecutionsInput) GoString() string {
+	return s.String()
+}
+
 type ListDomainsInput struct {
 	// The maximum number of results that will be returned per call. nextPageToken
 	// can be used to obtain futher pages of results. The default is 100, which
@@ -3575,6 +4186,16 @@ type metadataListDomainsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListDomainsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDomainsInput) GoString() string {
+	return s.String()
+}
+
 // Contains a paginated collection of DomainInfo structures.
 type ListDomainsOutput struct {
 	// A list of DomainInfo structures.
@@ -3593,6 +4214,16 @@ type ListDomainsOutput struct {
 
 type metadataListDomainsOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListDomainsOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListDomainsOutput) GoString() string {
+	return s.String()
 }
 
 type ListOpenWorkflowExecutionsInput struct {
@@ -3650,6 +4281,16 @@ type metadataListOpenWorkflowExecutionsInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListOpenWorkflowExecutionsInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListOpenWorkflowExecutionsInput) GoString() string {
+	return s.String()
+}
+
 type ListWorkflowTypesInput struct {
 	// The name of the domain in which the workflow types have been registered.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -3689,6 +4330,16 @@ type metadataListWorkflowTypesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ListWorkflowTypesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListWorkflowTypesInput) GoString() string {
+	return s.String()
+}
+
 // Contains a paginated list of information structures about workflow types.
 type ListWorkflowTypesOutput struct {
 	// If a NextPageToken was returned by a previous call, there are more results
@@ -3707,6 +4358,16 @@ type ListWorkflowTypesOutput struct {
 
 type metadataListWorkflowTypesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ListWorkflowTypesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ListWorkflowTypesOutput) GoString() string {
+	return s.String()
 }
 
 // Provides details of the MarkerRecorded event.
@@ -3730,6 +4391,16 @@ type metadataMarkerRecordedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s MarkerRecordedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s MarkerRecordedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Contains the count of tasks in a task list.
 type PendingTaskCount struct {
 	// The number of tasks in the task list.
@@ -3744,6 +4415,16 @@ type PendingTaskCount struct {
 
 type metadataPendingTaskCount struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PendingTaskCount) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PendingTaskCount) GoString() string {
+	return s.String()
 }
 
 type PollForActivityTaskInput struct {
@@ -3768,6 +4449,16 @@ type PollForActivityTaskInput struct {
 
 type metadataPollForActivityTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PollForActivityTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PollForActivityTaskInput) GoString() string {
+	return s.String()
 }
 
 // Unit of work sent to an activity worker.
@@ -3798,6 +4489,16 @@ type PollForActivityTaskOutput struct {
 
 type metadataPollForActivityTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s PollForActivityTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PollForActivityTaskOutput) GoString() string {
+	return s.String()
 }
 
 type PollForDecisionTaskInput struct {
@@ -3850,6 +4551,16 @@ type metadataPollForDecisionTaskInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PollForDecisionTaskInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PollForDecisionTaskInput) GoString() string {
+	return s.String()
+}
+
 // A structure that represents a decision task. Decision tasks are sent to deciders
 // in order for them to make decisions.
 type PollForDecisionTaskOutput struct {
@@ -3892,6 +4603,16 @@ type metadataPollForDecisionTaskOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s PollForDecisionTaskOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s PollForDecisionTaskOutput) GoString() string {
+	return s.String()
+}
+
 type RecordActivityTaskHeartbeatInput struct {
 	// If specified, contains details about the progress of the task.
 	Details *string `locationName:"details" type:"string"`
@@ -3910,6 +4631,16 @@ type metadataRecordActivityTaskHeartbeatInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecordActivityTaskHeartbeatInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecordActivityTaskHeartbeatInput) GoString() string {
+	return s.String()
+}
+
 // Status information about an activity task.
 type RecordActivityTaskHeartbeatOutput struct {
 	// Set to true if cancellation of the task is requested.
@@ -3920,6 +4651,16 @@ type RecordActivityTaskHeartbeatOutput struct {
 
 type metadataRecordActivityTaskHeartbeatOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RecordActivityTaskHeartbeatOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecordActivityTaskHeartbeatOutput) GoString() string {
+	return s.String()
 }
 
 // Provides details of the RecordMarker decision.
@@ -3951,6 +4692,16 @@ type metadataRecordMarkerDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RecordMarkerDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecordMarkerDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the RecordMarkerFailed event.
 type RecordMarkerFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -3975,6 +4726,16 @@ type RecordMarkerFailedEventAttributes struct {
 
 type metadataRecordMarkerFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RecordMarkerFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RecordMarkerFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 type RegisterActivityTypeInput struct {
@@ -4060,12 +4821,32 @@ type metadataRegisterActivityTypeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterActivityTypeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterActivityTypeInput) GoString() string {
+	return s.String()
+}
+
 type RegisterActivityTypeOutput struct {
 	metadataRegisterActivityTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterActivityTypeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterActivityTypeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterActivityTypeOutput) GoString() string {
+	return s.String()
 }
 
 type RegisterDomainInput struct {
@@ -4101,12 +4882,32 @@ type metadataRegisterDomainInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterDomainInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterDomainInput) GoString() string {
+	return s.String()
+}
+
 type RegisterDomainOutput struct {
 	metadataRegisterDomainOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterDomainOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterDomainOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterDomainOutput) GoString() string {
+	return s.String()
 }
 
 type RegisterWorkflowTypeInput struct {
@@ -4192,12 +4993,32 @@ type metadataRegisterWorkflowTypeInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RegisterWorkflowTypeInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterWorkflowTypeInput) GoString() string {
+	return s.String()
+}
+
 type RegisterWorkflowTypeOutput struct {
 	metadataRegisterWorkflowTypeOutput `json:"-" xml:"-"`
 }
 
 type metadataRegisterWorkflowTypeOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RegisterWorkflowTypeOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RegisterWorkflowTypeOutput) GoString() string {
+	return s.String()
 }
 
 // Provides details of the RequestCancelActivityTask decision.
@@ -4226,6 +5047,16 @@ type metadataRequestCancelActivityTaskDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RequestCancelActivityTaskDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestCancelActivityTaskDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the RequestCancelActivityTaskFailed event.
 type RequestCancelActivityTaskFailedEventAttributes struct {
 	// The activityId provided in the RequestCancelActivityTask decision that failed.
@@ -4250,6 +5081,16 @@ type RequestCancelActivityTaskFailedEventAttributes struct {
 
 type metadataRequestCancelActivityTaskFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RequestCancelActivityTaskFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestCancelActivityTaskFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the RequestCancelExternalWorkflowExecution decision.
@@ -4283,6 +5124,16 @@ type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 
 type metadataRequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RequestCancelExternalWorkflowExecutionDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestCancelExternalWorkflowExecutionDecisionAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the RequestCancelExternalWorkflowExecutionFailed event.
@@ -4323,6 +5174,16 @@ type metadataRequestCancelExternalWorkflowExecutionFailedEventAttributes struct 
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RequestCancelExternalWorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestCancelExternalWorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the RequestCancelExternalWorkflowExecutionInitiated event.
 type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
 	// Optional. Data attached to the event that can be used by the decider in subsequent
@@ -4348,6 +5209,16 @@ type metadataRequestCancelExternalWorkflowExecutionInitiatedEventAttributes stru
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) GoString() string {
+	return s.String()
+}
+
 type RequestCancelWorkflowExecutionInput struct {
 	// The name of the domain containing the workflow execution to cancel.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -4365,12 +5236,32 @@ type metadataRequestCancelWorkflowExecutionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RequestCancelWorkflowExecutionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestCancelWorkflowExecutionInput) GoString() string {
+	return s.String()
+}
+
 type RequestCancelWorkflowExecutionOutput struct {
 	metadataRequestCancelWorkflowExecutionOutput `json:"-" xml:"-"`
 }
 
 type metadataRequestCancelWorkflowExecutionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RequestCancelWorkflowExecutionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RequestCancelWorkflowExecutionOutput) GoString() string {
+	return s.String()
 }
 
 type RespondActivityTaskCanceledInput struct {
@@ -4391,12 +5282,32 @@ type metadataRespondActivityTaskCanceledInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RespondActivityTaskCanceledInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RespondActivityTaskCanceledInput) GoString() string {
+	return s.String()
+}
+
 type RespondActivityTaskCanceledOutput struct {
 	metadataRespondActivityTaskCanceledOutput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskCanceledOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RespondActivityTaskCanceledOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RespondActivityTaskCanceledOutput) GoString() string {
+	return s.String()
 }
 
 type RespondActivityTaskCompletedInput struct {
@@ -4418,12 +5329,32 @@ type metadataRespondActivityTaskCompletedInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RespondActivityTaskCompletedInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RespondActivityTaskCompletedInput) GoString() string {
+	return s.String()
+}
+
 type RespondActivityTaskCompletedOutput struct {
 	metadataRespondActivityTaskCompletedOutput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskCompletedOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RespondActivityTaskCompletedOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RespondActivityTaskCompletedOutput) GoString() string {
+	return s.String()
 }
 
 type RespondActivityTaskFailedInput struct {
@@ -4447,12 +5378,32 @@ type metadataRespondActivityTaskFailedInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RespondActivityTaskFailedInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RespondActivityTaskFailedInput) GoString() string {
+	return s.String()
+}
+
 type RespondActivityTaskFailedOutput struct {
 	metadataRespondActivityTaskFailedOutput `json:"-" xml:"-"`
 }
 
 type metadataRespondActivityTaskFailedOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RespondActivityTaskFailedOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RespondActivityTaskFailedOutput) GoString() string {
+	return s.String()
 }
 
 type RespondDecisionTaskCompletedInput struct {
@@ -4477,12 +5428,32 @@ type metadataRespondDecisionTaskCompletedInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RespondDecisionTaskCompletedInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RespondDecisionTaskCompletedInput) GoString() string {
+	return s.String()
+}
+
 type RespondDecisionTaskCompletedOutput struct {
 	metadataRespondDecisionTaskCompletedOutput `json:"-" xml:"-"`
 }
 
 type metadataRespondDecisionTaskCompletedOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RespondDecisionTaskCompletedOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RespondDecisionTaskCompletedOutput) GoString() string {
+	return s.String()
 }
 
 // Provides details of the ScheduleActivityTask decision.
@@ -4601,6 +5572,16 @@ type metadataScheduleActivityTaskDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ScheduleActivityTaskDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScheduleActivityTaskDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the ScheduleActivityTaskFailed event.
 type ScheduleActivityTaskFailedEventAttributes struct {
 	// The activityId provided in the ScheduleActivityTask decision that failed.
@@ -4628,6 +5609,16 @@ type ScheduleActivityTaskFailedEventAttributes struct {
 
 type metadataScheduleActivityTaskFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s ScheduleActivityTaskFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ScheduleActivityTaskFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the SignalExternalWorkflowExecution decision.
@@ -4671,6 +5662,16 @@ type metadataSignalExternalWorkflowExecutionDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SignalExternalWorkflowExecutionDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SignalExternalWorkflowExecutionDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the SignalExternalWorkflowExecutionFailed event.
 type SignalExternalWorkflowExecutionFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -4710,6 +5711,16 @@ type metadataSignalExternalWorkflowExecutionFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SignalExternalWorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SignalExternalWorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the SignalExternalWorkflowExecutionInitiated event.
 type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 	// Optional. data attached to the event that can be used by the decider in subsequent
@@ -4741,6 +5752,16 @@ type metadataSignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SignalExternalWorkflowExecutionInitiatedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SignalExternalWorkflowExecutionInitiatedEventAttributes) GoString() string {
+	return s.String()
+}
+
 type SignalWorkflowExecutionInput struct {
 	// The name of the domain containing the workflow execution to signal.
 	Domain *string `locationName:"domain" type:"string" required:"true"`
@@ -4765,12 +5786,32 @@ type metadataSignalWorkflowExecutionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s SignalWorkflowExecutionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SignalWorkflowExecutionInput) GoString() string {
+	return s.String()
+}
+
 type SignalWorkflowExecutionOutput struct {
 	metadataSignalWorkflowExecutionOutput `json:"-" xml:"-"`
 }
 
 type metadataSignalWorkflowExecutionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s SignalWorkflowExecutionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s SignalWorkflowExecutionOutput) GoString() string {
+	return s.String()
 }
 
 // Provides details of the StartChildWorkflowExecution decision.
@@ -4890,6 +5931,16 @@ type metadataStartChildWorkflowExecutionDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartChildWorkflowExecutionDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartChildWorkflowExecutionDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the StartChildWorkflowExecutionFailed event.
 type StartChildWorkflowExecutionFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -4926,6 +5977,16 @@ type StartChildWorkflowExecutionFailedEventAttributes struct {
 
 type metadataStartChildWorkflowExecutionFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartChildWorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartChildWorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the StartChildWorkflowExecutionInitiated event.
@@ -4999,6 +6060,16 @@ type metadataStartChildWorkflowExecutionInitiatedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartChildWorkflowExecutionInitiatedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartChildWorkflowExecutionInitiatedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the StartTimer decision.
 //
 // Access Control
@@ -5040,6 +6111,16 @@ type metadataStartTimerDecisionAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartTimerDecisionAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartTimerDecisionAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the StartTimerFailed event.
 type StartTimerFailedEventAttributes struct {
 	// The cause of the failure. This information is generated by the system and
@@ -5064,6 +6145,16 @@ type StartTimerFailedEventAttributes struct {
 
 type metadataStartTimerFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartTimerFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartTimerFailedEventAttributes) GoString() string {
+	return s.String()
 }
 
 type StartWorkflowExecutionInput struct {
@@ -5174,6 +6265,16 @@ type metadataStartWorkflowExecutionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s StartWorkflowExecutionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartWorkflowExecutionInput) GoString() string {
+	return s.String()
+}
+
 // Specifies the runId of a workflow execution.
 type StartWorkflowExecutionOutput struct {
 	// The runId of a workflow execution. This Id is generated by the service and
@@ -5185,6 +6286,16 @@ type StartWorkflowExecutionOutput struct {
 
 type metadataStartWorkflowExecutionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s StartWorkflowExecutionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s StartWorkflowExecutionOutput) GoString() string {
+	return s.String()
 }
 
 // Used to filter the workflow executions in visibility APIs based on a tag.
@@ -5200,6 +6311,16 @@ type metadataTagFilter struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TagFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TagFilter) GoString() string {
+	return s.String()
+}
+
 // Represents a task list.
 type TaskList struct {
 	// The name of the task list.
@@ -5210,6 +6331,16 @@ type TaskList struct {
 
 type metadataTaskList struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TaskList) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TaskList) GoString() string {
+	return s.String()
 }
 
 type TerminateWorkflowExecutionInput struct {
@@ -5253,12 +6384,32 @@ type metadataTerminateWorkflowExecutionInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TerminateWorkflowExecutionInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateWorkflowExecutionInput) GoString() string {
+	return s.String()
+}
+
 type TerminateWorkflowExecutionOutput struct {
 	metadataTerminateWorkflowExecutionOutput `json:"-" xml:"-"`
 }
 
 type metadataTerminateWorkflowExecutionOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TerminateWorkflowExecutionOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateWorkflowExecutionOutput) GoString() string {
+	return s.String()
 }
 
 // Provides details of the TimerCanceled event.
@@ -5284,6 +6435,16 @@ type metadataTimerCanceledEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TimerCanceledEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TimerCanceledEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the TimerFired event.
 type TimerFiredEventAttributes struct {
 	// The id of the TimerStarted event that was recorded when this timer was started.
@@ -5299,6 +6460,16 @@ type TimerFiredEventAttributes struct {
 
 type metadataTimerFiredEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TimerFiredEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TimerFiredEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of the TimerStarted event.
@@ -5329,6 +6500,16 @@ type metadataTimerStartedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TimerStartedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TimerStartedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Represents a workflow execution.
 type WorkflowExecution struct {
 	// A system-generated unique identifier for the workflow execution.
@@ -5342,6 +6523,16 @@ type WorkflowExecution struct {
 
 type metadataWorkflowExecution struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowExecution) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecution) GoString() string {
+	return s.String()
 }
 
 // Provides details of the WorkflowExecutionCancelRequested event.
@@ -5368,6 +6559,16 @@ type metadataWorkflowExecutionCancelRequestedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowExecutionCancelRequestedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionCancelRequestedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the WorkflowExecutionCanceled event.
 type WorkflowExecutionCanceledEventAttributes struct {
 	// The id of the DecisionTaskCompleted event corresponding to the decision task
@@ -5386,6 +6587,16 @@ type metadataWorkflowExecutionCanceledEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowExecutionCanceledEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionCanceledEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the WorkflowExecutionCompleted event.
 type WorkflowExecutionCompletedEventAttributes struct {
 	// The id of the DecisionTaskCompleted event corresponding to the decision task
@@ -5402,6 +6613,16 @@ type WorkflowExecutionCompletedEventAttributes struct {
 
 type metadataWorkflowExecutionCompletedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowExecutionCompletedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionCompletedEventAttributes) GoString() string {
+	return s.String()
 }
 
 // The configuration settings for a workflow execution including timeout values,
@@ -5451,6 +6672,16 @@ type WorkflowExecutionConfiguration struct {
 
 type metadataWorkflowExecutionConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowExecutionConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionConfiguration) GoString() string {
+	return s.String()
 }
 
 // Provides details of the WorkflowExecutionContinuedAsNew event.
@@ -5510,6 +6741,16 @@ type metadataWorkflowExecutionContinuedAsNewEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowExecutionContinuedAsNewEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionContinuedAsNewEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Contains the count of workflow executions returned from CountOpenWorkflowExecutions
 // or CountClosedWorkflowExecutions
 type WorkflowExecutionCount struct {
@@ -5525,6 +6766,16 @@ type WorkflowExecutionCount struct {
 
 type metadataWorkflowExecutionCount struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowExecutionCount) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionCount) GoString() string {
+	return s.String()
 }
 
 // Provides details of the WorkflowExecutionFailed event.
@@ -5548,6 +6799,16 @@ type metadataWorkflowExecutionFailedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowExecutionFailedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionFailedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Used to filter the workflow executions in visibility APIs by their workflowId.
 type WorkflowExecutionFilter struct {
 	// The workflowId to pass of match the criteria of this filter.
@@ -5558,6 +6819,16 @@ type WorkflowExecutionFilter struct {
 
 type metadataWorkflowExecutionFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowExecutionFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionFilter) GoString() string {
+	return s.String()
 }
 
 // Contains information about a workflow execution.
@@ -5609,6 +6880,16 @@ type metadataWorkflowExecutionInfo struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowExecutionInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionInfo) GoString() string {
+	return s.String()
+}
+
 // Contains a paginated list of information about workflow executions.
 type WorkflowExecutionInfos struct {
 	// The list of workflow information structures.
@@ -5627,6 +6908,16 @@ type WorkflowExecutionInfos struct {
 
 type metadataWorkflowExecutionInfos struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowExecutionInfos) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionInfos) GoString() string {
+	return s.String()
 }
 
 // Contains the counts of open tasks, child workflow executions and timers for
@@ -5651,6 +6942,16 @@ type WorkflowExecutionOpenCounts struct {
 
 type metadataWorkflowExecutionOpenCounts struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowExecutionOpenCounts) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionOpenCounts) GoString() string {
+	return s.String()
 }
 
 // Provides details of the WorkflowExecutionSignaled event.
@@ -5680,6 +6981,16 @@ type WorkflowExecutionSignaledEventAttributes struct {
 
 type metadataWorkflowExecutionSignaledEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowExecutionSignaledEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionSignaledEventAttributes) GoString() string {
+	return s.String()
 }
 
 // Provides details of WorkflowExecutionStarted event.
@@ -5748,6 +7059,16 @@ type metadataWorkflowExecutionStartedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowExecutionStartedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionStartedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the WorkflowExecutionTerminated event.
 type WorkflowExecutionTerminatedEventAttributes struct {
 	// If set, indicates that the workflow execution was automatically terminated,
@@ -5779,6 +7100,16 @@ type metadataWorkflowExecutionTerminatedEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowExecutionTerminatedEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionTerminatedEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Provides details of the WorkflowExecutionTimedOut event.
 type WorkflowExecutionTimedOutEventAttributes struct {
 	// The policy used for the child workflow executions of this workflow execution.
@@ -5802,6 +7133,16 @@ type metadataWorkflowExecutionTimedOutEventAttributes struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowExecutionTimedOutEventAttributes) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowExecutionTimedOutEventAttributes) GoString() string {
+	return s.String()
+}
+
 // Represents a workflow type.
 type WorkflowType struct {
 	// Required. The name of the workflow type.
@@ -5821,6 +7162,16 @@ type WorkflowType struct {
 
 type metadataWorkflowType struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowType) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowType) GoString() string {
+	return s.String()
 }
 
 // The configuration settings of a workflow type.
@@ -5887,6 +7238,16 @@ type metadataWorkflowTypeConfiguration struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkflowTypeConfiguration) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowTypeConfiguration) GoString() string {
+	return s.String()
+}
+
 // Used to filter workflow execution query results by type. Each parameter,
 // if specified, defines a rule that must be satisfied by each returned result.
 type WorkflowTypeFilter struct {
@@ -5901,6 +7262,16 @@ type WorkflowTypeFilter struct {
 
 type metadataWorkflowTypeFilter struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowTypeFilter) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowTypeFilter) GoString() string {
+	return s.String()
 }
 
 // Contains information about a workflow type.
@@ -5926,4 +7297,14 @@ type WorkflowTypeInfo struct {
 
 type metadataWorkflowTypeInfo struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkflowTypeInfo) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkflowTypeInfo) GoString() string {
+	return s.String()
 }

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -5,6 +5,7 @@ package workspaces
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
 )
 
 const opCreateWorkspaces = "CreateWorkspaces"
@@ -303,6 +304,16 @@ type metadataComputeType struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s ComputeType) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s ComputeType) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the CreateWorkspaces operation.
 type CreateWorkspacesInput struct {
 	// An array of structures that specify the WorkSpaces to create.
@@ -313,6 +324,16 @@ type CreateWorkspacesInput struct {
 
 type metadataCreateWorkspacesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateWorkspacesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateWorkspacesInput) GoString() string {
+	return s.String()
 }
 
 // Contains the result of the CreateWorkspaces operation.
@@ -332,6 +353,16 @@ type CreateWorkspacesOutput struct {
 
 type metadataCreateWorkspacesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s CreateWorkspacesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s CreateWorkspacesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains default WorkSpace creation information.
@@ -361,6 +392,16 @@ type metadataDefaultWorkspaceCreationProperties struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DefaultWorkspaceCreationProperties) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DefaultWorkspaceCreationProperties) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the DescribeWorkspaceBundles operation.
 type DescribeWorkspaceBundlesInput struct {
 	// An array of strings that contains the identifiers of the bundles to retrieve.
@@ -387,6 +428,16 @@ type metadataDescribeWorkspaceBundlesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeWorkspaceBundlesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkspaceBundlesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the DescribeWorkspaceBundles operation.
 type DescribeWorkspaceBundlesOutput struct {
 	// An array of structures that contain information about the bundles.
@@ -402,6 +453,16 @@ type DescribeWorkspaceBundlesOutput struct {
 
 type metadataDescribeWorkspaceBundlesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeWorkspaceBundlesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkspaceBundlesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DescribeWorkspaceDirectories operation.
@@ -421,6 +482,16 @@ type metadataDescribeWorkspaceDirectoriesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeWorkspaceDirectoriesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkspaceDirectoriesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the DescribeWorkspaceDirectories operation.
 type DescribeWorkspaceDirectoriesOutput struct {
 	// An array of structures that contain information about the directories.
@@ -436,6 +507,16 @@ type DescribeWorkspaceDirectoriesOutput struct {
 
 type metadataDescribeWorkspaceDirectoriesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeWorkspaceDirectoriesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkspaceDirectoriesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the DescribeWorkspaces operation.
@@ -477,6 +558,16 @@ type metadataDescribeWorkspacesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s DescribeWorkspacesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkspacesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results for the DescribeWorkspaces operation.
 type DescribeWorkspacesOutput struct {
 	// If not null, more results are available. Pass this value for the NextToken
@@ -495,6 +586,16 @@ type DescribeWorkspacesOutput struct {
 
 type metadataDescribeWorkspacesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s DescribeWorkspacesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s DescribeWorkspacesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information about a WorkSpace that could not be created.
@@ -516,6 +617,16 @@ type metadataFailedCreateWorkspaceRequest struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FailedCreateWorkspaceRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FailedCreateWorkspaceRequest) GoString() string {
+	return s.String()
+}
+
 // Contains information about a WorkSpace that could not be rebooted (RebootWorkspaces),
 // rebuilt (RebuildWorkspaces), or terminated (TerminateWorkspaces).
 type FailedWorkspaceChangeRequest struct {
@@ -535,6 +646,16 @@ type metadataFailedWorkspaceChangeRequest struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s FailedWorkspaceChangeRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s FailedWorkspaceChangeRequest) GoString() string {
+	return s.String()
+}
+
 // Contains information used with the RebootWorkspaces operation to reboot a
 // WorkSpace.
 type RebootRequest struct {
@@ -546,6 +667,16 @@ type RebootRequest struct {
 
 type metadataRebootRequest struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebootRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootRequest) GoString() string {
+	return s.String()
 }
 
 // Contains the inputs for the RebootWorkspaces operation.
@@ -560,6 +691,16 @@ type metadataRebootWorkspacesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebootWorkspacesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootWorkspacesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the RebootWorkspaces operation.
 type RebootWorkspacesOutput struct {
 	// An array of structures that represent any WorkSpaces that could not be rebooted.
@@ -570,6 +711,16 @@ type RebootWorkspacesOutput struct {
 
 type metadataRebootWorkspacesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebootWorkspacesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebootWorkspacesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information used with the RebuildWorkspaces operation to rebuild
@@ -585,6 +736,16 @@ type metadataRebuildRequest struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebuildRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebuildRequest) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the RebuildWorkspaces operation.
 type RebuildWorkspacesInput struct {
 	// An array of structures that specify the WorkSpaces to rebuild.
@@ -597,6 +758,16 @@ type metadataRebuildWorkspacesInput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s RebuildWorkspacesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebuildWorkspacesInput) GoString() string {
+	return s.String()
+}
+
 // Contains the results of the RebuildWorkspaces operation.
 type RebuildWorkspacesOutput struct {
 	// An array of structures that represent any WorkSpaces that could not be rebuilt.
@@ -607,6 +778,16 @@ type RebuildWorkspacesOutput struct {
 
 type metadataRebuildWorkspacesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s RebuildWorkspacesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s RebuildWorkspacesOutput) GoString() string {
+	return s.String()
 }
 
 // Contains information used with the TerminateWorkspaces operation to terminate
@@ -622,6 +803,16 @@ type metadataTerminateRequest struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TerminateRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateRequest) GoString() string {
+	return s.String()
+}
+
 // Contains the inputs for the TerminateWorkspaces operation.
 type TerminateWorkspacesInput struct {
 	// An array of structures that specify the WorkSpaces to terminate.
@@ -632,6 +823,16 @@ type TerminateWorkspacesInput struct {
 
 type metadataTerminateWorkspacesInput struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s TerminateWorkspacesInput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateWorkspacesInput) GoString() string {
+	return s.String()
 }
 
 // Contains the results of the TerminateWorkspaces operation.
@@ -646,6 +847,16 @@ type metadataTerminateWorkspacesOutput struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s TerminateWorkspacesOutput) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s TerminateWorkspacesOutput) GoString() string {
+	return s.String()
+}
+
 // Contains information about the user storage for a WorkSpace bundle.
 type UserStorage struct {
 	// The amount of user storage for the bundle.
@@ -656,6 +867,16 @@ type UserStorage struct {
 
 type metadataUserStorage struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s UserStorage) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s UserStorage) GoString() string {
+	return s.String()
 }
 
 // Contains information about a WorkSpace.
@@ -696,6 +917,16 @@ type metadataWorkspace struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s Workspace) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s Workspace) GoString() string {
+	return s.String()
+}
+
 // Contains information about a WorkSpace bundle.
 type WorkspaceBundle struct {
 	// The bundle identifier.
@@ -723,6 +954,16 @@ type WorkspaceBundle struct {
 
 type metadataWorkspaceBundle struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkspaceBundle) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkspaceBundle) GoString() string {
+	return s.String()
 }
 
 // Contains information about an AWS Directory Service directory for use with
@@ -776,6 +1017,16 @@ type metadataWorkspaceDirectory struct {
 	SDKShapeTraits bool `type:"structure"`
 }
 
+// String returns the string representation
+func (s WorkspaceDirectory) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkspaceDirectory) GoString() string {
+	return s.String()
+}
+
 // Contains information about a WorkSpace creation request.
 type WorkspaceRequest struct {
 	// The identifier of the bundle to create the WorkSpace from. You can use the
@@ -797,4 +1048,14 @@ type WorkspaceRequest struct {
 
 type metadataWorkspaceRequest struct {
 	SDKShapeTraits bool `type:"structure"`
+}
+
+// String returns the string representation
+func (s WorkspaceRequest) String() string {
+	return awsutil.StringValue(s)
+}
+
+// GoString returns the string representation
+func (s WorkspaceRequest) GoString() string {
+	return s.String()
 }


### PR DESCRIPTION
Adds the stringer methods to the service structs to make it easier when
logging service input/output values.

Example:
```go
svc := s3.New(nil)
result, err := svc.ListBuckets(&s3.ListBucketsInput)

fmt.Println(result)

// Output:
{
  Buckets: [{
      CreationDate: 2015-06-20 21:04:01 +0000 UTC,
      Name: "bucket01"
    },{
      CreationDate: 2015-05-22 23:33:02 +0000 UTC,
      Name: "bucket02"
    }],
  Owner: {
    DisplayName: "userName",
    ID: "userID"
  }
}
```