### PR TITLE
aws: Config refactor to use pointer for fields [breaking change]

### DIFF
--- a/aws/awsutil/copy_test.go
+++ b/aws/awsutil/copy_test.go
@@ -27,7 +27,7 @@ func ExampleCopy() {
 	awsutil.Copy(&f2, f1)
 
 	// Print the result
-	fmt.Println(awsutil.StringValue(f2))
+	fmt.Println(awsutil.Prettify(f2))
 
 	// Output:
 	// {
@@ -191,7 +191,7 @@ func ExampleCopyOf() {
 	var f2 *Foo = v.(*Foo)
 
 	// Print the result
-	fmt.Println(awsutil.StringValue(f2))
+	fmt.Println(awsutil.Prettify(f2))
 
 	// Output:
 	// {

--- a/aws/awsutil/path_value_test.go
+++ b/aws/awsutil/path_value_test.go
@@ -63,6 +63,6 @@ func TestSetValueAtPathSuccess(t *testing.T) {
 	var s2 Struct
 	awsutil.SetValueAtAnyPath(&s2, "b.b.c", "test0")
 	assert.Equal(t, "test0", s2.B.B.C)
-	awsutil.SetValueAtAnyPath(&s2, "A", []Struct{Struct{}})
-	assert.Equal(t, []Struct{Struct{}}, s2.A)
+	awsutil.SetValueAtAnyPath(&s2, "A", []Struct{{}})
+	assert.Equal(t, []Struct{{}}, s2.A)
 }

--- a/aws/awsutil/prettify.go
+++ b/aws/awsutil/prettify.go
@@ -8,16 +8,16 @@ import (
 	"strings"
 )
 
-// StringValue returns the string representation of a value.
-func StringValue(i interface{}) string {
+// Prettify returns the string representation of a value.
+func Prettify(i interface{}) string {
 	var buf bytes.Buffer
-	stringValue(reflect.ValueOf(i), 0, &buf)
+	prettify(reflect.ValueOf(i), 0, &buf)
 	return buf.String()
 }
 
-// stringValue will recursively walk value v to build a textual
+// prettify will recursively walk value v to build a textual
 // representation of the value.
-func stringValue(v reflect.Value, indent int, buf *bytes.Buffer) {
+func prettify(v reflect.Value, indent int, buf *bytes.Buffer) {
 	for v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
@@ -52,7 +52,7 @@ func stringValue(v reflect.Value, indent int, buf *bytes.Buffer) {
 			val := v.FieldByName(n)
 			buf.WriteString(strings.Repeat(" ", indent+2))
 			buf.WriteString(n + ": ")
-			stringValue(val, indent+2, buf)
+			prettify(val, indent+2, buf)
 
 			if i < len(names)-1 {
 				buf.WriteString(",\n")
@@ -68,7 +68,7 @@ func stringValue(v reflect.Value, indent int, buf *bytes.Buffer) {
 		buf.WriteString("[" + nl)
 		for i := 0; i < v.Len(); i++ {
 			buf.WriteString(id2)
-			stringValue(v.Index(i), indent+2, buf)
+			prettify(v.Index(i), indent+2, buf)
 
 			if i < v.Len()-1 {
 				buf.WriteString("," + nl)
@@ -82,7 +82,7 @@ func stringValue(v reflect.Value, indent int, buf *bytes.Buffer) {
 		for i, k := range v.MapKeys() {
 			buf.WriteString(strings.Repeat(" ", indent+2))
 			buf.WriteString(k.String() + ": ")
-			stringValue(v.MapIndex(k), indent+2, buf)
+			prettify(v.MapIndex(k), indent+2, buf)
 
 			if i < v.Len()-1 {
 				buf.WriteString(",\n")

--- a/aws/config.go
+++ b/aws/config.go
@@ -32,20 +32,11 @@ const DefaultRetries = -1
 // You may modify this global structure to change all default configuration
 // in the SDK. Note that configuration options are copied by value, so any
 // modifications must happen before constructing a client.
-var DefaultConfig = &Config{
-	Credentials:             DefaultChainCredentials,
-	Endpoint:                "",
-	Region:                  os.Getenv("AWS_REGION"),
-	DisableSSL:              false,
-	HTTPClient:              http.DefaultClient,
-	LogHTTPBody:             false,
-	LogLevel:                0,
-	Logger:                  os.Stdout,
-	MaxRetries:              DefaultRetries,
-	DisableParamValidation:  false,
-	DisableComputeChecksums: false,
-	S3ForcePathStyle:        false,
-}
+var DefaultConfig = NewConfig().
+	WithCredentials(DefaultChainCredentials).
+	WithRegion(os.Getenv("AWS_REGION")).
+	WithHTTPClient(http.DefaultClient).
+	WithMaxRetries(DefaultRetries)
 
 // A Config provides service configuration for service clients. By default,
 // all clients will use the {DefaultConfig} structure.
@@ -60,7 +51,7 @@ type Config struct {
 	//
 	// @note You must still provide a `Region` value when specifying an
 	//   endpoint for a client.
-	Endpoint string
+	Endpoint *string
 
 	// The region to send requests to. This parameter is required and must
 	// be configured globally or on a per-client basis unless otherwise
@@ -69,11 +60,11 @@ type Config struct {
 	//
 	// @see http://docs.aws.amazon.com/general/latest/gr/rande.html
 	//   AWS Regions and Endpoints
-	Region string
+	Region *string
 
 	// Set this to `true` to disable SSL when sending requests. Defaults
 	// to `false`.
-	DisableSSL bool
+	DisableSSL *bool
 
 	// The HTTP client to use when sending requests. Defaults to
 	// `http.DefaultClient`.
@@ -84,12 +75,12 @@ type Config struct {
 	//
 	// @note `LogLevel` must be set to a non-zero value in order to activate
 	//   body logging.
-	LogHTTPBody bool
+	LogHTTPBody *bool
 
 	// An integer value representing the logging level. The default log level
 	// is zero (0), which represents no logging. Set to a non-zero value to
 	// perform logging.
-	LogLevel uint
+	LogLevel *int
 
 	// The logger writer interface to write logging messages to. Defaults to
 	// standard out.
@@ -98,15 +89,15 @@ type Config struct {
 	// The maximum number of times that a request will be retried for failures.
 	// Defaults to -1, which defers the max retry setting to the service specific
 	// configuration.
-	MaxRetries int
+	MaxRetries *int
 
 	// Disables semantic parameter validation, which validates input for missing
 	// required fields and/or other semantic request input errors.
-	DisableParamValidation bool
+	DisableParamValidation *bool
 
 	// Disables the computation of request and response checksums, e.g.,
 	// CRC32 checksums in Amazon DynamoDB.
-	DisableComputeChecksums bool
+	DisableComputeChecksums *bool
 
 	// Set this to `true` to force the request to use path-style addressing,
 	// i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will
@@ -116,111 +107,166 @@ type Config struct {
 	// @note This configuration option is specific to the Amazon S3 service.
 	// @see http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
 	//   Amazon S3: Virtual Hosting of Buckets
-	S3ForcePathStyle bool
+	S3ForcePathStyle *bool
 }
 
-// Copy will return a shallow copy of the Config object.
-func (c Config) Copy() Config {
-	dst := Config{}
-	dst.Credentials = c.Credentials
-	dst.Endpoint = c.Endpoint
-	dst.Region = c.Region
-	dst.DisableSSL = c.DisableSSL
-	dst.HTTPClient = c.HTTPClient
-	dst.LogHTTPBody = c.LogHTTPBody
-	dst.LogLevel = c.LogLevel
-	dst.Logger = c.Logger
-	dst.MaxRetries = c.MaxRetries
-	dst.DisableParamValidation = c.DisableParamValidation
-	dst.DisableComputeChecksums = c.DisableComputeChecksums
-	dst.S3ForcePathStyle = c.S3ForcePathStyle
-
-	return dst
+// NewConfig returns a new Config pointer that can be chained with builder methods to
+// set multiple configuration values inline without using pointers.
+//
+//     svc := s3.New(aws.NewConfig().WithRegion("us-west-2").WithMaxRetries(10))
+//
+func NewConfig() *Config {
+	return &Config{}
 }
 
-// Merge merges the newcfg attribute values into this Config. Each attribute
-// will be merged into this config if the newcfg attribute's value is non-zero.
-// Due to this, newcfg attributes with zero values cannot be merged in. For
-// example bool attributes cannot be cleared using Merge, and must be explicitly
-// set on the Config structure.
-func (c Config) Merge(newcfg *Config) *Config {
-	if newcfg == nil {
+// WithCredentials sets a config Credentials value returning a Config pointer
+// for chaining.
+func (c *Config) WithCredentials(creds *credentials.Credentials) *Config {
+	c.Credentials = creds
+	return c
+}
+
+// WithEndpoint sets a config Endpoint value returning a Config pointer for
+// chaining.
+func (c *Config) WithEndpoint(endpoint string) *Config {
+	c.Endpoint = &endpoint
+	return c
+}
+
+// WithRegion sets a config Region value returning a Config pointer for
+// chaining.
+func (c *Config) WithRegion(region string) *Config {
+	c.Region = &region
+	return c
+}
+
+// WithDisableSSL sets a config DisableSSL value returning a Config pointer
+// for chaining.
+func (c *Config) WithDisableSSL(disable bool) *Config {
+	c.DisableSSL = &disable
+	return c
+}
+
+// WithHTTPClient sets a config HTTPClient value returning a Config pointer
+// for chaining.
+func (c *Config) WithHTTPClient(client *http.Client) *Config {
+	c.HTTPClient = client
+	return c
+}
+
+// WithMaxRetries sets a config MaxRetries value returning a Config pointer
+// for chaining.
+func (c *Config) WithMaxRetries(max int) *Config {
+	c.MaxRetries = &max
+	return c
+}
+
+// WithDisableParamValidation sets a config DisableParamValidation value
+// returning a Config pointer for chaining.
+func (c *Config) WithDisableParamValidation(disable bool) *Config {
+	c.DisableParamValidation = &disable
+	return c
+}
+
+// WithDisableComputeChecksums sets a config DisableComputeChecksums value
+// returning a Config pointer for chaining.
+func (c *Config) WithDisableComputeChecksums(disable bool) *Config {
+	c.DisableComputeChecksums = &disable
+	return c
+}
+
+// WithLogHTTPBody sets a config LogHTTPBody value returning a Config pointer
+// for chaining.
+func (c *Config) WithLogHTTPBody(logHTTPBody bool) *Config {
+	c.LogHTTPBody = &logHTTPBody
+	return c
+}
+
+// WithLogLevel sets a config LogLevel value returning a Config pointer for
+// chaining.
+func (c *Config) WithLogLevel(level int) *Config {
+	c.LogLevel = &level
+	return c
+}
+
+// WithLogger sets a config Logger value returning a Config pointer for
+// chaining.
+func (c *Config) WithLogger(logger io.Writer) *Config {
+	c.Logger = logger
+	return c
+}
+
+// WithS3ForcePathStyle sets a config S3ForcePathStyle value returning a Config
+// pointer for chaining.
+func (c *Config) WithS3ForcePathStyle(force bool) *Config {
+	c.S3ForcePathStyle = &force
+	return c
+}
+
+// Merge returns a new Config with the other Config's attribute values merged into
+// this Config. If the other Config's attribute is nil it will not be merged into
+// the new Config to be returned.
+func (c Config) Merge(other *Config) *Config {
+	if other == nil {
 		return &c
 	}
 
-	cfg := Config{}
+	dst := c
 
-	if newcfg.Credentials != nil {
-		cfg.Credentials = newcfg.Credentials
-	} else {
-		cfg.Credentials = c.Credentials
+	if other.Credentials != nil {
+		dst.Credentials = other.Credentials
 	}
 
-	if newcfg.Endpoint != "" {
-		cfg.Endpoint = newcfg.Endpoint
-	} else {
-		cfg.Endpoint = c.Endpoint
+	if other.Endpoint != nil {
+		dst.Endpoint = other.Endpoint
 	}
 
-	if newcfg.Region != "" {
-		cfg.Region = newcfg.Region
-	} else {
-		cfg.Region = c.Region
+	if other.Region != nil {
+		dst.Region = other.Region
 	}
 
-	if newcfg.DisableSSL {
-		cfg.DisableSSL = newcfg.DisableSSL
-	} else {
-		cfg.DisableSSL = c.DisableSSL
+	if other.DisableSSL != nil {
+		dst.DisableSSL = other.DisableSSL
 	}
 
-	if newcfg.HTTPClient != nil {
-		cfg.HTTPClient = newcfg.HTTPClient
-	} else {
-		cfg.HTTPClient = c.HTTPClient
+
+	if other.HTTPClient != nil {
+		dst.HTTPClient = other.HTTPClient
 	}
 
-	if newcfg.LogHTTPBody {
-		cfg.LogHTTPBody = newcfg.LogHTTPBody
-	} else {
-		cfg.LogHTTPBody = c.LogHTTPBody
+	if other.LogHTTPBody != nil {
+		dst.LogHTTPBody = other.LogHTTPBody
 	}
 
-	if newcfg.LogLevel != 0 {
-		cfg.LogLevel = newcfg.LogLevel
-	} else {
-		cfg.LogLevel = c.LogLevel
+	if other.LogLevel != nil {
+		dst.LogLevel = other.LogLevel
 	}
 
-	if newcfg.Logger != nil {
-		cfg.Logger = newcfg.Logger
-	} else {
-		cfg.Logger = c.Logger
+	if other.Logger != nil {
+		dst.Logger = other.Logger
 	}
 
-	if newcfg.MaxRetries != DefaultRetries {
-		cfg.MaxRetries = newcfg.MaxRetries
-	} else {
-		cfg.MaxRetries = c.MaxRetries
+	if other.MaxRetries != nil {
+		dst.MaxRetries = other.MaxRetries
 	}
 
-	if newcfg.DisableParamValidation {
-		cfg.DisableParamValidation = newcfg.DisableParamValidation
-	} else {
-		cfg.DisableParamValidation = c.DisableParamValidation
+	if other.DisableParamValidation != nil {
+		dst.DisableParamValidation = other.DisableParamValidation
 	}
 
-	if newcfg.DisableComputeChecksums {
-		cfg.DisableComputeChecksums = newcfg.DisableComputeChecksums
-	} else {
-		cfg.DisableComputeChecksums = c.DisableComputeChecksums
+	if other.DisableComputeChecksums != nil {
+		dst.DisableComputeChecksums = other.DisableComputeChecksums
 	}
 
-	if newcfg.S3ForcePathStyle {
-		cfg.S3ForcePathStyle = newcfg.S3ForcePathStyle
-	} else {
-		cfg.S3ForcePathStyle = c.S3ForcePathStyle
+	if other.S3ForcePathStyle != nil {
+		dst.S3ForcePathStyle = other.S3ForcePathStyle
 	}
 
-	return &cfg
+	return &dst
+}
+
+// Copy will return a shallow copy of the Config object.
+func (c Config) Copy() *Config {
+	dst := c
+	return &dst
 }

--- a/aws/config.go
+++ b/aws/config.go
@@ -229,7 +229,6 @@ func (c Config) Merge(other *Config) *Config {
 		dst.DisableSSL = other.DisableSSL
 	}
 
-
 	if other.HTTPClient != nil {
 		dst.HTTPClient = other.HTTPClient
 	}

--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -20,23 +20,23 @@ var testCredentials = credentials.NewChainCredentials([]credentials.Provider{
 
 var copyTestConfig = Config{
 	Credentials:             testCredentials,
-	Endpoint:                "CopyTestEndpoint",
-	Region:                  "COPY_TEST_AWS_REGION",
-	DisableSSL:              true,
+	Endpoint:                String("CopyTestEndpoint"),
+	Region:                  String("COPY_TEST_AWS_REGION"),
+	DisableSSL:              Boolean(true),
 	HTTPClient:              http.DefaultClient,
-	LogHTTPBody:             true,
-	LogLevel:                2,
+	LogHTTPBody:             Boolean(true),
+	LogLevel:                Int(2),
 	Logger:                  os.Stdout,
-	MaxRetries:              DefaultRetries,
-	DisableParamValidation:  true,
-	DisableComputeChecksums: true,
-	S3ForcePathStyle:        true,
+	MaxRetries:              Int(DefaultRetries),
+	DisableParamValidation:  Boolean(true),
+	DisableComputeChecksums: Boolean(true),
+	S3ForcePathStyle:        Boolean(true),
 }
 
 func TestCopy(t *testing.T) {
 	want := copyTestConfig
 	got := copyTestConfig.Copy()
-	if !reflect.DeepEqual(got, want) {
+	if !reflect.DeepEqual(*got, want) {
 		t.Errorf("Copy() = %+v", got)
 		t.Errorf("    want %+v", want)
 	}
@@ -45,26 +45,26 @@ func TestCopy(t *testing.T) {
 func TestCopyReturnsNewInstance(t *testing.T) {
 	want := copyTestConfig
 	got := copyTestConfig.Copy()
-	if &got == &want {
-		t.Errorf("Copy() = %p; want different instance as source %p", &got, &want)
+	if got == &want {
+		t.Errorf("Copy() = %p; want different instance as source %p", got, &want)
 	}
 }
 
-var mergeTestZeroValueConfig = Config{MaxRetries: DefaultRetries}
+var mergeTestZeroValueConfig = Config{}
 
 var mergeTestConfig = Config{
 	Credentials:             testCredentials,
-	Endpoint:                "MergeTestEndpoint",
-	Region:                  "MERGE_TEST_AWS_REGION",
-	DisableSSL:              true,
+	Endpoint:                String("MergeTestEndpoint"),
+	Region:                  String("MERGE_TEST_AWS_REGION"),
+	DisableSSL:              Boolean(true),
 	HTTPClient:              http.DefaultClient,
-	LogHTTPBody:             true,
-	LogLevel:                2,
+	LogHTTPBody:             Boolean(true),
+	LogLevel:                Int(2),
 	Logger:                  os.Stdout,
-	MaxRetries:              10,
-	DisableParamValidation:  true,
-	DisableComputeChecksums: true,
-	S3ForcePathStyle:        true,
+	MaxRetries:              Int(10),
+	DisableParamValidation:  Boolean(true),
+	DisableComputeChecksums: Boolean(true),
+	S3ForcePathStyle:        Boolean(true),
 }
 
 var mergeTests = []struct {
@@ -78,13 +78,13 @@ var mergeTests = []struct {
 }
 
 func TestMerge(t *testing.T) {
-	for _, tt := range mergeTests {
+	for i, tt := range mergeTests {
 		got := tt.cfg.Merge(tt.in)
 		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("Config %+v", tt.cfg)
-			t.Errorf(" Merge(%+v)", tt.in)
-			t.Errorf("   got %+v", got)
-			t.Errorf("  want %+v", tt.want)
+			t.Errorf("Config %d %+v", i, tt.cfg)
+			t.Errorf("   Merge(%+v)", tt.in)
+			t.Errorf("     got %+v", got)
+			t.Errorf("    want %+v", tt.want)
 		}
 	}
 }

--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -22,15 +22,15 @@ var copyTestConfig = Config{
 	Credentials:             testCredentials,
 	Endpoint:                String("CopyTestEndpoint"),
 	Region:                  String("COPY_TEST_AWS_REGION"),
-	DisableSSL:              Boolean(true),
+	DisableSSL:              Bool(true),
 	HTTPClient:              http.DefaultClient,
-	LogHTTPBody:             Boolean(true),
+	LogHTTPBody:             Bool(true),
 	LogLevel:                Int(2),
 	Logger:                  os.Stdout,
 	MaxRetries:              Int(DefaultRetries),
-	DisableParamValidation:  Boolean(true),
-	DisableComputeChecksums: Boolean(true),
-	S3ForcePathStyle:        Boolean(true),
+	DisableParamValidation:  Bool(true),
+	DisableComputeChecksums: Bool(true),
+	S3ForcePathStyle:        Bool(true),
 }
 
 func TestCopy(t *testing.T) {
@@ -56,15 +56,15 @@ var mergeTestConfig = Config{
 	Credentials:             testCredentials,
 	Endpoint:                String("MergeTestEndpoint"),
 	Region:                  String("MERGE_TEST_AWS_REGION"),
-	DisableSSL:              Boolean(true),
+	DisableSSL:              Bool(true),
 	HTTPClient:              http.DefaultClient,
-	LogHTTPBody:             Boolean(true),
+	LogHTTPBody:             Bool(true),
 	LogLevel:                Int(2),
 	Logger:                  os.Stdout,
 	MaxRetries:              Int(10),
-	DisableParamValidation:  Boolean(true),
-	DisableComputeChecksums: Boolean(true),
-	S3ForcePathStyle:        Boolean(true),
+	DisableParamValidation:  Bool(true),
+	DisableComputeChecksums: Bool(true),
+	S3ForcePathStyle:        Bool(true),
 }
 
 var mergeTests = []struct {

--- a/aws/credentials/stscreds/assume_role_provider.go
+++ b/aws/credentials/stscreds/assume_role_provider.go
@@ -100,7 +100,7 @@ func (p *AssumeRoleProvider) Retrieve() (credentials.Value, error) {
 	}
 
 	roleOutput, err := p.Client.AssumeRole(&sts.AssumeRoleInput{
-		DurationSeconds: aws.Long(int64(p.Duration / time.Second)),
+		DurationSeconds: aws.Int64(int64(p.Duration / time.Second)),
 		RoleARN:         aws.String(p.RoleARN),
 		RoleSessionName: aws.String(p.RoleSessionName),
 	})

--- a/aws/handler_functions.go
+++ b/aws/handler_functions.go
@@ -149,7 +149,7 @@ var (
 // appropriate Region and Endpoint set. Will set r.Error if the endpoint or
 // region is not valid.
 func ValidateEndpointHandler(r *Request) {
-	if r.Service.SigningRegion == "" && r.Service.Config.Region == "" {
+	if r.Service.SigningRegion == "" && StringValue(r.Service.Config.Region) == "" {
 		r.Error = ErrMissingRegion
 	} else if r.Service.Endpoint == "" {
 		r.Error = ErrMissingEndpoint

--- a/aws/handler_functions.go
+++ b/aws/handler_functions.go
@@ -90,7 +90,7 @@ func SendHandler(r *Request) {
 		}
 		// Catch all other request errors.
 		r.Error = awserr.New("RequestError", "send request failed", err)
-		r.Retryable.Set(true) // network errors are retryable
+		r.Retryable = Bool(true) // network errors are retryable
 	}
 }
 
@@ -107,8 +107,8 @@ func ValidateResponseHandler(r *Request) {
 func AfterRetryHandler(r *Request) {
 	// If one of the other handlers already set the retry state
 	// we don't want to override it based on the service's state
-	if !r.Retryable.IsSet() {
-		r.Retryable.Set(r.Service.ShouldRetry(r))
+	if r.Retryable == nil {
+		r.Retryable = Bool(r.Service.ShouldRetry(r))
 	}
 
 	if r.WillRetry() {

--- a/aws/handler_functions_test.go
+++ b/aws/handler_functions_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestValidateEndpointHandler(t *testing.T) {
 	os.Clearenv()
-	svc := NewService(&Config{Region: "us-west-2"})
+	svc := NewService(NewConfig().WithRegion("us-west-2"))
 	svc.Handlers.Clear()
 	svc.Handlers.Validate.PushBack(ValidateEndpointHandler)
 
@@ -37,11 +37,11 @@ func TestValidateEndpointHandlerErrorRegion(t *testing.T) {
 
 type mockCredsProvider struct {
 	expired        bool
-	retreiveCalled bool
+	retrieveCalled bool
 }
 
 func (m *mockCredsProvider) Retrieve() (credentials.Value, error) {
-	m.retreiveCalled = true
+	m.retrieveCalled = true
 	return credentials.Value{}, nil
 }
 
@@ -52,7 +52,7 @@ func (m *mockCredsProvider) IsExpired() bool {
 func TestAfterRetryRefreshCreds(t *testing.T) {
 	os.Clearenv()
 	credProvider := &mockCredsProvider{}
-	svc := NewService(&Config{Credentials: credentials.NewCredentials(credProvider), MaxRetries: 1})
+	svc := NewService(&Config{Credentials: credentials.NewCredentials(credProvider), MaxRetries: Int(1)})
 
 	svc.Handlers.Clear()
 	svc.Handlers.ValidateResponse.PushBack(func(r *Request) {
@@ -67,15 +67,15 @@ func TestAfterRetryRefreshCreds(t *testing.T) {
 	})
 
 	assert.True(t, svc.Config.Credentials.IsExpired(), "Expect to start out expired")
-	assert.False(t, credProvider.retreiveCalled)
+	assert.False(t, credProvider.retrieveCalled)
 
 	req := NewRequest(svc, &Operation{Name: "Operation"}, nil, nil)
 	req.Send()
 
 	assert.True(t, svc.Config.Credentials.IsExpired())
-	assert.False(t, credProvider.retreiveCalled)
+	assert.False(t, credProvider.retrieveCalled)
 
 	_, err := svc.Config.Credentials.Get()
 	assert.NoError(t, err)
-	assert.True(t, credProvider.retreiveCalled)
+	assert.True(t, credProvider.retrieveCalled)
 }

--- a/aws/handlers_test.go
+++ b/aws/handlers_test.go
@@ -23,7 +23,7 @@ func TestMultipleHandlers(t *testing.T) {
 	r := &Request{}
 	l := HandlerList{}
 	l.PushBack(func(r *Request) { r.Data = nil })
-	l.PushFront(func(r *Request) { r.Data = Boolean(true) })
+	l.PushFront(func(r *Request) { r.Data = Bool(true) })
 	l.Run(r)
 	if r.Data != nil {
 		t.Error("Expected handler to execute")

--- a/aws/param_validator_test.go
+++ b/aws/param_validator_test.go
@@ -44,7 +44,7 @@ func TestNoErrors(t *testing.T) {
 			"key1": {Name: aws.String("Name")},
 			"key2": {Name: aws.String("Name")},
 		},
-		RequiredBool:   aws.Boolean(true),
+		RequiredBool:   aws.Bool(true),
 		OptionalStruct: &ConditionalStructShape{Name: aws.String("Name")},
 	}
 
@@ -70,7 +70,7 @@ func TestNestedMissingRequiredParameters(t *testing.T) {
 			"key1": {Name: aws.String("Name")},
 			"key2": {},
 		},
-		RequiredBool:   aws.Boolean(true),
+		RequiredBool:   aws.Bool(true),
 		OptionalStruct: &ConditionalStructShape{},
 	}
 

--- a/aws/request_pagination_test.go
+++ b/aws/request_pagination_test.go
@@ -41,7 +41,7 @@ func TestPagination(t *testing.T) {
 		reqNum++
 	})
 
-	params := &dynamodb.ListTablesInput{Limit: aws.Long(2)}
+	params := &dynamodb.ListTablesInput{Limit: aws.Int64(2)}
 	err := db.ListTablesPages(params, func(p *dynamodb.ListTablesOutput, last bool) bool {
 		numPages++
 		for _, t := range p.TableNames {
@@ -93,7 +93,7 @@ func TestPaginationEachPage(t *testing.T) {
 		reqNum++
 	})
 
-	params := &dynamodb.ListTablesInput{Limit: aws.Long(2)}
+	params := &dynamodb.ListTablesInput{Limit: aws.Int64(2)}
 	req, _ := db.ListTablesRequest(params)
 	err := req.EachPage(func(p interface{}, last bool) bool {
 		numPages++
@@ -138,7 +138,7 @@ func TestPaginationEarlyExit(t *testing.T) {
 		reqNum++
 	})
 
-	params := &dynamodb.ListTablesInput{Limit: aws.Long(2)}
+	params := &dynamodb.ListTablesInput{Limit: aws.Int64(2)}
 	err := db.ListTablesPages(params, func(p *dynamodb.ListTablesOutput, last bool) bool {
 		numPages++
 		if numPages == 2 {
@@ -189,10 +189,10 @@ func TestPaginationTruncation(t *testing.T) {
 
 	reqNum := &count
 	resps := []*s3.ListObjectsOutput{
-		{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{{Key: aws.String("Key1")}}},
-		{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{{Key: aws.String("Key2")}}},
-		{IsTruncated: aws.Boolean(false), Contents: []*s3.Object{{Key: aws.String("Key3")}}},
-		{IsTruncated: aws.Boolean(true), Contents: []*s3.Object{{Key: aws.String("Key4")}}},
+		{IsTruncated: aws.Bool(true), Contents: []*s3.Object{{Key: aws.String("Key1")}}},
+		{IsTruncated: aws.Bool(true), Contents: []*s3.Object{{Key: aws.String("Key2")}}},
+		{IsTruncated: aws.Bool(false), Contents: []*s3.Object{{Key: aws.String("Key3")}}},
+		{IsTruncated: aws.Bool(true), Contents: []*s3.Object{{Key: aws.String("Key4")}}},
 	}
 
 	client.Handlers.Send.Clear() // mock sending
@@ -218,7 +218,7 @@ func TestPaginationTruncation(t *testing.T) {
 	// Try again without truncation token at all
 	count = 0
 	resps[1].IsTruncated = nil
-	resps[2].IsTruncated = aws.Boolean(true)
+	resps[2].IsTruncated = aws.Bool(true)
 	results = []string{}
 	err = client.ListObjectsPages(params, func(p *s3.ListObjectsOutput, last bool) bool {
 		results = append(results, *p.Contents[0].Key)
@@ -265,7 +265,7 @@ func BenchmarkCodegenIterator(b *testing.B) {
 		reqNum++
 	})
 
-	input := &dynamodb.ListTablesInput{Limit: aws.Long(2)}
+	input := &dynamodb.ListTablesInput{Limit: aws.Int64(2)}
 	iter := func(fn func(*dynamodb.ListTablesOutput, bool) bool) error {
 		page, _ := db.ListTablesRequest(input)
 		for ; page != nil; page = page.NextPage() {
@@ -294,7 +294,7 @@ func BenchmarkEachPageIterator(b *testing.B) {
 		reqNum++
 	})
 
-	input := &dynamodb.ListTablesInput{Limit: aws.Long(2)}
+	input := &dynamodb.ListTablesInput{Limit: aws.Int64(2)}
 	for i := 0; i < b.N; i++ {
 		reqNum = 0
 		req, _ := db.ListTablesRequest(input)

--- a/aws/request_test.go
+++ b/aws/request_test.go
@@ -72,7 +72,7 @@ func TestRequestRecoverRetry5xx(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := NewService(&Config{MaxRetries: 10})
+	s := NewService(NewConfig().WithMaxRetries(10))
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -98,7 +98,7 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := NewService(&Config{MaxRetries: 10})
+	s := NewService(NewConfig().WithMaxRetries(10))
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -117,7 +117,7 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 
 // test that retries don't occur for 4xx status codes with a response type that can't be retried
 func TestRequest4xxUnretryable(t *testing.T) {
-	s := NewService(&Config{MaxRetries: 10})
+	s := NewService(NewConfig().WithMaxRetries(10))
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -153,7 +153,7 @@ func TestRequestExhaustRetries(t *testing.T) {
 		{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
 	}
 
-	s := NewService(&Config{MaxRetries: -1})
+	s := NewService(NewConfig().WithMaxRetries(DefaultRetries))
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -184,7 +184,7 @@ func TestRequestRecoverExpiredCreds(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := NewService(&Config{MaxRetries: 10, Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "")})
+	s := NewService(&Config{MaxRetries: Int(10), Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "")})
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)

--- a/aws/service.go
+++ b/aws/service.go
@@ -65,23 +65,23 @@ func (s *Service) Initialize() {
 	s.AddDebugHandlers()
 	s.buildEndpoint()
 
-	if !s.Config.DisableParamValidation {
+	if !BooleanValue(s.Config.DisableParamValidation) {
 		s.Handlers.Validate.PushBack(ValidateParameters)
 	}
 }
 
 // buildEndpoint builds the endpoint values the service will use to make requests with.
 func (s *Service) buildEndpoint() {
-	if s.Config.Endpoint != "" {
-		s.Endpoint = s.Config.Endpoint
+	if StringValue(s.Config.Endpoint) != "" {
+		s.Endpoint = *s.Config.Endpoint
 	} else {
 		s.Endpoint, s.SigningRegion =
-			endpoints.EndpointForRegion(s.ServiceName, s.Config.Region)
+			endpoints.EndpointForRegion(s.ServiceName, StringValue(s.Config.Region))
 	}
 
 	if s.Endpoint != "" && !schemeRE.MatchString(s.Endpoint) {
 		scheme := "https"
-		if s.Config.DisableSSL {
+		if BooleanValue(s.Config.DisableSSL) {
 			scheme = "http"
 		}
 		s.Endpoint = scheme + "://" + s.Endpoint
@@ -92,12 +92,12 @@ func (s *Service) buildEndpoint() {
 // debug information.
 func (s *Service) AddDebugHandlers() {
 	out := s.Config.Logger
-	if s.Config.LogLevel == 0 {
+	if IntValue(s.Config.LogLevel) == 0 {
 		return
 	}
 
 	s.Handlers.Send.PushFront(func(r *Request) {
-		logBody := r.Config.LogHTTPBody
+		logBody := BooleanValue(r.Config.LogHTTPBody)
 		dumpedBody, _ := httputil.DumpRequestOut(r.HTTPRequest, logBody)
 
 		fmt.Fprintf(out, "---[ REQUEST POST-SIGN ]-----------------------------\n")
@@ -107,7 +107,7 @@ func (s *Service) AddDebugHandlers() {
 	s.Handlers.Send.PushBack(func(r *Request) {
 		fmt.Fprintf(out, "---[ RESPONSE ]--------------------------------------\n")
 		if r.HTTPResponse != nil {
-			logBody := r.Config.LogHTTPBody
+			logBody := BooleanValue(r.Config.LogHTTPBody)
 			dumpedBody, _ := httputil.DumpResponse(r.HTTPResponse, logBody)
 			fmt.Fprintf(out, "%s\n", string(dumpedBody))
 		} else if r.Error != nil {
@@ -120,10 +120,10 @@ func (s *Service) AddDebugHandlers() {
 // MaxRetries returns the number of maximum returns the service will use to make
 // an individual API request.
 func (s *Service) MaxRetries() uint {
-	if s.Config.MaxRetries < 0 {
+	if IntValue(s.Config.MaxRetries) < 0 {
 		return s.DefaultMaxRetries
 	}
-	return uint(s.Config.MaxRetries)
+	return uint(IntValue(s.Config.MaxRetries))
 }
 
 // retryRules returns the delay duration before retrying this request again

--- a/aws/service.go
+++ b/aws/service.go
@@ -65,7 +65,7 @@ func (s *Service) Initialize() {
 	s.AddDebugHandlers()
 	s.buildEndpoint()
 
-	if !BooleanValue(s.Config.DisableParamValidation) {
+	if !BoolValue(s.Config.DisableParamValidation) {
 		s.Handlers.Validate.PushBack(ValidateParameters)
 	}
 }
@@ -81,7 +81,7 @@ func (s *Service) buildEndpoint() {
 
 	if s.Endpoint != "" && !schemeRE.MatchString(s.Endpoint) {
 		scheme := "https"
-		if BooleanValue(s.Config.DisableSSL) {
+		if BoolValue(s.Config.DisableSSL) {
 			scheme = "http"
 		}
 		s.Endpoint = scheme + "://" + s.Endpoint
@@ -97,7 +97,7 @@ func (s *Service) AddDebugHandlers() {
 	}
 
 	s.Handlers.Send.PushFront(func(r *Request) {
-		logBody := BooleanValue(r.Config.LogHTTPBody)
+		logBody := BoolValue(r.Config.LogHTTPBody)
 		dumpedBody, _ := httputil.DumpRequestOut(r.HTTPRequest, logBody)
 
 		fmt.Fprintf(out, "---[ REQUEST POST-SIGN ]-----------------------------\n")
@@ -107,7 +107,7 @@ func (s *Service) AddDebugHandlers() {
 	s.Handlers.Send.PushBack(func(r *Request) {
 		fmt.Fprintf(out, "---[ RESPONSE ]--------------------------------------\n")
 		if r.HTTPResponse != nil {
-			logBody := BooleanValue(r.Config.LogHTTPBody)
+			logBody := BoolValue(r.Config.LogHTTPBody)
 			dumpedBody, _ := httputil.DumpResponse(r.HTTPResponse, logBody)
 			fmt.Fprintf(out, "%s\n", string(dumpedBody))
 		} else if r.Error != nil {

--- a/aws/types.go
+++ b/aws/types.go
@@ -6,29 +6,88 @@ import (
 	"time"
 )
 
-// String converts a Go string into a string pointer.
+// String returns a pointer of the string value passed in.
 func String(v string) *string {
 	return &v
 }
 
-// Boolean converts a Go bool into a boolean pointer.
+// StringValue returns the value of the string pointer passed in or empty
+// string if the pointer is nil.
+func StringValue(a *string) string {
+	if a != nil {
+		return *a
+	}
+	return ""
+}
+
+// Boolean returns a pointer of the bool value passed in.
 func Boolean(v bool) *bool {
 	return &v
 }
 
-// Long converts a Go int64 into a long pointer.
+// BooleanValue returns the value of the bool pointer passed in or false if the
+// pointer is nil.
+func BooleanValue(a *bool) bool {
+	if a != nil {
+		return *a
+	}
+	return false
+}
+
+// Int returns a pointer of the int value passed in.
+func Int(v int) *int {
+	return &v
+}
+
+// IntValue returns the value of the int pointer passed in or zero if the
+// pointer is nil.
+func IntValue(a *int) int {
+	if a != nil {
+		return *a
+	}
+	return 0
+}
+
+// Long returns a pointer of the int64 value passed in.
 func Long(v int64) *int64 {
 	return &v
 }
 
-// Double converts a Go float64 into a double pointer.
+// LongValue returns the value of the int64 pointer passed in or zero if the
+// pointer is nil.
+func LongValue(a *int64) int64 {
+	if a != nil {
+		return *a
+	}
+	return 0
+}
+
+// Double returns a pointer of the float64 value passed in.
 func Double(v float64) *float64 {
 	return &v
 }
 
-// Time converts a Go Time into a Time pointer
+// DoubleValue returns the value of the float64 pointer passed in or zero if the
+// pointer is nil.
+func DoubleValue(a *float64) float64 {
+	if a != nil {
+		return *a
+	}
+	return 0
+}
+
+// Time returns a pointer of the Time value passed in.
 func Time(t time.Time) *time.Time {
 	return &t
+}
+
+// TimeValue returns the value of the Time pointer passed in or zero
+// time if the pointer is nil.
+func TimeValue(a *time.Time) time.Time {
+	if a != nil {
+		return *a
+	}
+	return time.Time{}
 }
 
 // ReadSeekCloser wraps a io.Reader returning a ReaderSeakerCloser

--- a/aws/types.go
+++ b/aws/types.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"io"
 	"time"
 )
@@ -20,14 +19,14 @@ func StringValue(a *string) string {
 	return ""
 }
 
-// Boolean returns a pointer of the bool value passed in.
-func Boolean(v bool) *bool {
+// Bool returns a pointer of the bool value passed in.
+func Bool(v bool) *bool {
 	return &v
 }
 
-// BooleanValue returns the value of the bool pointer passed in or false if the
+// BoolValue returns the value of the bool pointer passed in or false if the
 // pointer is nil.
-func BooleanValue(a *bool) bool {
+func BoolValue(a *bool) bool {
 	if a != nil {
 		return *a
 	}
@@ -48,28 +47,28 @@ func IntValue(a *int) int {
 	return 0
 }
 
-// Long returns a pointer of the int64 value passed in.
-func Long(v int64) *int64 {
+// Int64 returns a pointer of the int64 value passed in.
+func Int64(v int64) *int64 {
 	return &v
 }
 
-// LongValue returns the value of the int64 pointer passed in or zero if the
+// Int64Value returns the value of the int64 pointer passed in or zero if the
 // pointer is nil.
-func LongValue(a *int64) int64 {
+func Int64Value(a *int64) int64 {
 	if a != nil {
 		return *a
 	}
 	return 0
 }
 
-// Double returns a pointer of the float64 value passed in.
-func Double(v float64) *float64 {
+// Float64 returns a pointer of the float64 value passed in.
+func Float64(v float64) *float64 {
 	return &v
 }
 
-// DoubleValue returns the value of the float64 pointer passed in or zero if the
+// Float64Value returns the value of the float64 pointer passed in or zero if the
 // pointer is nil.
-func DoubleValue(a *float64) float64 {
+func Float64Value(a *float64) float64 {
 	if a != nil {
 		return *a
 	}
@@ -138,53 +137,4 @@ func (r ReaderSeekerCloser) Close() error {
 		return t.Close()
 	}
 	return nil
-}
-
-// A SettableBool provides a boolean value which includes the state if
-// the value was set or unset.  The set state is in addition to the value's
-// value(true|false)
-type SettableBool struct {
-	value bool
-	set   bool
-}
-
-// SetBool returns a SettableBool with a value set
-func SetBool(value bool) SettableBool {
-	return SettableBool{value: value, set: true}
-}
-
-// Get returns the value. Will always be false if the SettableBool was not set.
-func (b *SettableBool) Get() bool {
-	if !b.set {
-		return false
-	}
-	return b.value
-}
-
-// Set sets the value and updates the state that the value has been set.
-func (b *SettableBool) Set(value bool) {
-	b.value = value
-	b.set = true
-}
-
-// IsSet returns if the value has been set
-func (b *SettableBool) IsSet() bool {
-	return b.set
-}
-
-// Reset resets the state and value of the SettableBool to its initial default
-// state of not set and zero value.
-func (b *SettableBool) Reset() {
-	b.value = false
-	b.set = false
-}
-
-// String returns the string representation of the value if set. Zero if not set.
-func (b *SettableBool) String() string {
-	return fmt.Sprintf("%t", b.Get())
-}
-
-// GoString returns the string representation of the SettableBool value and state
-func (b *SettableBool) GoString() string {
-	return fmt.Sprintf("Bool{value:%t, set:%t}", b.value, b.set)
 }

--- a/internal/features/efs/client.go
+++ b/internal/features/efs/client.go
@@ -13,6 +13,6 @@ var _ = shared.Imported
 func init() {
 	Before("@efs", func() {
 		// FIXME remove custom region
-		World["client"] = efs.New(&aws.Config{Region: "us-west-2"})
+		World["client"] = efs.New(aws.NewConfig().WithRegion("us-west-2"))
 	})
 }

--- a/internal/features/shared/shared.go
+++ b/internal/features/shared/shared.go
@@ -26,11 +26,11 @@ const Imported = true
 
 func init() {
 	if os.Getenv("DEBUG") != "" {
-		aws.DefaultConfig.LogLevel = 1
+		aws.DefaultConfig.WithLogLevel(1)
 	}
 	if os.Getenv("DEBUG_BODY") != "" {
-		aws.DefaultConfig.LogLevel = 1
-		aws.DefaultConfig.LogHTTPBody = true
+		aws.DefaultConfig.WithLogLevel(1)
+		aws.DefaultConfig.WithLogHTTPBody(true)
 	}
 
 	When(`^I call the "(.+?)" API$`, func(op string) {

--- a/internal/fixtures/helpers/param_filler.go
+++ b/internal/fixtures/helpers/param_filler.go
@@ -63,17 +63,17 @@ func (f paramFiller) paramsStructAny(value interface{}, shape *api.Shape) string
 	case "boolean":
 		v := reflect.Indirect(reflect.ValueOf(value))
 		if v.IsValid() {
-			return fmt.Sprintf("aws.Boolean(%#v)", v.Interface())
+			return fmt.Sprintf("aws.Bool(%#v)", v.Interface())
 		}
 	case "integer", "long":
 		v := reflect.Indirect(reflect.ValueOf(value))
 		if v.IsValid() {
-			return fmt.Sprintf("aws.Long(%v)", v.Interface())
+			return fmt.Sprintf("aws.Int64(%v)", v.Interface())
 		}
 	case "float", "double":
 		v := reflect.Indirect(reflect.ValueOf(value))
 		if v.IsValid() {
-			return fmt.Sprintf("aws.Double(%v)", v.Interface())
+			return fmt.Sprintf("aws.Float64(%v)", v.Interface())
 		}
 	case "timestamp":
 		v := reflect.Indirect(reflect.ValueOf(value))

--- a/internal/fixtures/protocol/generate.go
+++ b/internal/fixtures/protocol/generate.go
@@ -254,8 +254,8 @@ func generateTestSuite(filename string) string {
 			suite.API.Operations[c.Given.ExportedName] = c.Given
 		}
 
-		suite.API.NoInflections = true // don't require inflections
-		suite.API.NoInitMethods = true // don't generate init methods
+		suite.API.NoInflections = true     // don't require inflections
+		suite.API.NoInitMethods = true     // don't generate init methods
 		suite.API.NoStringerMethods = true // don't generate stringer methods
 		suite.API.Setup()
 		suite.API.Metadata.EndpointPrefix = suite.API.PackageName()

--- a/internal/model/api/operation.go
+++ b/internal/model/api/operation.go
@@ -140,7 +140,7 @@ func Example{{ .API.StructName }}_{{ .ExportedName }}() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 `))
 
@@ -290,9 +290,9 @@ func (e *example) traverseScalar(s *Shape, required, payload bool) string {
 	str := ""
 	switch s.Type {
 	case "integer", "long":
-		str = `aws.Long(1)`
+		str = `aws.Int64(1)`
 	case "float", "double":
-		str = `aws.Double(1.0)`
+		str = `aws.Float64(1.0)`
 	case "string", "character":
 		str = `aws.String("` + s.ShapeName + `")`
 	case "blob":
@@ -302,7 +302,7 @@ func (e *example) traverseScalar(s *Shape, required, payload bool) string {
 			str = `[]byte("PAYLOAD")`
 		}
 	case "boolean":
-		str = `aws.Boolean(true)`
+		str = `aws.Bool(true)`
 	case "timestamp":
 		str = `aws.Time(time.Now())`
 	default:

--- a/internal/model/api/shape.go
+++ b/internal/model/api/shape.go
@@ -250,7 +250,7 @@ func (s *Shape) Docstring() string {
 const goCodeStringerTmpl = `
 // String returns the string representation
 func (s {{ .ShapeName }}) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 // GoString returns the string representation
 func (s {{ .ShapeName }}) GoString() string {

--- a/internal/model/api/shape.go
+++ b/internal/model/api/shape.go
@@ -299,7 +299,7 @@ func (s *Shape) GoCode() string {
 		code += "SDKShapeTraits bool " + ref.GoTags(true, false)
 		code += "}"
 
-		if (!s.API.NoStringerMethods) {
+		if !s.API.NoStringerMethods {
 			code += s.goCodeStringers()
 		}
 	default:

--- a/internal/model/cli/gen-api/main.go
+++ b/internal/model/cli/gen-api/main.go
@@ -25,8 +25,8 @@ type generateInfo struct {
 }
 
 var excludeServices = map[string]struct{}{
-	"simpledb":     struct{}{},
-	"importexport": struct{}{},
+	"simpledb":     {},
+	"importexport": {},
 }
 
 // newGenerateInfo initializes the service API's folder structure for a specific service.

--- a/internal/protocol/restxml/build_test.go
+++ b/internal/protocol/restxml/build_test.go
@@ -1966,10 +1966,10 @@ func TestInputService2ProtocolTestSerializeOtherScalarTypesCase1(t *testing.T) {
 	svc.Endpoint = "https://test"
 
 	input := &InputService2TestShapeInputShape{
-		First:  aws.Boolean(true),
-		Fourth: aws.Long(3),
-		Second: aws.Boolean(false),
-		Third:  aws.Double(1.2),
+		First:  aws.Bool(true),
+		Fourth: aws.Int64(3),
+		Second: aws.Bool(false),
+		Third:  aws.Float64(1.2),
 	}
 	req, _ := svc.InputService2TestCaseOperation1Request(input)
 	r := req.HTTPRequest

--- a/internal/signer/v4/v4.go
+++ b/internal/signer/v4/v4.go
@@ -73,7 +73,7 @@ func Sign(req *aws.Request) {
 
 	region := req.Service.SigningRegion
 	if region == "" {
-		region = req.Service.Config.Region
+		region = aws.StringValue(req.Service.Config.Region)
 	}
 
 	name := req.Service.SigningName
@@ -90,7 +90,7 @@ func Sign(req *aws.Request) {
 		ServiceName: name,
 		Region:      region,
 		Credentials: req.Service.Config.Credentials,
-		Debug:       req.Service.Config.LogLevel,
+		Debug:       uint(aws.IntValue(req.Service.Config.LogLevel)),
 		Logger:      req.Service.Config.Logger,
 	}
 

--- a/internal/signer/v4/v4_test.go
+++ b/internal/signer/v4/v4_test.go
@@ -143,7 +143,7 @@ func TestIgnoreResignRequestWithValidCreds(t *testing.T) {
 	r := aws.NewRequest(
 		aws.NewService(&aws.Config{
 			Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
-			Region:      "us-west-2",
+			Region:      aws.String("us-west-2"),
 		}),
 		&aws.Operation{
 			Name:       "BatchGetItem",
@@ -165,7 +165,7 @@ func TestIgnorePreResignRequestWithValidCreds(t *testing.T) {
 	r := aws.NewRequest(
 		aws.NewService(&aws.Config{
 			Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
-			Region:      "us-west-2",
+			Region:      aws.String("us-west-2"),
 		}),
 		&aws.Operation{
 			Name:       "BatchGetItem",

--- a/internal/test/integration/integration.go
+++ b/internal/test/integration/integration.go
@@ -21,14 +21,14 @@ const Imported = true
 
 func init() {
 	if os.Getenv("DEBUG") != "" {
-		aws.DefaultConfig.LogLevel = 1
+		aws.DefaultConfig.WithLogLevel(1)
 	}
 	if os.Getenv("DEBUG_BODY") != "" {
-		aws.DefaultConfig.LogLevel = 1
-		aws.DefaultConfig.LogHTTPBody = true
+		aws.DefaultConfig.WithLogLevel(1)
+		aws.DefaultConfig.WithLogHTTPBody(true)
 	}
 
-	if aws.DefaultConfig.Region == "" {
+	if aws.StringValue(aws.DefaultConfig.Region) == "" {
 		panic("AWS_REGION must be configured to run integration tests")
 	}
 }

--- a/internal/test/unit/unit.go
+++ b/internal/test/unit/unit.go
@@ -18,5 +18,5 @@ func init() {
 	// mock region and credentials
 	aws.DefaultConfig.Credentials =
 		credentials.NewStaticCredentials("AKID", "SECRET", "SESSION")
-	aws.DefaultConfig.Region = "mock-region"
+	aws.DefaultConfig.WithRegion("mock-region")
 }

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -1668,7 +1668,7 @@ type metadataActivity struct {
 
 // String returns the string representation
 func (s Activity) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1694,7 +1694,7 @@ type metadataAdjustmentType struct {
 
 // String returns the string representation
 func (s AdjustmentType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1719,7 +1719,7 @@ type metadataAlarm struct {
 
 // String returns the string representation
 func (s Alarm) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1743,7 +1743,7 @@ type metadataAttachInstancesInput struct {
 
 // String returns the string representation
 func (s AttachInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1761,7 +1761,7 @@ type metadataAttachInstancesOutput struct {
 
 // String returns the string representation
 func (s AttachInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1785,7 +1785,7 @@ type metadataAttachLoadBalancersInput struct {
 
 // String returns the string representation
 func (s AttachLoadBalancersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1803,7 +1803,7 @@ type metadataAttachLoadBalancersOutput struct {
 
 // String returns the string representation
 func (s AttachLoadBalancersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1838,7 +1838,7 @@ type metadataBlockDeviceMapping struct {
 
 // String returns the string representation
 func (s BlockDeviceMapping) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1871,7 +1871,7 @@ type metadataCompleteLifecycleActionInput struct {
 
 // String returns the string representation
 func (s CompleteLifecycleActionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1889,7 +1889,7 @@ type metadataCompleteLifecycleActionOutput struct {
 
 // String returns the string representation
 func (s CompleteLifecycleActionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2010,7 +2010,7 @@ type metadataCreateAutoScalingGroupInput struct {
 
 // String returns the string representation
 func (s CreateAutoScalingGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2028,7 +2028,7 @@ type metadataCreateAutoScalingGroupOutput struct {
 
 // String returns the string representation
 func (s CreateAutoScalingGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2189,7 +2189,7 @@ type metadataCreateLaunchConfigurationInput struct {
 
 // String returns the string representation
 func (s CreateLaunchConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2207,7 +2207,7 @@ type metadataCreateLaunchConfigurationOutput struct {
 
 // String returns the string representation
 func (s CreateLaunchConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2228,7 +2228,7 @@ type metadataCreateOrUpdateTagsInput struct {
 
 // String returns the string representation
 func (s CreateOrUpdateTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2246,7 +2246,7 @@ type metadataCreateOrUpdateTagsOutput struct {
 
 // String returns the string representation
 func (s CreateOrUpdateTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2272,7 +2272,7 @@ type metadataDeleteAutoScalingGroupInput struct {
 
 // String returns the string representation
 func (s DeleteAutoScalingGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2290,7 +2290,7 @@ type metadataDeleteAutoScalingGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteAutoScalingGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2311,7 +2311,7 @@ type metadataDeleteLaunchConfigurationInput struct {
 
 // String returns the string representation
 func (s DeleteLaunchConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2329,7 +2329,7 @@ type metadataDeleteLaunchConfigurationOutput struct {
 
 // String returns the string representation
 func (s DeleteLaunchConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2353,7 +2353,7 @@ type metadataDeleteLifecycleHookInput struct {
 
 // String returns the string representation
 func (s DeleteLifecycleHookInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2371,7 +2371,7 @@ type metadataDeleteLifecycleHookOutput struct {
 
 // String returns the string representation
 func (s DeleteLifecycleHookOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2396,7 +2396,7 @@ type metadataDeleteNotificationConfigurationInput struct {
 
 // String returns the string representation
 func (s DeleteNotificationConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2414,7 +2414,7 @@ type metadataDeleteNotificationConfigurationOutput struct {
 
 // String returns the string representation
 func (s DeleteNotificationConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2438,7 +2438,7 @@ type metadataDeletePolicyInput struct {
 
 // String returns the string representation
 func (s DeletePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2456,7 +2456,7 @@ type metadataDeletePolicyOutput struct {
 
 // String returns the string representation
 func (s DeletePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2480,7 +2480,7 @@ type metadataDeleteScheduledActionInput struct {
 
 // String returns the string representation
 func (s DeleteScheduledActionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2498,7 +2498,7 @@ type metadataDeleteScheduledActionOutput struct {
 
 // String returns the string representation
 func (s DeleteScheduledActionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2522,7 +2522,7 @@ type metadataDeleteTagsInput struct {
 
 // String returns the string representation
 func (s DeleteTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2540,7 +2540,7 @@ type metadataDeleteTagsOutput struct {
 
 // String returns the string representation
 func (s DeleteTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2558,7 +2558,7 @@ type metadataDescribeAccountLimitsInput struct {
 
 // String returns the string representation
 func (s DescribeAccountLimitsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2584,7 +2584,7 @@ type metadataDescribeAccountLimitsOutput struct {
 
 // String returns the string representation
 func (s DescribeAccountLimitsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2602,7 +2602,7 @@ type metadataDescribeAdjustmentTypesInput struct {
 
 // String returns the string representation
 func (s DescribeAdjustmentTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2623,7 +2623,7 @@ type metadataDescribeAdjustmentTypesOutput struct {
 
 // String returns the string representation
 func (s DescribeAdjustmentTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2651,7 +2651,7 @@ type metadataDescribeAutoScalingGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeAutoScalingGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2676,7 +2676,7 @@ type metadataDescribeAutoScalingGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeAutoScalingGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2706,7 +2706,7 @@ type metadataDescribeAutoScalingInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeAutoScalingInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2731,7 +2731,7 @@ type metadataDescribeAutoScalingInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeAutoScalingInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2749,7 +2749,7 @@ type metadataDescribeAutoScalingNotificationTypesInput struct {
 
 // String returns the string representation
 func (s DescribeAutoScalingNotificationTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2780,7 +2780,7 @@ type metadataDescribeAutoScalingNotificationTypesOutput struct {
 
 // String returns the string representation
 func (s DescribeAutoScalingNotificationTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2808,7 +2808,7 @@ type metadataDescribeLaunchConfigurationsInput struct {
 
 // String returns the string representation
 func (s DescribeLaunchConfigurationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2833,7 +2833,7 @@ type metadataDescribeLaunchConfigurationsOutput struct {
 
 // String returns the string representation
 func (s DescribeLaunchConfigurationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2851,7 +2851,7 @@ type metadataDescribeLifecycleHookTypesInput struct {
 
 // String returns the string representation
 func (s DescribeLifecycleHookTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2876,7 +2876,7 @@ type metadataDescribeLifecycleHookTypesOutput struct {
 
 // String returns the string representation
 func (s DescribeLifecycleHookTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2900,7 +2900,7 @@ type metadataDescribeLifecycleHooksInput struct {
 
 // String returns the string representation
 func (s DescribeLifecycleHooksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2921,7 +2921,7 @@ type metadataDescribeLifecycleHooksOutput struct {
 
 // String returns the string representation
 func (s DescribeLifecycleHooksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2949,7 +2949,7 @@ type metadataDescribeLoadBalancersInput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2974,7 +2974,7 @@ type metadataDescribeLoadBalancersOutput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2992,7 +2992,7 @@ type metadataDescribeMetricCollectionTypesInput struct {
 
 // String returns the string representation
 func (s DescribeMetricCollectionTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3016,7 +3016,7 @@ type metadataDescribeMetricCollectionTypesOutput struct {
 
 // String returns the string representation
 func (s DescribeMetricCollectionTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3044,7 +3044,7 @@ type metadataDescribeNotificationConfigurationsInput struct {
 
 // String returns the string representation
 func (s DescribeNotificationConfigurationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3069,7 +3069,7 @@ type metadataDescribeNotificationConfigurationsOutput struct {
 
 // String returns the string representation
 func (s DescribeNotificationConfigurationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3106,7 +3106,7 @@ type metadataDescribePoliciesInput struct {
 
 // String returns the string representation
 func (s DescribePoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3131,7 +3131,7 @@ type metadataDescribePoliciesOutput struct {
 
 // String returns the string representation
 func (s DescribePoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3166,7 +3166,7 @@ type metadataDescribeScalingActivitiesInput struct {
 
 // String returns the string representation
 func (s DescribeScalingActivitiesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3191,7 +3191,7 @@ type metadataDescribeScalingActivitiesOutput struct {
 
 // String returns the string representation
 func (s DescribeScalingActivitiesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3209,7 +3209,7 @@ type metadataDescribeScalingProcessTypesInput struct {
 
 // String returns the string representation
 func (s DescribeScalingProcessTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3230,7 +3230,7 @@ type metadataDescribeScalingProcessTypesOutput struct {
 
 // String returns the string representation
 func (s DescribeScalingProcessTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3275,7 +3275,7 @@ type metadataDescribeScheduledActionsInput struct {
 
 // String returns the string representation
 func (s DescribeScheduledActionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3300,7 +3300,7 @@ type metadataDescribeScheduledActionsOutput struct {
 
 // String returns the string representation
 func (s DescribeScheduledActionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3328,7 +3328,7 @@ type metadataDescribeTagsInput struct {
 
 // String returns the string representation
 func (s DescribeTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3353,7 +3353,7 @@ type metadataDescribeTagsOutput struct {
 
 // String returns the string representation
 func (s DescribeTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3371,7 +3371,7 @@ type metadataDescribeTerminationPolicyTypesInput struct {
 
 // String returns the string representation
 func (s DescribeTerminationPolicyTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3393,7 +3393,7 @@ type metadataDescribeTerminationPolicyTypesOutput struct {
 
 // String returns the string representation
 func (s DescribeTerminationPolicyTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3421,7 +3421,7 @@ type metadataDetachInstancesInput struct {
 
 // String returns the string representation
 func (s DetachInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3442,7 +3442,7 @@ type metadataDetachInstancesOutput struct {
 
 // String returns the string representation
 func (s DetachInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3466,7 +3466,7 @@ type metadataDetachLoadBalancersInput struct {
 
 // String returns the string representation
 func (s DetachLoadBalancersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3484,7 +3484,7 @@ type metadataDetachLoadBalancersOutput struct {
 
 // String returns the string representation
 func (s DetachLoadBalancersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3524,7 +3524,7 @@ type metadataDisableMetricsCollectionInput struct {
 
 // String returns the string representation
 func (s DisableMetricsCollectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3542,7 +3542,7 @@ type metadataDisableMetricsCollectionOutput struct {
 
 // String returns the string representation
 func (s DisableMetricsCollectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3596,7 +3596,7 @@ type metadataEBS struct {
 
 // String returns the string representation
 func (s EBS) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3643,7 +3643,7 @@ type metadataEnableMetricsCollectionInput struct {
 
 // String returns the string representation
 func (s EnableMetricsCollectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3661,7 +3661,7 @@ type metadataEnableMetricsCollectionOutput struct {
 
 // String returns the string representation
 func (s EnableMetricsCollectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3702,7 +3702,7 @@ type metadataEnabledMetric struct {
 
 // String returns the string representation
 func (s EnabledMetric) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3733,7 +3733,7 @@ type metadataEnterStandbyInput struct {
 
 // String returns the string representation
 func (s EnterStandbyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3754,7 +3754,7 @@ type metadataEnterStandbyOutput struct {
 
 // String returns the string representation
 func (s EnterStandbyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3807,7 +3807,7 @@ type metadataExecutePolicyInput struct {
 
 // String returns the string representation
 func (s ExecutePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3825,7 +3825,7 @@ type metadataExecutePolicyOutput struct {
 
 // String returns the string representation
 func (s ExecutePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3849,7 +3849,7 @@ type metadataExitStandbyInput struct {
 
 // String returns the string representation
 func (s ExitStandbyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3870,7 +3870,7 @@ type metadataExitStandbyOutput struct {
 
 // String returns the string representation
 func (s ExitStandbyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3896,7 +3896,7 @@ type metadataFilter struct {
 
 // String returns the string representation
 func (s Filter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3982,7 +3982,7 @@ type metadataGroup struct {
 
 // String returns the string representation
 func (s Group) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4017,7 +4017,7 @@ type metadataInstance struct {
 
 // String returns the string representation
 func (s Instance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4058,7 +4058,7 @@ type metadataInstanceDetails struct {
 
 // String returns the string representation
 func (s InstanceDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4080,7 +4080,7 @@ type metadataInstanceMonitoring struct {
 
 // String returns the string representation
 func (s InstanceMonitoring) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4166,7 +4166,7 @@ type metadataLaunchConfiguration struct {
 
 // String returns the string representation
 func (s LaunchConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4235,7 +4235,7 @@ type metadataLifecycleHook struct {
 
 // String returns the string representation
 func (s LifecycleHook) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4271,7 +4271,7 @@ type metadataLoadBalancerState struct {
 
 // String returns the string representation
 func (s LoadBalancerState) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4309,7 +4309,7 @@ type metadataMetricCollectionType struct {
 
 // String returns the string representation
 func (s MetricCollectionType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4331,7 +4331,7 @@ type metadataMetricGranularityType struct {
 
 // String returns the string representation
 func (s MetricGranularityType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4370,7 +4370,7 @@ type metadataNotificationConfiguration struct {
 
 // String returns the string representation
 func (s NotificationConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4411,7 +4411,7 @@ type metadataProcessType struct {
 
 // String returns the string representation
 func (s ProcessType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4488,7 +4488,7 @@ type metadataPutLifecycleHookInput struct {
 
 // String returns the string representation
 func (s PutLifecycleHookInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4506,7 +4506,7 @@ type metadataPutLifecycleHookOutput struct {
 
 // String returns the string representation
 func (s PutLifecycleHookOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4535,7 +4535,7 @@ type metadataPutNotificationConfigurationInput struct {
 
 // String returns the string representation
 func (s PutNotificationConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4553,7 +4553,7 @@ type metadataPutNotificationConfigurationOutput struct {
 
 // String returns the string representation
 func (s PutNotificationConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4636,7 +4636,7 @@ type metadataPutScalingPolicyInput struct {
 
 // String returns the string representation
 func (s PutScalingPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4657,7 +4657,7 @@ type metadataPutScalingPolicyOutput struct {
 
 // String returns the string representation
 func (s PutScalingPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4717,7 +4717,7 @@ type metadataPutScheduledUpdateGroupActionInput struct {
 
 // String returns the string representation
 func (s PutScheduledUpdateGroupActionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4735,7 +4735,7 @@ type metadataPutScheduledUpdateGroupActionOutput struct {
 
 // String returns the string representation
 func (s PutScheduledUpdateGroupActionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4764,7 +4764,7 @@ type metadataRecordLifecycleActionHeartbeatInput struct {
 
 // String returns the string representation
 func (s RecordLifecycleActionHeartbeatInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4782,7 +4782,7 @@ type metadataRecordLifecycleActionHeartbeatOutput struct {
 
 // String returns the string representation
 func (s RecordLifecycleActionHeartbeatOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4800,7 +4800,7 @@ type metadataResumeProcessesOutput struct {
 
 // String returns the string representation
 func (s ResumeProcessesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4868,7 +4868,7 @@ type metadataScalingPolicy struct {
 
 // String returns the string representation
 func (s ScalingPolicy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4908,7 +4908,7 @@ type metadataScalingProcessQuery struct {
 
 // String returns the string representation
 func (s ScalingProcessQuery) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4962,7 +4962,7 @@ type metadataScheduledUpdateGroupAction struct {
 
 // String returns the string representation
 func (s ScheduledUpdateGroupAction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4992,7 +4992,7 @@ type metadataSetDesiredCapacityInput struct {
 
 // String returns the string representation
 func (s SetDesiredCapacityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5010,7 +5010,7 @@ type metadataSetDesiredCapacityOutput struct {
 
 // String returns the string representation
 func (s SetDesiredCapacityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5045,7 +5045,7 @@ type metadataSetInstanceHealthInput struct {
 
 // String returns the string representation
 func (s SetInstanceHealthInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5063,7 +5063,7 @@ type metadataSetInstanceHealthOutput struct {
 
 // String returns the string representation
 func (s SetInstanceHealthOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5131,7 +5131,7 @@ type metadataStepAdjustment struct {
 
 // String returns the string representation
 func (s StepAdjustment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5149,7 +5149,7 @@ type metadataSuspendProcessesOutput struct {
 
 // String returns the string representation
 func (s SuspendProcessesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5175,7 +5175,7 @@ type metadataSuspendedProcess struct {
 
 // String returns the string representation
 func (s SuspendedProcess) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5210,7 +5210,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5245,7 +5245,7 @@ type metadataTagDescription struct {
 
 // String returns the string representation
 func (s TagDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5270,7 +5270,7 @@ type metadataTerminateInstanceInAutoScalingGroupInput struct {
 
 // String returns the string representation
 func (s TerminateInstanceInAutoScalingGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5291,7 +5291,7 @@ type metadataTerminateInstanceInAutoScalingGroupOutput struct {
 
 // String returns the string representation
 func (s TerminateInstanceInAutoScalingGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5369,7 +5369,7 @@ type metadataUpdateAutoScalingGroupInput struct {
 
 // String returns the string representation
 func (s UpdateAutoScalingGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5387,7 +5387,7 @@ type metadataUpdateAutoScalingGroupOutput struct {
 
 // String returns the string representation
 func (s UpdateAutoScalingGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/autoscaling/examples_test.go
+++ b/service/autoscaling/examples_test.go
@@ -44,7 +44,7 @@ func ExampleAutoScaling_AttachInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_AttachLoadBalancers() {
@@ -75,7 +75,7 @@ func ExampleAutoScaling_AttachLoadBalancers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_CompleteLifecycleAction() {
@@ -105,7 +105,7 @@ func ExampleAutoScaling_CompleteLifecycleAction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_CreateAutoScalingGroup() {
@@ -113,15 +113,15 @@ func ExampleAutoScaling_CreateAutoScalingGroup() {
 
 	params := &autoscaling.CreateAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String("XmlStringMaxLen255"), // Required
-		MaxSize:              aws.Long(1),                      // Required
-		MinSize:              aws.Long(1),                      // Required
+		MaxSize:              aws.Int64(1),                     // Required
+		MinSize:              aws.Int64(1),                     // Required
 		AvailabilityZones: []*string{
 			aws.String("XmlStringMaxLen255"), // Required
 			// More values...
 		},
-		DefaultCooldown:         aws.Long(1),
-		DesiredCapacity:         aws.Long(1),
-		HealthCheckGracePeriod:  aws.Long(1),
+		DefaultCooldown:         aws.Int64(1),
+		DesiredCapacity:         aws.Int64(1),
+		HealthCheckGracePeriod:  aws.Int64(1),
 		HealthCheckType:         aws.String("XmlStringMaxLen32"),
 		InstanceID:              aws.String("XmlStringMaxLen16"),
 		LaunchConfigurationName: aws.String("ResourceName"),
@@ -133,7 +133,7 @@ func ExampleAutoScaling_CreateAutoScalingGroup() {
 		Tags: []*autoscaling.Tag{
 			{ // Required
 				Key:               aws.String("TagKey"), // Required
-				PropagateAtLaunch: aws.Boolean(true),
+				PropagateAtLaunch: aws.Bool(true),
 				ResourceID:        aws.String("XmlString"),
 				ResourceType:      aws.String("XmlString"),
 				Value:             aws.String("TagValue"),
@@ -164,7 +164,7 @@ func ExampleAutoScaling_CreateAutoScalingGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_CreateLaunchConfiguration() {
@@ -172,18 +172,18 @@ func ExampleAutoScaling_CreateLaunchConfiguration() {
 
 	params := &autoscaling.CreateLaunchConfigurationInput{
 		LaunchConfigurationName:  aws.String("XmlStringMaxLen255"), // Required
-		AssociatePublicIPAddress: aws.Boolean(true),
+		AssociatePublicIPAddress: aws.Bool(true),
 		BlockDeviceMappings: []*autoscaling.BlockDeviceMapping{
 			{ // Required
 				DeviceName: aws.String("XmlStringMaxLen255"), // Required
 				EBS: &autoscaling.EBS{
-					DeleteOnTermination: aws.Boolean(true),
-					IOPS:                aws.Long(1),
+					DeleteOnTermination: aws.Bool(true),
+					IOPS:                aws.Int64(1),
 					SnapshotID:          aws.String("XmlStringMaxLen255"),
-					VolumeSize:          aws.Long(1),
+					VolumeSize:          aws.Int64(1),
 					VolumeType:          aws.String("BlockDeviceEbsVolumeType"),
 				},
-				NoDevice:    aws.Boolean(true),
+				NoDevice:    aws.Bool(true),
 				VirtualName: aws.String("XmlStringMaxLen255"),
 			},
 			// More values...
@@ -193,12 +193,12 @@ func ExampleAutoScaling_CreateLaunchConfiguration() {
 			aws.String("XmlStringMaxLen255"), // Required
 			// More values...
 		},
-		EBSOptimized:       aws.Boolean(true),
+		EBSOptimized:       aws.Bool(true),
 		IAMInstanceProfile: aws.String("XmlStringMaxLen1600"),
 		ImageID:            aws.String("XmlStringMaxLen255"),
 		InstanceID:         aws.String("XmlStringMaxLen16"),
 		InstanceMonitoring: &autoscaling.InstanceMonitoring{
-			Enabled: aws.Boolean(true),
+			Enabled: aws.Bool(true),
 		},
 		InstanceType:     aws.String("XmlStringMaxLen255"),
 		KernelID:         aws.String("XmlStringMaxLen255"),
@@ -230,7 +230,7 @@ func ExampleAutoScaling_CreateLaunchConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_CreateOrUpdateTags() {
@@ -240,7 +240,7 @@ func ExampleAutoScaling_CreateOrUpdateTags() {
 		Tags: []*autoscaling.Tag{ // Required
 			{ // Required
 				Key:               aws.String("TagKey"), // Required
-				PropagateAtLaunch: aws.Boolean(true),
+				PropagateAtLaunch: aws.Bool(true),
 				ResourceID:        aws.String("XmlString"),
 				ResourceType:      aws.String("XmlString"),
 				Value:             aws.String("TagValue"),
@@ -266,7 +266,7 @@ func ExampleAutoScaling_CreateOrUpdateTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DeleteAutoScalingGroup() {
@@ -274,7 +274,7 @@ func ExampleAutoScaling_DeleteAutoScalingGroup() {
 
 	params := &autoscaling.DeleteAutoScalingGroupInput{
 		AutoScalingGroupName: aws.String("ResourceName"), // Required
-		ForceDelete:          aws.Boolean(true),
+		ForceDelete:          aws.Bool(true),
 	}
 	resp, err := svc.DeleteAutoScalingGroup(params)
 
@@ -294,7 +294,7 @@ func ExampleAutoScaling_DeleteAutoScalingGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DeleteLaunchConfiguration() {
@@ -321,7 +321,7 @@ func ExampleAutoScaling_DeleteLaunchConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DeleteLifecycleHook() {
@@ -349,7 +349,7 @@ func ExampleAutoScaling_DeleteLifecycleHook() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DeleteNotificationConfiguration() {
@@ -377,7 +377,7 @@ func ExampleAutoScaling_DeleteNotificationConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DeletePolicy() {
@@ -405,7 +405,7 @@ func ExampleAutoScaling_DeletePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DeleteScheduledAction() {
@@ -433,7 +433,7 @@ func ExampleAutoScaling_DeleteScheduledAction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DeleteTags() {
@@ -443,7 +443,7 @@ func ExampleAutoScaling_DeleteTags() {
 		Tags: []*autoscaling.Tag{ // Required
 			{ // Required
 				Key:               aws.String("TagKey"), // Required
-				PropagateAtLaunch: aws.Boolean(true),
+				PropagateAtLaunch: aws.Bool(true),
 				ResourceID:        aws.String("XmlString"),
 				ResourceType:      aws.String("XmlString"),
 				Value:             aws.String("TagValue"),
@@ -469,7 +469,7 @@ func ExampleAutoScaling_DeleteTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeAccountLimits() {
@@ -494,7 +494,7 @@ func ExampleAutoScaling_DescribeAccountLimits() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeAdjustmentTypes() {
@@ -519,7 +519,7 @@ func ExampleAutoScaling_DescribeAdjustmentTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeAutoScalingGroups() {
@@ -530,7 +530,7 @@ func ExampleAutoScaling_DescribeAutoScalingGroups() {
 			aws.String("ResourceName"), // Required
 			// More values...
 		},
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		NextToken:  aws.String("XmlString"),
 	}
 	resp, err := svc.DescribeAutoScalingGroups(params)
@@ -551,7 +551,7 @@ func ExampleAutoScaling_DescribeAutoScalingGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeAutoScalingInstances() {
@@ -562,7 +562,7 @@ func ExampleAutoScaling_DescribeAutoScalingInstances() {
 			aws.String("XmlStringMaxLen16"), // Required
 			// More values...
 		},
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		NextToken:  aws.String("XmlString"),
 	}
 	resp, err := svc.DescribeAutoScalingInstances(params)
@@ -583,7 +583,7 @@ func ExampleAutoScaling_DescribeAutoScalingInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeAutoScalingNotificationTypes() {
@@ -608,7 +608,7 @@ func ExampleAutoScaling_DescribeAutoScalingNotificationTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeLaunchConfigurations() {
@@ -619,7 +619,7 @@ func ExampleAutoScaling_DescribeLaunchConfigurations() {
 			aws.String("ResourceName"), // Required
 			// More values...
 		},
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		NextToken:  aws.String("XmlString"),
 	}
 	resp, err := svc.DescribeLaunchConfigurations(params)
@@ -640,7 +640,7 @@ func ExampleAutoScaling_DescribeLaunchConfigurations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeLifecycleHookTypes() {
@@ -665,7 +665,7 @@ func ExampleAutoScaling_DescribeLifecycleHookTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeLifecycleHooks() {
@@ -696,7 +696,7 @@ func ExampleAutoScaling_DescribeLifecycleHooks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeLoadBalancers() {
@@ -704,7 +704,7 @@ func ExampleAutoScaling_DescribeLoadBalancers() {
 
 	params := &autoscaling.DescribeLoadBalancersInput{
 		AutoScalingGroupName: aws.String("ResourceName"), // Required
-		MaxRecords:           aws.Long(1),
+		MaxRecords:           aws.Int64(1),
 		NextToken:            aws.String("XmlString"),
 	}
 	resp, err := svc.DescribeLoadBalancers(params)
@@ -725,7 +725,7 @@ func ExampleAutoScaling_DescribeLoadBalancers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeMetricCollectionTypes() {
@@ -750,7 +750,7 @@ func ExampleAutoScaling_DescribeMetricCollectionTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeNotificationConfigurations() {
@@ -761,7 +761,7 @@ func ExampleAutoScaling_DescribeNotificationConfigurations() {
 			aws.String("ResourceName"), // Required
 			// More values...
 		},
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		NextToken:  aws.String("XmlString"),
 	}
 	resp, err := svc.DescribeNotificationConfigurations(params)
@@ -782,7 +782,7 @@ func ExampleAutoScaling_DescribeNotificationConfigurations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribePolicies() {
@@ -790,7 +790,7 @@ func ExampleAutoScaling_DescribePolicies() {
 
 	params := &autoscaling.DescribePoliciesInput{
 		AutoScalingGroupName: aws.String("ResourceName"),
-		MaxRecords:           aws.Long(1),
+		MaxRecords:           aws.Int64(1),
 		NextToken:            aws.String("XmlString"),
 		PolicyNames: []*string{
 			aws.String("ResourceName"), // Required
@@ -819,7 +819,7 @@ func ExampleAutoScaling_DescribePolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeScalingActivities() {
@@ -831,7 +831,7 @@ func ExampleAutoScaling_DescribeScalingActivities() {
 			// More values...
 		},
 		AutoScalingGroupName: aws.String("ResourceName"),
-		MaxRecords:           aws.Long(1),
+		MaxRecords:           aws.Int64(1),
 		NextToken:            aws.String("XmlString"),
 	}
 	resp, err := svc.DescribeScalingActivities(params)
@@ -852,7 +852,7 @@ func ExampleAutoScaling_DescribeScalingActivities() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeScalingProcessTypes() {
@@ -877,7 +877,7 @@ func ExampleAutoScaling_DescribeScalingProcessTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeScheduledActions() {
@@ -886,7 +886,7 @@ func ExampleAutoScaling_DescribeScheduledActions() {
 	params := &autoscaling.DescribeScheduledActionsInput{
 		AutoScalingGroupName: aws.String("ResourceName"),
 		EndTime:              aws.Time(time.Now()),
-		MaxRecords:           aws.Long(1),
+		MaxRecords:           aws.Int64(1),
 		NextToken:            aws.String("XmlString"),
 		ScheduledActionNames: []*string{
 			aws.String("ResourceName"), // Required
@@ -912,7 +912,7 @@ func ExampleAutoScaling_DescribeScheduledActions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeTags() {
@@ -929,7 +929,7 @@ func ExampleAutoScaling_DescribeTags() {
 			},
 			// More values...
 		},
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		NextToken:  aws.String("XmlString"),
 	}
 	resp, err := svc.DescribeTags(params)
@@ -950,7 +950,7 @@ func ExampleAutoScaling_DescribeTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DescribeTerminationPolicyTypes() {
@@ -975,7 +975,7 @@ func ExampleAutoScaling_DescribeTerminationPolicyTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DetachInstances() {
@@ -983,7 +983,7 @@ func ExampleAutoScaling_DetachInstances() {
 
 	params := &autoscaling.DetachInstancesInput{
 		AutoScalingGroupName:           aws.String("ResourceName"), // Required
-		ShouldDecrementDesiredCapacity: aws.Boolean(true),          // Required
+		ShouldDecrementDesiredCapacity: aws.Bool(true),             // Required
 		InstanceIDs: []*string{
 			aws.String("XmlStringMaxLen16"), // Required
 			// More values...
@@ -1007,7 +1007,7 @@ func ExampleAutoScaling_DetachInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DetachLoadBalancers() {
@@ -1038,7 +1038,7 @@ func ExampleAutoScaling_DetachLoadBalancers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_DisableMetricsCollection() {
@@ -1069,7 +1069,7 @@ func ExampleAutoScaling_DisableMetricsCollection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_EnableMetricsCollection() {
@@ -1101,7 +1101,7 @@ func ExampleAutoScaling_EnableMetricsCollection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_EnterStandby() {
@@ -1109,7 +1109,7 @@ func ExampleAutoScaling_EnterStandby() {
 
 	params := &autoscaling.EnterStandbyInput{
 		AutoScalingGroupName:           aws.String("ResourceName"), // Required
-		ShouldDecrementDesiredCapacity: aws.Boolean(true),          // Required
+		ShouldDecrementDesiredCapacity: aws.Bool(true),             // Required
 		InstanceIDs: []*string{
 			aws.String("XmlStringMaxLen16"), // Required
 			// More values...
@@ -1133,7 +1133,7 @@ func ExampleAutoScaling_EnterStandby() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_ExecutePolicy() {
@@ -1142,9 +1142,9 @@ func ExampleAutoScaling_ExecutePolicy() {
 	params := &autoscaling.ExecutePolicyInput{
 		PolicyName:           aws.String("ResourceName"), // Required
 		AutoScalingGroupName: aws.String("ResourceName"),
-		BreachThreshold:      aws.Double(1.0),
-		HonorCooldown:        aws.Boolean(true),
-		MetricValue:          aws.Double(1.0),
+		BreachThreshold:      aws.Float64(1.0),
+		HonorCooldown:        aws.Bool(true),
+		MetricValue:          aws.Float64(1.0),
 	}
 	resp, err := svc.ExecutePolicy(params)
 
@@ -1164,7 +1164,7 @@ func ExampleAutoScaling_ExecutePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_ExitStandby() {
@@ -1195,7 +1195,7 @@ func ExampleAutoScaling_ExitStandby() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_PutLifecycleHook() {
@@ -1205,7 +1205,7 @@ func ExampleAutoScaling_PutLifecycleHook() {
 		AutoScalingGroupName:  aws.String("ResourceName"),         // Required
 		LifecycleHookName:     aws.String("AsciiStringMaxLen255"), // Required
 		DefaultResult:         aws.String("LifecycleActionResult"),
-		HeartbeatTimeout:      aws.Long(1),
+		HeartbeatTimeout:      aws.Int64(1),
 		LifecycleTransition:   aws.String("LifecycleTransition"),
 		NotificationMetadata:  aws.String("XmlStringMaxLen1023"),
 		NotificationTargetARN: aws.String("ResourceName"),
@@ -1229,7 +1229,7 @@ func ExampleAutoScaling_PutLifecycleHook() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_PutNotificationConfiguration() {
@@ -1261,7 +1261,7 @@ func ExampleAutoScaling_PutNotificationConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_PutScalingPolicy() {
@@ -1271,18 +1271,18 @@ func ExampleAutoScaling_PutScalingPolicy() {
 		AdjustmentType:          aws.String("XmlStringMaxLen255"), // Required
 		AutoScalingGroupName:    aws.String("ResourceName"),       // Required
 		PolicyName:              aws.String("XmlStringMaxLen255"), // Required
-		Cooldown:                aws.Long(1),
-		EstimatedInstanceWarmup: aws.Long(1),
+		Cooldown:                aws.Int64(1),
+		EstimatedInstanceWarmup: aws.Int64(1),
 		MetricAggregationType:   aws.String("XmlStringMaxLen32"),
-		MinAdjustmentMagnitude:  aws.Long(1),
-		MinAdjustmentStep:       aws.Long(1),
+		MinAdjustmentMagnitude:  aws.Int64(1),
+		MinAdjustmentStep:       aws.Int64(1),
 		PolicyType:              aws.String("XmlStringMaxLen64"),
-		ScalingAdjustment:       aws.Long(1),
+		ScalingAdjustment:       aws.Int64(1),
 		StepAdjustments: []*autoscaling.StepAdjustment{
 			{ // Required
-				ScalingAdjustment:        aws.Long(1), // Required
-				MetricIntervalLowerBound: aws.Double(1.0),
-				MetricIntervalUpperBound: aws.Double(1.0),
+				ScalingAdjustment:        aws.Int64(1), // Required
+				MetricIntervalLowerBound: aws.Float64(1.0),
+				MetricIntervalUpperBound: aws.Float64(1.0),
 			},
 			// More values...
 		},
@@ -1305,7 +1305,7 @@ func ExampleAutoScaling_PutScalingPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_PutScheduledUpdateGroupAction() {
@@ -1314,10 +1314,10 @@ func ExampleAutoScaling_PutScheduledUpdateGroupAction() {
 	params := &autoscaling.PutScheduledUpdateGroupActionInput{
 		AutoScalingGroupName: aws.String("ResourceName"),       // Required
 		ScheduledActionName:  aws.String("XmlStringMaxLen255"), // Required
-		DesiredCapacity:      aws.Long(1),
+		DesiredCapacity:      aws.Int64(1),
 		EndTime:              aws.Time(time.Now()),
-		MaxSize:              aws.Long(1),
-		MinSize:              aws.Long(1),
+		MaxSize:              aws.Int64(1),
+		MinSize:              aws.Int64(1),
 		Recurrence:           aws.String("XmlStringMaxLen255"),
 		StartTime:            aws.Time(time.Now()),
 		Time:                 aws.Time(time.Now()),
@@ -1340,7 +1340,7 @@ func ExampleAutoScaling_PutScheduledUpdateGroupAction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_RecordLifecycleActionHeartbeat() {
@@ -1369,7 +1369,7 @@ func ExampleAutoScaling_RecordLifecycleActionHeartbeat() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_ResumeProcesses() {
@@ -1400,7 +1400,7 @@ func ExampleAutoScaling_ResumeProcesses() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_SetDesiredCapacity() {
@@ -1408,8 +1408,8 @@ func ExampleAutoScaling_SetDesiredCapacity() {
 
 	params := &autoscaling.SetDesiredCapacityInput{
 		AutoScalingGroupName: aws.String("ResourceName"), // Required
-		DesiredCapacity:      aws.Long(1),                // Required
-		HonorCooldown:        aws.Boolean(true),
+		DesiredCapacity:      aws.Int64(1),               // Required
+		HonorCooldown:        aws.Bool(true),
 	}
 	resp, err := svc.SetDesiredCapacity(params)
 
@@ -1429,7 +1429,7 @@ func ExampleAutoScaling_SetDesiredCapacity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_SetInstanceHealth() {
@@ -1438,7 +1438,7 @@ func ExampleAutoScaling_SetInstanceHealth() {
 	params := &autoscaling.SetInstanceHealthInput{
 		HealthStatus:             aws.String("XmlStringMaxLen32"), // Required
 		InstanceID:               aws.String("XmlStringMaxLen16"), // Required
-		ShouldRespectGracePeriod: aws.Boolean(true),
+		ShouldRespectGracePeriod: aws.Bool(true),
 	}
 	resp, err := svc.SetInstanceHealth(params)
 
@@ -1458,7 +1458,7 @@ func ExampleAutoScaling_SetInstanceHealth() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_SuspendProcesses() {
@@ -1489,7 +1489,7 @@ func ExampleAutoScaling_SuspendProcesses() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_TerminateInstanceInAutoScalingGroup() {
@@ -1497,7 +1497,7 @@ func ExampleAutoScaling_TerminateInstanceInAutoScalingGroup() {
 
 	params := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
 		InstanceID:                     aws.String("XmlStringMaxLen16"), // Required
-		ShouldDecrementDesiredCapacity: aws.Boolean(true),               // Required
+		ShouldDecrementDesiredCapacity: aws.Bool(true),                  // Required
 	}
 	resp, err := svc.TerminateInstanceInAutoScalingGroup(params)
 
@@ -1517,7 +1517,7 @@ func ExampleAutoScaling_TerminateInstanceInAutoScalingGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleAutoScaling_UpdateAutoScalingGroup() {
@@ -1529,13 +1529,13 @@ func ExampleAutoScaling_UpdateAutoScalingGroup() {
 			aws.String("XmlStringMaxLen255"), // Required
 			// More values...
 		},
-		DefaultCooldown:         aws.Long(1),
-		DesiredCapacity:         aws.Long(1),
-		HealthCheckGracePeriod:  aws.Long(1),
+		DefaultCooldown:         aws.Int64(1),
+		DesiredCapacity:         aws.Int64(1),
+		HealthCheckGracePeriod:  aws.Int64(1),
 		HealthCheckType:         aws.String("XmlStringMaxLen32"),
 		LaunchConfigurationName: aws.String("ResourceName"),
-		MaxSize:                 aws.Long(1),
-		MinSize:                 aws.Long(1),
+		MaxSize:                 aws.Int64(1),
+		MinSize:                 aws.Int64(1),
 		PlacementGroup:          aws.String("XmlStringMaxLen255"),
 		TerminationPolicies: []*string{
 			aws.String("XmlStringMaxLen1600"), // Required
@@ -1561,5 +1561,5 @@ func ExampleAutoScaling_UpdateAutoScalingGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -608,7 +608,7 @@ type metadataCancelUpdateStackInput struct {
 
 // String returns the string representation
 func (s CancelUpdateStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -626,7 +626,7 @@ type metadataCancelUpdateStackOutput struct {
 
 // String returns the string representation
 func (s CancelUpdateStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -732,7 +732,7 @@ type metadataCreateStackInput struct {
 
 // String returns the string representation
 func (s CreateStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -754,7 +754,7 @@ type metadataCreateStackOutput struct {
 
 // String returns the string representation
 func (s CreateStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -776,7 +776,7 @@ type metadataDeleteStackInput struct {
 
 // String returns the string representation
 func (s DeleteStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -794,7 +794,7 @@ type metadataDeleteStackOutput struct {
 
 // String returns the string representation
 func (s DeleteStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -827,7 +827,7 @@ type metadataDescribeStackEventsInput struct {
 
 // String returns the string representation
 func (s DescribeStackEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -853,7 +853,7 @@ type metadataDescribeStackEventsOutput struct {
 
 // String returns the string representation
 func (s DescribeStackEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -885,7 +885,7 @@ type metadataDescribeStackResourceInput struct {
 
 // String returns the string representation
 func (s DescribeStackResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -908,7 +908,7 @@ type metadataDescribeStackResourceOutput struct {
 
 // String returns the string representation
 func (s DescribeStackResourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -957,7 +957,7 @@ type metadataDescribeStackResourcesInput struct {
 
 // String returns the string representation
 func (s DescribeStackResourcesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -979,7 +979,7 @@ type metadataDescribeStackResourcesOutput struct {
 
 // String returns the string representation
 func (s DescribeStackResourcesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1010,7 +1010,7 @@ type metadataDescribeStacksInput struct {
 
 // String returns the string representation
 func (s DescribeStacksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1036,7 +1036,7 @@ type metadataDescribeStacksOutput struct {
 
 // String returns the string representation
 func (s DescribeStacksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1075,7 +1075,7 @@ type metadataEstimateTemplateCostInput struct {
 
 // String returns the string representation
 func (s EstimateTemplateCostInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1098,7 +1098,7 @@ type metadataEstimateTemplateCostOutput struct {
 
 // String returns the string representation
 func (s EstimateTemplateCostOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1121,7 +1121,7 @@ type metadataGetStackPolicyInput struct {
 
 // String returns the string representation
 func (s GetStackPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1145,7 +1145,7 @@ type metadataGetStackPolicyOutput struct {
 
 // String returns the string representation
 func (s GetStackPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1172,7 +1172,7 @@ type metadataGetTemplateInput struct {
 
 // String returns the string representation
 func (s GetTemplateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1196,7 +1196,7 @@ type metadataGetTemplateOutput struct {
 
 // String returns the string representation
 func (s GetTemplateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1242,7 +1242,7 @@ type metadataGetTemplateSummaryInput struct {
 
 // String returns the string representation
 func (s GetTemplateSummaryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1286,7 +1286,7 @@ type metadataGetTemplateSummaryOutput struct {
 
 // String returns the string representation
 func (s GetTemplateSummaryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1319,7 +1319,7 @@ type metadataListStackResourcesInput struct {
 
 // String returns the string representation
 func (s ListStackResourcesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1345,7 +1345,7 @@ type metadataListStackResourcesOutput struct {
 
 // String returns the string representation
 func (s ListStackResourcesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1375,7 +1375,7 @@ type metadataListStacksInput struct {
 
 // String returns the string representation
 func (s ListStacksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1402,7 +1402,7 @@ type metadataListStacksOutput struct {
 
 // String returns the string representation
 func (s ListStacksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1430,7 +1430,7 @@ type metadataOutput struct {
 
 // String returns the string representation
 func (s Output) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1462,7 +1462,7 @@ type metadataParameter struct {
 
 // String returns the string representation
 func (s Parameter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1486,7 +1486,7 @@ type metadataParameterConstraints struct {
 
 // String returns the string representation
 func (s ParameterConstraints) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1524,7 +1524,7 @@ type metadataParameterDeclaration struct {
 
 // String returns the string representation
 func (s ParameterDeclaration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1558,7 +1558,7 @@ type metadataSetStackPolicyInput struct {
 
 // String returns the string representation
 func (s SetStackPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1576,7 +1576,7 @@ type metadataSetStackPolicyOutput struct {
 
 // String returns the string representation
 func (s SetStackPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1613,7 +1613,7 @@ type metadataSignalResourceInput struct {
 
 // String returns the string representation
 func (s SignalResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1631,7 +1631,7 @@ type metadataSignalResourceOutput struct {
 
 // String returns the string representation
 func (s SignalResourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1695,7 +1695,7 @@ type metadataStack struct {
 
 // String returns the string representation
 func (s Stack) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1747,7 +1747,7 @@ type metadataStackEvent struct {
 
 // String returns the string representation
 func (s StackEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1796,7 +1796,7 @@ type metadataStackResource struct {
 
 // String returns the string representation
 func (s StackResource) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1850,7 +1850,7 @@ type metadataStackResourceDetail struct {
 
 // String returns the string representation
 func (s StackResourceDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1890,7 +1890,7 @@ type metadataStackResourceSummary struct {
 
 // String returns the string representation
 func (s StackResourceSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1934,7 +1934,7 @@ type metadataStackSummary struct {
 
 // String returns the string representation
 func (s StackSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1964,7 +1964,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1996,7 +1996,7 @@ type metadataTemplateParameter struct {
 
 // String returns the string representation
 func (s TemplateParameter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2102,7 +2102,7 @@ type metadataUpdateStackInput struct {
 
 // String returns the string representation
 func (s UpdateStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2124,7 +2124,7 @@ type metadataUpdateStackOutput struct {
 
 // String returns the string representation
 func (s UpdateStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2161,7 +2161,7 @@ type metadataValidateTemplateInput struct {
 
 // String returns the string representation
 func (s ValidateTemplateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2197,7 +2197,7 @@ type metadataValidateTemplateOutput struct {
 
 // String returns the string representation
 func (s ValidateTemplateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cloudformation/examples_test.go
+++ b/service/cloudformation/examples_test.go
@@ -40,7 +40,7 @@ func ExampleCloudFormation_CancelUpdateStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_CreateStack() {
@@ -52,7 +52,7 @@ func ExampleCloudFormation_CreateStack() {
 			aws.String("Capability"), // Required
 			// More values...
 		},
-		DisableRollback: aws.Boolean(true),
+		DisableRollback: aws.Bool(true),
 		NotificationARNs: []*string{
 			aws.String("NotificationARN"), // Required
 			// More values...
@@ -62,7 +62,7 @@ func ExampleCloudFormation_CreateStack() {
 			{ // Required
 				ParameterKey:     aws.String("ParameterKey"),
 				ParameterValue:   aws.String("ParameterValue"),
-				UsePreviousValue: aws.Boolean(true),
+				UsePreviousValue: aws.Bool(true),
 			},
 			// More values...
 		},
@@ -77,7 +77,7 @@ func ExampleCloudFormation_CreateStack() {
 		},
 		TemplateBody:     aws.String("TemplateBody"),
 		TemplateURL:      aws.String("TemplateURL"),
-		TimeoutInMinutes: aws.Long(1),
+		TimeoutInMinutes: aws.Int64(1),
 	}
 	resp, err := svc.CreateStack(params)
 
@@ -97,7 +97,7 @@ func ExampleCloudFormation_CreateStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_DeleteStack() {
@@ -124,7 +124,7 @@ func ExampleCloudFormation_DeleteStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_DescribeStackEvents() {
@@ -152,7 +152,7 @@ func ExampleCloudFormation_DescribeStackEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_DescribeStackResource() {
@@ -180,7 +180,7 @@ func ExampleCloudFormation_DescribeStackResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_DescribeStackResources() {
@@ -209,7 +209,7 @@ func ExampleCloudFormation_DescribeStackResources() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_DescribeStacks() {
@@ -237,7 +237,7 @@ func ExampleCloudFormation_DescribeStacks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_EstimateTemplateCost() {
@@ -248,7 +248,7 @@ func ExampleCloudFormation_EstimateTemplateCost() {
 			{ // Required
 				ParameterKey:     aws.String("ParameterKey"),
 				ParameterValue:   aws.String("ParameterValue"),
-				UsePreviousValue: aws.Boolean(true),
+				UsePreviousValue: aws.Bool(true),
 			},
 			// More values...
 		},
@@ -273,7 +273,7 @@ func ExampleCloudFormation_EstimateTemplateCost() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_GetStackPolicy() {
@@ -300,7 +300,7 @@ func ExampleCloudFormation_GetStackPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_GetTemplate() {
@@ -327,7 +327,7 @@ func ExampleCloudFormation_GetTemplate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_GetTemplateSummary() {
@@ -356,7 +356,7 @@ func ExampleCloudFormation_GetTemplateSummary() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_ListStackResources() {
@@ -384,7 +384,7 @@ func ExampleCloudFormation_ListStackResources() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_ListStacks() {
@@ -415,7 +415,7 @@ func ExampleCloudFormation_ListStacks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_SetStackPolicy() {
@@ -444,7 +444,7 @@ func ExampleCloudFormation_SetStackPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_SignalResource() {
@@ -474,7 +474,7 @@ func ExampleCloudFormation_SignalResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_UpdateStack() {
@@ -494,7 +494,7 @@ func ExampleCloudFormation_UpdateStack() {
 			{ // Required
 				ParameterKey:     aws.String("ParameterKey"),
 				ParameterValue:   aws.String("ParameterValue"),
-				UsePreviousValue: aws.Boolean(true),
+				UsePreviousValue: aws.Bool(true),
 			},
 			// More values...
 		},
@@ -504,7 +504,7 @@ func ExampleCloudFormation_UpdateStack() {
 		StackPolicyURL:              aws.String("StackPolicyURL"),
 		TemplateBody:                aws.String("TemplateBody"),
 		TemplateURL:                 aws.String("TemplateURL"),
-		UsePreviousTemplate:         aws.Boolean(true),
+		UsePreviousTemplate:         aws.Bool(true),
 	}
 	resp, err := svc.UpdateStack(params)
 
@@ -524,7 +524,7 @@ func ExampleCloudFormation_UpdateStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFormation_ValidateTemplate() {
@@ -552,5 +552,5 @@ func ExampleCloudFormation_ValidateTemplate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -656,7 +656,7 @@ type metadataActiveTrustedSigners struct {
 
 // String returns the string representation
 func (s ActiveTrustedSigners) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -683,7 +683,7 @@ type metadataAliases struct {
 
 // String returns the string representation
 func (s Aliases) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -726,7 +726,7 @@ type metadataAllowedMethods struct {
 
 // String returns the string representation
 func (s AllowedMethods) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -837,7 +837,7 @@ type metadataCacheBehavior struct {
 
 // String returns the string representation
 func (s CacheBehavior) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -863,7 +863,7 @@ type metadataCacheBehaviors struct {
 
 // String returns the string representation
 func (s CacheBehaviors) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -896,7 +896,7 @@ type metadataCachedMethods struct {
 
 // String returns the string representation
 func (s CachedMethods) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -923,7 +923,7 @@ type metadataCookieNames struct {
 
 // String returns the string representation
 func (s CookieNames) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -953,7 +953,7 @@ type metadataCookiePreference struct {
 
 // String returns the string representation
 func (s CookiePreference) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -975,7 +975,7 @@ type metadataCreateCloudFrontOriginAccessIdentityInput struct {
 
 // String returns the string representation
 func (s CreateCloudFrontOriginAccessIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1004,7 +1004,7 @@ type metadataCreateCloudFrontOriginAccessIdentityOutput struct {
 
 // String returns the string representation
 func (s CreateCloudFrontOriginAccessIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1026,7 +1026,7 @@ type metadataCreateDistributionInput struct {
 
 // String returns the string representation
 func (s CreateDistributionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1055,7 +1055,7 @@ type metadataCreateDistributionOutput struct {
 
 // String returns the string representation
 func (s CreateDistributionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1080,7 +1080,7 @@ type metadataCreateInvalidationInput struct {
 
 // String returns the string representation
 func (s CreateInvalidationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1106,7 +1106,7 @@ type metadataCreateInvalidationOutput struct {
 
 // String returns the string representation
 func (s CreateInvalidationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1128,7 +1128,7 @@ type metadataCreateStreamingDistributionInput struct {
 
 // String returns the string representation
 func (s CreateStreamingDistributionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1157,7 +1157,7 @@ type metadataCreateStreamingDistributionOutput struct {
 
 // String returns the string representation
 func (s CreateStreamingDistributionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1208,7 +1208,7 @@ type metadataCustomErrorResponse struct {
 
 // String returns the string representation
 func (s CustomErrorResponse) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1234,7 +1234,7 @@ type metadataCustomErrorResponses struct {
 
 // String returns the string representation
 func (s CustomErrorResponses) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1262,7 +1262,7 @@ type metadataCustomOriginConfig struct {
 
 // String returns the string representation
 func (s CustomOriginConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1353,7 +1353,7 @@ type metadataDefaultCacheBehavior struct {
 
 // String returns the string representation
 func (s DefaultCacheBehavior) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1379,7 +1379,7 @@ type metadataDeleteCloudFrontOriginAccessIdentityInput struct {
 
 // String returns the string representation
 func (s DeleteCloudFrontOriginAccessIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1397,7 +1397,7 @@ type metadataDeleteCloudFrontOriginAccessIdentityOutput struct {
 
 // String returns the string representation
 func (s DeleteCloudFrontOriginAccessIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1423,7 +1423,7 @@ type metadataDeleteDistributionInput struct {
 
 // String returns the string representation
 func (s DeleteDistributionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1441,7 +1441,7 @@ type metadataDeleteDistributionOutput struct {
 
 // String returns the string representation
 func (s DeleteDistributionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1467,7 +1467,7 @@ type metadataDeleteStreamingDistributionInput struct {
 
 // String returns the string representation
 func (s DeleteStreamingDistributionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1485,7 +1485,7 @@ type metadataDeleteStreamingDistributionOutput struct {
 
 // String returns the string representation
 func (s DeleteStreamingDistributionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1534,7 +1534,7 @@ type metadataDistribution struct {
 
 // String returns the string representation
 func (s Distribution) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1613,7 +1613,7 @@ type metadataDistributionConfig struct {
 
 // String returns the string representation
 func (s DistributionConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1656,7 +1656,7 @@ type metadataDistributionList struct {
 
 // String returns the string representation
 func (s DistributionList) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1723,7 +1723,7 @@ type metadataDistributionSummary struct {
 
 // String returns the string representation
 func (s DistributionSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1755,7 +1755,7 @@ type metadataForwardedValues struct {
 
 // String returns the string representation
 func (s ForwardedValues) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1803,7 +1803,7 @@ type metadataGeoRestriction struct {
 
 // String returns the string representation
 func (s GeoRestriction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1825,7 +1825,7 @@ type metadataGetCloudFrontOriginAccessIdentityConfigInput struct {
 
 // String returns the string representation
 func (s GetCloudFrontOriginAccessIdentityConfigInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1850,7 +1850,7 @@ type metadataGetCloudFrontOriginAccessIdentityConfigOutput struct {
 
 // String returns the string representation
 func (s GetCloudFrontOriginAccessIdentityConfigOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1872,7 +1872,7 @@ type metadataGetCloudFrontOriginAccessIdentityInput struct {
 
 // String returns the string representation
 func (s GetCloudFrontOriginAccessIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1898,7 +1898,7 @@ type metadataGetCloudFrontOriginAccessIdentityOutput struct {
 
 // String returns the string representation
 func (s GetCloudFrontOriginAccessIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1920,7 +1920,7 @@ type metadataGetDistributionConfigInput struct {
 
 // String returns the string representation
 func (s GetDistributionConfigInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1945,7 +1945,7 @@ type metadataGetDistributionConfigOutput struct {
 
 // String returns the string representation
 func (s GetDistributionConfigOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1967,7 +1967,7 @@ type metadataGetDistributionInput struct {
 
 // String returns the string representation
 func (s GetDistributionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1992,7 +1992,7 @@ type metadataGetDistributionOutput struct {
 
 // String returns the string representation
 func (s GetDistributionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2017,7 +2017,7 @@ type metadataGetInvalidationInput struct {
 
 // String returns the string representation
 func (s GetInvalidationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2039,7 +2039,7 @@ type metadataGetInvalidationOutput struct {
 
 // String returns the string representation
 func (s GetInvalidationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2061,7 +2061,7 @@ type metadataGetStreamingDistributionConfigInput struct {
 
 // String returns the string representation
 func (s GetStreamingDistributionConfigInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2086,7 +2086,7 @@ type metadataGetStreamingDistributionConfigOutput struct {
 
 // String returns the string representation
 func (s GetStreamingDistributionConfigOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2108,7 +2108,7 @@ type metadataGetStreamingDistributionInput struct {
 
 // String returns the string representation
 func (s GetStreamingDistributionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2134,7 +2134,7 @@ type metadataGetStreamingDistributionOutput struct {
 
 // String returns the string representation
 func (s GetStreamingDistributionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2174,7 +2174,7 @@ type metadataHeaders struct {
 
 // String returns the string representation
 func (s Headers) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2206,7 +2206,7 @@ type metadataInvalidation struct {
 
 // String returns the string representation
 func (s Invalidation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2244,7 +2244,7 @@ type metadataInvalidationBatch struct {
 
 // String returns the string representation
 func (s InvalidationBatch) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2287,7 +2287,7 @@ type metadataInvalidationList struct {
 
 // String returns the string representation
 func (s InvalidationList) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2314,7 +2314,7 @@ type metadataInvalidationSummary struct {
 
 // String returns the string representation
 func (s InvalidationSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2341,7 +2341,7 @@ type metadataKeyPairIDs struct {
 
 // String returns the string representation
 func (s KeyPairIDs) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2370,7 +2370,7 @@ type metadataListCloudFrontOriginAccessIdentitiesInput struct {
 
 // String returns the string representation
 func (s ListCloudFrontOriginAccessIdentitiesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2392,7 +2392,7 @@ type metadataListCloudFrontOriginAccessIdentitiesOutput struct {
 
 // String returns the string representation
 func (s ListCloudFrontOriginAccessIdentitiesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2421,7 +2421,7 @@ type metadataListDistributionsInput struct {
 
 // String returns the string representation
 func (s ListDistributionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2443,7 +2443,7 @@ type metadataListDistributionsOutput struct {
 
 // String returns the string representation
 func (s ListDistributionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2477,7 +2477,7 @@ type metadataListInvalidationsInput struct {
 
 // String returns the string representation
 func (s ListInvalidationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2499,7 +2499,7 @@ type metadataListInvalidationsOutput struct {
 
 // String returns the string representation
 func (s ListInvalidationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2528,7 +2528,7 @@ type metadataListStreamingDistributionsInput struct {
 
 // String returns the string representation
 func (s ListStreamingDistributionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2550,7 +2550,7 @@ type metadataListStreamingDistributionsOutput struct {
 
 // String returns the string representation
 func (s ListStreamingDistributionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2594,7 +2594,7 @@ type metadataLoggingConfig struct {
 
 // String returns the string representation
 func (s LoggingConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2641,7 +2641,7 @@ type metadataOrigin struct {
 
 // String returns the string representation
 func (s Origin) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2671,7 +2671,7 @@ type metadataOriginAccessIdentity struct {
 
 // String returns the string representation
 func (s OriginAccessIdentity) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2706,7 +2706,7 @@ type metadataOriginAccessIdentityConfig struct {
 
 // String returns the string representation
 func (s OriginAccessIdentityConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2750,7 +2750,7 @@ type metadataOriginAccessIdentityList struct {
 
 // String returns the string representation
 func (s OriginAccessIdentityList) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2781,7 +2781,7 @@ type metadataOriginAccessIdentitySummary struct {
 
 // String returns the string representation
 func (s OriginAccessIdentitySummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2806,7 +2806,7 @@ type metadataOrigins struct {
 
 // String returns the string representation
 func (s Origins) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2832,7 +2832,7 @@ type metadataPaths struct {
 
 // String returns the string representation
 func (s Paths) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2860,7 +2860,7 @@ type metadataRestrictions struct {
 
 // String returns the string representation
 func (s Restrictions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2886,7 +2886,7 @@ type metadataS3Origin struct {
 
 // String returns the string representation
 func (s S3Origin) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2919,7 +2919,7 @@ type metadataS3OriginConfig struct {
 
 // String returns the string representation
 func (s S3OriginConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2949,7 +2949,7 @@ type metadataSigner struct {
 
 // String returns the string representation
 func (s Signer) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2996,7 +2996,7 @@ type metadataStreamingDistribution struct {
 
 // String returns the string representation
 func (s StreamingDistribution) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3063,7 +3063,7 @@ type metadataStreamingDistributionConfig struct {
 
 // String returns the string representation
 func (s StreamingDistributionConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3107,7 +3107,7 @@ type metadataStreamingDistributionList struct {
 
 // String returns the string representation
 func (s StreamingDistributionList) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3169,7 +3169,7 @@ type metadataStreamingDistributionSummary struct {
 
 // String returns the string representation
 func (s StreamingDistributionSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3206,7 +3206,7 @@ type metadataStreamingLoggingConfig struct {
 
 // String returns the string representation
 func (s StreamingLoggingConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3246,7 +3246,7 @@ type metadataTrustedSigners struct {
 
 // String returns the string representation
 func (s TrustedSigners) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3275,7 +3275,7 @@ type metadataUpdateCloudFrontOriginAccessIdentityInput struct {
 
 // String returns the string representation
 func (s UpdateCloudFrontOriginAccessIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3300,7 +3300,7 @@ type metadataUpdateCloudFrontOriginAccessIdentityOutput struct {
 
 // String returns the string representation
 func (s UpdateCloudFrontOriginAccessIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3329,7 +3329,7 @@ type metadataUpdateDistributionInput struct {
 
 // String returns the string representation
 func (s UpdateDistributionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3354,7 +3354,7 @@ type metadataUpdateDistributionOutput struct {
 
 // String returns the string representation
 func (s UpdateDistributionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3383,7 +3383,7 @@ type metadataUpdateStreamingDistributionInput struct {
 
 // String returns the string representation
 func (s UpdateStreamingDistributionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3408,7 +3408,7 @@ type metadataUpdateStreamingDistributionOutput struct {
 
 // String returns the string representation
 func (s UpdateStreamingDistributionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3464,7 +3464,7 @@ type metadataViewerCertificate struct {
 
 // String returns the string representation
 func (s ViewerCertificate) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cloudfront/examples_test.go
+++ b/service/cloudfront/examples_test.go
@@ -43,7 +43,7 @@ func ExampleCloudFront_CreateCloudFrontOriginAccessIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_CreateDistribution() {
@@ -58,27 +58,27 @@ func ExampleCloudFront_CreateDistribution() {
 					Cookies: &cloudfront.CookiePreference{ // Required
 						Forward: aws.String("ItemSelection"), // Required
 						WhitelistedNames: &cloudfront.CookieNames{
-							Quantity: aws.Long(1), // Required
+							Quantity: aws.Int64(1), // Required
 							Items: []*string{
 								aws.String("string"), // Required
 								// More values...
 							},
 						},
 					},
-					QueryString: aws.Boolean(true), // Required
+					QueryString: aws.Bool(true), // Required
 					Headers: &cloudfront.Headers{
-						Quantity: aws.Long(1), // Required
+						Quantity: aws.Int64(1), // Required
 						Items: []*string{
 							aws.String("string"), // Required
 							// More values...
 						},
 					},
 				},
-				MinTTL:         aws.Long(1),          // Required
+				MinTTL:         aws.Int64(1),         // Required
 				TargetOriginID: aws.String("string"), // Required
 				TrustedSigners: &cloudfront.TrustedSigners{ // Required
-					Enabled:  aws.Boolean(true), // Required
-					Quantity: aws.Long(1),       // Required
+					Enabled:  aws.Bool(true), // Required
+					Quantity: aws.Int64(1),   // Required
 					Items: []*string{
 						aws.String("string"), // Required
 						// More values...
@@ -90,29 +90,29 @@ func ExampleCloudFront_CreateDistribution() {
 						aws.String("Method"), // Required
 						// More values...
 					},
-					Quantity: aws.Long(1), // Required
+					Quantity: aws.Int64(1), // Required
 					CachedMethods: &cloudfront.CachedMethods{
 						Items: []*string{ // Required
 							aws.String("Method"), // Required
 							// More values...
 						},
-						Quantity: aws.Long(1), // Required
+						Quantity: aws.Int64(1), // Required
 					},
 				},
-				DefaultTTL:      aws.Long(1),
-				MaxTTL:          aws.Long(1),
-				SmoothStreaming: aws.Boolean(true),
+				DefaultTTL:      aws.Int64(1),
+				MaxTTL:          aws.Int64(1),
+				SmoothStreaming: aws.Bool(true),
 			},
-			Enabled: aws.Boolean(true), // Required
+			Enabled: aws.Bool(true), // Required
 			Origins: &cloudfront.Origins{ // Required
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*cloudfront.Origin{
 					{ // Required
 						DomainName: aws.String("string"), // Required
 						ID:         aws.String("string"), // Required
 						CustomOriginConfig: &cloudfront.CustomOriginConfig{
-							HTTPPort:             aws.Long(1),                        // Required
-							HTTPSPort:            aws.Long(1),                        // Required
+							HTTPPort:             aws.Int64(1),                       // Required
+							HTTPSPort:            aws.Int64(1),                       // Required
 							OriginProtocolPolicy: aws.String("OriginProtocolPolicy"), // Required
 						},
 						OriginPath: aws.String("string"),
@@ -124,42 +124,42 @@ func ExampleCloudFront_CreateDistribution() {
 				},
 			},
 			Aliases: &cloudfront.Aliases{
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*string{
 					aws.String("string"), // Required
 					// More values...
 				},
 			},
 			CacheBehaviors: &cloudfront.CacheBehaviors{
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*cloudfront.CacheBehavior{
 					{ // Required
 						ForwardedValues: &cloudfront.ForwardedValues{ // Required
 							Cookies: &cloudfront.CookiePreference{ // Required
 								Forward: aws.String("ItemSelection"), // Required
 								WhitelistedNames: &cloudfront.CookieNames{
-									Quantity: aws.Long(1), // Required
+									Quantity: aws.Int64(1), // Required
 									Items: []*string{
 										aws.String("string"), // Required
 										// More values...
 									},
 								},
 							},
-							QueryString: aws.Boolean(true), // Required
+							QueryString: aws.Bool(true), // Required
 							Headers: &cloudfront.Headers{
-								Quantity: aws.Long(1), // Required
+								Quantity: aws.Int64(1), // Required
 								Items: []*string{
 									aws.String("string"), // Required
 									// More values...
 								},
 							},
 						},
-						MinTTL:         aws.Long(1),          // Required
+						MinTTL:         aws.Int64(1),         // Required
 						PathPattern:    aws.String("string"), // Required
 						TargetOriginID: aws.String("string"), // Required
 						TrustedSigners: &cloudfront.TrustedSigners{ // Required
-							Enabled:  aws.Boolean(true), // Required
-							Quantity: aws.Long(1),       // Required
+							Enabled:  aws.Bool(true), // Required
+							Quantity: aws.Int64(1),   // Required
 							Items: []*string{
 								aws.String("string"), // Required
 								// More values...
@@ -171,28 +171,28 @@ func ExampleCloudFront_CreateDistribution() {
 								aws.String("Method"), // Required
 								// More values...
 							},
-							Quantity: aws.Long(1), // Required
+							Quantity: aws.Int64(1), // Required
 							CachedMethods: &cloudfront.CachedMethods{
 								Items: []*string{ // Required
 									aws.String("Method"), // Required
 									// More values...
 								},
-								Quantity: aws.Long(1), // Required
+								Quantity: aws.Int64(1), // Required
 							},
 						},
-						DefaultTTL:      aws.Long(1),
-						MaxTTL:          aws.Long(1),
-						SmoothStreaming: aws.Boolean(true),
+						DefaultTTL:      aws.Int64(1),
+						MaxTTL:          aws.Int64(1),
+						SmoothStreaming: aws.Bool(true),
 					},
 					// More values...
 				},
 			},
 			CustomErrorResponses: &cloudfront.CustomErrorResponses{
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*cloudfront.CustomErrorResponse{
 					{ // Required
-						ErrorCode:          aws.Long(1), // Required
-						ErrorCachingMinTTL: aws.Long(1),
+						ErrorCode:          aws.Int64(1), // Required
+						ErrorCachingMinTTL: aws.Int64(1),
 						ResponseCode:       aws.String("string"),
 						ResponsePagePath:   aws.String("string"),
 					},
@@ -202,14 +202,14 @@ func ExampleCloudFront_CreateDistribution() {
 			DefaultRootObject: aws.String("string"),
 			Logging: &cloudfront.LoggingConfig{
 				Bucket:         aws.String("string"), // Required
-				Enabled:        aws.Boolean(true),    // Required
-				IncludeCookies: aws.Boolean(true),    // Required
+				Enabled:        aws.Bool(true),       // Required
+				IncludeCookies: aws.Bool(true),       // Required
 				Prefix:         aws.String("string"), // Required
 			},
 			PriceClass: aws.String("PriceClass"),
 			Restrictions: &cloudfront.Restrictions{
 				GeoRestriction: &cloudfront.GeoRestriction{ // Required
-					Quantity:        aws.Long(1),                      // Required
+					Quantity:        aws.Int64(1),                     // Required
 					RestrictionType: aws.String("GeoRestrictionType"), // Required
 					Items: []*string{
 						aws.String("string"), // Required
@@ -218,7 +218,7 @@ func ExampleCloudFront_CreateDistribution() {
 				},
 			},
 			ViewerCertificate: &cloudfront.ViewerCertificate{
-				CloudFrontDefaultCertificate: aws.Boolean(true),
+				CloudFrontDefaultCertificate: aws.Bool(true),
 				IAMCertificateID:             aws.String("string"),
 				MinimumProtocolVersion:       aws.String("MinimumProtocolVersion"),
 				SSLSupportMethod:             aws.String("SSLSupportMethod"),
@@ -243,7 +243,7 @@ func ExampleCloudFront_CreateDistribution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_CreateInvalidation() {
@@ -254,7 +254,7 @@ func ExampleCloudFront_CreateInvalidation() {
 		InvalidationBatch: &cloudfront.InvalidationBatch{ // Required
 			CallerReference: aws.String("string"), // Required
 			Paths: &cloudfront.Paths{ // Required
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*string{
 					aws.String("string"), // Required
 					// More values...
@@ -280,7 +280,7 @@ func ExampleCloudFront_CreateInvalidation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_CreateStreamingDistribution() {
@@ -290,21 +290,21 @@ func ExampleCloudFront_CreateStreamingDistribution() {
 		StreamingDistributionConfig: &cloudfront.StreamingDistributionConfig{ // Required
 			CallerReference: aws.String("string"), // Required
 			Comment:         aws.String("string"), // Required
-			Enabled:         aws.Boolean(true),    // Required
+			Enabled:         aws.Bool(true),       // Required
 			S3Origin: &cloudfront.S3Origin{ // Required
 				DomainName:           aws.String("string"), // Required
 				OriginAccessIdentity: aws.String("string"), // Required
 			},
 			TrustedSigners: &cloudfront.TrustedSigners{ // Required
-				Enabled:  aws.Boolean(true), // Required
-				Quantity: aws.Long(1),       // Required
+				Enabled:  aws.Bool(true), // Required
+				Quantity: aws.Int64(1),   // Required
 				Items: []*string{
 					aws.String("string"), // Required
 					// More values...
 				},
 			},
 			Aliases: &cloudfront.Aliases{
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*string{
 					aws.String("string"), // Required
 					// More values...
@@ -312,7 +312,7 @@ func ExampleCloudFront_CreateStreamingDistribution() {
 			},
 			Logging: &cloudfront.StreamingLoggingConfig{
 				Bucket:  aws.String("string"), // Required
-				Enabled: aws.Boolean(true),    // Required
+				Enabled: aws.Bool(true),       // Required
 				Prefix:  aws.String("string"), // Required
 			},
 			PriceClass: aws.String("PriceClass"),
@@ -336,7 +336,7 @@ func ExampleCloudFront_CreateStreamingDistribution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_DeleteCloudFrontOriginAccessIdentity() {
@@ -364,7 +364,7 @@ func ExampleCloudFront_DeleteCloudFrontOriginAccessIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_DeleteDistribution() {
@@ -392,7 +392,7 @@ func ExampleCloudFront_DeleteDistribution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_DeleteStreamingDistribution() {
@@ -420,7 +420,7 @@ func ExampleCloudFront_DeleteStreamingDistribution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_GetCloudFrontOriginAccessIdentity() {
@@ -447,7 +447,7 @@ func ExampleCloudFront_GetCloudFrontOriginAccessIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_GetCloudFrontOriginAccessIdentityConfig() {
@@ -474,7 +474,7 @@ func ExampleCloudFront_GetCloudFrontOriginAccessIdentityConfig() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_GetDistribution() {
@@ -501,7 +501,7 @@ func ExampleCloudFront_GetDistribution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_GetDistributionConfig() {
@@ -528,7 +528,7 @@ func ExampleCloudFront_GetDistributionConfig() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_GetInvalidation() {
@@ -556,7 +556,7 @@ func ExampleCloudFront_GetInvalidation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_GetStreamingDistribution() {
@@ -583,7 +583,7 @@ func ExampleCloudFront_GetStreamingDistribution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_GetStreamingDistributionConfig() {
@@ -610,7 +610,7 @@ func ExampleCloudFront_GetStreamingDistributionConfig() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_ListCloudFrontOriginAccessIdentities() {
@@ -618,7 +618,7 @@ func ExampleCloudFront_ListCloudFrontOriginAccessIdentities() {
 
 	params := &cloudfront.ListCloudFrontOriginAccessIdentitiesInput{
 		Marker:   aws.String("string"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListCloudFrontOriginAccessIdentities(params)
 
@@ -638,7 +638,7 @@ func ExampleCloudFront_ListCloudFrontOriginAccessIdentities() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_ListDistributions() {
@@ -646,7 +646,7 @@ func ExampleCloudFront_ListDistributions() {
 
 	params := &cloudfront.ListDistributionsInput{
 		Marker:   aws.String("string"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListDistributions(params)
 
@@ -666,7 +666,7 @@ func ExampleCloudFront_ListDistributions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_ListInvalidations() {
@@ -675,7 +675,7 @@ func ExampleCloudFront_ListInvalidations() {
 	params := &cloudfront.ListInvalidationsInput{
 		DistributionID: aws.String("string"), // Required
 		Marker:         aws.String("string"),
-		MaxItems:       aws.Long(1),
+		MaxItems:       aws.Int64(1),
 	}
 	resp, err := svc.ListInvalidations(params)
 
@@ -695,7 +695,7 @@ func ExampleCloudFront_ListInvalidations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_ListStreamingDistributions() {
@@ -703,7 +703,7 @@ func ExampleCloudFront_ListStreamingDistributions() {
 
 	params := &cloudfront.ListStreamingDistributionsInput{
 		Marker:   aws.String("string"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListStreamingDistributions(params)
 
@@ -723,7 +723,7 @@ func ExampleCloudFront_ListStreamingDistributions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_UpdateCloudFrontOriginAccessIdentity() {
@@ -755,7 +755,7 @@ func ExampleCloudFront_UpdateCloudFrontOriginAccessIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_UpdateDistribution() {
@@ -770,27 +770,27 @@ func ExampleCloudFront_UpdateDistribution() {
 					Cookies: &cloudfront.CookiePreference{ // Required
 						Forward: aws.String("ItemSelection"), // Required
 						WhitelistedNames: &cloudfront.CookieNames{
-							Quantity: aws.Long(1), // Required
+							Quantity: aws.Int64(1), // Required
 							Items: []*string{
 								aws.String("string"), // Required
 								// More values...
 							},
 						},
 					},
-					QueryString: aws.Boolean(true), // Required
+					QueryString: aws.Bool(true), // Required
 					Headers: &cloudfront.Headers{
-						Quantity: aws.Long(1), // Required
+						Quantity: aws.Int64(1), // Required
 						Items: []*string{
 							aws.String("string"), // Required
 							// More values...
 						},
 					},
 				},
-				MinTTL:         aws.Long(1),          // Required
+				MinTTL:         aws.Int64(1),         // Required
 				TargetOriginID: aws.String("string"), // Required
 				TrustedSigners: &cloudfront.TrustedSigners{ // Required
-					Enabled:  aws.Boolean(true), // Required
-					Quantity: aws.Long(1),       // Required
+					Enabled:  aws.Bool(true), // Required
+					Quantity: aws.Int64(1),   // Required
 					Items: []*string{
 						aws.String("string"), // Required
 						// More values...
@@ -802,29 +802,29 @@ func ExampleCloudFront_UpdateDistribution() {
 						aws.String("Method"), // Required
 						// More values...
 					},
-					Quantity: aws.Long(1), // Required
+					Quantity: aws.Int64(1), // Required
 					CachedMethods: &cloudfront.CachedMethods{
 						Items: []*string{ // Required
 							aws.String("Method"), // Required
 							// More values...
 						},
-						Quantity: aws.Long(1), // Required
+						Quantity: aws.Int64(1), // Required
 					},
 				},
-				DefaultTTL:      aws.Long(1),
-				MaxTTL:          aws.Long(1),
-				SmoothStreaming: aws.Boolean(true),
+				DefaultTTL:      aws.Int64(1),
+				MaxTTL:          aws.Int64(1),
+				SmoothStreaming: aws.Bool(true),
 			},
-			Enabled: aws.Boolean(true), // Required
+			Enabled: aws.Bool(true), // Required
 			Origins: &cloudfront.Origins{ // Required
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*cloudfront.Origin{
 					{ // Required
 						DomainName: aws.String("string"), // Required
 						ID:         aws.String("string"), // Required
 						CustomOriginConfig: &cloudfront.CustomOriginConfig{
-							HTTPPort:             aws.Long(1),                        // Required
-							HTTPSPort:            aws.Long(1),                        // Required
+							HTTPPort:             aws.Int64(1),                       // Required
+							HTTPSPort:            aws.Int64(1),                       // Required
 							OriginProtocolPolicy: aws.String("OriginProtocolPolicy"), // Required
 						},
 						OriginPath: aws.String("string"),
@@ -836,42 +836,42 @@ func ExampleCloudFront_UpdateDistribution() {
 				},
 			},
 			Aliases: &cloudfront.Aliases{
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*string{
 					aws.String("string"), // Required
 					// More values...
 				},
 			},
 			CacheBehaviors: &cloudfront.CacheBehaviors{
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*cloudfront.CacheBehavior{
 					{ // Required
 						ForwardedValues: &cloudfront.ForwardedValues{ // Required
 							Cookies: &cloudfront.CookiePreference{ // Required
 								Forward: aws.String("ItemSelection"), // Required
 								WhitelistedNames: &cloudfront.CookieNames{
-									Quantity: aws.Long(1), // Required
+									Quantity: aws.Int64(1), // Required
 									Items: []*string{
 										aws.String("string"), // Required
 										// More values...
 									},
 								},
 							},
-							QueryString: aws.Boolean(true), // Required
+							QueryString: aws.Bool(true), // Required
 							Headers: &cloudfront.Headers{
-								Quantity: aws.Long(1), // Required
+								Quantity: aws.Int64(1), // Required
 								Items: []*string{
 									aws.String("string"), // Required
 									// More values...
 								},
 							},
 						},
-						MinTTL:         aws.Long(1),          // Required
+						MinTTL:         aws.Int64(1),         // Required
 						PathPattern:    aws.String("string"), // Required
 						TargetOriginID: aws.String("string"), // Required
 						TrustedSigners: &cloudfront.TrustedSigners{ // Required
-							Enabled:  aws.Boolean(true), // Required
-							Quantity: aws.Long(1),       // Required
+							Enabled:  aws.Bool(true), // Required
+							Quantity: aws.Int64(1),   // Required
 							Items: []*string{
 								aws.String("string"), // Required
 								// More values...
@@ -883,28 +883,28 @@ func ExampleCloudFront_UpdateDistribution() {
 								aws.String("Method"), // Required
 								// More values...
 							},
-							Quantity: aws.Long(1), // Required
+							Quantity: aws.Int64(1), // Required
 							CachedMethods: &cloudfront.CachedMethods{
 								Items: []*string{ // Required
 									aws.String("Method"), // Required
 									// More values...
 								},
-								Quantity: aws.Long(1), // Required
+								Quantity: aws.Int64(1), // Required
 							},
 						},
-						DefaultTTL:      aws.Long(1),
-						MaxTTL:          aws.Long(1),
-						SmoothStreaming: aws.Boolean(true),
+						DefaultTTL:      aws.Int64(1),
+						MaxTTL:          aws.Int64(1),
+						SmoothStreaming: aws.Bool(true),
 					},
 					// More values...
 				},
 			},
 			CustomErrorResponses: &cloudfront.CustomErrorResponses{
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*cloudfront.CustomErrorResponse{
 					{ // Required
-						ErrorCode:          aws.Long(1), // Required
-						ErrorCachingMinTTL: aws.Long(1),
+						ErrorCode:          aws.Int64(1), // Required
+						ErrorCachingMinTTL: aws.Int64(1),
 						ResponseCode:       aws.String("string"),
 						ResponsePagePath:   aws.String("string"),
 					},
@@ -914,14 +914,14 @@ func ExampleCloudFront_UpdateDistribution() {
 			DefaultRootObject: aws.String("string"),
 			Logging: &cloudfront.LoggingConfig{
 				Bucket:         aws.String("string"), // Required
-				Enabled:        aws.Boolean(true),    // Required
-				IncludeCookies: aws.Boolean(true),    // Required
+				Enabled:        aws.Bool(true),       // Required
+				IncludeCookies: aws.Bool(true),       // Required
 				Prefix:         aws.String("string"), // Required
 			},
 			PriceClass: aws.String("PriceClass"),
 			Restrictions: &cloudfront.Restrictions{
 				GeoRestriction: &cloudfront.GeoRestriction{ // Required
-					Quantity:        aws.Long(1),                      // Required
+					Quantity:        aws.Int64(1),                     // Required
 					RestrictionType: aws.String("GeoRestrictionType"), // Required
 					Items: []*string{
 						aws.String("string"), // Required
@@ -930,7 +930,7 @@ func ExampleCloudFront_UpdateDistribution() {
 				},
 			},
 			ViewerCertificate: &cloudfront.ViewerCertificate{
-				CloudFrontDefaultCertificate: aws.Boolean(true),
+				CloudFrontDefaultCertificate: aws.Bool(true),
 				IAMCertificateID:             aws.String("string"),
 				MinimumProtocolVersion:       aws.String("MinimumProtocolVersion"),
 				SSLSupportMethod:             aws.String("SSLSupportMethod"),
@@ -957,7 +957,7 @@ func ExampleCloudFront_UpdateDistribution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudFront_UpdateStreamingDistribution() {
@@ -968,21 +968,21 @@ func ExampleCloudFront_UpdateStreamingDistribution() {
 		StreamingDistributionConfig: &cloudfront.StreamingDistributionConfig{ // Required
 			CallerReference: aws.String("string"), // Required
 			Comment:         aws.String("string"), // Required
-			Enabled:         aws.Boolean(true),    // Required
+			Enabled:         aws.Bool(true),       // Required
 			S3Origin: &cloudfront.S3Origin{ // Required
 				DomainName:           aws.String("string"), // Required
 				OriginAccessIdentity: aws.String("string"), // Required
 			},
 			TrustedSigners: &cloudfront.TrustedSigners{ // Required
-				Enabled:  aws.Boolean(true), // Required
-				Quantity: aws.Long(1),       // Required
+				Enabled:  aws.Bool(true), // Required
+				Quantity: aws.Int64(1),   // Required
 				Items: []*string{
 					aws.String("string"), // Required
 					// More values...
 				},
 			},
 			Aliases: &cloudfront.Aliases{
-				Quantity: aws.Long(1), // Required
+				Quantity: aws.Int64(1), // Required
 				Items: []*string{
 					aws.String("string"), // Required
 					// More values...
@@ -990,7 +990,7 @@ func ExampleCloudFront_UpdateStreamingDistribution() {
 			},
 			Logging: &cloudfront.StreamingLoggingConfig{
 				Bucket:  aws.String("string"), // Required
-				Enabled: aws.Boolean(true),    // Required
+				Enabled: aws.Bool(true),       // Required
 				Prefix:  aws.String("string"), // Required
 			},
 			PriceClass: aws.String("PriceClass"),
@@ -1015,5 +1015,5 @@ func ExampleCloudFront_UpdateStreamingDistribution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -505,7 +505,7 @@ type metadataCreateHAPGInput struct {
 
 // String returns the string representation
 func (s CreateHAPGInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -527,7 +527,7 @@ type metadataCreateHAPGOutput struct {
 
 // String returns the string representation
 func (s CreateHAPGOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -572,7 +572,7 @@ type metadataCreateHSMInput struct {
 
 // String returns the string representation
 func (s CreateHSMInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -594,7 +594,7 @@ type metadataCreateHSMOutput struct {
 
 // String returns the string representation
 func (s CreateHSMOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -620,7 +620,7 @@ type metadataCreateLunaClientInput struct {
 
 // String returns the string representation
 func (s CreateLunaClientInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -642,7 +642,7 @@ type metadataCreateLunaClientOutput struct {
 
 // String returns the string representation
 func (s CreateLunaClientOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -664,7 +664,7 @@ type metadataDeleteHAPGInput struct {
 
 // String returns the string representation
 func (s DeleteHAPGInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -686,7 +686,7 @@ type metadataDeleteHAPGOutput struct {
 
 // String returns the string representation
 func (s DeleteHAPGOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -708,7 +708,7 @@ type metadataDeleteHSMInput struct {
 
 // String returns the string representation
 func (s DeleteHSMInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -730,7 +730,7 @@ type metadataDeleteHSMOutput struct {
 
 // String returns the string representation
 func (s DeleteHSMOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -751,7 +751,7 @@ type metadataDeleteLunaClientInput struct {
 
 // String returns the string representation
 func (s DeleteLunaClientInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -772,7 +772,7 @@ type metadataDeleteLunaClientOutput struct {
 
 // String returns the string representation
 func (s DeleteLunaClientOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -794,7 +794,7 @@ type metadataDescribeHAPGInput struct {
 
 // String returns the string representation
 func (s DescribeHAPGInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -841,7 +841,7 @@ type metadataDescribeHAPGOutput struct {
 
 // String returns the string representation
 func (s DescribeHAPGOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -868,7 +868,7 @@ type metadataDescribeHSMInput struct {
 
 // String returns the string representation
 func (s DescribeHSMInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -950,7 +950,7 @@ type metadataDescribeHSMOutput struct {
 
 // String returns the string representation
 func (s DescribeHSMOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -974,7 +974,7 @@ type metadataDescribeLunaClientInput struct {
 
 // String returns the string representation
 func (s DescribeLunaClientInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1007,7 +1007,7 @@ type metadataDescribeLunaClientOutput struct {
 
 // String returns the string representation
 func (s DescribeLunaClientOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1035,7 +1035,7 @@ type metadataGetConfigInput struct {
 
 // String returns the string representation
 func (s GetConfigInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1062,7 +1062,7 @@ type metadataGetConfigOutput struct {
 
 // String returns the string representation
 func (s GetConfigOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1081,7 +1081,7 @@ type metadataListAvailableZonesInput struct {
 
 // String returns the string representation
 func (s ListAvailableZonesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1102,7 +1102,7 @@ type metadataListAvailableZonesOutput struct {
 
 // String returns the string representation
 func (s ListAvailableZonesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1124,7 +1124,7 @@ type metadataListHSMsInput struct {
 
 // String returns the string representation
 func (s ListHSMsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1150,7 +1150,7 @@ type metadataListHSMsOutput struct {
 
 // String returns the string representation
 func (s ListHSMsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1172,7 +1172,7 @@ type metadataListHapgsInput struct {
 
 // String returns the string representation
 func (s ListHapgsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1197,7 +1197,7 @@ type metadataListHapgsOutput struct {
 
 // String returns the string representation
 func (s ListHapgsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1219,7 +1219,7 @@ type metadataListLunaClientsInput struct {
 
 // String returns the string representation
 func (s ListLunaClientsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1244,7 +1244,7 @@ type metadataListLunaClientsOutput struct {
 
 // String returns the string representation
 func (s ListLunaClientsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1272,7 +1272,7 @@ type metadataModifyHAPGInput struct {
 
 // String returns the string representation
 func (s ModifyHAPGInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1293,7 +1293,7 @@ type metadataModifyHAPGOutput struct {
 
 // String returns the string representation
 func (s ModifyHAPGOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1330,7 +1330,7 @@ type metadataModifyHSMInput struct {
 
 // String returns the string representation
 func (s ModifyHSMInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1352,7 +1352,7 @@ type metadataModifyHSMOutput struct {
 
 // String returns the string representation
 func (s ModifyHSMOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1376,7 +1376,7 @@ type metadataModifyLunaClientInput struct {
 
 // String returns the string representation
 func (s ModifyLunaClientInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1397,7 +1397,7 @@ type metadataModifyLunaClientOutput struct {
 
 // String returns the string representation
 func (s ModifyLunaClientOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cloudhsm/examples_test.go
+++ b/service/cloudhsm/examples_test.go
@@ -40,7 +40,7 @@ func ExampleCloudHSM_CreateHAPG() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_CreateHSM() {
@@ -74,7 +74,7 @@ func ExampleCloudHSM_CreateHSM() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_CreateLunaClient() {
@@ -102,7 +102,7 @@ func ExampleCloudHSM_CreateLunaClient() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_DeleteHAPG() {
@@ -129,7 +129,7 @@ func ExampleCloudHSM_DeleteHAPG() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_DeleteHSM() {
@@ -156,7 +156,7 @@ func ExampleCloudHSM_DeleteHSM() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_DeleteLunaClient() {
@@ -183,7 +183,7 @@ func ExampleCloudHSM_DeleteLunaClient() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_DescribeHAPG() {
@@ -210,7 +210,7 @@ func ExampleCloudHSM_DescribeHAPG() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_DescribeHSM() {
@@ -238,7 +238,7 @@ func ExampleCloudHSM_DescribeHSM() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_DescribeLunaClient() {
@@ -266,7 +266,7 @@ func ExampleCloudHSM_DescribeLunaClient() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_GetConfig() {
@@ -298,7 +298,7 @@ func ExampleCloudHSM_GetConfig() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_ListAvailableZones() {
@@ -323,7 +323,7 @@ func ExampleCloudHSM_ListAvailableZones() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_ListHSMs() {
@@ -350,7 +350,7 @@ func ExampleCloudHSM_ListHSMs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_ListHapgs() {
@@ -377,7 +377,7 @@ func ExampleCloudHSM_ListHapgs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_ListLunaClients() {
@@ -404,7 +404,7 @@ func ExampleCloudHSM_ListLunaClients() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_ModifyHAPG() {
@@ -436,7 +436,7 @@ func ExampleCloudHSM_ModifyHAPG() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_ModifyHSM() {
@@ -468,7 +468,7 @@ func ExampleCloudHSM_ModifyHSM() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudHSM_ModifyLunaClient() {
@@ -496,5 +496,5 @@ func ExampleCloudHSM_ModifyLunaClient() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -768,7 +768,7 @@ type metadataAccessPoliciesStatus struct {
 
 // String returns the string representation
 func (s AccessPoliciesStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -824,7 +824,7 @@ type metadataAnalysisOptions struct {
 
 // String returns the string representation
 func (s AnalysisOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -858,7 +858,7 @@ type metadataAnalysisScheme struct {
 
 // String returns the string representation
 func (s AnalysisScheme) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -886,7 +886,7 @@ type metadataAnalysisSchemeStatus struct {
 
 // String returns the string representation
 func (s AnalysisSchemeStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -911,7 +911,7 @@ type metadataAvailabilityOptionsStatus struct {
 
 // String returns the string representation
 func (s AvailabilityOptionsStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -937,7 +937,7 @@ type metadataBuildSuggestersInput struct {
 
 // String returns the string representation
 func (s BuildSuggestersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -960,7 +960,7 @@ type metadataBuildSuggestersOutput struct {
 
 // String returns the string representation
 func (s BuildSuggestersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -985,7 +985,7 @@ type metadataCreateDomainInput struct {
 
 // String returns the string representation
 func (s CreateDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1008,7 +1008,7 @@ type metadataCreateDomainOutput struct {
 
 // String returns the string representation
 func (s CreateDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1043,7 +1043,7 @@ type metadataDateArrayOptions struct {
 
 // String returns the string representation
 func (s DateArrayOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1096,7 +1096,7 @@ type metadataDateOptions struct {
 
 // String returns the string representation
 func (s DateOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1128,7 +1128,7 @@ type metadataDefineAnalysisSchemeInput struct {
 
 // String returns the string representation
 func (s DefineAnalysisSchemeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1151,7 +1151,7 @@ type metadataDefineAnalysisSchemeOutput struct {
 
 // String returns the string representation
 func (s DefineAnalysisSchemeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1183,7 +1183,7 @@ type metadataDefineExpressionInput struct {
 
 // String returns the string representation
 func (s DefineExpressionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1206,7 +1206,7 @@ type metadataDefineExpressionOutput struct {
 
 // String returns the string representation
 func (s DefineExpressionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1235,7 +1235,7 @@ type metadataDefineIndexFieldInput struct {
 
 // String returns the string representation
 func (s DefineIndexFieldInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1258,7 +1258,7 @@ type metadataDefineIndexFieldOutput struct {
 
 // String returns the string representation
 func (s DefineIndexFieldOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1289,7 +1289,7 @@ type metadataDefineSuggesterInput struct {
 
 // String returns the string representation
 func (s DefineSuggesterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1312,7 +1312,7 @@ type metadataDefineSuggesterOutput struct {
 
 // String returns the string representation
 func (s DefineSuggesterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1342,7 +1342,7 @@ type metadataDeleteAnalysisSchemeInput struct {
 
 // String returns the string representation
 func (s DeleteAnalysisSchemeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1365,7 +1365,7 @@ type metadataDeleteAnalysisSchemeOutput struct {
 
 // String returns the string representation
 func (s DeleteAnalysisSchemeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1388,7 +1388,7 @@ type metadataDeleteDomainInput struct {
 
 // String returns the string representation
 func (s DeleteDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1411,7 +1411,7 @@ type metadataDeleteDomainOutput struct {
 
 // String returns the string representation
 func (s DeleteDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1441,7 +1441,7 @@ type metadataDeleteExpressionInput struct {
 
 // String returns the string representation
 func (s DeleteExpressionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1464,7 +1464,7 @@ type metadataDeleteExpressionOutput struct {
 
 // String returns the string representation
 func (s DeleteExpressionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1495,7 +1495,7 @@ type metadataDeleteIndexFieldInput struct {
 
 // String returns the string representation
 func (s DeleteIndexFieldInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1517,7 +1517,7 @@ type metadataDeleteIndexFieldOutput struct {
 
 // String returns the string representation
 func (s DeleteIndexFieldOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1547,7 +1547,7 @@ type metadataDeleteSuggesterInput struct {
 
 // String returns the string representation
 func (s DeleteSuggesterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1570,7 +1570,7 @@ type metadataDeleteSuggesterOutput struct {
 
 // String returns the string representation
 func (s DeleteSuggesterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1603,7 +1603,7 @@ type metadataDescribeAnalysisSchemesInput struct {
 
 // String returns the string representation
 func (s DescribeAnalysisSchemesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1626,7 +1626,7 @@ type metadataDescribeAnalysisSchemesOutput struct {
 
 // String returns the string representation
 func (s DescribeAnalysisSchemesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1655,7 +1655,7 @@ type metadataDescribeAvailabilityOptionsInput struct {
 
 // String returns the string representation
 func (s DescribeAvailabilityOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1679,7 +1679,7 @@ type metadataDescribeAvailabilityOptionsOutput struct {
 
 // String returns the string representation
 func (s DescribeAvailabilityOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1703,7 +1703,7 @@ type metadataDescribeDomainsInput struct {
 
 // String returns the string representation
 func (s DescribeDomainsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1726,7 +1726,7 @@ type metadataDescribeDomainsOutput struct {
 
 // String returns the string representation
 func (s DescribeDomainsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1760,7 +1760,7 @@ type metadataDescribeExpressionsInput struct {
 
 // String returns the string representation
 func (s DescribeExpressionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1783,7 +1783,7 @@ type metadataDescribeExpressionsOutput struct {
 
 // String returns the string representation
 func (s DescribeExpressionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1817,7 +1817,7 @@ type metadataDescribeIndexFieldsInput struct {
 
 // String returns the string representation
 func (s DescribeIndexFieldsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1840,7 +1840,7 @@ type metadataDescribeIndexFieldsOutput struct {
 
 // String returns the string representation
 func (s DescribeIndexFieldsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1866,7 +1866,7 @@ type metadataDescribeScalingParametersInput struct {
 
 // String returns the string representation
 func (s DescribeScalingParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1889,7 +1889,7 @@ type metadataDescribeScalingParametersOutput struct {
 
 // String returns the string representation
 func (s DescribeScalingParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1918,7 +1918,7 @@ type metadataDescribeServiceAccessPoliciesInput struct {
 
 // String returns the string representation
 func (s DescribeServiceAccessPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1940,7 +1940,7 @@ type metadataDescribeServiceAccessPoliciesOutput struct {
 
 // String returns the string representation
 func (s DescribeServiceAccessPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1973,7 +1973,7 @@ type metadataDescribeSuggestersInput struct {
 
 // String returns the string representation
 func (s DescribeSuggestersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1995,7 +1995,7 @@ type metadataDescribeSuggestersOutput struct {
 
 // String returns the string representation
 func (s DescribeSuggestersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2033,7 +2033,7 @@ type metadataDocumentSuggesterOptions struct {
 
 // String returns the string representation
 func (s DocumentSuggesterOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2102,7 +2102,7 @@ type metadataDomainStatus struct {
 
 // String returns the string representation
 func (s DomainStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2138,7 +2138,7 @@ type metadataDoubleArrayOptions struct {
 
 // String returns the string representation
 func (s DoubleArrayOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2178,7 +2178,7 @@ type metadataDoubleOptions struct {
 
 // String returns the string representation
 func (s DoubleOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2209,7 +2209,7 @@ type metadataExpression struct {
 
 // String returns the string representation
 func (s Expression) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2234,7 +2234,7 @@ type metadataExpressionStatus struct {
 
 // String returns the string representation
 func (s ExpressionStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2260,7 +2260,7 @@ type metadataIndexDocumentsInput struct {
 
 // String returns the string representation
 func (s IndexDocumentsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2283,7 +2283,7 @@ type metadataIndexDocumentsOutput struct {
 
 // String returns the string representation
 func (s IndexDocumentsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2377,7 +2377,7 @@ type metadataIndexField struct {
 
 // String returns the string representation
 func (s IndexField) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2403,7 +2403,7 @@ type metadataIndexFieldStatus struct {
 
 // String returns the string representation
 func (s IndexFieldStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2439,7 +2439,7 @@ type metadataIntArrayOptions struct {
 
 // String returns the string representation
 func (s IntArrayOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2479,7 +2479,7 @@ type metadataIntOptions struct {
 
 // String returns the string representation
 func (s IntOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2531,7 +2531,7 @@ type metadataLatLonOptions struct {
 
 // String returns the string representation
 func (s LatLonOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2553,7 +2553,7 @@ type metadataLimits struct {
 
 // String returns the string representation
 func (s Limits) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2571,7 +2571,7 @@ type metadataListDomainNamesInput struct {
 
 // String returns the string representation
 func (s ListDomainNamesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2594,7 +2594,7 @@ type metadataListDomainNamesOutput struct {
 
 // String returns the string representation
 func (s ListDomainNamesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2630,7 +2630,7 @@ type metadataLiteralArrayOptions struct {
 
 // String returns the string representation
 func (s LiteralArrayOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2681,7 +2681,7 @@ type metadataLiteralOptions struct {
 
 // String returns the string representation
 func (s LiteralOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2723,7 +2723,7 @@ type metadataOptionStatus struct {
 
 // String returns the string representation
 func (s OptionStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2753,7 +2753,7 @@ type metadataScalingParameters struct {
 
 // String returns the string representation
 func (s ScalingParameters) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2778,7 +2778,7 @@ type metadataScalingParametersStatus struct {
 
 // String returns the string representation
 func (s ScalingParametersStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2801,7 +2801,7 @@ type metadataServiceEndpoint struct {
 
 // String returns the string representation
 func (s ServiceEndpoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2829,7 +2829,7 @@ type metadataSuggester struct {
 
 // String returns the string representation
 func (s Suggester) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2856,7 +2856,7 @@ type metadataSuggesterStatus struct {
 
 // String returns the string representation
 func (s SuggesterStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2892,7 +2892,7 @@ type metadataTextArrayOptions struct {
 
 // String returns the string representation
 func (s TextArrayOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2944,7 +2944,7 @@ type metadataTextOptions struct {
 
 // String returns the string representation
 func (s TextOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2977,7 +2977,7 @@ type metadataUpdateAvailabilityOptionsInput struct {
 
 // String returns the string representation
 func (s UpdateAvailabilityOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3001,7 +3001,7 @@ type metadataUpdateAvailabilityOptionsOutput struct {
 
 // String returns the string representation
 func (s UpdateAvailabilityOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3031,7 +3031,7 @@ type metadataUpdateScalingParametersInput struct {
 
 // String returns the string representation
 func (s UpdateScalingParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3054,7 +3054,7 @@ type metadataUpdateScalingParametersOutput struct {
 
 // String returns the string representation
 func (s UpdateScalingParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3085,7 +3085,7 @@ type metadataUpdateServiceAccessPoliciesInput struct {
 
 // String returns the string representation
 func (s UpdateServiceAccessPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3108,7 +3108,7 @@ type metadataUpdateServiceAccessPoliciesOutput struct {
 
 // String returns the string representation
 func (s UpdateServiceAccessPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cloudsearch/examples_test.go
+++ b/service/cloudsearch/examples_test.go
@@ -40,7 +40,7 @@ func ExampleCloudSearch_BuildSuggesters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_CreateDomain() {
@@ -67,7 +67,7 @@ func ExampleCloudSearch_CreateDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DefineAnalysisScheme() {
@@ -105,7 +105,7 @@ func ExampleCloudSearch_DefineAnalysisScheme() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DefineExpression() {
@@ -136,7 +136,7 @@ func ExampleCloudSearch_DefineExpression() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DefineIndexField() {
@@ -149,85 +149,85 @@ func ExampleCloudSearch_DefineIndexField() {
 			IndexFieldType: aws.String("IndexFieldType"),   // Required
 			DateArrayOptions: &cloudsearch.DateArrayOptions{
 				DefaultValue:  aws.String("FieldValue"),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
 				SourceFields:  aws.String("FieldNameCommaList"),
 			},
 			DateOptions: &cloudsearch.DateOptions{
 				DefaultValue:  aws.String("FieldValue"),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
-				SortEnabled:   aws.Boolean(true),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
+				SortEnabled:   aws.Bool(true),
 				SourceField:   aws.String("FieldName"),
 			},
 			DoubleArrayOptions: &cloudsearch.DoubleArrayOptions{
-				DefaultValue:  aws.Double(1.0),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
+				DefaultValue:  aws.Float64(1.0),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
 				SourceFields:  aws.String("FieldNameCommaList"),
 			},
 			DoubleOptions: &cloudsearch.DoubleOptions{
-				DefaultValue:  aws.Double(1.0),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
-				SortEnabled:   aws.Boolean(true),
+				DefaultValue:  aws.Float64(1.0),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
+				SortEnabled:   aws.Bool(true),
 				SourceField:   aws.String("FieldName"),
 			},
 			IntArrayOptions: &cloudsearch.IntArrayOptions{
-				DefaultValue:  aws.Long(1),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
+				DefaultValue:  aws.Int64(1),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
 				SourceFields:  aws.String("FieldNameCommaList"),
 			},
 			IntOptions: &cloudsearch.IntOptions{
-				DefaultValue:  aws.Long(1),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
-				SortEnabled:   aws.Boolean(true),
+				DefaultValue:  aws.Int64(1),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
+				SortEnabled:   aws.Bool(true),
 				SourceField:   aws.String("FieldName"),
 			},
 			LatLonOptions: &cloudsearch.LatLonOptions{
 				DefaultValue:  aws.String("FieldValue"),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
-				SortEnabled:   aws.Boolean(true),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
+				SortEnabled:   aws.Bool(true),
 				SourceField:   aws.String("FieldName"),
 			},
 			LiteralArrayOptions: &cloudsearch.LiteralArrayOptions{
 				DefaultValue:  aws.String("FieldValue"),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
 				SourceFields:  aws.String("FieldNameCommaList"),
 			},
 			LiteralOptions: &cloudsearch.LiteralOptions{
 				DefaultValue:  aws.String("FieldValue"),
-				FacetEnabled:  aws.Boolean(true),
-				ReturnEnabled: aws.Boolean(true),
-				SearchEnabled: aws.Boolean(true),
-				SortEnabled:   aws.Boolean(true),
+				FacetEnabled:  aws.Bool(true),
+				ReturnEnabled: aws.Bool(true),
+				SearchEnabled: aws.Bool(true),
+				SortEnabled:   aws.Bool(true),
 				SourceField:   aws.String("FieldName"),
 			},
 			TextArrayOptions: &cloudsearch.TextArrayOptions{
 				AnalysisScheme:   aws.String("Word"),
 				DefaultValue:     aws.String("FieldValue"),
-				HighlightEnabled: aws.Boolean(true),
-				ReturnEnabled:    aws.Boolean(true),
+				HighlightEnabled: aws.Bool(true),
+				ReturnEnabled:    aws.Bool(true),
 				SourceFields:     aws.String("FieldNameCommaList"),
 			},
 			TextOptions: &cloudsearch.TextOptions{
 				AnalysisScheme:   aws.String("Word"),
 				DefaultValue:     aws.String("FieldValue"),
-				HighlightEnabled: aws.Boolean(true),
-				ReturnEnabled:    aws.Boolean(true),
-				SortEnabled:      aws.Boolean(true),
+				HighlightEnabled: aws.Bool(true),
+				ReturnEnabled:    aws.Bool(true),
+				SortEnabled:      aws.Bool(true),
 				SourceField:      aws.String("FieldName"),
 			},
 		},
@@ -250,7 +250,7 @@ func ExampleCloudSearch_DefineIndexField() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DefineSuggester() {
@@ -285,7 +285,7 @@ func ExampleCloudSearch_DefineSuggester() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DeleteAnalysisScheme() {
@@ -313,7 +313,7 @@ func ExampleCloudSearch_DeleteAnalysisScheme() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DeleteDomain() {
@@ -340,7 +340,7 @@ func ExampleCloudSearch_DeleteDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DeleteExpression() {
@@ -368,7 +368,7 @@ func ExampleCloudSearch_DeleteExpression() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DeleteIndexField() {
@@ -396,7 +396,7 @@ func ExampleCloudSearch_DeleteIndexField() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DeleteSuggester() {
@@ -424,7 +424,7 @@ func ExampleCloudSearch_DeleteSuggester() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DescribeAnalysisSchemes() {
@@ -436,7 +436,7 @@ func ExampleCloudSearch_DescribeAnalysisSchemes() {
 			aws.String("StandardName"), // Required
 			// More values...
 		},
-		Deployed: aws.Boolean(true),
+		Deployed: aws.Bool(true),
 	}
 	resp, err := svc.DescribeAnalysisSchemes(params)
 
@@ -456,7 +456,7 @@ func ExampleCloudSearch_DescribeAnalysisSchemes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DescribeAvailabilityOptions() {
@@ -464,7 +464,7 @@ func ExampleCloudSearch_DescribeAvailabilityOptions() {
 
 	params := &cloudsearch.DescribeAvailabilityOptionsInput{
 		DomainName: aws.String("DomainName"), // Required
-		Deployed:   aws.Boolean(true),
+		Deployed:   aws.Bool(true),
 	}
 	resp, err := svc.DescribeAvailabilityOptions(params)
 
@@ -484,7 +484,7 @@ func ExampleCloudSearch_DescribeAvailabilityOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DescribeDomains() {
@@ -514,7 +514,7 @@ func ExampleCloudSearch_DescribeDomains() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DescribeExpressions() {
@@ -522,7 +522,7 @@ func ExampleCloudSearch_DescribeExpressions() {
 
 	params := &cloudsearch.DescribeExpressionsInput{
 		DomainName: aws.String("DomainName"), // Required
-		Deployed:   aws.Boolean(true),
+		Deployed:   aws.Bool(true),
 		ExpressionNames: []*string{
 			aws.String("StandardName"), // Required
 			// More values...
@@ -546,7 +546,7 @@ func ExampleCloudSearch_DescribeExpressions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DescribeIndexFields() {
@@ -554,7 +554,7 @@ func ExampleCloudSearch_DescribeIndexFields() {
 
 	params := &cloudsearch.DescribeIndexFieldsInput{
 		DomainName: aws.String("DomainName"), // Required
-		Deployed:   aws.Boolean(true),
+		Deployed:   aws.Bool(true),
 		FieldNames: []*string{
 			aws.String("DynamicFieldName"), // Required
 			// More values...
@@ -578,7 +578,7 @@ func ExampleCloudSearch_DescribeIndexFields() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DescribeScalingParameters() {
@@ -605,7 +605,7 @@ func ExampleCloudSearch_DescribeScalingParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DescribeServiceAccessPolicies() {
@@ -613,7 +613,7 @@ func ExampleCloudSearch_DescribeServiceAccessPolicies() {
 
 	params := &cloudsearch.DescribeServiceAccessPoliciesInput{
 		DomainName: aws.String("DomainName"), // Required
-		Deployed:   aws.Boolean(true),
+		Deployed:   aws.Bool(true),
 	}
 	resp, err := svc.DescribeServiceAccessPolicies(params)
 
@@ -633,7 +633,7 @@ func ExampleCloudSearch_DescribeServiceAccessPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_DescribeSuggesters() {
@@ -641,7 +641,7 @@ func ExampleCloudSearch_DescribeSuggesters() {
 
 	params := &cloudsearch.DescribeSuggestersInput{
 		DomainName: aws.String("DomainName"), // Required
-		Deployed:   aws.Boolean(true),
+		Deployed:   aws.Bool(true),
 		SuggesterNames: []*string{
 			aws.String("StandardName"), // Required
 			// More values...
@@ -665,7 +665,7 @@ func ExampleCloudSearch_DescribeSuggesters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_IndexDocuments() {
@@ -692,7 +692,7 @@ func ExampleCloudSearch_IndexDocuments() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_ListDomainNames() {
@@ -717,7 +717,7 @@ func ExampleCloudSearch_ListDomainNames() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_UpdateAvailabilityOptions() {
@@ -725,7 +725,7 @@ func ExampleCloudSearch_UpdateAvailabilityOptions() {
 
 	params := &cloudsearch.UpdateAvailabilityOptionsInput{
 		DomainName: aws.String("DomainName"), // Required
-		MultiAZ:    aws.Boolean(true),        // Required
+		MultiAZ:    aws.Bool(true),
 	}
 	resp, err := svc.UpdateAvailabilityOptions(params)
 
@@ -745,7 +745,7 @@ func ExampleCloudSearch_UpdateAvailabilityOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_UpdateScalingParameters() {
@@ -755,8 +755,8 @@ func ExampleCloudSearch_UpdateScalingParameters() {
 		DomainName: aws.String("DomainName"), // Required
 		ScalingParameters: &cloudsearch.ScalingParameters{ // Required
 			DesiredInstanceType:     aws.String("PartitionInstanceType"),
-			DesiredPartitionCount:   aws.Long(1),
-			DesiredReplicationCount: aws.Long(1),
+			DesiredPartitionCount:   aws.Int64(1),
+			DesiredReplicationCount: aws.Int64(1),
 		},
 	}
 	resp, err := svc.UpdateScalingParameters(params)
@@ -777,7 +777,7 @@ func ExampleCloudSearch_UpdateScalingParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearch_UpdateServiceAccessPolicies() {
@@ -805,5 +805,5 @@ func ExampleCloudSearch_UpdateServiceAccessPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -163,7 +163,7 @@ type metadataBucket struct {
 
 // String returns the string representation
 func (s Bucket) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -185,7 +185,7 @@ type metadataBucketInfo struct {
 
 // String returns the string representation
 func (s BucketInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -208,7 +208,7 @@ type metadataDocumentServiceWarning struct {
 
 // String returns the string representation
 func (s DocumentServiceWarning) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -239,7 +239,7 @@ type metadataHit struct {
 
 // String returns the string representation
 func (s Hit) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -271,7 +271,7 @@ type metadataHits struct {
 
 // String returns the string representation
 func (s Hits) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -567,7 +567,7 @@ type metadataSearchInput struct {
 
 // String returns the string representation
 func (s SearchInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -596,7 +596,7 @@ type metadataSearchOutput struct {
 
 // String returns the string representation
 func (s SearchOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -622,7 +622,7 @@ type metadataSearchStatus struct {
 
 // String returns the string representation
 func (s SearchStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -650,7 +650,7 @@ type metadataSuggestInput struct {
 
 // String returns the string representation
 func (s SuggestInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -678,7 +678,7 @@ type metadataSuggestModel struct {
 
 // String returns the string representation
 func (s SuggestModel) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -704,7 +704,7 @@ type metadataSuggestOutput struct {
 
 // String returns the string representation
 func (s SuggestOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -730,7 +730,7 @@ type metadataSuggestStatus struct {
 
 // String returns the string representation
 func (s SuggestStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -758,7 +758,7 @@ type metadataSuggestionMatch struct {
 
 // String returns the string representation
 func (s SuggestionMatch) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -786,7 +786,7 @@ type metadataUploadDocumentsInput struct {
 
 // String returns the string representation
 func (s UploadDocumentsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -817,7 +817,7 @@ type metadataUploadDocumentsOutput struct {
 
 // String returns the string representation
 func (s UploadDocumentsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cloudsearchdomain/customizations_test.go
+++ b/service/cloudsearchdomain/customizations_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestRequireEndpointIfRegionProvided(t *testing.T) {
 	svc := cloudsearchdomain.New(&aws.Config{
-		Region:                 "mock-region",
-		DisableParamValidation: true,
+		Region:                 aws.String("mock-region"),
+		DisableParamValidation: aws.Boolean(true),
 	})
 	req, _ := svc.SearchRequest(nil)
 	err := req.Build()
@@ -23,8 +23,8 @@ func TestRequireEndpointIfRegionProvided(t *testing.T) {
 
 func TestRequireEndpointIfNoRegionProvided(t *testing.T) {
 	svc := cloudsearchdomain.New(&aws.Config{
-		Region:                 "",
-		DisableParamValidation: true,
+		Region:                 aws.String(""),
+		DisableParamValidation: aws.Boolean(true),
 	})
 	req, _ := svc.SearchRequest(nil)
 	err := req.Build()
@@ -36,9 +36,9 @@ func TestRequireEndpointIfNoRegionProvided(t *testing.T) {
 
 func TestRequireEndpointUsed(t *testing.T) {
 	svc := cloudsearchdomain.New(&aws.Config{
-		Region:                 "mock-region",
-		DisableParamValidation: true,
-		Endpoint:               "https://endpoint",
+		Region:                 aws.String("mock-region"),
+		DisableParamValidation: aws.Boolean(true),
+		Endpoint:               aws.String("https://endpoint"),
 	})
 	req, _ := svc.SearchRequest(nil)
 	err := req.Build()

--- a/service/cloudsearchdomain/customizations_test.go
+++ b/service/cloudsearchdomain/customizations_test.go
@@ -11,7 +11,7 @@ import (
 func TestRequireEndpointIfRegionProvided(t *testing.T) {
 	svc := cloudsearchdomain.New(&aws.Config{
 		Region:                 aws.String("mock-region"),
-		DisableParamValidation: aws.Boolean(true),
+		DisableParamValidation: aws.Bool(true),
 	})
 	req, _ := svc.SearchRequest(nil)
 	err := req.Build()
@@ -24,7 +24,7 @@ func TestRequireEndpointIfRegionProvided(t *testing.T) {
 func TestRequireEndpointIfNoRegionProvided(t *testing.T) {
 	svc := cloudsearchdomain.New(&aws.Config{
 		Region:                 aws.String(""),
-		DisableParamValidation: aws.Boolean(true),
+		DisableParamValidation: aws.Bool(true),
 	})
 	req, _ := svc.SearchRequest(nil)
 	err := req.Build()
@@ -37,7 +37,7 @@ func TestRequireEndpointIfNoRegionProvided(t *testing.T) {
 func TestRequireEndpointUsed(t *testing.T) {
 	svc := cloudsearchdomain.New(&aws.Config{
 		Region:                 aws.String("mock-region"),
-		DisableParamValidation: aws.Boolean(true),
+		DisableParamValidation: aws.Bool(true),
 		Endpoint:               aws.String("https://endpoint"),
 	})
 	req, _ := svc.SearchRequest(nil)

--- a/service/cloudsearchdomain/examples_test.go
+++ b/service/cloudsearchdomain/examples_test.go
@@ -26,13 +26,13 @@ func ExampleCloudSearchDomain_Search() {
 		Facet:        aws.String("Facet"),
 		FilterQuery:  aws.String("FilterQuery"),
 		Highlight:    aws.String("Highlight"),
-		Partial:      aws.Boolean(true),
+		Partial:      aws.Bool(true),
 		QueryOptions: aws.String("QueryOptions"),
 		QueryParser:  aws.String("QueryParser"),
 		Return:       aws.String("Return"),
-		Size:         aws.Long(1),
+		Size:         aws.Int64(1),
 		Sort:         aws.String("Sort"),
-		Start:        aws.Long(1),
+		Start:        aws.Int64(1),
 	}
 	resp, err := svc.Search(params)
 
@@ -52,7 +52,7 @@ func ExampleCloudSearchDomain_Search() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearchDomain_Suggest() {
@@ -61,7 +61,7 @@ func ExampleCloudSearchDomain_Suggest() {
 	params := &cloudsearchdomain.SuggestInput{
 		Query:     aws.String("Query"),     // Required
 		Suggester: aws.String("Suggester"), // Required
-		Size:      aws.Long(1),
+		Size:      aws.Int64(1),
 	}
 	resp, err := svc.Suggest(params)
 
@@ -81,7 +81,7 @@ func ExampleCloudSearchDomain_Suggest() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudSearchDomain_UploadDocuments() {
@@ -109,5 +109,5 @@ func ExampleCloudSearchDomain_UploadDocuments() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -292,7 +292,7 @@ type metadataCreateTrailInput struct {
 
 // String returns the string representation
 func (s CreateTrailInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -339,7 +339,7 @@ type metadataCreateTrailOutput struct {
 
 // String returns the string representation
 func (s CreateTrailOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -361,7 +361,7 @@ type metadataDeleteTrailInput struct {
 
 // String returns the string representation
 func (s DeleteTrailInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -381,7 +381,7 @@ type metadataDeleteTrailOutput struct {
 
 // String returns the string representation
 func (s DeleteTrailOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -403,7 +403,7 @@ type metadataDescribeTrailsInput struct {
 
 // String returns the string representation
 func (s DescribeTrailsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -426,7 +426,7 @@ type metadataDescribeTrailsOutput struct {
 
 // String returns the string representation
 func (s DescribeTrailsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -465,7 +465,7 @@ type metadataEvent struct {
 
 // String returns the string representation
 func (s Event) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -487,7 +487,7 @@ type metadataGetTrailStatusInput struct {
 
 // String returns the string representation
 func (s GetTrailStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -545,7 +545,7 @@ type metadataGetTrailStatusOutput struct {
 
 // String returns the string representation
 func (s GetTrailStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -570,7 +570,7 @@ type metadataLookupAttribute struct {
 
 // String returns the string representation
 func (s LookupAttribute) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -614,7 +614,7 @@ type metadataLookupEventsInput struct {
 
 // String returns the string representation
 func (s LookupEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -645,7 +645,7 @@ type metadataLookupEventsOutput struct {
 
 // String returns the string representation
 func (s LookupEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -677,7 +677,7 @@ type metadataResource struct {
 
 // String returns the string representation
 func (s Resource) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -699,7 +699,7 @@ type metadataStartLoggingInput struct {
 
 // String returns the string representation
 func (s StartLoggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -719,7 +719,7 @@ type metadataStartLoggingOutput struct {
 
 // String returns the string representation
 func (s StartLoggingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -743,7 +743,7 @@ type metadataStopLoggingInput struct {
 
 // String returns the string representation
 func (s StopLoggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -763,7 +763,7 @@ type metadataStopLoggingOutput struct {
 
 // String returns the string representation
 func (s StopLoggingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -807,7 +807,7 @@ type metadataTrail struct {
 
 // String returns the string representation
 func (s Trail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -854,7 +854,7 @@ type metadataUpdateTrailInput struct {
 
 // String returns the string representation
 func (s UpdateTrailInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -901,7 +901,7 @@ type metadataUpdateTrailOutput struct {
 
 // String returns the string representation
 func (s UpdateTrailOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cloudtrail/examples_test.go
+++ b/service/cloudtrail/examples_test.go
@@ -24,7 +24,7 @@ func ExampleCloudTrail_CreateTrail() {
 		S3BucketName:               aws.String("String"), // Required
 		CloudWatchLogsLogGroupARN:  aws.String("String"),
 		CloudWatchLogsRoleARN:      aws.String("String"),
-		IncludeGlobalServiceEvents: aws.Boolean(true),
+		IncludeGlobalServiceEvents: aws.Bool(true),
 		S3KeyPrefix:                aws.String("String"),
 		SNSTopicName:               aws.String("String"),
 	}
@@ -46,7 +46,7 @@ func ExampleCloudTrail_CreateTrail() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudTrail_DeleteTrail() {
@@ -73,7 +73,7 @@ func ExampleCloudTrail_DeleteTrail() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudTrail_DescribeTrails() {
@@ -103,7 +103,7 @@ func ExampleCloudTrail_DescribeTrails() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudTrail_GetTrailStatus() {
@@ -130,7 +130,7 @@ func ExampleCloudTrail_GetTrailStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudTrail_LookupEvents() {
@@ -145,7 +145,7 @@ func ExampleCloudTrail_LookupEvents() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("NextToken"),
 		StartTime:  aws.Time(time.Now()),
 	}
@@ -167,7 +167,7 @@ func ExampleCloudTrail_LookupEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudTrail_StartLogging() {
@@ -194,7 +194,7 @@ func ExampleCloudTrail_StartLogging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudTrail_StopLogging() {
@@ -221,7 +221,7 @@ func ExampleCloudTrail_StopLogging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudTrail_UpdateTrail() {
@@ -231,7 +231,7 @@ func ExampleCloudTrail_UpdateTrail() {
 		Name: aws.String("String"), // Required
 		CloudWatchLogsLogGroupARN:  aws.String("String"),
 		CloudWatchLogsRoleARN:      aws.String("String"),
-		IncludeGlobalServiceEvents: aws.Boolean(true),
+		IncludeGlobalServiceEvents: aws.Bool(true),
 		S3BucketName:               aws.String("String"),
 		S3KeyPrefix:                aws.String("String"),
 		SNSTopicName:               aws.String("String"),
@@ -254,5 +254,5 @@ func ExampleCloudTrail_UpdateTrail() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -433,7 +433,7 @@ type metadataAlarmHistoryItem struct {
 
 // String returns the string representation
 func (s AlarmHistoryItem) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -479,7 +479,7 @@ type metadataDatapoint struct {
 
 // String returns the string representation
 func (s Datapoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -500,7 +500,7 @@ type metadataDeleteAlarmsInput struct {
 
 // String returns the string representation
 func (s DeleteAlarmsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -518,7 +518,7 @@ type metadataDeleteAlarmsOutput struct {
 
 // String returns the string representation
 func (s DeleteAlarmsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -555,7 +555,7 @@ type metadataDescribeAlarmHistoryInput struct {
 
 // String returns the string representation
 func (s DescribeAlarmHistoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -580,7 +580,7 @@ type metadataDescribeAlarmHistoryOutput struct {
 
 // String returns the string representation
 func (s DescribeAlarmHistoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -616,7 +616,7 @@ type metadataDescribeAlarmsForMetricInput struct {
 
 // String returns the string representation
 func (s DescribeAlarmsForMetricInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -638,7 +638,7 @@ type metadataDescribeAlarmsForMetricOutput struct {
 
 // String returns the string representation
 func (s DescribeAlarmsForMetricOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -676,7 +676,7 @@ type metadataDescribeAlarmsInput struct {
 
 // String returns the string representation
 func (s DescribeAlarmsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -701,7 +701,7 @@ type metadataDescribeAlarmsOutput struct {
 
 // String returns the string representation
 func (s DescribeAlarmsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -729,7 +729,7 @@ type metadataDimension struct {
 
 // String returns the string representation
 func (s Dimension) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -754,7 +754,7 @@ type metadataDimensionFilter struct {
 
 // String returns the string representation
 func (s DimensionFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -775,7 +775,7 @@ type metadataDisableAlarmActionsInput struct {
 
 // String returns the string representation
 func (s DisableAlarmActionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -793,7 +793,7 @@ type metadataDisableAlarmActionsOutput struct {
 
 // String returns the string representation
 func (s DisableAlarmActionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -814,7 +814,7 @@ type metadataEnableAlarmActionsInput struct {
 
 // String returns the string representation
 func (s EnableAlarmActionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -832,7 +832,7 @@ type metadataEnableAlarmActionsOutput struct {
 
 // String returns the string representation
 func (s EnableAlarmActionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -883,7 +883,7 @@ type metadataGetMetricStatisticsInput struct {
 
 // String returns the string representation
 func (s GetMetricStatisticsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -908,7 +908,7 @@ type metadataGetMetricStatisticsOutput struct {
 
 // String returns the string representation
 func (s GetMetricStatisticsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -939,7 +939,7 @@ type metadataListMetricsInput struct {
 
 // String returns the string representation
 func (s ListMetricsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -964,7 +964,7 @@ type metadataListMetricsOutput struct {
 
 // String returns the string representation
 func (s ListMetricsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -998,7 +998,7 @@ type metadataMetric struct {
 
 // String returns the string representation
 func (s Metric) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1102,7 +1102,7 @@ type metadataMetricAlarm struct {
 
 // String returns the string representation
 func (s MetricAlarm) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1152,7 +1152,7 @@ type metadataMetricDatum struct {
 
 // String returns the string representation
 func (s MetricDatum) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1227,7 +1227,7 @@ type metadataPutMetricAlarmInput struct {
 
 // String returns the string representation
 func (s PutMetricAlarmInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1245,7 +1245,7 @@ type metadataPutMetricAlarmOutput struct {
 
 // String returns the string representation
 func (s PutMetricAlarmOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1269,7 +1269,7 @@ type metadataPutMetricDataInput struct {
 
 // String returns the string representation
 func (s PutMetricDataInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1287,7 +1287,7 @@ type metadataPutMetricDataOutput struct {
 
 // String returns the string representation
 func (s PutMetricDataOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1320,7 +1320,7 @@ type metadataSetAlarmStateInput struct {
 
 // String returns the string representation
 func (s SetAlarmStateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1338,7 +1338,7 @@ type metadataSetAlarmStateOutput struct {
 
 // String returns the string representation
 func (s SetAlarmStateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1370,7 +1370,7 @@ type metadataStatisticSet struct {
 
 // String returns the string representation
 func (s StatisticSet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cloudwatch/examples_test.go
+++ b/service/cloudwatch/examples_test.go
@@ -43,7 +43,7 @@ func ExampleCloudWatch_DeleteAlarms() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_DescribeAlarmHistory() {
@@ -53,7 +53,7 @@ func ExampleCloudWatch_DescribeAlarmHistory() {
 		AlarmName:       aws.String("AlarmName"),
 		EndDate:         aws.Time(time.Now()),
 		HistoryItemType: aws.String("HistoryItemType"),
-		MaxRecords:      aws.Long(1),
+		MaxRecords:      aws.Int64(1),
 		NextToken:       aws.String("NextToken"),
 		StartDate:       aws.Time(time.Now()),
 	}
@@ -75,7 +75,7 @@ func ExampleCloudWatch_DescribeAlarmHistory() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_DescribeAlarms() {
@@ -88,7 +88,7 @@ func ExampleCloudWatch_DescribeAlarms() {
 			aws.String("AlarmName"), // Required
 			// More values...
 		},
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		NextToken:  aws.String("NextToken"),
 		StateValue: aws.String("StateValue"),
 	}
@@ -110,7 +110,7 @@ func ExampleCloudWatch_DescribeAlarms() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_DescribeAlarmsForMetric() {
@@ -126,7 +126,7 @@ func ExampleCloudWatch_DescribeAlarmsForMetric() {
 			},
 			// More values...
 		},
-		Period:    aws.Long(1),
+		Period:    aws.Int64(1),
 		Statistic: aws.String("Statistic"),
 		Unit:      aws.String("StandardUnit"),
 	}
@@ -148,7 +148,7 @@ func ExampleCloudWatch_DescribeAlarmsForMetric() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_DisableAlarmActions() {
@@ -178,7 +178,7 @@ func ExampleCloudWatch_DisableAlarmActions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_EnableAlarmActions() {
@@ -208,7 +208,7 @@ func ExampleCloudWatch_EnableAlarmActions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_GetMetricStatistics() {
@@ -218,7 +218,7 @@ func ExampleCloudWatch_GetMetricStatistics() {
 		EndTime:    aws.Time(time.Now()),     // Required
 		MetricName: aws.String("MetricName"), // Required
 		Namespace:  aws.String("Namespace"),  // Required
-		Period:     aws.Long(1),              // Required
+		Period:     aws.Int64(1),             // Required
 		StartTime:  aws.Time(time.Now()),     // Required
 		Statistics: []*string{ // Required
 			aws.String("Statistic"), // Required
@@ -251,7 +251,7 @@ func ExampleCloudWatch_GetMetricStatistics() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_ListMetrics() {
@@ -287,7 +287,7 @@ func ExampleCloudWatch_ListMetrics() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_PutMetricAlarm() {
@@ -296,13 +296,13 @@ func ExampleCloudWatch_PutMetricAlarm() {
 	params := &cloudwatch.PutMetricAlarmInput{
 		AlarmName:          aws.String("AlarmName"),          // Required
 		ComparisonOperator: aws.String("ComparisonOperator"), // Required
-		EvaluationPeriods:  aws.Long(1),                      // Required
+		EvaluationPeriods:  aws.Int64(1),                     // Required
 		MetricName:         aws.String("MetricName"),         // Required
 		Namespace:          aws.String("Namespace"),          // Required
-		Period:             aws.Long(1),                      // Required
+		Period:             aws.Int64(1),                     // Required
 		Statistic:          aws.String("Statistic"),          // Required
-		Threshold:          aws.Double(1.0),                  // Required
-		ActionsEnabled:     aws.Boolean(true),
+		Threshold:          aws.Float64(1.0),                 // Required
+		ActionsEnabled:     aws.Bool(true),
 		AlarmActions: []*string{
 			aws.String("ResourceName"), // Required
 			// More values...
@@ -343,7 +343,7 @@ func ExampleCloudWatch_PutMetricAlarm() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_PutMetricData() {
@@ -361,14 +361,14 @@ func ExampleCloudWatch_PutMetricData() {
 					// More values...
 				},
 				StatisticValues: &cloudwatch.StatisticSet{
-					Maximum:     aws.Double(1.0), // Required
-					Minimum:     aws.Double(1.0), // Required
-					SampleCount: aws.Double(1.0), // Required
-					Sum:         aws.Double(1.0), // Required
+					Maximum:     aws.Float64(1.0), // Required
+					Minimum:     aws.Float64(1.0), // Required
+					SampleCount: aws.Float64(1.0), // Required
+					Sum:         aws.Float64(1.0), // Required
 				},
 				Timestamp: aws.Time(time.Now()),
 				Unit:      aws.String("StandardUnit"),
-				Value:     aws.Double(1.0),
+				Value:     aws.Float64(1.0),
 			},
 			// More values...
 		},
@@ -392,7 +392,7 @@ func ExampleCloudWatch_PutMetricData() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatch_SetAlarmState() {
@@ -422,5 +422,5 @@ func ExampleCloudWatch_SetAlarmState() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -652,7 +652,7 @@ type metadataCreateLogGroupInput struct {
 
 // String returns the string representation
 func (s CreateLogGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -670,7 +670,7 @@ type metadataCreateLogGroupOutput struct {
 
 // String returns the string representation
 func (s CreateLogGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -694,7 +694,7 @@ type metadataCreateLogStreamInput struct {
 
 // String returns the string representation
 func (s CreateLogStreamInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -712,7 +712,7 @@ type metadataCreateLogStreamOutput struct {
 
 // String returns the string representation
 func (s CreateLogStreamOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -733,7 +733,7 @@ type metadataDeleteLogGroupInput struct {
 
 // String returns the string representation
 func (s DeleteLogGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -751,7 +751,7 @@ type metadataDeleteLogGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteLogGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -775,7 +775,7 @@ type metadataDeleteLogStreamInput struct {
 
 // String returns the string representation
 func (s DeleteLogStreamInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -793,7 +793,7 @@ type metadataDeleteLogStreamOutput struct {
 
 // String returns the string representation
 func (s DeleteLogStreamOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -817,7 +817,7 @@ type metadataDeleteMetricFilterInput struct {
 
 // String returns the string representation
 func (s DeleteMetricFilterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -835,7 +835,7 @@ type metadataDeleteMetricFilterOutput struct {
 
 // String returns the string representation
 func (s DeleteMetricFilterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -857,7 +857,7 @@ type metadataDeleteRetentionPolicyInput struct {
 
 // String returns the string representation
 func (s DeleteRetentionPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -875,7 +875,7 @@ type metadataDeleteRetentionPolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteRetentionPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -900,7 +900,7 @@ type metadataDeleteSubscriptionFilterInput struct {
 
 // String returns the string representation
 func (s DeleteSubscriptionFilterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -918,7 +918,7 @@ type metadataDeleteSubscriptionFilterOutput struct {
 
 // String returns the string representation
 func (s DeleteSubscriptionFilterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -949,7 +949,7 @@ type metadataDescribeLogGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeLogGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -975,7 +975,7 @@ type metadataDescribeLogGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeLogGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1019,7 +1019,7 @@ type metadataDescribeLogStreamsInput struct {
 
 // String returns the string representation
 func (s DescribeLogStreamsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1045,7 +1045,7 @@ type metadataDescribeLogStreamsOutput struct {
 
 // String returns the string representation
 func (s DescribeLogStreamsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1079,7 +1079,7 @@ type metadataDescribeMetricFiltersInput struct {
 
 // String returns the string representation
 func (s DescribeMetricFiltersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1104,7 +1104,7 @@ type metadataDescribeMetricFiltersOutput struct {
 
 // String returns the string representation
 func (s DescribeMetricFiltersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1137,7 +1137,7 @@ type metadataDescribeSubscriptionFiltersInput struct {
 
 // String returns the string representation
 func (s DescribeSubscriptionFiltersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1162,7 +1162,7 @@ type metadataDescribeSubscriptionFiltersOutput struct {
 
 // String returns the string representation
 func (s DescribeSubscriptionFiltersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1213,7 +1213,7 @@ type metadataFilterLogEventsInput struct {
 
 // String returns the string representation
 func (s FilterLogEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1244,7 +1244,7 @@ type metadataFilterLogEventsOutput struct {
 
 // String returns the string representation
 func (s FilterLogEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1280,7 +1280,7 @@ type metadataFilteredLogEvent struct {
 
 // String returns the string representation
 func (s FilteredLogEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1326,7 +1326,7 @@ type metadataGetLogEventsInput struct {
 
 // String returns the string representation
 func (s GetLogEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1356,7 +1356,7 @@ type metadataGetLogEventsOutput struct {
 
 // String returns the string representation
 func (s GetLogEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1384,7 +1384,7 @@ type metadataInputLogEvent struct {
 
 // String returns the string representation
 func (s InputLogEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1420,7 +1420,7 @@ type metadataLogGroup struct {
 
 // String returns the string representation
 func (s LogGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1466,7 +1466,7 @@ type metadataLogStream struct {
 
 // String returns the string representation
 func (s LogStream) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1502,7 +1502,7 @@ type metadataMetricFilter struct {
 
 // String returns the string representation
 func (s MetricFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1526,7 +1526,7 @@ type metadataMetricFilterMatchRecord struct {
 
 // String returns the string representation
 func (s MetricFilterMatchRecord) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1557,7 +1557,7 @@ type metadataMetricTransformation struct {
 
 // String returns the string representation
 func (s MetricTransformation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1585,7 +1585,7 @@ type metadataOutputLogEvent struct {
 
 // String returns the string representation
 func (s OutputLogEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1616,7 +1616,7 @@ type metadataPutLogEventsInput struct {
 
 // String returns the string representation
 func (s PutLogEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1641,7 +1641,7 @@ type metadataPutLogEventsOutput struct {
 
 // String returns the string representation
 func (s PutLogEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1672,7 +1672,7 @@ type metadataPutMetricFilterInput struct {
 
 // String returns the string representation
 func (s PutMetricFilterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1690,7 +1690,7 @@ type metadataPutMetricFilterOutput struct {
 
 // String returns the string representation
 func (s PutMetricFilterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1716,7 +1716,7 @@ type metadataPutRetentionPolicyInput struct {
 
 // String returns the string representation
 func (s PutRetentionPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1734,7 +1734,7 @@ type metadataPutRetentionPolicyOutput struct {
 
 // String returns the string representation
 func (s PutRetentionPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1769,7 +1769,7 @@ type metadataPutSubscriptionFilterInput struct {
 
 // String returns the string representation
 func (s PutSubscriptionFilterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1787,7 +1787,7 @@ type metadataPutSubscriptionFilterOutput struct {
 
 // String returns the string representation
 func (s PutSubscriptionFilterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1811,7 +1811,7 @@ type metadataRejectedLogEventsInfo struct {
 
 // String returns the string representation
 func (s RejectedLogEventsInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1838,7 +1838,7 @@ type metadataSearchedLogStream struct {
 
 // String returns the string representation
 func (s SearchedLogStream) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1875,7 +1875,7 @@ type metadataSubscriptionFilter struct {
 
 // String returns the string representation
 func (s SubscriptionFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1902,7 +1902,7 @@ type metadataTestMetricFilterInput struct {
 
 // String returns the string representation
 func (s TestMetricFilterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1922,7 +1922,7 @@ type metadataTestMetricFilterOutput struct {
 
 // String returns the string representation
 func (s TestMetricFilterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cloudwatchlogs/examples_test.go
+++ b/service/cloudwatchlogs/examples_test.go
@@ -40,7 +40,7 @@ func ExampleCloudWatchLogs_CreateLogGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_CreateLogStream() {
@@ -68,7 +68,7 @@ func ExampleCloudWatchLogs_CreateLogStream() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DeleteLogGroup() {
@@ -95,7 +95,7 @@ func ExampleCloudWatchLogs_DeleteLogGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DeleteLogStream() {
@@ -123,7 +123,7 @@ func ExampleCloudWatchLogs_DeleteLogStream() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DeleteMetricFilter() {
@@ -151,7 +151,7 @@ func ExampleCloudWatchLogs_DeleteMetricFilter() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DeleteRetentionPolicy() {
@@ -178,7 +178,7 @@ func ExampleCloudWatchLogs_DeleteRetentionPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DeleteSubscriptionFilter() {
@@ -206,14 +206,14 @@ func ExampleCloudWatchLogs_DeleteSubscriptionFilter() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DescribeLogGroups() {
 	svc := cloudwatchlogs.New(nil)
 
 	params := &cloudwatchlogs.DescribeLogGroupsInput{
-		Limit:              aws.Long(1),
+		Limit:              aws.Int64(1),
 		LogGroupNamePrefix: aws.String("LogGroupName"),
 		NextToken:          aws.String("NextToken"),
 	}
@@ -235,7 +235,7 @@ func ExampleCloudWatchLogs_DescribeLogGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DescribeLogStreams() {
@@ -243,8 +243,8 @@ func ExampleCloudWatchLogs_DescribeLogStreams() {
 
 	params := &cloudwatchlogs.DescribeLogStreamsInput{
 		LogGroupName:        aws.String("LogGroupName"), // Required
-		Descending:          aws.Boolean(true),
-		Limit:               aws.Long(1),
+		Descending:          aws.Bool(true),
+		Limit:               aws.Int64(1),
 		LogStreamNamePrefix: aws.String("LogStreamName"),
 		NextToken:           aws.String("NextToken"),
 		OrderBy:             aws.String("OrderBy"),
@@ -267,7 +267,7 @@ func ExampleCloudWatchLogs_DescribeLogStreams() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DescribeMetricFilters() {
@@ -276,7 +276,7 @@ func ExampleCloudWatchLogs_DescribeMetricFilters() {
 	params := &cloudwatchlogs.DescribeMetricFiltersInput{
 		LogGroupName:     aws.String("LogGroupName"), // Required
 		FilterNamePrefix: aws.String("FilterName"),
-		Limit:            aws.Long(1),
+		Limit:            aws.Int64(1),
 		NextToken:        aws.String("NextToken"),
 	}
 	resp, err := svc.DescribeMetricFilters(params)
@@ -297,7 +297,7 @@ func ExampleCloudWatchLogs_DescribeMetricFilters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_DescribeSubscriptionFilters() {
@@ -306,7 +306,7 @@ func ExampleCloudWatchLogs_DescribeSubscriptionFilters() {
 	params := &cloudwatchlogs.DescribeSubscriptionFiltersInput{
 		LogGroupName:     aws.String("LogGroupName"), // Required
 		FilterNamePrefix: aws.String("FilterName"),
-		Limit:            aws.Long(1),
+		Limit:            aws.Int64(1),
 		NextToken:        aws.String("NextToken"),
 	}
 	resp, err := svc.DescribeSubscriptionFilters(params)
@@ -327,7 +327,7 @@ func ExampleCloudWatchLogs_DescribeSubscriptionFilters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_FilterLogEvents() {
@@ -335,16 +335,16 @@ func ExampleCloudWatchLogs_FilterLogEvents() {
 
 	params := &cloudwatchlogs.FilterLogEventsInput{
 		LogGroupName:  aws.String("LogGroupName"), // Required
-		EndTime:       aws.Long(1),
+		EndTime:       aws.Int64(1),
 		FilterPattern: aws.String("FilterPattern"),
-		Interleaved:   aws.Boolean(true),
-		Limit:         aws.Long(1),
+		Interleaved:   aws.Bool(true),
+		Limit:         aws.Int64(1),
 		LogStreamNames: []*string{
 			aws.String("LogStreamName"), // Required
 			// More values...
 		},
 		NextToken: aws.String("NextToken"),
-		StartTime: aws.Long(1),
+		StartTime: aws.Int64(1),
 	}
 	resp, err := svc.FilterLogEvents(params)
 
@@ -364,7 +364,7 @@ func ExampleCloudWatchLogs_FilterLogEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_GetLogEvents() {
@@ -373,11 +373,11 @@ func ExampleCloudWatchLogs_GetLogEvents() {
 	params := &cloudwatchlogs.GetLogEventsInput{
 		LogGroupName:  aws.String("LogGroupName"),  // Required
 		LogStreamName: aws.String("LogStreamName"), // Required
-		EndTime:       aws.Long(1),
-		Limit:         aws.Long(1),
+		EndTime:       aws.Int64(1),
+		Limit:         aws.Int64(1),
 		NextToken:     aws.String("NextToken"),
-		StartFromHead: aws.Boolean(true),
-		StartTime:     aws.Long(1),
+		StartFromHead: aws.Bool(true),
+		StartTime:     aws.Int64(1),
 	}
 	resp, err := svc.GetLogEvents(params)
 
@@ -397,7 +397,7 @@ func ExampleCloudWatchLogs_GetLogEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_PutLogEvents() {
@@ -407,7 +407,7 @@ func ExampleCloudWatchLogs_PutLogEvents() {
 		LogEvents: []*cloudwatchlogs.InputLogEvent{ // Required
 			{ // Required
 				Message:   aws.String("EventMessage"), // Required
-				Timestamp: aws.Long(1),                // Required
+				Timestamp: aws.Int64(1),               // Required
 			},
 			// More values...
 		},
@@ -433,7 +433,7 @@ func ExampleCloudWatchLogs_PutLogEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_PutMetricFilter() {
@@ -470,7 +470,7 @@ func ExampleCloudWatchLogs_PutMetricFilter() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_PutRetentionPolicy() {
@@ -478,7 +478,7 @@ func ExampleCloudWatchLogs_PutRetentionPolicy() {
 
 	params := &cloudwatchlogs.PutRetentionPolicyInput{
 		LogGroupName:    aws.String("LogGroupName"), // Required
-		RetentionInDays: aws.Long(1),                // Required
+		RetentionInDays: aws.Int64(1),               // Required
 	}
 	resp, err := svc.PutRetentionPolicy(params)
 
@@ -498,7 +498,7 @@ func ExampleCloudWatchLogs_PutRetentionPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_PutSubscriptionFilter() {
@@ -529,7 +529,7 @@ func ExampleCloudWatchLogs_PutSubscriptionFilter() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCloudWatchLogs_TestMetricFilter() {
@@ -560,5 +560,5 @@ func ExampleCloudWatchLogs_TestMetricFilter() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -352,7 +352,7 @@ type metadataBatchGetRepositoriesInput struct {
 
 // String returns the string representation
 func (s BatchGetRepositoriesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -377,7 +377,7 @@ type metadataBatchGetRepositoriesOutput struct {
 
 // String returns the string representation
 func (s BatchGetRepositoriesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -402,7 +402,7 @@ type metadataBranchInfo struct {
 
 // String returns the string representation
 func (s BranchInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -433,7 +433,7 @@ type metadataCreateBranchInput struct {
 
 // String returns the string representation
 func (s CreateBranchInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -451,7 +451,7 @@ type metadataCreateBranchOutput struct {
 
 // String returns the string representation
 func (s CreateBranchOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -480,7 +480,7 @@ type metadataCreateRepositoryInput struct {
 
 // String returns the string representation
 func (s CreateRepositoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -502,7 +502,7 @@ type metadataCreateRepositoryOutput struct {
 
 // String returns the string representation
 func (s CreateRepositoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -524,7 +524,7 @@ type metadataDeleteRepositoryInput struct {
 
 // String returns the string representation
 func (s DeleteRepositoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -546,7 +546,7 @@ type metadataDeleteRepositoryOutput struct {
 
 // String returns the string representation
 func (s DeleteRepositoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -573,7 +573,7 @@ type metadataGetBranchInput struct {
 
 // String returns the string representation
 func (s GetBranchInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -595,7 +595,7 @@ type metadataGetBranchOutput struct {
 
 // String returns the string representation
 func (s GetBranchOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -617,7 +617,7 @@ type metadataGetRepositoryInput struct {
 
 // String returns the string representation
 func (s GetRepositoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -639,7 +639,7 @@ type metadataGetRepositoryOutput struct {
 
 // String returns the string representation
 func (s GetRepositoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -664,7 +664,7 @@ type metadataListBranchesInput struct {
 
 // String returns the string representation
 func (s ListBranchesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -689,7 +689,7 @@ type metadataListBranchesOutput struct {
 
 // String returns the string representation
 func (s ListBranchesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -720,7 +720,7 @@ type metadataListRepositoriesInput struct {
 
 // String returns the string representation
 func (s ListRepositoriesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -748,7 +748,7 @@ type metadataListRepositoriesOutput struct {
 
 // String returns the string representation
 func (s ListRepositoriesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -797,7 +797,7 @@ type metadataRepositoryMetadata struct {
 
 // String returns the string representation
 func (s RepositoryMetadata) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -824,7 +824,7 @@ type metadataRepositoryNameIDPair struct {
 
 // String returns the string representation
 func (s RepositoryNameIDPair) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -849,7 +849,7 @@ type metadataUpdateDefaultBranchInput struct {
 
 // String returns the string representation
 func (s UpdateDefaultBranchInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -867,7 +867,7 @@ type metadataUpdateDefaultBranchOutput struct {
 
 // String returns the string representation
 func (s UpdateDefaultBranchOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -892,7 +892,7 @@ type metadataUpdateRepositoryDescriptionInput struct {
 
 // String returns the string representation
 func (s UpdateRepositoryDescriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -910,7 +910,7 @@ type metadataUpdateRepositoryDescriptionOutput struct {
 
 // String returns the string representation
 func (s UpdateRepositoryDescriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -939,7 +939,7 @@ type metadataUpdateRepositoryNameInput struct {
 
 // String returns the string representation
 func (s UpdateRepositoryNameInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -957,7 +957,7 @@ type metadataUpdateRepositoryNameOutput struct {
 
 // String returns the string representation
 func (s UpdateRepositoryNameOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/codecommit/examples_test.go
+++ b/service/codecommit/examples_test.go
@@ -43,7 +43,7 @@ func ExampleCodeCommit_BatchGetRepositories() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_CreateBranch() {
@@ -72,7 +72,7 @@ func ExampleCodeCommit_CreateBranch() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_CreateRepository() {
@@ -100,7 +100,7 @@ func ExampleCodeCommit_CreateRepository() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_DeleteRepository() {
@@ -127,7 +127,7 @@ func ExampleCodeCommit_DeleteRepository() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_GetBranch() {
@@ -155,7 +155,7 @@ func ExampleCodeCommit_GetBranch() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_GetRepository() {
@@ -182,7 +182,7 @@ func ExampleCodeCommit_GetRepository() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_ListBranches() {
@@ -210,7 +210,7 @@ func ExampleCodeCommit_ListBranches() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_ListRepositories() {
@@ -239,7 +239,7 @@ func ExampleCodeCommit_ListRepositories() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_UpdateDefaultBranch() {
@@ -267,7 +267,7 @@ func ExampleCodeCommit_UpdateDefaultBranch() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_UpdateRepositoryDescription() {
@@ -295,7 +295,7 @@ func ExampleCodeCommit_UpdateRepositoryDescription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeCommit_UpdateRepositoryName() {
@@ -323,5 +323,5 @@ func ExampleCodeCommit_UpdateRepositoryName() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -982,7 +982,7 @@ type metadataAddTagsToOnPremisesInstancesInput struct {
 
 // String returns the string representation
 func (s AddTagsToOnPremisesInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1000,7 +1000,7 @@ type metadataAddTagsToOnPremisesInstancesOutput struct {
 
 // String returns the string representation
 func (s AddTagsToOnPremisesInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1032,7 +1032,7 @@ type metadataApplicationInfo struct {
 
 // String returns the string representation
 func (s ApplicationInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1057,7 +1057,7 @@ type metadataAutoScalingGroup struct {
 
 // String returns the string representation
 func (s AutoScalingGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1080,7 +1080,7 @@ type metadataBatchGetApplicationsInput struct {
 
 // String returns the string representation
 func (s BatchGetApplicationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1102,7 +1102,7 @@ type metadataBatchGetApplicationsOutput struct {
 
 // String returns the string representation
 func (s BatchGetApplicationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1124,7 +1124,7 @@ type metadataBatchGetDeploymentsInput struct {
 
 // String returns the string representation
 func (s BatchGetDeploymentsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1146,7 +1146,7 @@ type metadataBatchGetDeploymentsOutput struct {
 
 // String returns the string representation
 func (s BatchGetDeploymentsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1168,7 +1168,7 @@ type metadataBatchGetOnPremisesInstancesInput struct {
 
 // String returns the string representation
 func (s BatchGetOnPremisesInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1190,7 +1190,7 @@ type metadataBatchGetOnPremisesInstancesOutput struct {
 
 // String returns the string representation
 func (s BatchGetOnPremisesInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1213,7 +1213,7 @@ type metadataCreateApplicationInput struct {
 
 // String returns the string representation
 func (s CreateApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1235,7 +1235,7 @@ type metadataCreateApplicationOutput struct {
 
 // String returns the string representation
 func (s CreateApplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1275,7 +1275,7 @@ type metadataCreateDeploymentConfigInput struct {
 
 // String returns the string representation
 func (s CreateDeploymentConfigInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1297,7 +1297,7 @@ type metadataCreateDeploymentConfigOutput struct {
 
 // String returns the string representation
 func (s CreateDeploymentConfigOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1367,7 +1367,7 @@ type metadataCreateDeploymentGroupInput struct {
 
 // String returns the string representation
 func (s CreateDeploymentGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1389,7 +1389,7 @@ type metadataCreateDeploymentGroupOutput struct {
 
 // String returns the string representation
 func (s CreateDeploymentGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1441,7 +1441,7 @@ type metadataCreateDeploymentInput struct {
 
 // String returns the string representation
 func (s CreateDeploymentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1463,7 +1463,7 @@ type metadataCreateDeploymentOutput struct {
 
 // String returns the string representation
 func (s CreateDeploymentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1486,7 +1486,7 @@ type metadataDeleteApplicationInput struct {
 
 // String returns the string representation
 func (s DeleteApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1504,7 +1504,7 @@ type metadataDeleteApplicationOutput struct {
 
 // String returns the string representation
 func (s DeleteApplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1527,7 +1527,7 @@ type metadataDeleteDeploymentConfigInput struct {
 
 // String returns the string representation
 func (s DeleteDeploymentConfigInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1545,7 +1545,7 @@ type metadataDeleteDeploymentConfigOutput struct {
 
 // String returns the string representation
 func (s DeleteDeploymentConfigOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1571,7 +1571,7 @@ type metadataDeleteDeploymentGroupInput struct {
 
 // String returns the string representation
 func (s DeleteDeploymentGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1598,7 +1598,7 @@ type metadataDeleteDeploymentGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteDeploymentGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1629,7 +1629,7 @@ type metadataDeploymentConfigInfo struct {
 
 // String returns the string representation
 func (s DeploymentConfigInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1676,7 +1676,7 @@ type metadataDeploymentGroupInfo struct {
 
 // String returns the string representation
 func (s DeploymentGroupInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1754,7 +1754,7 @@ type metadataDeploymentInfo struct {
 
 // String returns the string representation
 func (s DeploymentInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1788,7 +1788,7 @@ type metadataDeploymentOverview struct {
 
 // String returns the string representation
 func (s DeploymentOverview) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1810,7 +1810,7 @@ type metadataDeregisterOnPremisesInstanceInput struct {
 
 // String returns the string representation
 func (s DeregisterOnPremisesInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1828,7 +1828,7 @@ type metadataDeregisterOnPremisesInstanceOutput struct {
 
 // String returns the string representation
 func (s DeregisterOnPremisesInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1866,7 +1866,7 @@ type metadataDiagnostics struct {
 
 // String returns the string representation
 func (s Diagnostics) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1896,7 +1896,7 @@ type metadataEC2TagFilter struct {
 
 // String returns the string representation
 func (s EC2TagFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1941,7 +1941,7 @@ type metadataErrorInformation struct {
 
 // String returns the string representation
 func (s ErrorInformation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1975,7 +1975,7 @@ type metadataGenericRevisionInfo struct {
 
 // String returns the string representation
 func (s GenericRevisionInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1998,7 +1998,7 @@ type metadataGetApplicationInput struct {
 
 // String returns the string representation
 func (s GetApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2020,7 +2020,7 @@ type metadataGetApplicationOutput struct {
 
 // String returns the string representation
 func (s GetApplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2046,7 +2046,7 @@ type metadataGetApplicationRevisionInput struct {
 
 // String returns the string representation
 func (s GetApplicationRevisionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2075,7 +2075,7 @@ type metadataGetApplicationRevisionOutput struct {
 
 // String returns the string representation
 func (s GetApplicationRevisionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2098,7 +2098,7 @@ type metadataGetDeploymentConfigInput struct {
 
 // String returns the string representation
 func (s GetDeploymentConfigInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2120,7 +2120,7 @@ type metadataGetDeploymentConfigOutput struct {
 
 // String returns the string representation
 func (s GetDeploymentConfigOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2146,7 +2146,7 @@ type metadataGetDeploymentGroupInput struct {
 
 // String returns the string representation
 func (s GetDeploymentGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2168,7 +2168,7 @@ type metadataGetDeploymentGroupOutput struct {
 
 // String returns the string representation
 func (s GetDeploymentGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2191,7 +2191,7 @@ type metadataGetDeploymentInput struct {
 
 // String returns the string representation
 func (s GetDeploymentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2216,7 +2216,7 @@ type metadataGetDeploymentInstanceInput struct {
 
 // String returns the string representation
 func (s GetDeploymentInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2238,7 +2238,7 @@ type metadataGetDeploymentInstanceOutput struct {
 
 // String returns the string representation
 func (s GetDeploymentInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2260,7 +2260,7 @@ type metadataGetDeploymentOutput struct {
 
 // String returns the string representation
 func (s GetDeploymentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2282,7 +2282,7 @@ type metadataGetOnPremisesInstanceInput struct {
 
 // String returns the string representation
 func (s GetOnPremisesInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2304,7 +2304,7 @@ type metadataGetOnPremisesInstanceOutput struct {
 
 // String returns the string representation
 func (s GetOnPremisesInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2334,7 +2334,7 @@ type metadataGitHubLocation struct {
 
 // String returns the string representation
 func (s GitHubLocation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2372,7 +2372,7 @@ type metadataInstanceInfo struct {
 
 // String returns the string representation
 func (s InstanceInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2412,7 +2412,7 @@ type metadataInstanceSummary struct {
 
 // String returns the string representation
 func (s InstanceSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2453,7 +2453,7 @@ type metadataLifecycleEvent struct {
 
 // String returns the string representation
 func (s LifecycleEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2516,7 +2516,7 @@ type metadataListApplicationRevisionsInput struct {
 
 // String returns the string representation
 func (s ListApplicationRevisionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2544,7 +2544,7 @@ type metadataListApplicationRevisionsOutput struct {
 
 // String returns the string representation
 func (s ListApplicationRevisionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2567,7 +2567,7 @@ type metadataListApplicationsInput struct {
 
 // String returns the string representation
 func (s ListApplicationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2594,7 +2594,7 @@ type metadataListApplicationsOutput struct {
 
 // String returns the string representation
 func (s ListApplicationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2618,7 +2618,7 @@ type metadataListDeploymentConfigsInput struct {
 
 // String returns the string representation
 func (s ListDeploymentConfigsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2647,7 +2647,7 @@ type metadataListDeploymentConfigsOutput struct {
 
 // String returns the string representation
 func (s ListDeploymentConfigsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2675,7 +2675,7 @@ type metadataListDeploymentGroupsInput struct {
 
 // String returns the string representation
 func (s ListDeploymentGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2706,7 +2706,7 @@ type metadataListDeploymentGroupsOutput struct {
 
 // String returns the string representation
 func (s ListDeploymentGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2744,7 +2744,7 @@ type metadataListDeploymentInstancesInput struct {
 
 // String returns the string representation
 func (s ListDeploymentInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2772,7 +2772,7 @@ type metadataListDeploymentInstancesOutput struct {
 
 // String returns the string representation
 func (s ListDeploymentInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2815,7 +2815,7 @@ type metadataListDeploymentsInput struct {
 
 // String returns the string representation
 func (s ListDeploymentsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2842,7 +2842,7 @@ type metadataListDeploymentsOutput struct {
 
 // String returns the string representation
 func (s ListDeploymentsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2878,7 +2878,7 @@ type metadataListOnPremisesInstancesInput struct {
 
 // String returns the string representation
 func (s ListOnPremisesInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2906,7 +2906,7 @@ type metadataListOnPremisesInstancesOutput struct {
 
 // String returns the string representation
 func (s ListOnPremisesInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2945,7 +2945,7 @@ type metadataMinimumHealthyHosts struct {
 
 // String returns the string representation
 func (s MinimumHealthyHosts) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2975,7 +2975,7 @@ type metadataRegisterApplicationRevisionInput struct {
 
 // String returns the string representation
 func (s RegisterApplicationRevisionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2993,7 +2993,7 @@ type metadataRegisterApplicationRevisionOutput struct {
 
 // String returns the string representation
 func (s RegisterApplicationRevisionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3018,7 +3018,7 @@ type metadataRegisterOnPremisesInstanceInput struct {
 
 // String returns the string representation
 func (s RegisterOnPremisesInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3036,7 +3036,7 @@ type metadataRegisterOnPremisesInstanceOutput struct {
 
 // String returns the string representation
 func (s RegisterOnPremisesInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3061,7 +3061,7 @@ type metadataRemoveTagsFromOnPremisesInstancesInput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromOnPremisesInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3079,7 +3079,7 @@ type metadataRemoveTagsFromOnPremisesInstancesOutput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromOnPremisesInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3112,7 +3112,7 @@ type metadataRevisionLocation struct {
 
 // String returns the string representation
 func (s RevisionLocation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3159,7 +3159,7 @@ type metadataS3Location struct {
 
 // String returns the string representation
 func (s S3Location) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3181,7 +3181,7 @@ type metadataStopDeploymentInput struct {
 
 // String returns the string representation
 func (s StopDeploymentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3208,7 +3208,7 @@ type metadataStopDeploymentOutput struct {
 
 // String returns the string representation
 func (s StopDeploymentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3233,7 +3233,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3263,7 +3263,7 @@ type metadataTagFilter struct {
 
 // String returns the string representation
 func (s TagFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3292,7 +3292,7 @@ type metadataTimeRange struct {
 
 // String returns the string representation
 func (s TimeRange) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3317,7 +3317,7 @@ type metadataUpdateApplicationInput struct {
 
 // String returns the string representation
 func (s UpdateApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3335,7 +3335,7 @@ type metadataUpdateApplicationOutput struct {
 
 // String returns the string representation
 func (s UpdateApplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3382,7 +3382,7 @@ type metadataUpdateDeploymentGroupInput struct {
 
 // String returns the string representation
 func (s UpdateDeploymentGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3408,7 +3408,7 @@ type metadataUpdateDeploymentGroupOutput struct {
 
 // String returns the string representation
 func (s UpdateDeploymentGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/codedeploy/examples_test.go
+++ b/service/codedeploy/examples_test.go
@@ -50,7 +50,7 @@ func ExampleCodeDeploy_AddTagsToOnPremisesInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_BatchGetApplications() {
@@ -80,7 +80,7 @@ func ExampleCodeDeploy_BatchGetApplications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_BatchGetDeployments() {
@@ -110,7 +110,7 @@ func ExampleCodeDeploy_BatchGetDeployments() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_BatchGetOnPremisesInstances() {
@@ -140,7 +140,7 @@ func ExampleCodeDeploy_BatchGetOnPremisesInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_CreateApplication() {
@@ -167,7 +167,7 @@ func ExampleCodeDeploy_CreateApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_CreateDeployment() {
@@ -178,7 +178,7 @@ func ExampleCodeDeploy_CreateDeployment() {
 		DeploymentConfigName:          aws.String("DeploymentConfigName"),
 		DeploymentGroupName:           aws.String("DeploymentGroupName"),
 		Description:                   aws.String("Description"),
-		IgnoreApplicationStopFailures: aws.Boolean(true),
+		IgnoreApplicationStopFailures: aws.Bool(true),
 		Revision: &codedeploy.RevisionLocation{
 			GitHubLocation: &codedeploy.GitHubLocation{
 				CommitID:   aws.String("CommitId"),
@@ -212,7 +212,7 @@ func ExampleCodeDeploy_CreateDeployment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_CreateDeploymentConfig() {
@@ -222,7 +222,7 @@ func ExampleCodeDeploy_CreateDeploymentConfig() {
 		DeploymentConfigName: aws.String("DeploymentConfigName"), // Required
 		MinimumHealthyHosts: &codedeploy.MinimumHealthyHosts{
 			Type:  aws.String("MinimumHealthyHostsType"),
-			Value: aws.Long(1),
+			Value: aws.Int64(1),
 		},
 	}
 	resp, err := svc.CreateDeploymentConfig(params)
@@ -243,7 +243,7 @@ func ExampleCodeDeploy_CreateDeploymentConfig() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_CreateDeploymentGroup() {
@@ -293,7 +293,7 @@ func ExampleCodeDeploy_CreateDeploymentGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_DeleteApplication() {
@@ -320,7 +320,7 @@ func ExampleCodeDeploy_DeleteApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_DeleteDeploymentConfig() {
@@ -347,7 +347,7 @@ func ExampleCodeDeploy_DeleteDeploymentConfig() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_DeleteDeploymentGroup() {
@@ -375,7 +375,7 @@ func ExampleCodeDeploy_DeleteDeploymentGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_DeregisterOnPremisesInstance() {
@@ -402,7 +402,7 @@ func ExampleCodeDeploy_DeregisterOnPremisesInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_GetApplication() {
@@ -429,7 +429,7 @@ func ExampleCodeDeploy_GetApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_GetApplicationRevision() {
@@ -470,7 +470,7 @@ func ExampleCodeDeploy_GetApplicationRevision() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_GetDeployment() {
@@ -497,7 +497,7 @@ func ExampleCodeDeploy_GetDeployment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_GetDeploymentConfig() {
@@ -524,7 +524,7 @@ func ExampleCodeDeploy_GetDeploymentConfig() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_GetDeploymentGroup() {
@@ -552,7 +552,7 @@ func ExampleCodeDeploy_GetDeploymentGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_GetDeploymentInstance() {
@@ -580,7 +580,7 @@ func ExampleCodeDeploy_GetDeploymentInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_GetOnPremisesInstance() {
@@ -607,7 +607,7 @@ func ExampleCodeDeploy_GetOnPremisesInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_ListApplicationRevisions() {
@@ -640,7 +640,7 @@ func ExampleCodeDeploy_ListApplicationRevisions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_ListApplications() {
@@ -667,7 +667,7 @@ func ExampleCodeDeploy_ListApplications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_ListDeploymentConfigs() {
@@ -694,7 +694,7 @@ func ExampleCodeDeploy_ListDeploymentConfigs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_ListDeploymentGroups() {
@@ -722,7 +722,7 @@ func ExampleCodeDeploy_ListDeploymentGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_ListDeploymentInstances() {
@@ -754,7 +754,7 @@ func ExampleCodeDeploy_ListDeploymentInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_ListDeployments() {
@@ -791,7 +791,7 @@ func ExampleCodeDeploy_ListDeployments() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_ListOnPremisesInstances() {
@@ -827,7 +827,7 @@ func ExampleCodeDeploy_ListOnPremisesInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_RegisterApplicationRevision() {
@@ -869,7 +869,7 @@ func ExampleCodeDeploy_RegisterApplicationRevision() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_RegisterOnPremisesInstance() {
@@ -897,7 +897,7 @@ func ExampleCodeDeploy_RegisterOnPremisesInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_RemoveTagsFromOnPremisesInstances() {
@@ -934,7 +934,7 @@ func ExampleCodeDeploy_RemoveTagsFromOnPremisesInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_StopDeployment() {
@@ -961,7 +961,7 @@ func ExampleCodeDeploy_StopDeployment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_UpdateApplication() {
@@ -989,7 +989,7 @@ func ExampleCodeDeploy_UpdateApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodeDeploy_UpdateDeploymentGroup() {
@@ -1040,5 +1040,5 @@ func ExampleCodeDeploy_UpdateDeploymentGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -695,7 +695,7 @@ type metadataAWSSessionCredentials struct {
 
 // String returns the string representation
 func (s AWSSessionCredentials) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -722,7 +722,7 @@ type metadataAcknowledgeJobInput struct {
 
 // String returns the string representation
 func (s AcknowledgeJobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -744,7 +744,7 @@ type metadataAcknowledgeJobOutput struct {
 
 // String returns the string representation
 func (s AcknowledgeJobOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -775,7 +775,7 @@ type metadataAcknowledgeThirdPartyJobInput struct {
 
 // String returns the string representation
 func (s AcknowledgeThirdPartyJobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -797,7 +797,7 @@ type metadataAcknowledgeThirdPartyJobOutput struct {
 
 // String returns the string representation
 func (s AcknowledgeThirdPartyJobOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -819,7 +819,7 @@ type metadataActionConfiguration struct {
 
 // String returns the string representation
 func (s ActionConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -873,7 +873,7 @@ type metadataActionConfigurationProperty struct {
 
 // String returns the string representation
 func (s ActionConfigurationProperty) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -896,7 +896,7 @@ type metadataActionContext struct {
 
 // String returns the string representation
 func (s ActionContext) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -939,7 +939,7 @@ type metadataActionDeclaration struct {
 
 // String returns the string representation
 func (s ActionDeclaration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -981,7 +981,7 @@ type metadataActionExecution struct {
 
 // String returns the string representation
 func (s ActionExecution) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1012,7 +1012,7 @@ type metadataActionRevision struct {
 
 // String returns the string representation
 func (s ActionRevision) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1048,7 +1048,7 @@ type metadataActionState struct {
 
 // String returns the string representation
 func (s ActionState) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1082,7 +1082,7 @@ type metadataActionType struct {
 
 // String returns the string representation
 func (s ActionType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1118,7 +1118,7 @@ type metadataActionTypeID struct {
 
 // String returns the string representation
 func (s ActionTypeID) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1159,7 +1159,7 @@ type metadataActionTypeSettings struct {
 
 // String returns the string representation
 func (s ActionTypeSettings) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1189,7 +1189,7 @@ type metadataArtifact struct {
 
 // String returns the string representation
 func (s Artifact) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1214,7 +1214,7 @@ type metadataArtifactDetails struct {
 
 // String returns the string representation
 func (s ArtifactDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1239,7 +1239,7 @@ type metadataArtifactLocation struct {
 
 // String returns the string representation
 func (s ArtifactLocation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1267,7 +1267,7 @@ type metadataArtifactStore struct {
 
 // String returns the string representation
 func (s ArtifactStore) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1292,7 +1292,7 @@ type metadataBlockerDeclaration struct {
 
 // String returns the string representation
 func (s BlockerDeclaration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1335,7 +1335,7 @@ type metadataCreateCustomActionTypeInput struct {
 
 // String returns the string representation
 func (s CreateCustomActionTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1357,7 +1357,7 @@ type metadataCreateCustomActionTypeOutput struct {
 
 // String returns the string representation
 func (s CreateCustomActionTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1379,7 +1379,7 @@ type metadataCreatePipelineInput struct {
 
 // String returns the string representation
 func (s CreatePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1401,7 +1401,7 @@ type metadataCreatePipelineOutput struct {
 
 // String returns the string representation
 func (s CreatePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1426,7 +1426,7 @@ type metadataCurrentRevision struct {
 
 // String returns the string representation
 func (s CurrentRevision) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1456,7 +1456,7 @@ type metadataDeleteCustomActionTypeInput struct {
 
 // String returns the string representation
 func (s DeleteCustomActionTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1474,7 +1474,7 @@ type metadataDeleteCustomActionTypeOutput struct {
 
 // String returns the string representation
 func (s DeleteCustomActionTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1496,7 +1496,7 @@ type metadataDeletePipelineInput struct {
 
 // String returns the string representation
 func (s DeletePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1514,7 +1514,7 @@ type metadataDeletePipelineOutput struct {
 
 // String returns the string representation
 func (s DeletePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1552,7 +1552,7 @@ type metadataDisableStageTransitionInput struct {
 
 // String returns the string representation
 func (s DisableStageTransitionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1570,7 +1570,7 @@ type metadataDisableStageTransitionOutput struct {
 
 // String returns the string representation
 func (s DisableStageTransitionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1602,7 +1602,7 @@ type metadataEnableStageTransitionInput struct {
 
 // String returns the string representation
 func (s EnableStageTransitionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1620,7 +1620,7 @@ type metadataEnableStageTransitionOutput struct {
 
 // String returns the string representation
 func (s EnableStageTransitionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1645,7 +1645,7 @@ type metadataErrorDetails struct {
 
 // String returns the string representation
 func (s ErrorDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1676,7 +1676,7 @@ type metadataExecutionDetails struct {
 
 // String returns the string representation
 func (s ExecutionDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1704,7 +1704,7 @@ type metadataFailureDetails struct {
 
 // String returns the string representation
 func (s FailureDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1726,7 +1726,7 @@ type metadataGetJobDetailsInput struct {
 
 // String returns the string representation
 func (s GetJobDetailsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1751,7 +1751,7 @@ type metadataGetJobDetailsOutput struct {
 
 // String returns the string representation
 func (s GetJobDetailsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1778,7 +1778,7 @@ type metadataGetPipelineInput struct {
 
 // String returns the string representation
 func (s GetPipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1800,7 +1800,7 @@ type metadataGetPipelineOutput struct {
 
 // String returns the string representation
 func (s GetPipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1822,7 +1822,7 @@ type metadataGetPipelineStateInput struct {
 
 // String returns the string representation
 func (s GetPipelineStateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1859,7 +1859,7 @@ type metadataGetPipelineStateOutput struct {
 
 // String returns the string representation
 func (s GetPipelineStateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1885,7 +1885,7 @@ type metadataGetThirdPartyJobDetailsInput struct {
 
 // String returns the string representation
 func (s GetThirdPartyJobDetailsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1907,7 +1907,7 @@ type metadataGetThirdPartyJobDetailsOutput struct {
 
 // String returns the string representation
 func (s GetThirdPartyJobDetailsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1936,7 +1936,7 @@ type metadataInputArtifact struct {
 
 // String returns the string representation
 func (s InputArtifact) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1969,7 +1969,7 @@ type metadataJob struct {
 
 // String returns the string representation
 func (s Job) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2014,7 +2014,7 @@ type metadataJobData struct {
 
 // String returns the string representation
 func (s JobData) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2043,7 +2043,7 @@ type metadataJobDetails struct {
 
 // String returns the string representation
 func (s JobDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2069,7 +2069,7 @@ type metadataListActionTypesInput struct {
 
 // String returns the string representation
 func (s ListActionTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2096,7 +2096,7 @@ type metadataListActionTypesOutput struct {
 
 // String returns the string representation
 func (s ListActionTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2119,7 +2119,7 @@ type metadataListPipelinesInput struct {
 
 // String returns the string representation
 func (s ListPipelinesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2146,7 +2146,7 @@ type metadataListPipelinesOutput struct {
 
 // String returns the string representation
 func (s ListPipelinesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2176,7 +2176,7 @@ type metadataOutputArtifact struct {
 
 // String returns the string representation
 func (s OutputArtifact) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2206,7 +2206,7 @@ type metadataPipelineContext struct {
 
 // String returns the string representation
 func (s PipelineContext) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2245,7 +2245,7 @@ type metadataPipelineDeclaration struct {
 
 // String returns the string representation
 func (s PipelineDeclaration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2276,7 +2276,7 @@ type metadataPipelineSummary struct {
 
 // String returns the string representation
 func (s PipelineSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2307,7 +2307,7 @@ type metadataPollForJobsInput struct {
 
 // String returns the string representation
 func (s PollForJobsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2329,7 +2329,7 @@ type metadataPollForJobsOutput struct {
 
 // String returns the string representation
 func (s PollForJobsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2354,7 +2354,7 @@ type metadataPollForThirdPartyJobsInput struct {
 
 // String returns the string representation
 func (s PollForThirdPartyJobsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2376,7 +2376,7 @@ type metadataPollForThirdPartyJobsOutput struct {
 
 // String returns the string representation
 func (s PollForThirdPartyJobsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2407,7 +2407,7 @@ type metadataPutActionRevisionInput struct {
 
 // String returns the string representation
 func (s PutActionRevisionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2432,7 +2432,7 @@ type metadataPutActionRevisionOutput struct {
 
 // String returns the string representation
 func (s PutActionRevisionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2458,7 +2458,7 @@ type metadataPutJobFailureResultInput struct {
 
 // String returns the string representation
 func (s PutJobFailureResultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2476,7 +2476,7 @@ type metadataPutJobFailureResultOutput struct {
 
 // String returns the string representation
 func (s PutJobFailureResultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2511,7 +2511,7 @@ type metadataPutJobSuccessResultInput struct {
 
 // String returns the string representation
 func (s PutJobSuccessResultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2529,7 +2529,7 @@ type metadataPutJobSuccessResultOutput struct {
 
 // String returns the string representation
 func (s PutJobSuccessResultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2558,7 +2558,7 @@ type metadataPutThirdPartyJobFailureResultInput struct {
 
 // String returns the string representation
 func (s PutThirdPartyJobFailureResultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2576,7 +2576,7 @@ type metadataPutThirdPartyJobFailureResultOutput struct {
 
 // String returns the string representation
 func (s PutThirdPartyJobFailureResultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2614,7 +2614,7 @@ type metadataPutThirdPartyJobSuccessResultInput struct {
 
 // String returns the string representation
 func (s PutThirdPartyJobSuccessResultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2632,7 +2632,7 @@ type metadataPutThirdPartyJobSuccessResultOutput struct {
 
 // String returns the string representation
 func (s PutThirdPartyJobSuccessResultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2658,7 +2658,7 @@ type metadataS3ArtifactLocation struct {
 
 // String returns the string representation
 func (s S3ArtifactLocation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2680,7 +2680,7 @@ type metadataStageContext struct {
 
 // String returns the string representation
 func (s StageContext) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2708,7 +2708,7 @@ type metadataStageDeclaration struct {
 
 // String returns the string representation
 func (s StageDeclaration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2736,7 +2736,7 @@ type metadataStageState struct {
 
 // String returns the string representation
 func (s StageState) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2758,7 +2758,7 @@ type metadataStartPipelineExecutionInput struct {
 
 // String returns the string representation
 func (s StartPipelineExecutionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2780,7 +2780,7 @@ type metadataStartPipelineExecutionOutput struct {
 
 // String returns the string representation
 func (s StartPipelineExecutionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2807,7 +2807,7 @@ type metadataThirdPartyJob struct {
 
 // String returns the string representation
 func (s ThirdPartyJob) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2857,7 +2857,7 @@ type metadataThirdPartyJobData struct {
 
 // String returns the string representation
 func (s ThirdPartyJobData) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2887,7 +2887,7 @@ type metadataThirdPartyJobDetails struct {
 
 // String returns the string representation
 func (s ThirdPartyJobDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2920,7 +2920,7 @@ type metadataTransitionState struct {
 
 // String returns the string representation
 func (s TransitionState) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2942,7 +2942,7 @@ type metadataUpdatePipelineInput struct {
 
 // String returns the string representation
 func (s UpdatePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2964,7 +2964,7 @@ type metadataUpdatePipelineOutput struct {
 
 // String returns the string representation
 func (s UpdatePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/codepipeline/examples_test.go
+++ b/service/codepipeline/examples_test.go
@@ -41,7 +41,7 @@ func ExampleCodePipeline_AcknowledgeJob() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_AcknowledgeThirdPartyJob() {
@@ -70,7 +70,7 @@ func ExampleCodePipeline_AcknowledgeThirdPartyJob() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_CreateCustomActionType() {
@@ -79,23 +79,23 @@ func ExampleCodePipeline_CreateCustomActionType() {
 	params := &codepipeline.CreateCustomActionTypeInput{
 		Category: aws.String("ActionCategory"), // Required
 		InputArtifactDetails: &codepipeline.ArtifactDetails{ // Required
-			MaximumCount: aws.Long(1), // Required
-			MinimumCount: aws.Long(1), // Required
+			MaximumCount: aws.Int64(1), // Required
+			MinimumCount: aws.Int64(1), // Required
 		},
 		OutputArtifactDetails: &codepipeline.ArtifactDetails{ // Required
-			MaximumCount: aws.Long(1), // Required
-			MinimumCount: aws.Long(1), // Required
+			MaximumCount: aws.Int64(1), // Required
+			MinimumCount: aws.Int64(1), // Required
 		},
 		Provider: aws.String("ActionProvider"), // Required
 		Version:  aws.String("Version"),        // Required
 		ConfigurationProperties: []*codepipeline.ActionConfigurationProperty{
 			{ // Required
-				Key:         aws.Boolean(true),                    // Required
+				Key:         aws.Bool(true),                       // Required
 				Name:        aws.String("ActionConfigurationKey"), // Required
-				Required:    aws.Boolean(true),                    // Required
-				Secret:      aws.Boolean(true),                    // Required
+				Required:    aws.Bool(true),                       // Required
+				Secret:      aws.Bool(true),                       // Required
 				Description: aws.String("Description"),
-				Queryable:   aws.Boolean(true),
+				Queryable:   aws.Bool(true),
 				Type:        aws.String("ActionConfigurationPropertyType"),
 			},
 			// More values...
@@ -125,7 +125,7 @@ func ExampleCodePipeline_CreateCustomActionType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_CreatePipeline() {
@@ -167,7 +167,7 @@ func ExampleCodePipeline_CreatePipeline() {
 								// More values...
 							},
 							RoleARN:  aws.String("RoleArn"),
-							RunOrder: aws.Long(1),
+							RunOrder: aws.Int64(1),
 						},
 						// More values...
 					},
@@ -182,7 +182,7 @@ func ExampleCodePipeline_CreatePipeline() {
 				},
 				// More values...
 			},
-			Version: aws.Long(1),
+			Version: aws.Int64(1),
 		},
 	}
 	resp, err := svc.CreatePipeline(params)
@@ -203,7 +203,7 @@ func ExampleCodePipeline_CreatePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_DeleteCustomActionType() {
@@ -232,7 +232,7 @@ func ExampleCodePipeline_DeleteCustomActionType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_DeletePipeline() {
@@ -259,7 +259,7 @@ func ExampleCodePipeline_DeletePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_DisableStageTransition() {
@@ -289,7 +289,7 @@ func ExampleCodePipeline_DisableStageTransition() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_EnableStageTransition() {
@@ -318,7 +318,7 @@ func ExampleCodePipeline_EnableStageTransition() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_GetJobDetails() {
@@ -345,7 +345,7 @@ func ExampleCodePipeline_GetJobDetails() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_GetPipeline() {
@@ -353,7 +353,7 @@ func ExampleCodePipeline_GetPipeline() {
 
 	params := &codepipeline.GetPipelineInput{
 		Name:    aws.String("PipelineName"), // Required
-		Version: aws.Long(1),
+		Version: aws.Int64(1),
 	}
 	resp, err := svc.GetPipeline(params)
 
@@ -373,7 +373,7 @@ func ExampleCodePipeline_GetPipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_GetPipelineState() {
@@ -400,7 +400,7 @@ func ExampleCodePipeline_GetPipelineState() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_GetThirdPartyJobDetails() {
@@ -428,7 +428,7 @@ func ExampleCodePipeline_GetThirdPartyJobDetails() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_ListActionTypes() {
@@ -456,7 +456,7 @@ func ExampleCodePipeline_ListActionTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_ListPipelines() {
@@ -483,7 +483,7 @@ func ExampleCodePipeline_ListPipelines() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_PollForJobs() {
@@ -496,7 +496,7 @@ func ExampleCodePipeline_PollForJobs() {
 			Provider: aws.String("ActionProvider"), // Required
 			Version:  aws.String("Version"),        // Required
 		},
-		MaxBatchSize: aws.Long(1),
+		MaxBatchSize: aws.Int64(1),
 		QueryParam: map[string]*string{
 			"Key": aws.String("ActionConfigurationQueryableValue"), // Required
 			// More values...
@@ -520,7 +520,7 @@ func ExampleCodePipeline_PollForJobs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_PollForThirdPartyJobs() {
@@ -533,7 +533,7 @@ func ExampleCodePipeline_PollForThirdPartyJobs() {
 			Provider: aws.String("ActionProvider"), // Required
 			Version:  aws.String("Version"),        // Required
 		},
-		MaxBatchSize: aws.Long(1),
+		MaxBatchSize: aws.Int64(1),
 	}
 	resp, err := svc.PollForThirdPartyJobs(params)
 
@@ -553,7 +553,7 @@ func ExampleCodePipeline_PollForThirdPartyJobs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_PutActionRevision() {
@@ -587,7 +587,7 @@ func ExampleCodePipeline_PutActionRevision() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_PutJobFailureResult() {
@@ -619,7 +619,7 @@ func ExampleCodePipeline_PutJobFailureResult() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_PutJobSuccessResult() {
@@ -634,7 +634,7 @@ func ExampleCodePipeline_PutJobSuccessResult() {
 		},
 		ExecutionDetails: &codepipeline.ExecutionDetails{
 			ExternalExecutionID: aws.String("ExecutionId"),
-			PercentComplete:     aws.Long(1),
+			PercentComplete:     aws.Int64(1),
 			Summary:             aws.String("ExecutionSummary"),
 		},
 	}
@@ -656,7 +656,7 @@ func ExampleCodePipeline_PutJobSuccessResult() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_PutThirdPartyJobFailureResult() {
@@ -689,7 +689,7 @@ func ExampleCodePipeline_PutThirdPartyJobFailureResult() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_PutThirdPartyJobSuccessResult() {
@@ -705,7 +705,7 @@ func ExampleCodePipeline_PutThirdPartyJobSuccessResult() {
 		},
 		ExecutionDetails: &codepipeline.ExecutionDetails{
 			ExternalExecutionID: aws.String("ExecutionId"),
-			PercentComplete:     aws.Long(1),
+			PercentComplete:     aws.Int64(1),
 			Summary:             aws.String("ExecutionSummary"),
 		},
 	}
@@ -727,7 +727,7 @@ func ExampleCodePipeline_PutThirdPartyJobSuccessResult() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_StartPipelineExecution() {
@@ -754,7 +754,7 @@ func ExampleCodePipeline_StartPipelineExecution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCodePipeline_UpdatePipeline() {
@@ -796,7 +796,7 @@ func ExampleCodePipeline_UpdatePipeline() {
 								// More values...
 							},
 							RoleARN:  aws.String("RoleArn"),
-							RunOrder: aws.Long(1),
+							RunOrder: aws.Int64(1),
 						},
 						// More values...
 					},
@@ -811,7 +811,7 @@ func ExampleCodePipeline_UpdatePipeline() {
 				},
 				// More values...
 			},
-			Version: aws.Long(1),
+			Version: aws.Int64(1),
 		},
 	}
 	resp, err := svc.UpdatePipeline(params)
@@ -832,5 +832,5 @@ func ExampleCodePipeline_UpdatePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -610,7 +610,7 @@ type metadataCreateIdentityPoolInput struct {
 
 // String returns the string representation
 func (s CreateIdentityPoolInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -641,7 +641,7 @@ type metadataCredentials struct {
 
 // String returns the string representation
 func (s Credentials) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -663,7 +663,7 @@ type metadataDeleteIdentitiesInput struct {
 
 // String returns the string representation
 func (s DeleteIdentitiesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -686,7 +686,7 @@ type metadataDeleteIdentitiesOutput struct {
 
 // String returns the string representation
 func (s DeleteIdentitiesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -708,7 +708,7 @@ type metadataDeleteIdentityPoolInput struct {
 
 // String returns the string representation
 func (s DeleteIdentityPoolInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -726,7 +726,7 @@ type metadataDeleteIdentityPoolOutput struct {
 
 // String returns the string representation
 func (s DeleteIdentityPoolOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -748,7 +748,7 @@ type metadataDescribeIdentityInput struct {
 
 // String returns the string representation
 func (s DescribeIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -770,7 +770,7 @@ type metadataDescribeIdentityPoolInput struct {
 
 // String returns the string representation
 func (s DescribeIdentityPoolInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -795,7 +795,7 @@ type metadataGetCredentialsForIdentityInput struct {
 
 // String returns the string representation
 func (s GetCredentialsForIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -820,7 +820,7 @@ type metadataGetCredentialsForIdentityOutput struct {
 
 // String returns the string representation
 func (s GetCredentialsForIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -852,7 +852,7 @@ type metadataGetIDInput struct {
 
 // String returns the string representation
 func (s GetIDInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -874,7 +874,7 @@ type metadataGetIDOutput struct {
 
 // String returns the string representation
 func (s GetIDOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -896,7 +896,7 @@ type metadataGetIdentityPoolRolesInput struct {
 
 // String returns the string representation
 func (s GetIdentityPoolRolesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -922,7 +922,7 @@ type metadataGetIdentityPoolRolesOutput struct {
 
 // String returns the string representation
 func (s GetIdentityPoolRolesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -968,7 +968,7 @@ type metadataGetOpenIDTokenForDeveloperIdentityInput struct {
 
 // String returns the string representation
 func (s GetOpenIDTokenForDeveloperIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -993,7 +993,7 @@ type metadataGetOpenIDTokenForDeveloperIdentityOutput struct {
 
 // String returns the string representation
 func (s GetOpenIDTokenForDeveloperIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1021,7 +1021,7 @@ type metadataGetOpenIDTokenInput struct {
 
 // String returns the string representation
 func (s GetOpenIDTokenInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1047,7 +1047,7 @@ type metadataGetOpenIDTokenOutput struct {
 
 // String returns the string representation
 func (s GetOpenIDTokenOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1078,7 +1078,7 @@ type metadataIdentityDescription struct {
 
 // String returns the string representation
 func (s IdentityDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1115,7 +1115,7 @@ type metadataIdentityPool struct {
 
 // String returns the string representation
 func (s IdentityPool) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1140,7 +1140,7 @@ type metadataIdentityPoolShortDescription struct {
 
 // String returns the string representation
 func (s IdentityPoolShortDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1173,7 +1173,7 @@ type metadataListIdentitiesInput struct {
 
 // String returns the string representation
 func (s ListIdentitiesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1201,7 +1201,7 @@ type metadataListIdentitiesOutput struct {
 
 // String returns the string representation
 func (s ListIdentitiesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1226,7 +1226,7 @@ type metadataListIdentityPoolsInput struct {
 
 // String returns the string representation
 func (s ListIdentityPoolsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1251,7 +1251,7 @@ type metadataListIdentityPoolsOutput struct {
 
 // String returns the string representation
 func (s ListIdentityPoolsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1292,7 +1292,7 @@ type metadataLookupDeveloperIdentityInput struct {
 
 // String returns the string representation
 func (s LookupDeveloperIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1327,7 +1327,7 @@ type metadataLookupDeveloperIdentityOutput struct {
 
 // String returns the string representation
 func (s LookupDeveloperIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1362,7 +1362,7 @@ type metadataMergeDeveloperIdentitiesInput struct {
 
 // String returns the string representation
 func (s MergeDeveloperIdentitiesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1384,7 +1384,7 @@ type metadataMergeDeveloperIdentitiesOutput struct {
 
 // String returns the string representation
 func (s MergeDeveloperIdentitiesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1411,7 +1411,7 @@ type metadataSetIdentityPoolRolesInput struct {
 
 // String returns the string representation
 func (s SetIdentityPoolRolesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1429,7 +1429,7 @@ type metadataSetIdentityPoolRolesOutput struct {
 
 // String returns the string representation
 func (s SetIdentityPoolRolesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1460,7 +1460,7 @@ type metadataUnlinkDeveloperIdentityInput struct {
 
 // String returns the string representation
 func (s UnlinkDeveloperIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1478,7 +1478,7 @@ type metadataUnlinkDeveloperIdentityOutput struct {
 
 // String returns the string representation
 func (s UnlinkDeveloperIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1506,7 +1506,7 @@ type metadataUnlinkIdentityInput struct {
 
 // String returns the string representation
 func (s UnlinkIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1524,7 +1524,7 @@ type metadataUnlinkIdentityOutput struct {
 
 // String returns the string representation
 func (s UnlinkIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1550,7 +1550,7 @@ type metadataUnprocessedIdentityID struct {
 
 // String returns the string representation
 func (s UnprocessedIdentityID) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cognitoidentity/customizations_test.go
+++ b/service/cognitoidentity/customizations_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var svc = cognitoidentity.New(&aws.Config{
-	Region: "mock-region",
+	Region: aws.String("mock-region"),
 })
 
 func TestUnsignedRequest_GetID(t *testing.T) {

--- a/service/cognitoidentity/examples_test.go
+++ b/service/cognitoidentity/examples_test.go
@@ -20,7 +20,7 @@ func ExampleCognitoIdentity_CreateIdentityPool() {
 	svc := cognitoidentity.New(nil)
 
 	params := &cognitoidentity.CreateIdentityPoolInput{
-		AllowUnauthenticatedIdentities: aws.Boolean(true),              // Required
+		AllowUnauthenticatedIdentities: aws.Bool(true),
 		IdentityPoolName:               aws.String("IdentityPoolName"), // Required
 		DeveloperProviderName:          aws.String("DeveloperProviderName"),
 		OpenIDConnectProviderARNs: []*string{
@@ -50,7 +50,7 @@ func ExampleCognitoIdentity_CreateIdentityPool() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_DeleteIdentities() {
@@ -80,7 +80,7 @@ func ExampleCognitoIdentity_DeleteIdentities() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_DeleteIdentityPool() {
@@ -107,7 +107,7 @@ func ExampleCognitoIdentity_DeleteIdentityPool() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_DescribeIdentity() {
@@ -134,7 +134,7 @@ func ExampleCognitoIdentity_DescribeIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_DescribeIdentityPool() {
@@ -161,7 +161,7 @@ func ExampleCognitoIdentity_DescribeIdentityPool() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_GetCredentialsForIdentity() {
@@ -192,7 +192,7 @@ func ExampleCognitoIdentity_GetCredentialsForIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_GetID() {
@@ -224,7 +224,7 @@ func ExampleCognitoIdentity_GetID() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_GetIdentityPoolRoles() {
@@ -251,7 +251,7 @@ func ExampleCognitoIdentity_GetIdentityPoolRoles() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_GetOpenIDToken() {
@@ -282,7 +282,7 @@ func ExampleCognitoIdentity_GetOpenIDToken() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_GetOpenIDTokenForDeveloperIdentity() {
@@ -295,7 +295,7 @@ func ExampleCognitoIdentity_GetOpenIDTokenForDeveloperIdentity() {
 			// More values...
 		},
 		IdentityID:    aws.String("IdentityId"),
-		TokenDuration: aws.Long(1),
+		TokenDuration: aws.Int64(1),
 	}
 	resp, err := svc.GetOpenIDTokenForDeveloperIdentity(params)
 
@@ -315,7 +315,7 @@ func ExampleCognitoIdentity_GetOpenIDTokenForDeveloperIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_ListIdentities() {
@@ -323,8 +323,8 @@ func ExampleCognitoIdentity_ListIdentities() {
 
 	params := &cognitoidentity.ListIdentitiesInput{
 		IdentityPoolID: aws.String("IdentityPoolId"), // Required
-		MaxResults:     aws.Long(1),                  // Required
-		HideDisabled:   aws.Boolean(true),
+		MaxResults:     aws.Int64(1),
+		HideDisabled:   aws.Bool(true),
 		NextToken:      aws.String("PaginationKey"),
 	}
 	resp, err := svc.ListIdentities(params)
@@ -345,14 +345,14 @@ func ExampleCognitoIdentity_ListIdentities() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_ListIdentityPools() {
 	svc := cognitoidentity.New(nil)
 
 	params := &cognitoidentity.ListIdentityPoolsInput{
-		MaxResults: aws.Long(1), // Required
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("PaginationKey"),
 	}
 	resp, err := svc.ListIdentityPools(params)
@@ -373,7 +373,7 @@ func ExampleCognitoIdentity_ListIdentityPools() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_LookupDeveloperIdentity() {
@@ -383,7 +383,7 @@ func ExampleCognitoIdentity_LookupDeveloperIdentity() {
 		IdentityPoolID:          aws.String("IdentityPoolId"), // Required
 		DeveloperUserIdentifier: aws.String("DeveloperUserIdentifier"),
 		IdentityID:              aws.String("IdentityId"),
-		MaxResults:              aws.Long(1),
+		MaxResults:              aws.Int64(1),
 		NextToken:               aws.String("PaginationKey"),
 	}
 	resp, err := svc.LookupDeveloperIdentity(params)
@@ -404,7 +404,7 @@ func ExampleCognitoIdentity_LookupDeveloperIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_MergeDeveloperIdentities() {
@@ -434,7 +434,7 @@ func ExampleCognitoIdentity_MergeDeveloperIdentities() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_SetIdentityPoolRoles() {
@@ -465,7 +465,7 @@ func ExampleCognitoIdentity_SetIdentityPoolRoles() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_UnlinkDeveloperIdentity() {
@@ -495,7 +495,7 @@ func ExampleCognitoIdentity_UnlinkDeveloperIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_UnlinkIdentity() {
@@ -530,14 +530,14 @@ func ExampleCognitoIdentity_UnlinkIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoIdentity_UpdateIdentityPool() {
 	svc := cognitoidentity.New(nil)
 
 	params := &cognitoidentity.IdentityPool{
-		AllowUnauthenticatedIdentities: aws.Boolean(true),              // Required
+		AllowUnauthenticatedIdentities: aws.Bool(true),
 		IdentityPoolID:                 aws.String("IdentityPoolId"),   // Required
 		IdentityPoolName:               aws.String("IdentityPoolName"), // Required
 		DeveloperProviderName:          aws.String("DeveloperProviderName"),
@@ -568,5 +568,5 @@ func ExampleCognitoIdentity_UpdateIdentityPool() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -572,7 +572,7 @@ type metadataBulkPublishInput struct {
 
 // String returns the string representation
 func (s BulkPublishInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -595,7 +595,7 @@ type metadataBulkPublishOutput struct {
 
 // String returns the string representation
 func (s BulkPublishOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -630,7 +630,7 @@ type metadataCognitoStreams struct {
 
 // String returns the string representation
 func (s CognitoStreams) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -676,7 +676,7 @@ type metadataDataset struct {
 
 // String returns the string representation
 func (s Dataset) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -707,7 +707,7 @@ type metadataDeleteDatasetInput struct {
 
 // String returns the string representation
 func (s DeleteDatasetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -733,7 +733,7 @@ type metadataDeleteDatasetOutput struct {
 
 // String returns the string representation
 func (s DeleteDatasetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -765,7 +765,7 @@ type metadataDescribeDatasetInput struct {
 
 // String returns the string representation
 func (s DescribeDatasetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -791,7 +791,7 @@ type metadataDescribeDatasetOutput struct {
 
 // String returns the string representation
 func (s DescribeDatasetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -814,7 +814,7 @@ type metadataDescribeIdentityPoolUsageInput struct {
 
 // String returns the string representation
 func (s DescribeIdentityPoolUsageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -836,7 +836,7 @@ type metadataDescribeIdentityPoolUsageOutput struct {
 
 // String returns the string representation
 func (s DescribeIdentityPoolUsageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -863,7 +863,7 @@ type metadataDescribeIdentityUsageInput struct {
 
 // String returns the string representation
 func (s DescribeIdentityUsageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -885,7 +885,7 @@ type metadataDescribeIdentityUsageOutput struct {
 
 // String returns the string representation
 func (s DescribeIdentityUsageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -908,7 +908,7 @@ type metadataGetBulkPublishDetailsInput struct {
 
 // String returns the string representation
 func (s GetBulkPublishDetailsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -954,7 +954,7 @@ type metadataGetBulkPublishDetailsOutput struct {
 
 // String returns the string representation
 func (s GetBulkPublishDetailsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -976,7 +976,7 @@ type metadataGetCognitoEventsInput struct {
 
 // String returns the string representation
 func (s GetCognitoEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -998,7 +998,7 @@ type metadataGetCognitoEventsOutput struct {
 
 // String returns the string representation
 func (s GetCognitoEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1022,7 +1022,7 @@ type metadataGetIdentityPoolConfigurationInput struct {
 
 // String returns the string representation
 func (s GetIdentityPoolConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1051,7 +1051,7 @@ type metadataGetIdentityPoolConfigurationOutput struct {
 
 // String returns the string representation
 func (s GetIdentityPoolConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1083,7 +1083,7 @@ type metadataIdentityPoolUsage struct {
 
 // String returns the string representation
 func (s IdentityPoolUsage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1119,7 +1119,7 @@ type metadataIdentityUsage struct {
 
 // String returns the string representation
 func (s IdentityUsage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1152,7 +1152,7 @@ type metadataListDatasetsInput struct {
 
 // String returns the string representation
 func (s ListDatasetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1180,7 +1180,7 @@ type metadataListDatasetsOutput struct {
 
 // String returns the string representation
 func (s ListDatasetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1205,7 +1205,7 @@ type metadataListIdentityPoolUsageInput struct {
 
 // String returns the string representation
 func (s ListIdentityPoolUsageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1236,7 +1236,7 @@ type metadataListIdentityPoolUsageOutput struct {
 
 // String returns the string representation
 func (s ListIdentityPoolUsageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1279,7 +1279,7 @@ type metadataListRecordsInput struct {
 
 // String returns the string representation
 func (s ListRecordsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1325,7 +1325,7 @@ type metadataListRecordsOutput struct {
 
 // String returns the string representation
 func (s ListRecordsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1350,7 +1350,7 @@ type metadataPushSync struct {
 
 // String returns the string representation
 func (s PushSync) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1387,7 +1387,7 @@ type metadataRecord struct {
 
 // String returns the string representation
 func (s Record) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1421,7 +1421,7 @@ type metadataRecordPatch struct {
 
 // String returns the string representation
 func (s RecordPatch) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1454,7 +1454,7 @@ type metadataRegisterDeviceInput struct {
 
 // String returns the string representation
 func (s RegisterDeviceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1476,7 +1476,7 @@ type metadataRegisterDeviceOutput struct {
 
 // String returns the string representation
 func (s RegisterDeviceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1503,7 +1503,7 @@ type metadataSetCognitoEventsInput struct {
 
 // String returns the string representation
 func (s SetCognitoEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1521,7 +1521,7 @@ type metadataSetCognitoEventsOutput struct {
 
 // String returns the string representation
 func (s SetCognitoEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1550,7 +1550,7 @@ type metadataSetIdentityPoolConfigurationInput struct {
 
 // String returns the string representation
 func (s SetIdentityPoolConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1579,7 +1579,7 @@ type metadataSetIdentityPoolConfigurationOutput struct {
 
 // String returns the string representation
 func (s SetIdentityPoolConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1611,7 +1611,7 @@ type metadataSubscribeToDatasetInput struct {
 
 // String returns the string representation
 func (s SubscribeToDatasetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1630,7 +1630,7 @@ type metadataSubscribeToDatasetOutput struct {
 
 // String returns the string representation
 func (s SubscribeToDatasetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1662,7 +1662,7 @@ type metadataUnsubscribeFromDatasetInput struct {
 
 // String returns the string representation
 func (s UnsubscribeFromDatasetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1681,7 +1681,7 @@ type metadataUnsubscribeFromDatasetOutput struct {
 
 // String returns the string representation
 func (s UnsubscribeFromDatasetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1727,7 +1727,7 @@ type metadataUpdateRecordsInput struct {
 
 // String returns the string representation
 func (s UpdateRecordsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1749,7 +1749,7 @@ type metadataUpdateRecordsOutput struct {
 
 // String returns the string representation
 func (s UpdateRecordsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/cognitosync/examples_test.go
+++ b/service/cognitosync/examples_test.go
@@ -40,7 +40,7 @@ func ExampleCognitoSync_BulkPublish() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_DeleteDataset() {
@@ -69,7 +69,7 @@ func ExampleCognitoSync_DeleteDataset() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_DescribeDataset() {
@@ -98,7 +98,7 @@ func ExampleCognitoSync_DescribeDataset() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_DescribeIdentityPoolUsage() {
@@ -125,7 +125,7 @@ func ExampleCognitoSync_DescribeIdentityPoolUsage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_DescribeIdentityUsage() {
@@ -153,7 +153,7 @@ func ExampleCognitoSync_DescribeIdentityUsage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_GetBulkPublishDetails() {
@@ -180,7 +180,7 @@ func ExampleCognitoSync_GetBulkPublishDetails() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_GetCognitoEvents() {
@@ -207,7 +207,7 @@ func ExampleCognitoSync_GetCognitoEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_GetIdentityPoolConfiguration() {
@@ -234,7 +234,7 @@ func ExampleCognitoSync_GetIdentityPoolConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_ListDatasets() {
@@ -243,7 +243,7 @@ func ExampleCognitoSync_ListDatasets() {
 	params := &cognitosync.ListDatasetsInput{
 		IdentityID:     aws.String("IdentityId"),     // Required
 		IdentityPoolID: aws.String("IdentityPoolId"), // Required
-		MaxResults:     aws.Long(1),
+		MaxResults:     aws.Int64(1),
 		NextToken:      aws.String("String"),
 	}
 	resp, err := svc.ListDatasets(params)
@@ -264,14 +264,14 @@ func ExampleCognitoSync_ListDatasets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_ListIdentityPoolUsage() {
 	svc := cognitosync.New(nil)
 
 	params := &cognitosync.ListIdentityPoolUsageInput{
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.ListIdentityPoolUsage(params)
@@ -292,7 +292,7 @@ func ExampleCognitoSync_ListIdentityPoolUsage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_ListRecords() {
@@ -302,8 +302,8 @@ func ExampleCognitoSync_ListRecords() {
 		DatasetName:      aws.String("DatasetName"),    // Required
 		IdentityID:       aws.String("IdentityId"),     // Required
 		IdentityPoolID:   aws.String("IdentityPoolId"), // Required
-		LastSyncCount:    aws.Long(1),
-		MaxResults:       aws.Long(1),
+		LastSyncCount:    aws.Int64(1),
+		MaxResults:       aws.Int64(1),
 		NextToken:        aws.String("String"),
 		SyncSessionToken: aws.String("SyncSessionToken"),
 	}
@@ -325,7 +325,7 @@ func ExampleCognitoSync_ListRecords() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_RegisterDevice() {
@@ -355,7 +355,7 @@ func ExampleCognitoSync_RegisterDevice() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_SetCognitoEvents() {
@@ -386,7 +386,7 @@ func ExampleCognitoSync_SetCognitoEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_SetIdentityPoolConfiguration() {
@@ -425,7 +425,7 @@ func ExampleCognitoSync_SetIdentityPoolConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_SubscribeToDataset() {
@@ -455,7 +455,7 @@ func ExampleCognitoSync_SubscribeToDataset() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_UnsubscribeFromDataset() {
@@ -485,7 +485,7 @@ func ExampleCognitoSync_UnsubscribeFromDataset() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleCognitoSync_UpdateRecords() {
@@ -502,7 +502,7 @@ func ExampleCognitoSync_UpdateRecords() {
 			{ // Required
 				Key:                    aws.String("RecordKey"), // Required
 				Op:                     aws.String("Operation"), // Required
-				SyncCount:              aws.Long(1),             // Required
+				SyncCount:              aws.Int64(1),            // Required
 				DeviceLastModifiedDate: aws.Time(time.Now()),
 				Value: aws.String("RecordValue"),
 			},
@@ -527,5 +527,5 @@ func ExampleCognitoSync_UpdateRecords() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -406,7 +406,7 @@ type metadataConfigExportDeliveryInfo struct {
 
 // String returns the string representation
 func (s ConfigExportDeliveryInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -442,7 +442,7 @@ type metadataConfigStreamDeliveryInfo struct {
 
 // String returns the string representation
 func (s ConfigStreamDeliveryInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -520,7 +520,7 @@ type metadataConfigurationItem struct {
 
 // String returns the string representation
 func (s ConfigurationItem) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -554,7 +554,7 @@ type metadataConfigurationRecorder struct {
 
 // String returns the string representation
 func (s ConfigurationRecorder) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -597,7 +597,7 @@ type metadataConfigurationRecorderStatus struct {
 
 // String returns the string representation
 func (s ConfigurationRecorderStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -620,7 +620,7 @@ type metadataDeleteDeliveryChannelInput struct {
 
 // String returns the string representation
 func (s DeleteDeliveryChannelInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -638,7 +638,7 @@ type metadataDeleteDeliveryChannelOutput struct {
 
 // String returns the string representation
 func (s DeleteDeliveryChannelOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -660,7 +660,7 @@ type metadataDeliverConfigSnapshotInput struct {
 
 // String returns the string representation
 func (s DeliverConfigSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -682,7 +682,7 @@ type metadataDeliverConfigSnapshotOutput struct {
 
 // String returns the string representation
 func (s DeliverConfigSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -718,7 +718,7 @@ type metadataDeliveryChannel struct {
 
 // String returns the string representation
 func (s DeliveryChannel) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -754,7 +754,7 @@ type metadataDeliveryChannelStatus struct {
 
 // String returns the string representation
 func (s DeliveryChannelStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -778,7 +778,7 @@ type metadataDescribeConfigurationRecorderStatusInput struct {
 
 // String returns the string representation
 func (s DescribeConfigurationRecorderStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -800,7 +800,7 @@ type metadataDescribeConfigurationRecorderStatusOutput struct {
 
 // String returns the string representation
 func (s DescribeConfigurationRecorderStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -822,7 +822,7 @@ type metadataDescribeConfigurationRecordersInput struct {
 
 // String returns the string representation
 func (s DescribeConfigurationRecordersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -844,7 +844,7 @@ type metadataDescribeConfigurationRecordersOutput struct {
 
 // String returns the string representation
 func (s DescribeConfigurationRecordersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -866,7 +866,7 @@ type metadataDescribeDeliveryChannelStatusInput struct {
 
 // String returns the string representation
 func (s DescribeDeliveryChannelStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -888,7 +888,7 @@ type metadataDescribeDeliveryChannelStatusOutput struct {
 
 // String returns the string representation
 func (s DescribeDeliveryChannelStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -910,7 +910,7 @@ type metadataDescribeDeliveryChannelsInput struct {
 
 // String returns the string representation
 func (s DescribeDeliveryChannelsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -932,7 +932,7 @@ type metadataDescribeDeliveryChannelsOutput struct {
 
 // String returns the string representation
 func (s DescribeDeliveryChannelsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -977,7 +977,7 @@ type metadataGetResourceConfigHistoryInput struct {
 
 // String returns the string representation
 func (s GetResourceConfigHistoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1002,7 +1002,7 @@ type metadataGetResourceConfigHistoryOutput struct {
 
 // String returns the string representation
 func (s GetResourceConfigHistoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1025,7 +1025,7 @@ type metadataPutConfigurationRecorderInput struct {
 
 // String returns the string representation
 func (s PutConfigurationRecorderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1043,7 +1043,7 @@ type metadataPutConfigurationRecorderOutput struct {
 
 // String returns the string representation
 func (s PutConfigurationRecorderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1066,7 +1066,7 @@ type metadataPutDeliveryChannelInput struct {
 
 // String returns the string representation
 func (s PutDeliveryChannelInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1084,7 +1084,7 @@ type metadataPutDeliveryChannelOutput struct {
 
 // String returns the string representation
 func (s PutDeliveryChannelOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1119,7 +1119,7 @@ type metadataRecordingGroup struct {
 
 // String returns the string representation
 func (s RecordingGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1147,7 +1147,7 @@ type metadataRelationship struct {
 
 // String returns the string representation
 func (s Relationship) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1170,7 +1170,7 @@ type metadataStartConfigurationRecorderInput struct {
 
 // String returns the string representation
 func (s StartConfigurationRecorderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1188,7 +1188,7 @@ type metadataStartConfigurationRecorderOutput struct {
 
 // String returns the string representation
 func (s StartConfigurationRecorderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1211,7 +1211,7 @@ type metadataStopConfigurationRecorderInput struct {
 
 // String returns the string representation
 func (s StopConfigurationRecorderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1229,7 +1229,7 @@ type metadataStopConfigurationRecorderOutput struct {
 
 // String returns the string representation
 func (s StopConfigurationRecorderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/configservice/examples_test.go
+++ b/service/configservice/examples_test.go
@@ -40,7 +40,7 @@ func ExampleConfigService_DeleteDeliveryChannel() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_DeliverConfigSnapshot() {
@@ -67,7 +67,7 @@ func ExampleConfigService_DeliverConfigSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_DescribeConfigurationRecorderStatus() {
@@ -97,7 +97,7 @@ func ExampleConfigService_DescribeConfigurationRecorderStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_DescribeConfigurationRecorders() {
@@ -127,7 +127,7 @@ func ExampleConfigService_DescribeConfigurationRecorders() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_DescribeDeliveryChannelStatus() {
@@ -157,7 +157,7 @@ func ExampleConfigService_DescribeDeliveryChannelStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_DescribeDeliveryChannels() {
@@ -187,7 +187,7 @@ func ExampleConfigService_DescribeDeliveryChannels() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_GetResourceConfigHistory() {
@@ -199,7 +199,7 @@ func ExampleConfigService_GetResourceConfigHistory() {
 		ChronologicalOrder: aws.String("ChronologicalOrder"),
 		EarlierTime:        aws.Time(time.Now()),
 		LaterTime:          aws.Time(time.Now()),
-		Limit:              aws.Long(1),
+		Limit:              aws.Int64(1),
 		NextToken:          aws.String("NextToken"),
 	}
 	resp, err := svc.GetResourceConfigHistory(params)
@@ -220,7 +220,7 @@ func ExampleConfigService_GetResourceConfigHistory() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_PutConfigurationRecorder() {
@@ -230,7 +230,7 @@ func ExampleConfigService_PutConfigurationRecorder() {
 		ConfigurationRecorder: &configservice.ConfigurationRecorder{ // Required
 			Name: aws.String("RecorderName"),
 			RecordingGroup: &configservice.RecordingGroup{
-				AllSupported: aws.Boolean(true),
+				AllSupported: aws.Bool(true),
 				ResourceTypes: []*string{
 					aws.String("ResourceType"), // Required
 					// More values...
@@ -257,7 +257,7 @@ func ExampleConfigService_PutConfigurationRecorder() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_PutDeliveryChannel() {
@@ -289,7 +289,7 @@ func ExampleConfigService_PutDeliveryChannel() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_StartConfigurationRecorder() {
@@ -316,7 +316,7 @@ func ExampleConfigService_StartConfigurationRecorder() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleConfigService_StopConfigurationRecorder() {
@@ -343,5 +343,5 @@ func ExampleConfigService_StopConfigurationRecorder() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -666,7 +666,7 @@ type metadataActivatePipelineInput struct {
 
 // String returns the string representation
 func (s ActivatePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -685,7 +685,7 @@ type metadataActivatePipelineOutput struct {
 
 // String returns the string representation
 func (s ActivatePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -710,7 +710,7 @@ type metadataAddTagsInput struct {
 
 // String returns the string representation
 func (s AddTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -729,7 +729,7 @@ type metadataAddTagsOutput struct {
 
 // String returns the string representation
 func (s AddTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -775,7 +775,7 @@ type metadataCreatePipelineInput struct {
 
 // String returns the string representation
 func (s CreatePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -798,7 +798,7 @@ type metadataCreatePipelineOutput struct {
 
 // String returns the string representation
 func (s CreatePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -825,7 +825,7 @@ type metadataDeactivatePipelineInput struct {
 
 // String returns the string representation
 func (s DeactivatePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -844,7 +844,7 @@ type metadataDeactivatePipelineOutput struct {
 
 // String returns the string representation
 func (s DeactivatePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -866,7 +866,7 @@ type metadataDeletePipelineInput struct {
 
 // String returns the string representation
 func (s DeletePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -884,7 +884,7 @@ type metadataDeletePipelineOutput struct {
 
 // String returns the string representation
 func (s DeletePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -920,7 +920,7 @@ type metadataDescribeObjectsInput struct {
 
 // String returns the string representation
 func (s DescribeObjectsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -950,7 +950,7 @@ type metadataDescribeObjectsOutput struct {
 
 // String returns the string representation
 func (s DescribeObjectsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -973,7 +973,7 @@ type metadataDescribePipelinesInput struct {
 
 // String returns the string representation
 func (s DescribePipelinesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -995,7 +995,7 @@ type metadataDescribePipelinesOutput struct {
 
 // String returns the string representation
 func (s DescribePipelinesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1023,7 +1023,7 @@ type metadataEvaluateExpressionInput struct {
 
 // String returns the string representation
 func (s EvaluateExpressionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1045,7 +1045,7 @@ type metadataEvaluateExpressionOutput struct {
 
 // String returns the string representation
 func (s EvaluateExpressionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1075,7 +1075,7 @@ type metadataField struct {
 
 // String returns the string representation
 func (s Field) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1102,7 +1102,7 @@ type metadataGetPipelineDefinitionInput struct {
 
 // String returns the string representation
 func (s GetPipelineDefinitionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1130,7 +1130,7 @@ type metadataGetPipelineDefinitionOutput struct {
 
 // String returns the string representation
 func (s GetPipelineDefinitionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1163,7 +1163,7 @@ type metadataInstanceIdentity struct {
 
 // String returns the string representation
 func (s InstanceIdentity) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1188,7 +1188,7 @@ type metadataListPipelinesInput struct {
 
 // String returns the string representation
 func (s ListPipelinesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1220,7 +1220,7 @@ type metadataListPipelinesOutput struct {
 
 // String returns the string representation
 func (s ListPipelinesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1263,7 +1263,7 @@ type metadataOperator struct {
 
 // String returns the string representation
 func (s Operator) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1288,7 +1288,7 @@ type metadataParameterAttribute struct {
 
 // String returns the string representation
 func (s ParameterAttribute) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1313,7 +1313,7 @@ type metadataParameterObject struct {
 
 // String returns the string representation
 func (s ParameterObject) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1338,7 +1338,7 @@ type metadataParameterValue struct {
 
 // String returns the string representation
 func (s ParameterValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1377,7 +1377,7 @@ type metadataPipelineDescription struct {
 
 // String returns the string representation
 func (s PipelineDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1403,7 +1403,7 @@ type metadataPipelineIDName struct {
 
 // String returns the string representation
 func (s PipelineIDName) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1433,7 +1433,7 @@ type metadataPipelineObject struct {
 
 // String returns the string representation
 func (s PipelineObject) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1470,7 +1470,7 @@ type metadataPollForTaskInput struct {
 
 // String returns the string representation
 func (s PollForTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1495,7 +1495,7 @@ type metadataPollForTaskOutput struct {
 
 // String returns the string representation
 func (s PollForTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1527,7 +1527,7 @@ type metadataPutPipelineDefinitionInput struct {
 
 // String returns the string representation
 func (s PutPipelineDefinitionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1557,7 +1557,7 @@ type metadataPutPipelineDefinitionOutput struct {
 
 // String returns the string representation
 func (s PutPipelineDefinitionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1580,7 +1580,7 @@ type metadataQuery struct {
 
 // String returns the string representation
 func (s Query) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1622,7 +1622,7 @@ type metadataQueryObjectsInput struct {
 
 // String returns the string representation
 func (s QueryObjectsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1653,7 +1653,7 @@ type metadataQueryObjectsOutput struct {
 
 // String returns the string representation
 func (s QueryObjectsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1678,7 +1678,7 @@ type metadataRemoveTagsInput struct {
 
 // String returns the string representation
 func (s RemoveTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1697,7 +1697,7 @@ type metadataRemoveTagsOutput struct {
 
 // String returns the string representation
 func (s RemoveTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1724,7 +1724,7 @@ type metadataReportTaskProgressInput struct {
 
 // String returns the string representation
 func (s ReportTaskProgressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1747,7 +1747,7 @@ type metadataReportTaskProgressOutput struct {
 
 // String returns the string representation
 func (s ReportTaskProgressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1783,7 +1783,7 @@ type metadataReportTaskRunnerHeartbeatInput struct {
 
 // String returns the string representation
 func (s ReportTaskRunnerHeartbeatInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1805,7 +1805,7 @@ type metadataReportTaskRunnerHeartbeatOutput struct {
 
 // String returns the string representation
 func (s ReportTaskRunnerHeartbeatOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1835,7 +1835,7 @@ type metadataSelector struct {
 
 // String returns the string representation
 func (s Selector) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1865,7 +1865,7 @@ type metadataSetStatusInput struct {
 
 // String returns the string representation
 func (s SetStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1883,7 +1883,7 @@ type metadataSetStatusOutput struct {
 
 // String returns the string representation
 func (s SetStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1928,7 +1928,7 @@ type metadataSetTaskStatusInput struct {
 
 // String returns the string representation
 func (s SetTaskStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1947,7 +1947,7 @@ type metadataSetTaskStatusOutput struct {
 
 // String returns the string representation
 func (s SetTaskStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1980,7 +1980,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2014,7 +2014,7 @@ type metadataTaskObject struct {
 
 // String returns the string representation
 func (s TaskObject) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2045,7 +2045,7 @@ type metadataValidatePipelineDefinitionInput struct {
 
 // String returns the string representation
 func (s ValidatePipelineDefinitionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2073,7 +2073,7 @@ type metadataValidatePipelineDefinitionOutput struct {
 
 // String returns the string representation
 func (s ValidatePipelineDefinitionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2100,7 +2100,7 @@ type metadataValidationError struct {
 
 // String returns the string representation
 func (s ValidationError) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2127,7 +2127,7 @@ type metadataValidationWarning struct {
 
 // String returns the string representation
 func (s ValidationWarning) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/datapipeline/examples_test.go
+++ b/service/datapipeline/examples_test.go
@@ -48,7 +48,7 @@ func ExampleDataPipeline_ActivatePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_AddTags() {
@@ -82,7 +82,7 @@ func ExampleDataPipeline_AddTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_CreatePipeline() {
@@ -118,7 +118,7 @@ func ExampleDataPipeline_CreatePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_DeactivatePipeline() {
@@ -126,7 +126,7 @@ func ExampleDataPipeline_DeactivatePipeline() {
 
 	params := &datapipeline.DeactivatePipelineInput{
 		PipelineID:   aws.String("id"), // Required
-		CancelActive: aws.Boolean(true),
+		CancelActive: aws.Bool(true),
 	}
 	resp, err := svc.DeactivatePipeline(params)
 
@@ -146,7 +146,7 @@ func ExampleDataPipeline_DeactivatePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_DeletePipeline() {
@@ -173,7 +173,7 @@ func ExampleDataPipeline_DeletePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_DescribeObjects() {
@@ -185,7 +185,7 @@ func ExampleDataPipeline_DescribeObjects() {
 			// More values...
 		},
 		PipelineID:          aws.String("id"), // Required
-		EvaluateExpressions: aws.Boolean(true),
+		EvaluateExpressions: aws.Bool(true),
 		Marker:              aws.String("string"),
 	}
 	resp, err := svc.DescribeObjects(params)
@@ -206,7 +206,7 @@ func ExampleDataPipeline_DescribeObjects() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_DescribePipelines() {
@@ -236,7 +236,7 @@ func ExampleDataPipeline_DescribePipelines() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_EvaluateExpression() {
@@ -265,7 +265,7 @@ func ExampleDataPipeline_EvaluateExpression() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_GetPipelineDefinition() {
@@ -293,7 +293,7 @@ func ExampleDataPipeline_GetPipelineDefinition() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_ListPipelines() {
@@ -320,7 +320,7 @@ func ExampleDataPipeline_ListPipelines() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_PollForTask() {
@@ -352,7 +352,7 @@ func ExampleDataPipeline_PollForTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_PutPipelineDefinition() {
@@ -414,7 +414,7 @@ func ExampleDataPipeline_PutPipelineDefinition() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_QueryObjects() {
@@ -423,7 +423,7 @@ func ExampleDataPipeline_QueryObjects() {
 	params := &datapipeline.QueryObjectsInput{
 		PipelineID: aws.String("id"),     // Required
 		Sphere:     aws.String("string"), // Required
-		Limit:      aws.Long(1),
+		Limit:      aws.Int64(1),
 		Marker:     aws.String("string"),
 		Query: &datapipeline.Query{
 			Selectors: []*datapipeline.Selector{
@@ -459,7 +459,7 @@ func ExampleDataPipeline_QueryObjects() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_RemoveTags() {
@@ -490,7 +490,7 @@ func ExampleDataPipeline_RemoveTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_ReportTaskProgress() {
@@ -525,7 +525,7 @@ func ExampleDataPipeline_ReportTaskProgress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_ReportTaskRunnerHeartbeat() {
@@ -554,7 +554,7 @@ func ExampleDataPipeline_ReportTaskRunnerHeartbeat() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_SetStatus() {
@@ -586,7 +586,7 @@ func ExampleDataPipeline_SetStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_SetTaskStatus() {
@@ -617,7 +617,7 @@ func ExampleDataPipeline_SetTaskStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDataPipeline_ValidatePipelineDefinition() {
@@ -679,5 +679,5 @@ func ExampleDataPipeline_ValidatePipelineDefinition() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -654,7 +654,7 @@ type metadataAllocateConnectionOnInterconnectInput struct {
 
 // String returns the string representation
 func (s AllocateConnectionOnInterconnectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -688,7 +688,7 @@ type metadataAllocatePrivateVirtualInterfaceInput struct {
 
 // String returns the string representation
 func (s AllocatePrivateVirtualInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -722,7 +722,7 @@ type metadataAllocatePublicVirtualInterfaceInput struct {
 
 // String returns the string representation
 func (s AllocatePublicVirtualInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -748,7 +748,7 @@ type metadataConfirmConnectionInput struct {
 
 // String returns the string representation
 func (s ConfirmConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -779,7 +779,7 @@ type metadataConfirmConnectionOutput struct {
 
 // String returns the string representation
 func (s ConfirmConnectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -814,7 +814,7 @@ type metadataConfirmPrivateVirtualInterfaceInput struct {
 
 // String returns the string representation
 func (s ConfirmPrivateVirtualInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -851,7 +851,7 @@ type metadataConfirmPrivateVirtualInterfaceOutput struct {
 
 // String returns the string representation
 func (s ConfirmPrivateVirtualInterfaceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -877,7 +877,7 @@ type metadataConfirmPublicVirtualInterfaceInput struct {
 
 // String returns the string representation
 func (s ConfirmPublicVirtualInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -914,7 +914,7 @@ type metadataConfirmPublicVirtualInterfaceOutput struct {
 
 // String returns the string representation
 func (s ConfirmPublicVirtualInterfaceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -990,7 +990,7 @@ type metadataConnection struct {
 
 // String returns the string representation
 func (s Connection) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1012,7 +1012,7 @@ type metadataConnections struct {
 
 // String returns the string representation
 func (s Connections) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1052,7 +1052,7 @@ type metadataCreateConnectionInput struct {
 
 // String returns the string representation
 func (s CreateConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1094,7 +1094,7 @@ type metadataCreateInterconnectInput struct {
 
 // String returns the string representation
 func (s CreateInterconnectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1125,7 +1125,7 @@ type metadataCreatePrivateVirtualInterfaceInput struct {
 
 // String returns the string representation
 func (s CreatePrivateVirtualInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1156,7 +1156,7 @@ type metadataCreatePublicVirtualInterfaceInput struct {
 
 // String returns the string representation
 func (s CreatePublicVirtualInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1182,7 +1182,7 @@ type metadataDeleteConnectionInput struct {
 
 // String returns the string representation
 func (s DeleteConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1206,7 +1206,7 @@ type metadataDeleteInterconnectInput struct {
 
 // String returns the string representation
 func (s DeleteInterconnectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1233,7 +1233,7 @@ type metadataDeleteInterconnectOutput struct {
 
 // String returns the string representation
 func (s DeleteInterconnectOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1259,7 +1259,7 @@ type metadataDeleteVirtualInterfaceInput struct {
 
 // String returns the string representation
 func (s DeleteVirtualInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1296,7 +1296,7 @@ type metadataDeleteVirtualInterfaceOutput struct {
 
 // String returns the string representation
 func (s DeleteVirtualInterfaceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1322,7 +1322,7 @@ type metadataDescribeConnectionsInput struct {
 
 // String returns the string representation
 func (s DescribeConnectionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1348,7 +1348,7 @@ type metadataDescribeConnectionsOnInterconnectInput struct {
 
 // String returns the string representation
 func (s DescribeConnectionsOnInterconnectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1372,7 +1372,7 @@ type metadataDescribeInterconnectsInput struct {
 
 // String returns the string representation
 func (s DescribeInterconnectsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1394,7 +1394,7 @@ type metadataDescribeInterconnectsOutput struct {
 
 // String returns the string representation
 func (s DescribeInterconnectsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1412,7 +1412,7 @@ type metadataDescribeLocationsInput struct {
 
 // String returns the string representation
 func (s DescribeLocationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1432,7 +1432,7 @@ type metadataDescribeLocationsOutput struct {
 
 // String returns the string representation
 func (s DescribeLocationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1450,7 +1450,7 @@ type metadataDescribeVirtualGatewaysInput struct {
 
 // String returns the string representation
 func (s DescribeVirtualGatewaysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1472,7 +1472,7 @@ type metadataDescribeVirtualGatewaysOutput struct {
 
 // String returns the string representation
 func (s DescribeVirtualGatewaysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1505,7 +1505,7 @@ type metadataDescribeVirtualInterfacesInput struct {
 
 // String returns the string representation
 func (s DescribeVirtualInterfacesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1527,7 +1527,7 @@ type metadataDescribeVirtualInterfacesOutput struct {
 
 // String returns the string representation
 func (s DescribeVirtualInterfacesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1596,7 +1596,7 @@ type metadataInterconnect struct {
 
 // String returns the string representation
 func (s Interconnect) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1623,7 +1623,7 @@ type metadataLocation struct {
 
 // String returns the string representation
 func (s Location) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1678,7 +1678,7 @@ type metadataNewPrivateVirtualInterface struct {
 
 // String returns the string representation
 func (s NewPrivateVirtualInterface) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1728,7 +1728,7 @@ type metadataNewPrivateVirtualInterfaceAllocation struct {
 
 // String returns the string representation
 func (s NewPrivateVirtualInterfaceAllocation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1781,7 +1781,7 @@ type metadataNewPublicVirtualInterface struct {
 
 // String returns the string representation
 func (s NewPublicVirtualInterface) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1835,7 +1835,7 @@ type metadataNewPublicVirtualInterfaceAllocation struct {
 
 // String returns the string representation
 func (s NewPublicVirtualInterfaceAllocation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1861,7 +1861,7 @@ type metadataRouteFilterPrefix struct {
 
 // String returns the string representation
 func (s RouteFilterPrefix) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1897,7 +1897,7 @@ type metadataVirtualGateway struct {
 
 // String returns the string representation
 func (s VirtualGateway) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2007,7 +2007,7 @@ type metadataVirtualInterface struct {
 
 // String returns the string representation
 func (s VirtualInterface) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/directconnect/examples_test.go
+++ b/service/directconnect/examples_test.go
@@ -24,7 +24,7 @@ func ExampleDirectConnect_AllocateConnectionOnInterconnect() {
 		ConnectionName: aws.String("ConnectionName"), // Required
 		InterconnectID: aws.String("InterconnectId"), // Required
 		OwnerAccount:   aws.String("OwnerAccount"),   // Required
-		VLAN:           aws.Long(1),                  // Required
+		VLAN:           aws.Int64(1),                 // Required
 	}
 	resp, err := svc.AllocateConnectionOnInterconnect(params)
 
@@ -44,7 +44,7 @@ func ExampleDirectConnect_AllocateConnectionOnInterconnect() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_AllocatePrivateVirtualInterface() {
@@ -53,8 +53,8 @@ func ExampleDirectConnect_AllocatePrivateVirtualInterface() {
 	params := &directconnect.AllocatePrivateVirtualInterfaceInput{
 		ConnectionID: aws.String("ConnectionId"), // Required
 		NewPrivateVirtualInterfaceAllocation: &directconnect.NewPrivateVirtualInterfaceAllocation{ // Required
-			ASN:                  aws.Long(1),                        // Required
-			VLAN:                 aws.Long(1),                        // Required
+			ASN:                  aws.Int64(1),                       // Required
+			VLAN:                 aws.Int64(1),                       // Required
 			VirtualInterfaceName: aws.String("VirtualInterfaceName"), // Required
 			AmazonAddress:        aws.String("AmazonAddress"),
 			AuthKey:              aws.String("BGPAuthKey"),
@@ -80,7 +80,7 @@ func ExampleDirectConnect_AllocatePrivateVirtualInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_AllocatePublicVirtualInterface() {
@@ -89,7 +89,7 @@ func ExampleDirectConnect_AllocatePublicVirtualInterface() {
 	params := &directconnect.AllocatePublicVirtualInterfaceInput{
 		ConnectionID: aws.String("ConnectionId"), // Required
 		NewPublicVirtualInterfaceAllocation: &directconnect.NewPublicVirtualInterfaceAllocation{ // Required
-			ASN:             aws.Long(1),                   // Required
+			ASN:             aws.Int64(1),                  // Required
 			AmazonAddress:   aws.String("AmazonAddress"),   // Required
 			CustomerAddress: aws.String("CustomerAddress"), // Required
 			RouteFilterPrefixes: []*directconnect.RouteFilterPrefix{ // Required
@@ -98,7 +98,7 @@ func ExampleDirectConnect_AllocatePublicVirtualInterface() {
 				},
 				// More values...
 			},
-			VLAN:                 aws.Long(1),                        // Required
+			VLAN:                 aws.Int64(1),                       // Required
 			VirtualInterfaceName: aws.String("VirtualInterfaceName"), // Required
 			AuthKey:              aws.String("BGPAuthKey"),
 		},
@@ -122,7 +122,7 @@ func ExampleDirectConnect_AllocatePublicVirtualInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_ConfirmConnection() {
@@ -149,7 +149,7 @@ func ExampleDirectConnect_ConfirmConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_ConfirmPrivateVirtualInterface() {
@@ -177,7 +177,7 @@ func ExampleDirectConnect_ConfirmPrivateVirtualInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_ConfirmPublicVirtualInterface() {
@@ -204,7 +204,7 @@ func ExampleDirectConnect_ConfirmPublicVirtualInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_CreateConnection() {
@@ -233,7 +233,7 @@ func ExampleDirectConnect_CreateConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_CreateInterconnect() {
@@ -262,7 +262,7 @@ func ExampleDirectConnect_CreateInterconnect() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_CreatePrivateVirtualInterface() {
@@ -271,8 +271,8 @@ func ExampleDirectConnect_CreatePrivateVirtualInterface() {
 	params := &directconnect.CreatePrivateVirtualInterfaceInput{
 		ConnectionID: aws.String("ConnectionId"), // Required
 		NewPrivateVirtualInterface: &directconnect.NewPrivateVirtualInterface{ // Required
-			ASN:                  aws.Long(1),                        // Required
-			VLAN:                 aws.Long(1),                        // Required
+			ASN:                  aws.Int64(1),                       // Required
+			VLAN:                 aws.Int64(1),                       // Required
 			VirtualGatewayID:     aws.String("VirtualGatewayId"),     // Required
 			VirtualInterfaceName: aws.String("VirtualInterfaceName"), // Required
 			AmazonAddress:        aws.String("AmazonAddress"),
@@ -298,7 +298,7 @@ func ExampleDirectConnect_CreatePrivateVirtualInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_CreatePublicVirtualInterface() {
@@ -307,7 +307,7 @@ func ExampleDirectConnect_CreatePublicVirtualInterface() {
 	params := &directconnect.CreatePublicVirtualInterfaceInput{
 		ConnectionID: aws.String("ConnectionId"), // Required
 		NewPublicVirtualInterface: &directconnect.NewPublicVirtualInterface{ // Required
-			ASN:             aws.Long(1),                   // Required
+			ASN:             aws.Int64(1),                  // Required
 			AmazonAddress:   aws.String("AmazonAddress"),   // Required
 			CustomerAddress: aws.String("CustomerAddress"), // Required
 			RouteFilterPrefixes: []*directconnect.RouteFilterPrefix{ // Required
@@ -316,7 +316,7 @@ func ExampleDirectConnect_CreatePublicVirtualInterface() {
 				},
 				// More values...
 			},
-			VLAN:                 aws.Long(1),                        // Required
+			VLAN:                 aws.Int64(1),                       // Required
 			VirtualInterfaceName: aws.String("VirtualInterfaceName"), // Required
 			AuthKey:              aws.String("BGPAuthKey"),
 		},
@@ -339,7 +339,7 @@ func ExampleDirectConnect_CreatePublicVirtualInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DeleteConnection() {
@@ -366,7 +366,7 @@ func ExampleDirectConnect_DeleteConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DeleteInterconnect() {
@@ -393,7 +393,7 @@ func ExampleDirectConnect_DeleteInterconnect() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DeleteVirtualInterface() {
@@ -420,7 +420,7 @@ func ExampleDirectConnect_DeleteVirtualInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DescribeConnections() {
@@ -447,7 +447,7 @@ func ExampleDirectConnect_DescribeConnections() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DescribeConnectionsOnInterconnect() {
@@ -474,7 +474,7 @@ func ExampleDirectConnect_DescribeConnectionsOnInterconnect() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DescribeInterconnects() {
@@ -501,7 +501,7 @@ func ExampleDirectConnect_DescribeInterconnects() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DescribeLocations() {
@@ -526,7 +526,7 @@ func ExampleDirectConnect_DescribeLocations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DescribeVirtualGateways() {
@@ -551,7 +551,7 @@ func ExampleDirectConnect_DescribeVirtualGateways() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectConnect_DescribeVirtualInterfaces() {
@@ -579,5 +579,5 @@ func ExampleDirectConnect_DescribeVirtualInterfaces() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -523,7 +523,7 @@ type metadataAttribute struct {
 
 // String returns the string representation
 func (s Attribute) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -552,7 +552,7 @@ type metadataComputer struct {
 
 // String returns the string representation
 func (s Computer) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -590,7 +590,7 @@ type metadataConnectDirectoryInput struct {
 
 // String returns the string representation
 func (s ConnectDirectoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -612,7 +612,7 @@ type metadataConnectDirectoryOutput struct {
 
 // String returns the string representation
 func (s ConnectDirectoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -640,7 +640,7 @@ type metadataCreateAliasInput struct {
 
 // String returns the string representation
 func (s CreateAliasInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -665,7 +665,7 @@ type metadataCreateAliasOutput struct {
 
 // String returns the string representation
 func (s CreateAliasOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -702,7 +702,7 @@ type metadataCreateComputerInput struct {
 
 // String returns the string representation
 func (s CreateComputerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -724,7 +724,7 @@ type metadataCreateComputerOutput struct {
 
 // String returns the string representation
 func (s CreateComputerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -764,7 +764,7 @@ type metadataCreateDirectoryInput struct {
 
 // String returns the string representation
 func (s CreateDirectoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -786,7 +786,7 @@ type metadataCreateDirectoryOutput struct {
 
 // String returns the string representation
 func (s CreateDirectoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -811,7 +811,7 @@ type metadataCreateSnapshotInput struct {
 
 // String returns the string representation
 func (s CreateSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -833,7 +833,7 @@ type metadataCreateSnapshotOutput struct {
 
 // String returns the string representation
 func (s CreateSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -855,7 +855,7 @@ type metadataDeleteDirectoryInput struct {
 
 // String returns the string representation
 func (s DeleteDirectoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -877,7 +877,7 @@ type metadataDeleteDirectoryOutput struct {
 
 // String returns the string representation
 func (s DeleteDirectoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -899,7 +899,7 @@ type metadataDeleteSnapshotInput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -921,7 +921,7 @@ type metadataDeleteSnapshotOutput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -955,7 +955,7 @@ type metadataDescribeDirectoriesInput struct {
 
 // String returns the string representation
 func (s DescribeDirectoriesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -987,7 +987,7 @@ type metadataDescribeDirectoriesOutput struct {
 
 // String returns the string representation
 func (s DescribeDirectoriesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1021,7 +1021,7 @@ type metadataDescribeSnapshotsInput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1052,7 +1052,7 @@ type metadataDescribeSnapshotsOutput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1089,7 +1089,7 @@ type metadataDirectoryConnectSettings struct {
 
 // String returns the string representation
 func (s DirectoryConnectSettings) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1126,7 +1126,7 @@ type metadataDirectoryConnectSettingsDescription struct {
 
 // String returns the string representation
 func (s DirectoryConnectSettingsDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1209,7 +1209,7 @@ type metadataDirectoryDescription struct {
 
 // String returns the string representation
 func (s DirectoryDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1246,7 +1246,7 @@ type metadataDirectoryLimits struct {
 
 // String returns the string representation
 func (s DirectoryLimits) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1274,7 +1274,7 @@ type metadataDirectoryVPCSettings struct {
 
 // String returns the string representation
 func (s DirectoryVPCSettings) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1305,7 +1305,7 @@ type metadataDirectoryVPCSettingsDescription struct {
 
 // String returns the string representation
 func (s DirectoryVPCSettingsDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1327,7 +1327,7 @@ type metadataDisableRadiusInput struct {
 
 // String returns the string representation
 func (s DisableRadiusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1346,7 +1346,7 @@ type metadataDisableRadiusOutput struct {
 
 // String returns the string representation
 func (s DisableRadiusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1384,7 +1384,7 @@ type metadataDisableSSOInput struct {
 
 // String returns the string representation
 func (s DisableSSOInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1403,7 +1403,7 @@ type metadataDisableSSOOutput struct {
 
 // String returns the string representation
 func (s DisableSSOOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1428,7 +1428,7 @@ type metadataEnableRadiusInput struct {
 
 // String returns the string representation
 func (s EnableRadiusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1447,7 +1447,7 @@ type metadataEnableRadiusOutput struct {
 
 // String returns the string representation
 func (s EnableRadiusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1485,7 +1485,7 @@ type metadataEnableSSOInput struct {
 
 // String returns the string representation
 func (s EnableSSOInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1504,7 +1504,7 @@ type metadataEnableSSOOutput struct {
 
 // String returns the string representation
 func (s EnableSSOOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1523,7 +1523,7 @@ type metadataGetDirectoryLimitsInput struct {
 
 // String returns the string representation
 func (s GetDirectoryLimitsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1546,7 +1546,7 @@ type metadataGetDirectoryLimitsOutput struct {
 
 // String returns the string representation
 func (s GetDirectoryLimitsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1568,7 +1568,7 @@ type metadataGetSnapshotLimitsInput struct {
 
 // String returns the string representation
 func (s GetSnapshotLimitsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1591,7 +1591,7 @@ type metadataGetSnapshotLimitsOutput struct {
 
 // String returns the string representation
 func (s GetSnapshotLimitsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1640,7 +1640,7 @@ type metadataRadiusSettings struct {
 
 // String returns the string representation
 func (s RadiusSettings) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1662,7 +1662,7 @@ type metadataRestoreFromSnapshotInput struct {
 
 // String returns the string representation
 func (s RestoreFromSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1681,7 +1681,7 @@ type metadataRestoreFromSnapshotOutput struct {
 
 // String returns the string representation
 func (s RestoreFromSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1718,7 +1718,7 @@ type metadataSnapshot struct {
 
 // String returns the string representation
 func (s Snapshot) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1746,7 +1746,7 @@ type metadataSnapshotLimits struct {
 
 // String returns the string representation
 func (s SnapshotLimits) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1771,7 +1771,7 @@ type metadataUpdateRadiusInput struct {
 
 // String returns the string representation
 func (s UpdateRadiusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1790,7 +1790,7 @@ type metadataUpdateRadiusOutput struct {
 
 // String returns the string representation
 func (s UpdateRadiusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/directoryservice/examples_test.go
+++ b/service/directoryservice/examples_test.go
@@ -56,7 +56,7 @@ func ExampleDirectoryService_ConnectDirectory() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_CreateAlias() {
@@ -84,7 +84,7 @@ func ExampleDirectoryService_CreateAlias() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_CreateComputer() {
@@ -121,7 +121,7 @@ func ExampleDirectoryService_CreateComputer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_CreateDirectory() {
@@ -159,7 +159,7 @@ func ExampleDirectoryService_CreateDirectory() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_CreateSnapshot() {
@@ -187,7 +187,7 @@ func ExampleDirectoryService_CreateSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_DeleteDirectory() {
@@ -214,7 +214,7 @@ func ExampleDirectoryService_DeleteDirectory() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_DeleteSnapshot() {
@@ -241,7 +241,7 @@ func ExampleDirectoryService_DeleteSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_DescribeDirectories() {
@@ -252,7 +252,7 @@ func ExampleDirectoryService_DescribeDirectories() {
 			aws.String("DirectoryId"), // Required
 			// More values...
 		},
-		Limit:     aws.Long(1),
+		Limit:     aws.Int64(1),
 		NextToken: aws.String("NextToken"),
 	}
 	resp, err := svc.DescribeDirectories(params)
@@ -273,7 +273,7 @@ func ExampleDirectoryService_DescribeDirectories() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_DescribeSnapshots() {
@@ -281,7 +281,7 @@ func ExampleDirectoryService_DescribeSnapshots() {
 
 	params := &directoryservice.DescribeSnapshotsInput{
 		DirectoryID: aws.String("DirectoryId"),
-		Limit:       aws.Long(1),
+		Limit:       aws.Int64(1),
 		NextToken:   aws.String("NextToken"),
 		SnapshotIDs: []*string{
 			aws.String("SnapshotId"), // Required
@@ -306,7 +306,7 @@ func ExampleDirectoryService_DescribeSnapshots() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_DisableRadius() {
@@ -333,7 +333,7 @@ func ExampleDirectoryService_DisableRadius() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_DisableSSO() {
@@ -362,7 +362,7 @@ func ExampleDirectoryService_DisableSSO() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_EnableRadius() {
@@ -373,15 +373,15 @@ func ExampleDirectoryService_EnableRadius() {
 		RadiusSettings: &directoryservice.RadiusSettings{ // Required
 			AuthenticationProtocol: aws.String("RadiusAuthenticationProtocol"),
 			DisplayLabel:           aws.String("RadiusDisplayLabel"),
-			RadiusPort:             aws.Long(1),
-			RadiusRetries:          aws.Long(1),
+			RadiusPort:             aws.Int64(1),
+			RadiusRetries:          aws.Int64(1),
 			RadiusServers: []*string{
 				aws.String("Server"), // Required
 				// More values...
 			},
-			RadiusTimeout:   aws.Long(1),
+			RadiusTimeout:   aws.Int64(1),
 			SharedSecret:    aws.String("RadiusSharedSecret"),
-			UseSameUsername: aws.Boolean(true),
+			UseSameUsername: aws.Bool(true),
 		},
 	}
 	resp, err := svc.EnableRadius(params)
@@ -402,7 +402,7 @@ func ExampleDirectoryService_EnableRadius() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_EnableSSO() {
@@ -431,7 +431,7 @@ func ExampleDirectoryService_EnableSSO() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_GetDirectoryLimits() {
@@ -456,7 +456,7 @@ func ExampleDirectoryService_GetDirectoryLimits() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_GetSnapshotLimits() {
@@ -483,7 +483,7 @@ func ExampleDirectoryService_GetSnapshotLimits() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_RestoreFromSnapshot() {
@@ -510,7 +510,7 @@ func ExampleDirectoryService_RestoreFromSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDirectoryService_UpdateRadius() {
@@ -521,15 +521,15 @@ func ExampleDirectoryService_UpdateRadius() {
 		RadiusSettings: &directoryservice.RadiusSettings{ // Required
 			AuthenticationProtocol: aws.String("RadiusAuthenticationProtocol"),
 			DisplayLabel:           aws.String("RadiusDisplayLabel"),
-			RadiusPort:             aws.Long(1),
-			RadiusRetries:          aws.Long(1),
+			RadiusPort:             aws.Int64(1),
+			RadiusRetries:          aws.Int64(1),
 			RadiusServers: []*string{
 				aws.String("Server"), // Required
 				// More values...
 			},
-			RadiusTimeout:   aws.Long(1),
+			RadiusTimeout:   aws.Int64(1),
 			SharedSecret:    aws.String("RadiusSharedSecret"),
-			UseSameUsername: aws.Boolean(true),
+			UseSameUsername: aws.Bool(true),
 		},
 	}
 	resp, err := svc.UpdateRadius(params)
@@ -550,5 +550,5 @@ func ExampleDirectoryService_UpdateRadius() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -690,7 +690,7 @@ type metadataAttributeDefinition struct {
 
 // String returns the string representation
 func (s AttributeDefinition) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -745,7 +745,7 @@ type metadataAttributeValue struct {
 
 // String returns the string representation
 func (s AttributeValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -846,7 +846,7 @@ type metadataAttributeValueUpdate struct {
 
 // String returns the string representation
 func (s AttributeValueUpdate) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -953,7 +953,7 @@ type metadataBatchGetItemInput struct {
 
 // String returns the string representation
 func (s BatchGetItemInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1008,7 +1008,7 @@ type metadataBatchGetItemOutput struct {
 
 // String returns the string representation
 func (s BatchGetItemOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1066,7 +1066,7 @@ type metadataBatchWriteItemInput struct {
 
 // String returns the string representation
 func (s BatchWriteItemInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1146,7 +1146,7 @@ type metadataBatchWriteItemOutput struct {
 
 // String returns the string representation
 func (s BatchWriteItemOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1169,7 +1169,7 @@ type metadataCapacity struct {
 
 // String returns the string representation
 func (s Capacity) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1347,7 +1347,7 @@ type metadataCondition struct {
 
 // String returns the string representation
 func (s Condition) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1386,7 +1386,7 @@ type metadataConsumedCapacity struct {
 
 // String returns the string representation
 func (s ConsumedCapacity) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1424,7 +1424,7 @@ type metadataCreateGlobalSecondaryIndexAction struct {
 
 // String returns the string representation
 func (s CreateGlobalSecondaryIndexAction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1545,7 +1545,7 @@ type metadataCreateTableInput struct {
 
 // String returns the string representation
 func (s CreateTableInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1567,7 +1567,7 @@ type metadataCreateTableOutput struct {
 
 // String returns the string representation
 func (s CreateTableOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1589,7 +1589,7 @@ type metadataDeleteGlobalSecondaryIndexAction struct {
 
 // String returns the string representation
 func (s DeleteGlobalSecondaryIndexAction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1935,7 +1935,7 @@ type metadataDeleteItemInput struct {
 
 // String returns the string representation
 func (s DeleteItemInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1988,7 +1988,7 @@ type metadataDeleteItemOutput struct {
 
 // String returns the string representation
 func (s DeleteItemOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2012,7 +2012,7 @@ type metadataDeleteRequest struct {
 
 // String returns the string representation
 func (s DeleteRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2034,7 +2034,7 @@ type metadataDeleteTableInput struct {
 
 // String returns the string representation
 func (s DeleteTableInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2056,7 +2056,7 @@ type metadataDeleteTableOutput struct {
 
 // String returns the string representation
 func (s DeleteTableOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2078,7 +2078,7 @@ type metadataDescribeTableInput struct {
 
 // String returns the string representation
 func (s DescribeTableInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2100,7 +2100,7 @@ type metadataDescribeTableOutput struct {
 
 // String returns the string representation
 func (s DescribeTableOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2317,7 +2317,7 @@ type metadataExpectedAttributeValue struct {
 
 // String returns the string representation
 func (s ExpectedAttributeValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2425,7 +2425,7 @@ type metadataGetItemInput struct {
 
 // String returns the string representation
 func (s GetItemInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2455,7 +2455,7 @@ type metadataGetItemOutput struct {
 
 // String returns the string representation
 func (s GetItemOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2495,7 +2495,7 @@ type metadataGlobalSecondaryIndex struct {
 
 // String returns the string representation
 func (s GlobalSecondaryIndex) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2561,7 +2561,7 @@ type metadataGlobalSecondaryIndexDescription struct {
 
 // String returns the string representation
 func (s GlobalSecondaryIndexDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2607,7 +2607,7 @@ type metadataGlobalSecondaryIndexUpdate struct {
 
 // String returns the string representation
 func (s GlobalSecondaryIndexUpdate) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2644,7 +2644,7 @@ type metadataItemCollectionMetrics struct {
 
 // String returns the string representation
 func (s ItemCollectionMetrics) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2675,7 +2675,7 @@ type metadataKeySchemaElement struct {
 
 // String returns the string representation
 func (s KeySchemaElement) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2763,7 +2763,7 @@ type metadataKeysAndAttributes struct {
 
 // String returns the string representation
 func (s KeysAndAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2791,7 +2791,7 @@ type metadataListTablesInput struct {
 
 // String returns the string representation
 func (s ListTablesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2826,7 +2826,7 @@ type metadataListTablesOutput struct {
 
 // String returns the string representation
 func (s ListTablesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2858,7 +2858,7 @@ type metadataLocalSecondaryIndex struct {
 
 // String returns the string representation
 func (s LocalSecondaryIndex) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2898,7 +2898,7 @@ type metadataLocalSecondaryIndexDescription struct {
 
 // String returns the string representation
 func (s LocalSecondaryIndexDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2937,7 +2937,7 @@ type metadataProjection struct {
 
 // String returns the string representation
 func (s Projection) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2973,7 +2973,7 @@ type metadataProvisionedThroughput struct {
 
 // String returns the string representation
 func (s ProvisionedThroughput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3015,7 +3015,7 @@ type metadataProvisionedThroughputDescription struct {
 
 // String returns the string representation
 func (s ProvisionedThroughputDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3373,7 +3373,7 @@ type metadataPutItemInput struct {
 
 // String returns the string representation
 func (s PutItemInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3426,7 +3426,7 @@ type metadataPutItemOutput struct {
 
 // String returns the string representation
 func (s PutItemOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3452,7 +3452,7 @@ type metadataPutRequest struct {
 
 // String returns the string representation
 func (s PutRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3930,7 +3930,7 @@ type metadataQueryInput struct {
 
 // String returns the string representation
 func (s QueryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3992,7 +3992,7 @@ type metadataQueryOutput struct {
 
 // String returns the string representation
 func (s QueryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4268,7 +4268,7 @@ type metadataScanInput struct {
 
 // String returns the string representation
 func (s ScanInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4329,7 +4329,7 @@ type metadataScanOutput struct {
 
 // String returns the string representation
 func (s ScanOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4504,7 +4504,7 @@ type metadataTableDescription struct {
 
 // String returns the string representation
 func (s TableDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4535,7 +4535,7 @@ type metadataUpdateGlobalSecondaryIndexAction struct {
 
 // String returns the string representation
 func (s UpdateGlobalSecondaryIndexAction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5053,7 +5053,7 @@ type metadataUpdateItemInput struct {
 
 // String returns the string representation
 func (s UpdateItemInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5091,7 +5091,7 @@ type metadataUpdateItemOutput struct {
 
 // String returns the string representation
 func (s UpdateItemOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5137,7 +5137,7 @@ type metadataUpdateTableInput struct {
 
 // String returns the string representation
 func (s UpdateTableInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5159,7 +5159,7 @@ type metadataUpdateTableOutput struct {
 
 // String returns the string representation
 func (s UpdateTableOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5187,7 +5187,7 @@ type metadataWriteRequest struct {
 
 // String returns the string representation
 func (s WriteRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/dynamodb/customizations.go
+++ b/service/dynamodb/customizations.go
@@ -47,7 +47,7 @@ func validateCRC32(r *aws.Request) {
 	}
 
 	// Checksum validation is off, skip
-	if aws.BooleanValue(r.Service.Config.DisableComputeChecksums) {
+	if aws.BoolValue(r.Service.Config.DisableComputeChecksums) {
 		return
 	}
 
@@ -75,7 +75,7 @@ func validateCRC32(r *aws.Request) {
 
 	if crc != uint32(expected) {
 		// CRC does not match, set a retryable error
-		r.Retryable.Set(true)
+		r.Retryable = aws.Bool(true)
 		r.Error = awserr.New("CRC32CheckFailed", "CRC32 integrity check failed", nil)
 	}
 }

--- a/service/dynamodb/customizations.go
+++ b/service/dynamodb/customizations.go
@@ -47,7 +47,7 @@ func validateCRC32(r *aws.Request) {
 	}
 
 	// Checksum validation is off, skip
-	if r.Service.Config.DisableComputeChecksums {
+	if aws.BooleanValue(r.Service.Config.DisableComputeChecksums) {
 		return
 	}
 

--- a/service/dynamodb/customizations_test.go
+++ b/service/dynamodb/customizations_test.go
@@ -19,7 +19,7 @@ var db *dynamodb.DynamoDB
 
 func TestMain(m *testing.M) {
 	db = dynamodb.New(&aws.Config{
-		MaxRetries: 2,
+		MaxRetries: aws.Int(2),
 	})
 	db.Handlers.Send.Clear() // mock sending
 
@@ -43,7 +43,7 @@ func mockCRCResponse(svc *dynamodb.DynamoDB, status int, body, crc string) (req 
 }
 
 func TestCustomRetryRules(t *testing.T) {
-	d := dynamodb.New(&aws.Config{MaxRetries: -1})
+	d := dynamodb.New(&aws.Config{MaxRetries: aws.Int(-1)})
 	assert.Equal(t, d.MaxRetries(), uint(10))
 }
 
@@ -83,8 +83,8 @@ func TestValidateCRC32DoesNotMatch(t *testing.T) {
 
 func TestValidateCRC32DoesNotMatchNoComputeChecksum(t *testing.T) {
 	svc := dynamodb.New(&aws.Config{
-		MaxRetries:              2,
-		DisableComputeChecksums: true,
+		MaxRetries:              aws.Int(2),
+		DisableComputeChecksums: aws.Boolean(true),
 	})
 	svc.Handlers.Send.Clear() // mock sending
 

--- a/service/dynamodb/customizations_test.go
+++ b/service/dynamodb/customizations_test.go
@@ -84,7 +84,7 @@ func TestValidateCRC32DoesNotMatch(t *testing.T) {
 func TestValidateCRC32DoesNotMatchNoComputeChecksum(t *testing.T) {
 	svc := dynamodb.New(&aws.Config{
 		MaxRetries:              aws.Int(2),
-		DisableComputeChecksums: aws.Boolean(true),
+		DisableComputeChecksums: aws.Bool(true),
 	})
 	svc.Handlers.Send.Clear() // mock sending
 

--- a/service/dynamodb/dynamodbattribute/converter_test.go
+++ b/service/dynamodb/dynamodbattribute/converter_test.go
@@ -481,8 +481,8 @@ func compareObjects(t *testing.T, expected interface{}, actual interface{}) {
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("\nExpected %s:\n%s\nActual %s:\n%s\n",
 			reflect.ValueOf(expected).Kind(),
-			awsutil.StringValue(expected),
+			awsutil.Prettify(expected),
 			reflect.ValueOf(actual).Kind(),
-			awsutil.StringValue(actual))
+			awsutil.Prettify(actual))
 	}
 }

--- a/service/dynamodb/examples_test.go
+++ b/service/dynamodb/examples_test.go
@@ -26,7 +26,7 @@ func ExampleDynamoDB_BatchGetItem() {
 					{ // Required
 						"Key": { // Required
 							B:    []byte("PAYLOAD"),
-							BOOL: aws.Boolean(true),
+							BOOL: aws.Bool(true),
 							BS: [][]byte{
 								[]byte("PAYLOAD"), // Required
 								// More values...
@@ -48,7 +48,7 @@ func ExampleDynamoDB_BatchGetItem() {
 								aws.String("NumberAttributeValue"), // Required
 								// More values...
 							},
-							NULL: aws.Boolean(true),
+							NULL: aws.Bool(true),
 							S:    aws.String("StringAttributeValue"),
 							SS: []*string{
 								aws.String("StringAttributeValue"), // Required
@@ -63,7 +63,7 @@ func ExampleDynamoDB_BatchGetItem() {
 					aws.String("AttributeName"), // Required
 					// More values...
 				},
-				ConsistentRead: aws.Boolean(true),
+				ConsistentRead: aws.Bool(true),
 				ExpressionAttributeNames: map[string]*string{
 					"Key": aws.String("AttributeName"), // Required
 					// More values...
@@ -92,7 +92,7 @@ func ExampleDynamoDB_BatchGetItem() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_BatchWriteItem() {
@@ -106,7 +106,7 @@ func ExampleDynamoDB_BatchWriteItem() {
 						Key: map[string]*dynamodb.AttributeValue{ // Required
 							"Key": { // Required
 								B:    []byte("PAYLOAD"),
-								BOOL: aws.Boolean(true),
+								BOOL: aws.Bool(true),
 								BS: [][]byte{
 									[]byte("PAYLOAD"), // Required
 									// More values...
@@ -128,7 +128,7 @@ func ExampleDynamoDB_BatchWriteItem() {
 									aws.String("NumberAttributeValue"), // Required
 									// More values...
 								},
-								NULL: aws.Boolean(true),
+								NULL: aws.Bool(true),
 								S:    aws.String("StringAttributeValue"),
 								SS: []*string{
 									aws.String("StringAttributeValue"), // Required
@@ -142,7 +142,7 @@ func ExampleDynamoDB_BatchWriteItem() {
 						Item: map[string]*dynamodb.AttributeValue{ // Required
 							"Key": { // Required
 								B:    []byte("PAYLOAD"),
-								BOOL: aws.Boolean(true),
+								BOOL: aws.Bool(true),
 								BS: [][]byte{
 									[]byte("PAYLOAD"), // Required
 									// More values...
@@ -164,7 +164,7 @@ func ExampleDynamoDB_BatchWriteItem() {
 									aws.String("NumberAttributeValue"), // Required
 									// More values...
 								},
-								NULL: aws.Boolean(true),
+								NULL: aws.Bool(true),
 								S:    aws.String("StringAttributeValue"),
 								SS: []*string{
 									aws.String("StringAttributeValue"), // Required
@@ -200,7 +200,7 @@ func ExampleDynamoDB_BatchWriteItem() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_CreateTable() {
@@ -222,8 +222,8 @@ func ExampleDynamoDB_CreateTable() {
 			// More values...
 		},
 		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{ // Required
-			ReadCapacityUnits:  aws.Long(1), // Required
-			WriteCapacityUnits: aws.Long(1), // Required
+			ReadCapacityUnits:  aws.Int64(1), // Required
+			WriteCapacityUnits: aws.Int64(1), // Required
 		},
 		TableName: aws.String("TableName"), // Required
 		GlobalSecondaryIndexes: []*dynamodb.GlobalSecondaryIndex{
@@ -244,8 +244,8 @@ func ExampleDynamoDB_CreateTable() {
 					ProjectionType: aws.String("ProjectionType"),
 				},
 				ProvisionedThroughput: &dynamodb.ProvisionedThroughput{ // Required
-					ReadCapacityUnits:  aws.Long(1), // Required
-					WriteCapacityUnits: aws.Long(1), // Required
+					ReadCapacityUnits:  aws.Int64(1), // Required
+					WriteCapacityUnits: aws.Int64(1), // Required
 				},
 			},
 			// More values...
@@ -289,7 +289,7 @@ func ExampleDynamoDB_CreateTable() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_DeleteItem() {
@@ -299,7 +299,7 @@ func ExampleDynamoDB_DeleteItem() {
 		Key: map[string]*dynamodb.AttributeValue{ // Required
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -321,7 +321,7 @@ func ExampleDynamoDB_DeleteItem() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -338,7 +338,7 @@ func ExampleDynamoDB_DeleteItem() {
 				AttributeValueList: []*dynamodb.AttributeValue{
 					{ // Required
 						B:    []byte("PAYLOAD"),
-						BOOL: aws.Boolean(true),
+						BOOL: aws.Bool(true),
 						BS: [][]byte{
 							[]byte("PAYLOAD"), // Required
 							// More values...
@@ -360,7 +360,7 @@ func ExampleDynamoDB_DeleteItem() {
 							aws.String("NumberAttributeValue"), // Required
 							// More values...
 						},
-						NULL: aws.Boolean(true),
+						NULL: aws.Bool(true),
 						S:    aws.String("StringAttributeValue"),
 						SS: []*string{
 							aws.String("StringAttributeValue"), // Required
@@ -370,10 +370,10 @@ func ExampleDynamoDB_DeleteItem() {
 					// More values...
 				},
 				ComparisonOperator: aws.String("ComparisonOperator"),
-				Exists:             aws.Boolean(true),
+				Exists:             aws.Bool(true),
 				Value: &dynamodb.AttributeValue{
 					B:    []byte("PAYLOAD"),
-					BOOL: aws.Boolean(true),
+					BOOL: aws.Bool(true),
 					BS: [][]byte{
 						[]byte("PAYLOAD"), // Required
 						// More values...
@@ -395,7 +395,7 @@ func ExampleDynamoDB_DeleteItem() {
 						aws.String("NumberAttributeValue"), // Required
 						// More values...
 					},
-					NULL: aws.Boolean(true),
+					NULL: aws.Bool(true),
 					S:    aws.String("StringAttributeValue"),
 					SS: []*string{
 						aws.String("StringAttributeValue"), // Required
@@ -412,7 +412,7 @@ func ExampleDynamoDB_DeleteItem() {
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -434,7 +434,7 @@ func ExampleDynamoDB_DeleteItem() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -465,7 +465,7 @@ func ExampleDynamoDB_DeleteItem() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_DeleteTable() {
@@ -492,7 +492,7 @@ func ExampleDynamoDB_DeleteTable() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_DescribeTable() {
@@ -519,7 +519,7 @@ func ExampleDynamoDB_DescribeTable() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_GetItem() {
@@ -529,7 +529,7 @@ func ExampleDynamoDB_GetItem() {
 		Key: map[string]*dynamodb.AttributeValue{ // Required
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -551,7 +551,7 @@ func ExampleDynamoDB_GetItem() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -565,7 +565,7 @@ func ExampleDynamoDB_GetItem() {
 			aws.String("AttributeName"), // Required
 			// More values...
 		},
-		ConsistentRead: aws.Boolean(true),
+		ConsistentRead: aws.Bool(true),
 		ExpressionAttributeNames: map[string]*string{
 			"Key": aws.String("AttributeName"), // Required
 			// More values...
@@ -591,7 +591,7 @@ func ExampleDynamoDB_GetItem() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_ListTables() {
@@ -599,7 +599,7 @@ func ExampleDynamoDB_ListTables() {
 
 	params := &dynamodb.ListTablesInput{
 		ExclusiveStartTableName: aws.String("TableName"),
-		Limit: aws.Long(1),
+		Limit: aws.Int64(1),
 	}
 	resp, err := svc.ListTables(params)
 
@@ -619,7 +619,7 @@ func ExampleDynamoDB_ListTables() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_PutItem() {
@@ -629,7 +629,7 @@ func ExampleDynamoDB_PutItem() {
 		Item: map[string]*dynamodb.AttributeValue{ // Required
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -651,7 +651,7 @@ func ExampleDynamoDB_PutItem() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -668,7 +668,7 @@ func ExampleDynamoDB_PutItem() {
 				AttributeValueList: []*dynamodb.AttributeValue{
 					{ // Required
 						B:    []byte("PAYLOAD"),
-						BOOL: aws.Boolean(true),
+						BOOL: aws.Bool(true),
 						BS: [][]byte{
 							[]byte("PAYLOAD"), // Required
 							// More values...
@@ -690,7 +690,7 @@ func ExampleDynamoDB_PutItem() {
 							aws.String("NumberAttributeValue"), // Required
 							// More values...
 						},
-						NULL: aws.Boolean(true),
+						NULL: aws.Bool(true),
 						S:    aws.String("StringAttributeValue"),
 						SS: []*string{
 							aws.String("StringAttributeValue"), // Required
@@ -700,10 +700,10 @@ func ExampleDynamoDB_PutItem() {
 					// More values...
 				},
 				ComparisonOperator: aws.String("ComparisonOperator"),
-				Exists:             aws.Boolean(true),
+				Exists:             aws.Bool(true),
 				Value: &dynamodb.AttributeValue{
 					B:    []byte("PAYLOAD"),
-					BOOL: aws.Boolean(true),
+					BOOL: aws.Bool(true),
 					BS: [][]byte{
 						[]byte("PAYLOAD"), // Required
 						// More values...
@@ -725,7 +725,7 @@ func ExampleDynamoDB_PutItem() {
 						aws.String("NumberAttributeValue"), // Required
 						// More values...
 					},
-					NULL: aws.Boolean(true),
+					NULL: aws.Bool(true),
 					S:    aws.String("StringAttributeValue"),
 					SS: []*string{
 						aws.String("StringAttributeValue"), // Required
@@ -742,7 +742,7 @@ func ExampleDynamoDB_PutItem() {
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -764,7 +764,7 @@ func ExampleDynamoDB_PutItem() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -795,7 +795,7 @@ func ExampleDynamoDB_PutItem() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_Query() {
@@ -808,11 +808,11 @@ func ExampleDynamoDB_Query() {
 			// More values...
 		},
 		ConditionalOperator: aws.String("ConditionalOperator"),
-		ConsistentRead:      aws.Boolean(true),
+		ConsistentRead:      aws.Bool(true),
 		ExclusiveStartKey: map[string]*dynamodb.AttributeValue{
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -834,7 +834,7 @@ func ExampleDynamoDB_Query() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -850,7 +850,7 @@ func ExampleDynamoDB_Query() {
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -872,7 +872,7 @@ func ExampleDynamoDB_Query() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -890,7 +890,7 @@ func ExampleDynamoDB_Query() {
 				AttributeValueList: []*dynamodb.AttributeValue{
 					{ // Required
 						B:    []byte("PAYLOAD"),
-						BOOL: aws.Boolean(true),
+						BOOL: aws.Bool(true),
 						BS: [][]byte{
 							[]byte("PAYLOAD"), // Required
 							// More values...
@@ -912,7 +912,7 @@ func ExampleDynamoDB_Query() {
 							aws.String("NumberAttributeValue"), // Required
 							// More values...
 						},
-						NULL: aws.Boolean(true),
+						NULL: aws.Bool(true),
 						S:    aws.String("StringAttributeValue"),
 						SS: []*string{
 							aws.String("StringAttributeValue"), // Required
@@ -924,7 +924,7 @@ func ExampleDynamoDB_Query() {
 			},
 			// More values...
 		},
-		Limit:                aws.Long(1),
+		Limit:                aws.Int64(1),
 		ProjectionExpression: aws.String("ProjectionExpression"),
 		QueryFilter: map[string]*dynamodb.Condition{
 			"Key": { // Required
@@ -932,7 +932,7 @@ func ExampleDynamoDB_Query() {
 				AttributeValueList: []*dynamodb.AttributeValue{
 					{ // Required
 						B:    []byte("PAYLOAD"),
-						BOOL: aws.Boolean(true),
+						BOOL: aws.Bool(true),
 						BS: [][]byte{
 							[]byte("PAYLOAD"), // Required
 							// More values...
@@ -954,7 +954,7 @@ func ExampleDynamoDB_Query() {
 							aws.String("NumberAttributeValue"), // Required
 							// More values...
 						},
-						NULL: aws.Boolean(true),
+						NULL: aws.Bool(true),
 						S:    aws.String("StringAttributeValue"),
 						SS: []*string{
 							aws.String("StringAttributeValue"), // Required
@@ -967,7 +967,7 @@ func ExampleDynamoDB_Query() {
 			// More values...
 		},
 		ReturnConsumedCapacity: aws.String("ReturnConsumedCapacity"),
-		ScanIndexForward:       aws.Boolean(true),
+		ScanIndexForward:       aws.Bool(true),
 		Select:                 aws.String("Select"),
 	}
 	resp, err := svc.Query(params)
@@ -988,7 +988,7 @@ func ExampleDynamoDB_Query() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_Scan() {
@@ -1004,7 +1004,7 @@ func ExampleDynamoDB_Scan() {
 		ExclusiveStartKey: map[string]*dynamodb.AttributeValue{
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -1026,7 +1026,7 @@ func ExampleDynamoDB_Scan() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -1042,7 +1042,7 @@ func ExampleDynamoDB_Scan() {
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -1064,7 +1064,7 @@ func ExampleDynamoDB_Scan() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -1075,7 +1075,7 @@ func ExampleDynamoDB_Scan() {
 		},
 		FilterExpression:       aws.String("ConditionExpression"),
 		IndexName:              aws.String("IndexName"),
-		Limit:                  aws.Long(1),
+		Limit:                  aws.Int64(1),
 		ProjectionExpression:   aws.String("ProjectionExpression"),
 		ReturnConsumedCapacity: aws.String("ReturnConsumedCapacity"),
 		ScanFilter: map[string]*dynamodb.Condition{
@@ -1084,7 +1084,7 @@ func ExampleDynamoDB_Scan() {
 				AttributeValueList: []*dynamodb.AttributeValue{
 					{ // Required
 						B:    []byte("PAYLOAD"),
-						BOOL: aws.Boolean(true),
+						BOOL: aws.Bool(true),
 						BS: [][]byte{
 							[]byte("PAYLOAD"), // Required
 							// More values...
@@ -1106,7 +1106,7 @@ func ExampleDynamoDB_Scan() {
 							aws.String("NumberAttributeValue"), // Required
 							// More values...
 						},
-						NULL: aws.Boolean(true),
+						NULL: aws.Bool(true),
 						S:    aws.String("StringAttributeValue"),
 						SS: []*string{
 							aws.String("StringAttributeValue"), // Required
@@ -1118,9 +1118,9 @@ func ExampleDynamoDB_Scan() {
 			},
 			// More values...
 		},
-		Segment:       aws.Long(1),
+		Segment:       aws.Int64(1),
 		Select:        aws.String("Select"),
-		TotalSegments: aws.Long(1),
+		TotalSegments: aws.Int64(1),
 	}
 	resp, err := svc.Scan(params)
 
@@ -1140,7 +1140,7 @@ func ExampleDynamoDB_Scan() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_UpdateItem() {
@@ -1150,7 +1150,7 @@ func ExampleDynamoDB_UpdateItem() {
 		Key: map[string]*dynamodb.AttributeValue{ // Required
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -1172,7 +1172,7 @@ func ExampleDynamoDB_UpdateItem() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -1187,7 +1187,7 @@ func ExampleDynamoDB_UpdateItem() {
 				Action: aws.String("AttributeAction"),
 				Value: &dynamodb.AttributeValue{
 					B:    []byte("PAYLOAD"),
-					BOOL: aws.Boolean(true),
+					BOOL: aws.Bool(true),
 					BS: [][]byte{
 						[]byte("PAYLOAD"), // Required
 						// More values...
@@ -1209,7 +1209,7 @@ func ExampleDynamoDB_UpdateItem() {
 						aws.String("NumberAttributeValue"), // Required
 						// More values...
 					},
-					NULL: aws.Boolean(true),
+					NULL: aws.Bool(true),
 					S:    aws.String("StringAttributeValue"),
 					SS: []*string{
 						aws.String("StringAttributeValue"), // Required
@@ -1226,7 +1226,7 @@ func ExampleDynamoDB_UpdateItem() {
 				AttributeValueList: []*dynamodb.AttributeValue{
 					{ // Required
 						B:    []byte("PAYLOAD"),
-						BOOL: aws.Boolean(true),
+						BOOL: aws.Bool(true),
 						BS: [][]byte{
 							[]byte("PAYLOAD"), // Required
 							// More values...
@@ -1248,7 +1248,7 @@ func ExampleDynamoDB_UpdateItem() {
 							aws.String("NumberAttributeValue"), // Required
 							// More values...
 						},
-						NULL: aws.Boolean(true),
+						NULL: aws.Bool(true),
 						S:    aws.String("StringAttributeValue"),
 						SS: []*string{
 							aws.String("StringAttributeValue"), // Required
@@ -1258,10 +1258,10 @@ func ExampleDynamoDB_UpdateItem() {
 					// More values...
 				},
 				ComparisonOperator: aws.String("ComparisonOperator"),
-				Exists:             aws.Boolean(true),
+				Exists:             aws.Bool(true),
 				Value: &dynamodb.AttributeValue{
 					B:    []byte("PAYLOAD"),
-					BOOL: aws.Boolean(true),
+					BOOL: aws.Bool(true),
 					BS: [][]byte{
 						[]byte("PAYLOAD"), // Required
 						// More values...
@@ -1283,7 +1283,7 @@ func ExampleDynamoDB_UpdateItem() {
 						aws.String("NumberAttributeValue"), // Required
 						// More values...
 					},
-					NULL: aws.Boolean(true),
+					NULL: aws.Bool(true),
 					S:    aws.String("StringAttributeValue"),
 					SS: []*string{
 						aws.String("StringAttributeValue"), // Required
@@ -1300,7 +1300,7 @@ func ExampleDynamoDB_UpdateItem() {
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			"Key": { // Required
 				B:    []byte("PAYLOAD"),
-				BOOL: aws.Boolean(true),
+				BOOL: aws.Bool(true),
 				BS: [][]byte{
 					[]byte("PAYLOAD"), // Required
 					// More values...
@@ -1322,7 +1322,7 @@ func ExampleDynamoDB_UpdateItem() {
 					aws.String("NumberAttributeValue"), // Required
 					// More values...
 				},
-				NULL: aws.Boolean(true),
+				NULL: aws.Bool(true),
 				S:    aws.String("StringAttributeValue"),
 				SS: []*string{
 					aws.String("StringAttributeValue"), // Required
@@ -1354,7 +1354,7 @@ func ExampleDynamoDB_UpdateItem() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleDynamoDB_UpdateTable() {
@@ -1388,8 +1388,8 @@ func ExampleDynamoDB_UpdateTable() {
 						ProjectionType: aws.String("ProjectionType"),
 					},
 					ProvisionedThroughput: &dynamodb.ProvisionedThroughput{ // Required
-						ReadCapacityUnits:  aws.Long(1), // Required
-						WriteCapacityUnits: aws.Long(1), // Required
+						ReadCapacityUnits:  aws.Int64(1), // Required
+						WriteCapacityUnits: aws.Int64(1), // Required
 					},
 				},
 				Delete: &dynamodb.DeleteGlobalSecondaryIndexAction{
@@ -1398,16 +1398,16 @@ func ExampleDynamoDB_UpdateTable() {
 				Update: &dynamodb.UpdateGlobalSecondaryIndexAction{
 					IndexName: aws.String("IndexName"), // Required
 					ProvisionedThroughput: &dynamodb.ProvisionedThroughput{ // Required
-						ReadCapacityUnits:  aws.Long(1), // Required
-						WriteCapacityUnits: aws.Long(1), // Required
+						ReadCapacityUnits:  aws.Int64(1), // Required
+						WriteCapacityUnits: aws.Int64(1), // Required
 					},
 				},
 			},
 			// More values...
 		},
 		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
-			ReadCapacityUnits:  aws.Long(1), // Required
-			WriteCapacityUnits: aws.Long(1), // Required
+			ReadCapacityUnits:  aws.Int64(1), // Required
+			WriteCapacityUnits: aws.Int64(1), // Required
 		},
 	}
 	resp, err := svc.UpdateTable(params)
@@ -1428,5 +1428,5 @@ func ExampleDynamoDB_UpdateTable() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -6276,7 +6276,7 @@ type metadataAcceptVPCPeeringConnectionInput struct {
 
 // String returns the string representation
 func (s AcceptVPCPeeringConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6297,7 +6297,7 @@ type metadataAcceptVPCPeeringConnectionOutput struct {
 
 // String returns the string representation
 func (s AcceptVPCPeeringConnectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6322,7 +6322,7 @@ type metadataAccountAttribute struct {
 
 // String returns the string representation
 func (s AccountAttribute) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6344,7 +6344,7 @@ type metadataAccountAttributeValue struct {
 
 // String returns the string representation
 func (s AccountAttributeValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6372,7 +6372,7 @@ type metadataActiveInstance struct {
 
 // String returns the string representation
 func (s ActiveInstance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6417,7 +6417,7 @@ type metadataAddress struct {
 
 // String returns the string representation
 func (s Address) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6446,7 +6446,7 @@ type metadataAllocateAddressInput struct {
 
 // String returns the string representation
 func (s AllocateAddressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6475,7 +6475,7 @@ type metadataAllocateAddressOutput struct {
 
 // String returns the string representation
 func (s AllocateAddressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6512,7 +6512,7 @@ type metadataAssignPrivateIPAddressesInput struct {
 
 // String returns the string representation
 func (s AssignPrivateIPAddressesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6530,7 +6530,7 @@ type metadataAssignPrivateIPAddressesOutput struct {
 
 // String returns the string representation
 func (s AssignPrivateIPAddressesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6582,7 +6582,7 @@ type metadataAssociateAddressInput struct {
 
 // String returns the string representation
 func (s AssociateAddressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6604,7 +6604,7 @@ type metadataAssociateAddressOutput struct {
 
 // String returns the string representation
 func (s AssociateAddressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6635,7 +6635,7 @@ type metadataAssociateDHCPOptionsInput struct {
 
 // String returns the string representation
 func (s AssociateDHCPOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6653,7 +6653,7 @@ type metadataAssociateDHCPOptionsOutput struct {
 
 // String returns the string representation
 func (s AssociateDHCPOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6683,7 +6683,7 @@ type metadataAssociateRouteTableInput struct {
 
 // String returns the string representation
 func (s AssociateRouteTableInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6704,7 +6704,7 @@ type metadataAssociateRouteTableOutput struct {
 
 // String returns the string representation
 func (s AssociateRouteTableOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6738,7 +6738,7 @@ type metadataAttachClassicLinkVPCInput struct {
 
 // String returns the string representation
 func (s AttachClassicLinkVPCInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6759,7 +6759,7 @@ type metadataAttachClassicLinkVPCOutput struct {
 
 // String returns the string representation
 func (s AttachClassicLinkVPCOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6789,7 +6789,7 @@ type metadataAttachInternetGatewayInput struct {
 
 // String returns the string representation
 func (s AttachInternetGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6807,7 +6807,7 @@ type metadataAttachInternetGatewayOutput struct {
 
 // String returns the string representation
 func (s AttachInternetGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6840,7 +6840,7 @@ type metadataAttachNetworkInterfaceInput struct {
 
 // String returns the string representation
 func (s AttachNetworkInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6861,7 +6861,7 @@ type metadataAttachNetworkInterfaceOutput struct {
 
 // String returns the string representation
 func (s AttachNetworkInterfaceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6891,7 +6891,7 @@ type metadataAttachVPNGatewayInput struct {
 
 // String returns the string representation
 func (s AttachVPNGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6912,7 +6912,7 @@ type metadataAttachVPNGatewayOutput struct {
 
 // String returns the string representation
 func (s AttachVPNGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6946,7 +6946,7 @@ type metadataAttachVolumeInput struct {
 
 // String returns the string representation
 func (s AttachVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6968,7 +6968,7 @@ type metadataAttributeBooleanValue struct {
 
 // String returns the string representation
 func (s AttributeBooleanValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6990,7 +6990,7 @@ type metadataAttributeValue struct {
 
 // String returns the string representation
 func (s AttributeValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7045,7 +7045,7 @@ type metadataAuthorizeSecurityGroupEgressInput struct {
 
 // String returns the string representation
 func (s AuthorizeSecurityGroupEgressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7063,7 +7063,7 @@ type metadataAuthorizeSecurityGroupEgressOutput struct {
 
 // String returns the string representation
 func (s AuthorizeSecurityGroupEgressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7124,7 +7124,7 @@ type metadataAuthorizeSecurityGroupIngressInput struct {
 
 // String returns the string representation
 func (s AuthorizeSecurityGroupIngressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7142,7 +7142,7 @@ type metadataAuthorizeSecurityGroupIngressOutput struct {
 
 // String returns the string representation
 func (s AuthorizeSecurityGroupIngressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7173,7 +7173,7 @@ type metadataAvailabilityZone struct {
 
 // String returns the string representation
 func (s AvailabilityZone) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7195,7 +7195,7 @@ type metadataAvailabilityZoneMessage struct {
 
 // String returns the string representation
 func (s AvailabilityZoneMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7215,7 +7215,7 @@ type metadataBlobAttributeValue struct {
 
 // String returns the string representation
 func (s BlobAttributeValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7257,7 +7257,7 @@ type metadataBlockDeviceMapping struct {
 
 // String returns the string representation
 func (s BlockDeviceMapping) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7295,7 +7295,7 @@ type metadataBundleInstanceInput struct {
 
 // String returns the string representation
 func (s BundleInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7316,7 +7316,7 @@ type metadataBundleInstanceOutput struct {
 
 // String returns the string representation
 func (s BundleInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7359,7 +7359,7 @@ type metadataBundleTask struct {
 
 // String returns the string representation
 func (s BundleTask) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7384,7 +7384,7 @@ type metadataBundleTaskError struct {
 
 // String returns the string representation
 func (s BundleTaskError) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7411,7 +7411,7 @@ type metadataCancelBundleTaskInput struct {
 
 // String returns the string representation
 func (s CancelBundleTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7432,7 +7432,7 @@ type metadataCancelBundleTaskOutput struct {
 
 // String returns the string representation
 func (s CancelBundleTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7462,7 +7462,7 @@ type metadataCancelConversionTaskInput struct {
 
 // String returns the string representation
 func (s CancelConversionTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7480,7 +7480,7 @@ type metadataCancelConversionTaskOutput struct {
 
 // String returns the string representation
 func (s CancelConversionTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7501,7 +7501,7 @@ type metadataCancelExportTaskInput struct {
 
 // String returns the string representation
 func (s CancelExportTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7519,7 +7519,7 @@ type metadataCancelExportTaskOutput struct {
 
 // String returns the string representation
 func (s CancelExportTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7549,7 +7549,7 @@ type metadataCancelImportTaskInput struct {
 
 // String returns the string representation
 func (s CancelImportTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7576,7 +7576,7 @@ type metadataCancelImportTaskOutput struct {
 
 // String returns the string representation
 func (s CancelImportTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7597,7 +7597,7 @@ type metadataCancelReservedInstancesListingInput struct {
 
 // String returns the string representation
 func (s CancelReservedInstancesListingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7618,7 +7618,7 @@ type metadataCancelReservedInstancesListingOutput struct {
 
 // String returns the string representation
 func (s CancelReservedInstancesListingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7643,7 +7643,7 @@ type metadataCancelSpotFleetRequestsError struct {
 
 // String returns the string representation
 func (s CancelSpotFleetRequestsError) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7668,7 +7668,7 @@ type metadataCancelSpotFleetRequestsErrorItem struct {
 
 // String returns the string representation
 func (s CancelSpotFleetRequestsErrorItem) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7700,7 +7700,7 @@ type metadataCancelSpotFleetRequestsInput struct {
 
 // String returns the string representation
 func (s CancelSpotFleetRequestsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7725,7 +7725,7 @@ type metadataCancelSpotFleetRequestsOutput struct {
 
 // String returns the string representation
 func (s CancelSpotFleetRequestsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7753,7 +7753,7 @@ type metadataCancelSpotFleetRequestsSuccessItem struct {
 
 // String returns the string representation
 func (s CancelSpotFleetRequestsSuccessItem) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7781,7 +7781,7 @@ type metadataCancelSpotInstanceRequestsInput struct {
 
 // String returns the string representation
 func (s CancelSpotInstanceRequestsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7803,7 +7803,7 @@ type metadataCancelSpotInstanceRequestsOutput struct {
 
 // String returns the string representation
 func (s CancelSpotInstanceRequestsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7828,7 +7828,7 @@ type metadataCancelledSpotInstanceRequest struct {
 
 // String returns the string representation
 func (s CancelledSpotInstanceRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7859,7 +7859,7 @@ type metadataClassicLinkInstance struct {
 
 // String returns the string representation
 func (s ClassicLinkInstance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7890,7 +7890,7 @@ type metadataClientData struct {
 
 // String returns the string representation
 func (s ClientData) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7920,7 +7920,7 @@ type metadataConfirmProductInstanceInput struct {
 
 // String returns the string representation
 func (s ConfirmProductInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7946,7 +7946,7 @@ type metadataConfirmProductInstanceOutput struct {
 
 // String returns the string representation
 func (s ConfirmProductInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7989,7 +7989,7 @@ type metadataConversionTask struct {
 
 // String returns the string representation
 func (s ConversionTask) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8030,7 +8030,7 @@ type metadataCopyImageInput struct {
 
 // String returns the string representation
 func (s CopyImageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8051,7 +8051,7 @@ type metadataCopyImageOutput struct {
 
 // String returns the string representation
 func (s CopyImageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8127,7 +8127,7 @@ type metadataCopySnapshotInput struct {
 
 // String returns the string representation
 func (s CopySnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8148,7 +8148,7 @@ type metadataCopySnapshotOutput struct {
 
 // String returns the string representation
 func (s CopySnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8184,7 +8184,7 @@ type metadataCreateCustomerGatewayInput struct {
 
 // String returns the string representation
 func (s CreateCustomerGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8205,7 +8205,7 @@ type metadataCreateCustomerGatewayOutput struct {
 
 // String returns the string representation
 func (s CreateCustomerGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8232,7 +8232,7 @@ type metadataCreateDHCPOptionsInput struct {
 
 // String returns the string representation
 func (s CreateDHCPOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8253,7 +8253,7 @@ type metadataCreateDHCPOptionsOutput struct {
 
 // String returns the string representation
 func (s CreateDHCPOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8291,7 +8291,7 @@ type metadataCreateFlowLogsInput struct {
 
 // String returns the string representation
 func (s CreateFlowLogsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8319,7 +8319,7 @@ type metadataCreateFlowLogsOutput struct {
 
 // String returns the string representation
 func (s CreateFlowLogsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8366,7 +8366,7 @@ type metadataCreateImageInput struct {
 
 // String returns the string representation
 func (s CreateImageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8387,7 +8387,7 @@ type metadataCreateImageOutput struct {
 
 // String returns the string representation
 func (s CreateImageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8418,7 +8418,7 @@ type metadataCreateInstanceExportTaskInput struct {
 
 // String returns the string representation
 func (s CreateInstanceExportTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8439,7 +8439,7 @@ type metadataCreateInstanceExportTaskOutput struct {
 
 // String returns the string representation
 func (s CreateInstanceExportTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8463,7 +8463,7 @@ type metadataCreateInternetGatewayInput struct {
 
 // String returns the string representation
 func (s CreateInternetGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8484,7 +8484,7 @@ type metadataCreateInternetGatewayOutput struct {
 
 // String returns the string representation
 func (s CreateInternetGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8513,7 +8513,7 @@ type metadataCreateKeyPairInput struct {
 
 // String returns the string representation
 func (s CreateKeyPairInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8541,7 +8541,7 @@ type metadataCreateKeyPairOutput struct {
 
 // String returns the string representation
 func (s CreateKeyPairOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8594,7 +8594,7 @@ type metadataCreateNetworkACLEntryInput struct {
 
 // String returns the string representation
 func (s CreateNetworkACLEntryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8612,7 +8612,7 @@ type metadataCreateNetworkACLEntryOutput struct {
 
 // String returns the string representation
 func (s CreateNetworkACLEntryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8639,7 +8639,7 @@ type metadataCreateNetworkACLInput struct {
 
 // String returns the string representation
 func (s CreateNetworkACLInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8660,7 +8660,7 @@ type metadataCreateNetworkACLOutput struct {
 
 // String returns the string representation
 func (s CreateNetworkACLOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8713,7 +8713,7 @@ type metadataCreateNetworkInterfaceInput struct {
 
 // String returns the string representation
 func (s CreateNetworkInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8734,7 +8734,7 @@ type metadataCreateNetworkInterfaceOutput struct {
 
 // String returns the string representation
 func (s CreateNetworkInterfaceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8766,7 +8766,7 @@ type metadataCreatePlacementGroupInput struct {
 
 // String returns the string representation
 func (s CreatePlacementGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8784,7 +8784,7 @@ type metadataCreatePlacementGroupOutput struct {
 
 // String returns the string representation
 func (s CreatePlacementGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8820,7 +8820,7 @@ type metadataCreateReservedInstancesListingInput struct {
 
 // String returns the string representation
 func (s CreateReservedInstancesListingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8841,7 +8841,7 @@ type metadataCreateReservedInstancesListingOutput struct {
 
 // String returns the string representation
 func (s CreateReservedInstancesListingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8890,7 +8890,7 @@ type metadataCreateRouteInput struct {
 
 // String returns the string representation
 func (s CreateRouteInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8915,7 +8915,7 @@ type metadataCreateRouteOutput struct {
 
 // String returns the string representation
 func (s CreateRouteOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8942,7 +8942,7 @@ type metadataCreateRouteTableInput struct {
 
 // String returns the string representation
 func (s CreateRouteTableInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8963,7 +8963,7 @@ type metadataCreateRouteTableOutput struct {
 
 // String returns the string representation
 func (s CreateRouteTableOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9008,7 +9008,7 @@ type metadataCreateSecurityGroupInput struct {
 
 // String returns the string representation
 func (s CreateSecurityGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9029,7 +9029,7 @@ type metadataCreateSecurityGroupOutput struct {
 
 // String returns the string representation
 func (s CreateSecurityGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9059,7 +9059,7 @@ type metadataCreateSnapshotInput struct {
 
 // String returns the string representation
 func (s CreateSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9090,7 +9090,7 @@ type metadataCreateSpotDatafeedSubscriptionInput struct {
 
 // String returns the string representation
 func (s CreateSpotDatafeedSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9112,7 +9112,7 @@ type metadataCreateSpotDatafeedSubscriptionOutput struct {
 
 // String returns the string representation
 func (s CreateSpotDatafeedSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9147,7 +9147,7 @@ type metadataCreateSubnetInput struct {
 
 // String returns the string representation
 func (s CreateSubnetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9168,7 +9168,7 @@ type metadataCreateSubnetOutput struct {
 
 // String returns the string representation
 func (s CreateSubnetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9200,7 +9200,7 @@ type metadataCreateTagsInput struct {
 
 // String returns the string representation
 func (s CreateTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9218,7 +9218,7 @@ type metadataCreateTagsOutput struct {
 
 // String returns the string representation
 func (s CreateTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9261,7 +9261,7 @@ type metadataCreateVPCEndpointInput struct {
 
 // String returns the string representation
 func (s CreateVPCEndpointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9286,7 +9286,7 @@ type metadataCreateVPCEndpointOutput struct {
 
 // String returns the string representation
 func (s CreateVPCEndpointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9322,7 +9322,7 @@ type metadataCreateVPCInput struct {
 
 // String returns the string representation
 func (s CreateVPCInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9343,7 +9343,7 @@ type metadataCreateVPCOutput struct {
 
 // String returns the string representation
 func (s CreateVPCOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9378,7 +9378,7 @@ type metadataCreateVPCPeeringConnectionInput struct {
 
 // String returns the string representation
 func (s CreateVPCPeeringConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9399,7 +9399,7 @@ type metadataCreateVPCPeeringConnectionOutput struct {
 
 // String returns the string representation
 func (s CreateVPCPeeringConnectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9439,7 +9439,7 @@ type metadataCreateVPNConnectionInput struct {
 
 // String returns the string representation
 func (s CreateVPNConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9460,7 +9460,7 @@ type metadataCreateVPNConnectionOutput struct {
 
 // String returns the string representation
 func (s CreateVPNConnectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9484,7 +9484,7 @@ type metadataCreateVPNConnectionRouteInput struct {
 
 // String returns the string representation
 func (s CreateVPNConnectionRouteInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9502,7 +9502,7 @@ type metadataCreateVPNConnectionRouteOutput struct {
 
 // String returns the string representation
 func (s CreateVPNConnectionRouteOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9532,7 +9532,7 @@ type metadataCreateVPNGatewayInput struct {
 
 // String returns the string representation
 func (s CreateVPNGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9553,7 +9553,7 @@ type metadataCreateVPNGatewayOutput struct {
 
 // String returns the string representation
 func (s CreateVPNGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9625,7 +9625,7 @@ type metadataCreateVolumeInput struct {
 
 // String returns the string representation
 func (s CreateVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9653,7 +9653,7 @@ type metadataCreateVolumePermission struct {
 
 // String returns the string representation
 func (s CreateVolumePermission) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9680,7 +9680,7 @@ type metadataCreateVolumePermissionModifications struct {
 
 // String returns the string representation
 func (s CreateVolumePermissionModifications) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9719,7 +9719,7 @@ type metadataCustomerGateway struct {
 
 // String returns the string representation
 func (s CustomerGateway) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9744,7 +9744,7 @@ type metadataDHCPConfiguration struct {
 
 // String returns the string representation
 func (s DHCPConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9772,7 +9772,7 @@ type metadataDHCPOptions struct {
 
 // String returns the string representation
 func (s DHCPOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9799,7 +9799,7 @@ type metadataDeleteCustomerGatewayInput struct {
 
 // String returns the string representation
 func (s DeleteCustomerGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9817,7 +9817,7 @@ type metadataDeleteCustomerGatewayOutput struct {
 
 // String returns the string representation
 func (s DeleteCustomerGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9844,7 +9844,7 @@ type metadataDeleteDHCPOptionsInput struct {
 
 // String returns the string representation
 func (s DeleteDHCPOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9862,7 +9862,7 @@ type metadataDeleteDHCPOptionsOutput struct {
 
 // String returns the string representation
 func (s DeleteDHCPOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9883,7 +9883,7 @@ type metadataDeleteFlowLogsInput struct {
 
 // String returns the string representation
 func (s DeleteFlowLogsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9904,7 +9904,7 @@ type metadataDeleteFlowLogsOutput struct {
 
 // String returns the string representation
 func (s DeleteFlowLogsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9931,7 +9931,7 @@ type metadataDeleteInternetGatewayInput struct {
 
 // String returns the string representation
 func (s DeleteInternetGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9949,7 +9949,7 @@ type metadataDeleteInternetGatewayOutput struct {
 
 // String returns the string representation
 func (s DeleteInternetGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9976,7 +9976,7 @@ type metadataDeleteKeyPairInput struct {
 
 // String returns the string representation
 func (s DeleteKeyPairInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9994,7 +9994,7 @@ type metadataDeleteKeyPairOutput struct {
 
 // String returns the string representation
 func (s DeleteKeyPairOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10027,7 +10027,7 @@ type metadataDeleteNetworkACLEntryInput struct {
 
 // String returns the string representation
 func (s DeleteNetworkACLEntryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10045,7 +10045,7 @@ type metadataDeleteNetworkACLEntryOutput struct {
 
 // String returns the string representation
 func (s DeleteNetworkACLEntryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10072,7 +10072,7 @@ type metadataDeleteNetworkACLInput struct {
 
 // String returns the string representation
 func (s DeleteNetworkACLInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10090,7 +10090,7 @@ type metadataDeleteNetworkACLOutput struct {
 
 // String returns the string representation
 func (s DeleteNetworkACLOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10117,7 +10117,7 @@ type metadataDeleteNetworkInterfaceInput struct {
 
 // String returns the string representation
 func (s DeleteNetworkInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10135,7 +10135,7 @@ type metadataDeleteNetworkInterfaceOutput struct {
 
 // String returns the string representation
 func (s DeleteNetworkInterfaceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10162,7 +10162,7 @@ type metadataDeletePlacementGroupInput struct {
 
 // String returns the string representation
 func (s DeletePlacementGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10180,7 +10180,7 @@ type metadataDeletePlacementGroupOutput struct {
 
 // String returns the string representation
 func (s DeletePlacementGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10211,7 +10211,7 @@ type metadataDeleteRouteInput struct {
 
 // String returns the string representation
 func (s DeleteRouteInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10229,7 +10229,7 @@ type metadataDeleteRouteOutput struct {
 
 // String returns the string representation
 func (s DeleteRouteOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10256,7 +10256,7 @@ type metadataDeleteRouteTableInput struct {
 
 // String returns the string representation
 func (s DeleteRouteTableInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10274,7 +10274,7 @@ type metadataDeleteRouteTableOutput struct {
 
 // String returns the string representation
 func (s DeleteRouteTableOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10305,7 +10305,7 @@ type metadataDeleteSecurityGroupInput struct {
 
 // String returns the string representation
 func (s DeleteSecurityGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10323,7 +10323,7 @@ type metadataDeleteSecurityGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteSecurityGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10350,7 +10350,7 @@ type metadataDeleteSnapshotInput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10368,7 +10368,7 @@ type metadataDeleteSnapshotOutput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10393,7 +10393,7 @@ type metadataDeleteSpotDatafeedSubscriptionInput struct {
 
 // String returns the string representation
 func (s DeleteSpotDatafeedSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10411,7 +10411,7 @@ type metadataDeleteSpotDatafeedSubscriptionOutput struct {
 
 // String returns the string representation
 func (s DeleteSpotDatafeedSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10438,7 +10438,7 @@ type metadataDeleteSubnetInput struct {
 
 // String returns the string representation
 func (s DeleteSubnetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10456,7 +10456,7 @@ type metadataDeleteSubnetOutput struct {
 
 // String returns the string representation
 func (s DeleteSubnetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10489,7 +10489,7 @@ type metadataDeleteTagsInput struct {
 
 // String returns the string representation
 func (s DeleteTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10507,7 +10507,7 @@ type metadataDeleteTagsOutput struct {
 
 // String returns the string representation
 func (s DeleteTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10534,7 +10534,7 @@ type metadataDeleteVPCEndpointsInput struct {
 
 // String returns the string representation
 func (s DeleteVPCEndpointsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10555,7 +10555,7 @@ type metadataDeleteVPCEndpointsOutput struct {
 
 // String returns the string representation
 func (s DeleteVPCEndpointsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10582,7 +10582,7 @@ type metadataDeleteVPCInput struct {
 
 // String returns the string representation
 func (s DeleteVPCInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10600,7 +10600,7 @@ type metadataDeleteVPCOutput struct {
 
 // String returns the string representation
 func (s DeleteVPCOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10627,7 +10627,7 @@ type metadataDeleteVPCPeeringConnectionInput struct {
 
 // String returns the string representation
 func (s DeleteVPCPeeringConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10648,7 +10648,7 @@ type metadataDeleteVPCPeeringConnectionOutput struct {
 
 // String returns the string representation
 func (s DeleteVPCPeeringConnectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10675,7 +10675,7 @@ type metadataDeleteVPNConnectionInput struct {
 
 // String returns the string representation
 func (s DeleteVPNConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10693,7 +10693,7 @@ type metadataDeleteVPNConnectionOutput struct {
 
 // String returns the string representation
 func (s DeleteVPNConnectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10717,7 +10717,7 @@ type metadataDeleteVPNConnectionRouteInput struct {
 
 // String returns the string representation
 func (s DeleteVPNConnectionRouteInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10735,7 +10735,7 @@ type metadataDeleteVPNConnectionRouteOutput struct {
 
 // String returns the string representation
 func (s DeleteVPNConnectionRouteOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10762,7 +10762,7 @@ type metadataDeleteVPNGatewayInput struct {
 
 // String returns the string representation
 func (s DeleteVPNGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10780,7 +10780,7 @@ type metadataDeleteVPNGatewayOutput struct {
 
 // String returns the string representation
 func (s DeleteVPNGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10807,7 +10807,7 @@ type metadataDeleteVolumeInput struct {
 
 // String returns the string representation
 func (s DeleteVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10825,7 +10825,7 @@ type metadataDeleteVolumeOutput struct {
 
 // String returns the string representation
 func (s DeleteVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10852,7 +10852,7 @@ type metadataDeregisterImageInput struct {
 
 // String returns the string representation
 func (s DeregisterImageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10870,7 +10870,7 @@ type metadataDeregisterImageOutput struct {
 
 // String returns the string representation
 func (s DeregisterImageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10897,7 +10897,7 @@ type metadataDescribeAccountAttributesInput struct {
 
 // String returns the string representation
 func (s DescribeAccountAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10918,7 +10918,7 @@ type metadataDescribeAccountAttributesOutput struct {
 
 // String returns the string representation
 func (s DescribeAccountAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10975,7 +10975,7 @@ type metadataDescribeAddressesInput struct {
 
 // String returns the string representation
 func (s DescribeAddressesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10996,7 +10996,7 @@ type metadataDescribeAddressesOutput struct {
 
 // String returns the string representation
 func (s DescribeAddressesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11035,7 +11035,7 @@ type metadataDescribeAvailabilityZonesInput struct {
 
 // String returns the string representation
 func (s DescribeAvailabilityZonesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11056,7 +11056,7 @@ type metadataDescribeAvailabilityZonesOutput struct {
 
 // String returns the string representation
 func (s DescribeAvailabilityZonesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11110,7 +11110,7 @@ type metadataDescribeBundleTasksInput struct {
 
 // String returns the string representation
 func (s DescribeBundleTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11131,7 +11131,7 @@ type metadataDescribeBundleTasksOutput struct {
 
 // String returns the string representation
 func (s DescribeBundleTasksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11192,7 +11192,7 @@ type metadataDescribeClassicLinkInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeClassicLinkInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11217,7 +11217,7 @@ type metadataDescribeClassicLinkInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeClassicLinkInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11247,7 +11247,7 @@ type metadataDescribeConversionTasksInput struct {
 
 // String returns the string representation
 func (s DescribeConversionTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11268,7 +11268,7 @@ type metadataDescribeConversionTasksOutput struct {
 
 // String returns the string representation
 func (s DescribeConversionTasksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11326,7 +11326,7 @@ type metadataDescribeCustomerGatewaysInput struct {
 
 // String returns the string representation
 func (s DescribeCustomerGatewaysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11347,7 +11347,7 @@ type metadataDescribeCustomerGatewaysOutput struct {
 
 // String returns the string representation
 func (s DescribeCustomerGatewaysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11397,7 +11397,7 @@ type metadataDescribeDHCPOptionsInput struct {
 
 // String returns the string representation
 func (s DescribeDHCPOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11418,7 +11418,7 @@ type metadataDescribeDHCPOptionsOutput struct {
 
 // String returns the string representation
 func (s DescribeDHCPOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11439,7 +11439,7 @@ type metadataDescribeExportTasksInput struct {
 
 // String returns the string representation
 func (s DescribeExportTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11460,7 +11460,7 @@ type metadataDescribeExportTasksOutput struct {
 
 // String returns the string representation
 func (s DescribeExportTasksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11504,7 +11504,7 @@ type metadataDescribeFlowLogsInput struct {
 
 // String returns the string representation
 func (s DescribeFlowLogsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11529,7 +11529,7 @@ type metadataDescribeFlowLogsOutput struct {
 
 // String returns the string representation
 func (s DescribeFlowLogsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11563,7 +11563,7 @@ type metadataDescribeImageAttributeInput struct {
 
 // String returns the string representation
 func (s DescribeImageAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11606,7 +11606,7 @@ type metadataDescribeImageAttributeOutput struct {
 
 // String returns the string representation
 func (s DescribeImageAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11717,7 +11717,7 @@ type metadataDescribeImagesInput struct {
 
 // String returns the string representation
 func (s DescribeImagesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11738,7 +11738,7 @@ type metadataDescribeImagesOutput struct {
 
 // String returns the string representation
 func (s DescribeImagesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11774,7 +11774,7 @@ type metadataDescribeImportImageTasksInput struct {
 
 // String returns the string representation
 func (s DescribeImportImageTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11800,7 +11800,7 @@ type metadataDescribeImportImageTasksOutput struct {
 
 // String returns the string representation
 func (s DescribeImportImageTasksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11836,7 +11836,7 @@ type metadataDescribeImportSnapshotTasksInput struct {
 
 // String returns the string representation
 func (s DescribeImportSnapshotTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11862,7 +11862,7 @@ type metadataDescribeImportSnapshotTasksOutput struct {
 
 // String returns the string representation
 func (s DescribeImportSnapshotTasksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11892,7 +11892,7 @@ type metadataDescribeInstanceAttributeInput struct {
 
 // String returns the string representation
 func (s DescribeInstanceAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11957,7 +11957,7 @@ type metadataDescribeInstanceAttributeOutput struct {
 
 // String returns the string representation
 func (s DescribeInstanceAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12042,7 +12042,7 @@ type metadataDescribeInstanceStatusInput struct {
 
 // String returns the string representation
 func (s DescribeInstanceStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12067,7 +12067,7 @@ type metadataDescribeInstanceStatusOutput struct {
 
 // String returns the string representation
 func (s DescribeInstanceStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12332,7 +12332,7 @@ type metadataDescribeInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12357,7 +12357,7 @@ type metadataDescribeInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12408,7 +12408,7 @@ type metadataDescribeInternetGatewaysInput struct {
 
 // String returns the string representation
 func (s DescribeInternetGatewaysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12429,7 +12429,7 @@ type metadataDescribeInternetGatewaysOutput struct {
 
 // String returns the string representation
 func (s DescribeInternetGatewaysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12465,7 +12465,7 @@ type metadataDescribeKeyPairsInput struct {
 
 // String returns the string representation
 func (s DescribeKeyPairsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12486,7 +12486,7 @@ type metadataDescribeKeyPairsOutput struct {
 
 // String returns the string representation
 func (s DescribeKeyPairsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12529,7 +12529,7 @@ type metadataDescribeMovingAddressesInput struct {
 
 // String returns the string representation
 func (s DescribeMovingAddressesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12554,7 +12554,7 @@ type metadataDescribeMovingAddressesOutput struct {
 
 // String returns the string representation
 func (s DescribeMovingAddressesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12632,7 +12632,7 @@ type metadataDescribeNetworkACLsInput struct {
 
 // String returns the string representation
 func (s DescribeNetworkACLsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12653,7 +12653,7 @@ type metadataDescribeNetworkACLsOutput struct {
 
 // String returns the string representation
 func (s DescribeNetworkACLsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12683,7 +12683,7 @@ type metadataDescribeNetworkInterfaceAttributeInput struct {
 
 // String returns the string representation
 func (s DescribeNetworkInterfaceAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12716,7 +12716,7 @@ type metadataDescribeNetworkInterfaceAttributeOutput struct {
 
 // String returns the string representation
 func (s DescribeNetworkInterfaceAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12846,7 +12846,7 @@ type metadataDescribeNetworkInterfacesInput struct {
 
 // String returns the string representation
 func (s DescribeNetworkInterfacesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12867,7 +12867,7 @@ type metadataDescribeNetworkInterfacesOutput struct {
 
 // String returns the string representation
 func (s DescribeNetworkInterfacesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12906,7 +12906,7 @@ type metadataDescribePlacementGroupsInput struct {
 
 // String returns the string representation
 func (s DescribePlacementGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12927,7 +12927,7 @@ type metadataDescribePlacementGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribePlacementGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12973,7 +12973,7 @@ type metadataDescribePrefixListsInput struct {
 
 // String returns the string representation
 func (s DescribePrefixListsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -12998,7 +12998,7 @@ type metadataDescribePrefixListsOutput struct {
 
 // String returns the string representation
 func (s DescribePrefixListsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13032,7 +13032,7 @@ type metadataDescribeRegionsInput struct {
 
 // String returns the string representation
 func (s DescribeRegionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13053,7 +13053,7 @@ type metadataDescribeRegionsOutput struct {
 
 // String returns the string representation
 func (s DescribeRegionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13138,7 +13138,7 @@ type metadataDescribeReservedInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeReservedInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13174,7 +13174,7 @@ type metadataDescribeReservedInstancesListingsInput struct {
 
 // String returns the string representation
 func (s DescribeReservedInstancesListingsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13195,7 +13195,7 @@ type metadataDescribeReservedInstancesListingsOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedInstancesListingsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13255,7 +13255,7 @@ type metadataDescribeReservedInstancesModificationsInput struct {
 
 // String returns the string representation
 func (s DescribeReservedInstancesModificationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13280,7 +13280,7 @@ type metadataDescribeReservedInstancesModificationsOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedInstancesModificationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13393,7 +13393,7 @@ type metadataDescribeReservedInstancesOfferingsInput struct {
 
 // String returns the string representation
 func (s DescribeReservedInstancesOfferingsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13418,7 +13418,7 @@ type metadataDescribeReservedInstancesOfferingsOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedInstancesOfferingsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13439,7 +13439,7 @@ type metadataDescribeReservedInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13523,7 +13523,7 @@ type metadataDescribeRouteTablesInput struct {
 
 // String returns the string representation
 func (s DescribeRouteTablesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13544,7 +13544,7 @@ type metadataDescribeRouteTablesOutput struct {
 
 // String returns the string representation
 func (s DescribeRouteTablesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13622,7 +13622,7 @@ type metadataDescribeSecurityGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeSecurityGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13643,7 +13643,7 @@ type metadataDescribeSecurityGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeSecurityGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13673,7 +13673,7 @@ type metadataDescribeSnapshotAttributeInput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13700,7 +13700,7 @@ type metadataDescribeSnapshotAttributeOutput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13789,7 +13789,7 @@ type metadataDescribeSnapshotsInput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13816,7 +13816,7 @@ type metadataDescribeSnapshotsOutput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13841,7 +13841,7 @@ type metadataDescribeSpotDatafeedSubscriptionInput struct {
 
 // String returns the string representation
 func (s DescribeSpotDatafeedSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13863,7 +13863,7 @@ type metadataDescribeSpotDatafeedSubscriptionOutput struct {
 
 // String returns the string representation
 func (s DescribeSpotDatafeedSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13899,7 +13899,7 @@ type metadataDescribeSpotFleetInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeSpotFleetInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13929,7 +13929,7 @@ type metadataDescribeSpotFleetInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeSpotFleetInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -13971,7 +13971,7 @@ type metadataDescribeSpotFleetRequestHistoryInput struct {
 
 // String returns the string representation
 func (s DescribeSpotFleetRequestHistoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14009,7 +14009,7 @@ type metadataDescribeSpotFleetRequestHistoryOutput struct {
 
 // String returns the string representation
 func (s DescribeSpotFleetRequestHistoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14045,7 +14045,7 @@ type metadataDescribeSpotFleetRequestsInput struct {
 
 // String returns the string representation
 func (s DescribeSpotFleetRequestsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14071,7 +14071,7 @@ type metadataDescribeSpotFleetRequestsOutput struct {
 
 // String returns the string representation
 func (s DescribeSpotFleetRequestsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14209,7 +14209,7 @@ type metadataDescribeSpotInstanceRequestsInput struct {
 
 // String returns the string representation
 func (s DescribeSpotInstanceRequestsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14231,7 +14231,7 @@ type metadataDescribeSpotInstanceRequestsOutput struct {
 
 // String returns the string representation
 func (s DescribeSpotInstanceRequestsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14299,7 +14299,7 @@ type metadataDescribeSpotPriceHistoryInput struct {
 
 // String returns the string representation
 func (s DescribeSpotPriceHistoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14325,7 +14325,7 @@ type metadataDescribeSpotPriceHistoryOutput struct {
 
 // String returns the string representation
 func (s DescribeSpotPriceHistoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14388,7 +14388,7 @@ type metadataDescribeSubnetsInput struct {
 
 // String returns the string representation
 func (s DescribeSubnetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14409,7 +14409,7 @@ type metadataDescribeSubnetsOutput struct {
 
 // String returns the string representation
 func (s DescribeSubnetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14457,7 +14457,7 @@ type metadataDescribeTagsInput struct {
 
 // String returns the string representation
 func (s DescribeTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14482,7 +14482,7 @@ type metadataDescribeTagsOutput struct {
 
 // String returns the string representation
 func (s DescribeTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14512,7 +14512,7 @@ type metadataDescribeVPCAttributeInput struct {
 
 // String returns the string representation
 func (s DescribeVPCAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14543,7 +14543,7 @@ type metadataDescribeVPCAttributeOutput struct {
 
 // String returns the string representation
 func (s DescribeVPCAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14588,7 +14588,7 @@ type metadataDescribeVPCClassicLinkInput struct {
 
 // String returns the string representation
 func (s DescribeVPCClassicLinkInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14609,7 +14609,7 @@ type metadataDescribeVPCClassicLinkOutput struct {
 
 // String returns the string representation
 func (s DescribeVPCClassicLinkOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14644,7 +14644,7 @@ type metadataDescribeVPCEndpointServicesInput struct {
 
 // String returns the string representation
 func (s DescribeVPCEndpointServicesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14669,7 +14669,7 @@ type metadataDescribeVPCEndpointServicesOutput struct {
 
 // String returns the string representation
 func (s DescribeVPCEndpointServicesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14719,7 +14719,7 @@ type metadataDescribeVPCEndpointsInput struct {
 
 // String returns the string representation
 func (s DescribeVPCEndpointsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14744,7 +14744,7 @@ type metadataDescribeVPCEndpointsOutput struct {
 
 // String returns the string representation
 func (s DescribeVPCEndpointsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14812,7 +14812,7 @@ type metadataDescribeVPCPeeringConnectionsInput struct {
 
 // String returns the string representation
 func (s DescribeVPCPeeringConnectionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14833,7 +14833,7 @@ type metadataDescribeVPCPeeringConnectionsOutput struct {
 
 // String returns the string representation
 func (s DescribeVPCPeeringConnectionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14889,7 +14889,7 @@ type metadataDescribeVPCsInput struct {
 
 // String returns the string representation
 func (s DescribeVPCsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14910,7 +14910,7 @@ type metadataDescribeVPCsOutput struct {
 
 // String returns the string representation
 func (s DescribeVPCsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -14981,7 +14981,7 @@ type metadataDescribeVPNConnectionsInput struct {
 
 // String returns the string representation
 func (s DescribeVPNConnectionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15002,7 +15002,7 @@ type metadataDescribeVPNConnectionsOutput struct {
 
 // String returns the string representation
 func (s DescribeVPNConnectionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15061,7 +15061,7 @@ type metadataDescribeVPNGatewaysInput struct {
 
 // String returns the string representation
 func (s DescribeVPNGatewaysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15082,7 +15082,7 @@ type metadataDescribeVPNGatewaysOutput struct {
 
 // String returns the string representation
 func (s DescribeVPNGatewaysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15112,7 +15112,7 @@ type metadataDescribeVolumeAttributeInput struct {
 
 // String returns the string representation
 func (s DescribeVolumeAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15139,7 +15139,7 @@ type metadataDescribeVolumeAttributeOutput struct {
 
 // String returns the string representation
 func (s DescribeVolumeAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15217,7 +15217,7 @@ type metadataDescribeVolumeStatusInput struct {
 
 // String returns the string representation
 func (s DescribeVolumeStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15242,7 +15242,7 @@ type metadataDescribeVolumeStatusOutput struct {
 
 // String returns the string representation
 func (s DescribeVolumeStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15334,7 +15334,7 @@ type metadataDescribeVolumesInput struct {
 
 // String returns the string representation
 func (s DescribeVolumesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15361,7 +15361,7 @@ type metadataDescribeVolumesOutput struct {
 
 // String returns the string representation
 func (s DescribeVolumesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15391,7 +15391,7 @@ type metadataDetachClassicLinkVPCInput struct {
 
 // String returns the string representation
 func (s DetachClassicLinkVPCInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15412,7 +15412,7 @@ type metadataDetachClassicLinkVPCOutput struct {
 
 // String returns the string representation
 func (s DetachClassicLinkVPCOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15442,7 +15442,7 @@ type metadataDetachInternetGatewayInput struct {
 
 // String returns the string representation
 func (s DetachInternetGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15460,7 +15460,7 @@ type metadataDetachInternetGatewayOutput struct {
 
 // String returns the string representation
 func (s DetachInternetGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15490,7 +15490,7 @@ type metadataDetachNetworkInterfaceInput struct {
 
 // String returns the string representation
 func (s DetachNetworkInterfaceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15508,7 +15508,7 @@ type metadataDetachNetworkInterfaceOutput struct {
 
 // String returns the string representation
 func (s DetachNetworkInterfaceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15538,7 +15538,7 @@ type metadataDetachVPNGatewayInput struct {
 
 // String returns the string representation
 func (s DetachVPNGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15556,7 +15556,7 @@ type metadataDetachVPNGatewayOutput struct {
 
 // String returns the string representation
 func (s DetachVPNGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15598,7 +15598,7 @@ type metadataDetachVolumeInput struct {
 
 // String returns the string representation
 func (s DetachVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15622,7 +15622,7 @@ type metadataDisableVGWRoutePropagationInput struct {
 
 // String returns the string representation
 func (s DisableVGWRoutePropagationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15640,7 +15640,7 @@ type metadataDisableVGWRoutePropagationOutput struct {
 
 // String returns the string representation
 func (s DisableVGWRoutePropagationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15667,7 +15667,7 @@ type metadataDisableVPCClassicLinkInput struct {
 
 // String returns the string representation
 func (s DisableVPCClassicLinkInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15688,7 +15688,7 @@ type metadataDisableVPCClassicLinkOutput struct {
 
 // String returns the string representation
 func (s DisableVPCClassicLinkOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15718,7 +15718,7 @@ type metadataDisassociateAddressInput struct {
 
 // String returns the string representation
 func (s DisassociateAddressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15736,7 +15736,7 @@ type metadataDisassociateAddressOutput struct {
 
 // String returns the string representation
 func (s DisassociateAddressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15764,7 +15764,7 @@ type metadataDisassociateRouteTableInput struct {
 
 // String returns the string representation
 func (s DisassociateRouteTableInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15782,7 +15782,7 @@ type metadataDisassociateRouteTableOutput struct {
 
 // String returns the string representation
 func (s DisassociateRouteTableOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15810,7 +15810,7 @@ type metadataDiskImage struct {
 
 // String returns the string representation
 func (s DiskImage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15845,7 +15845,7 @@ type metadataDiskImageDescription struct {
 
 // String returns the string representation
 func (s DiskImageDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15877,7 +15877,7 @@ type metadataDiskImageDetail struct {
 
 // String returns the string representation
 func (s DiskImageDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15902,7 +15902,7 @@ type metadataDiskImageVolumeDescription struct {
 
 // String returns the string representation
 func (s DiskImageVolumeDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15962,7 +15962,7 @@ type metadataEBSBlockDevice struct {
 
 // String returns the string representation
 func (s EBSBlockDevice) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -15993,7 +15993,7 @@ type metadataEBSInstanceBlockDevice struct {
 
 // String returns the string representation
 func (s EBSInstanceBlockDevice) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16017,7 +16017,7 @@ type metadataEBSInstanceBlockDeviceSpecification struct {
 
 // String returns the string representation
 func (s EBSInstanceBlockDeviceSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16041,7 +16041,7 @@ type metadataEnableVGWRoutePropagationInput struct {
 
 // String returns the string representation
 func (s EnableVGWRoutePropagationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16059,7 +16059,7 @@ type metadataEnableVGWRoutePropagationOutput struct {
 
 // String returns the string representation
 func (s EnableVGWRoutePropagationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16086,7 +16086,7 @@ type metadataEnableVPCClassicLinkInput struct {
 
 // String returns the string representation
 func (s EnableVPCClassicLinkInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16107,7 +16107,7 @@ type metadataEnableVPCClassicLinkOutput struct {
 
 // String returns the string representation
 func (s EnableVPCClassicLinkOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16134,7 +16134,7 @@ type metadataEnableVolumeIOInput struct {
 
 // String returns the string representation
 func (s EnableVolumeIOInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16152,7 +16152,7 @@ type metadataEnableVolumeIOOutput struct {
 
 // String returns the string representation
 func (s EnableVolumeIOOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16221,7 +16221,7 @@ type metadataEventInformation struct {
 
 // String returns the string representation
 func (s EventInformation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16258,7 +16258,7 @@ type metadataExportTask struct {
 
 // String returns the string representation
 func (s ExportTask) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16291,7 +16291,7 @@ type metadataExportToS3Task struct {
 
 // String returns the string representation
 func (s ExportToS3Task) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16325,7 +16325,7 @@ type metadataExportToS3TaskSpecification struct {
 
 // String returns the string representation
 func (s ExportToS3TaskSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16352,7 +16352,7 @@ type metadataFilter struct {
 
 // String returns the string representation
 func (s Filter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16402,7 +16402,7 @@ type metadataFlowLog struct {
 
 // String returns the string representation
 func (s FlowLog) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16429,7 +16429,7 @@ type metadataGetConsoleOutputInput struct {
 
 // String returns the string representation
 func (s GetConsoleOutputInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16456,7 +16456,7 @@ type metadataGetConsoleOutputOutput struct {
 
 // String returns the string representation
 func (s GetConsoleOutputOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16483,7 +16483,7 @@ type metadataGetPasswordDataInput struct {
 
 // String returns the string representation
 func (s GetPasswordDataInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16510,7 +16510,7 @@ type metadataGetPasswordDataOutput struct {
 
 // String returns the string representation
 func (s GetPasswordDataOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16535,7 +16535,7 @@ type metadataGroupIdentifier struct {
 
 // String returns the string representation
 func (s GroupIdentifier) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16570,7 +16570,7 @@ type metadataHistoryRecord struct {
 
 // String returns the string representation
 func (s HistoryRecord) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16595,7 +16595,7 @@ type metadataIAMInstanceProfile struct {
 
 // String returns the string representation
 func (s IAMInstanceProfile) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16620,7 +16620,7 @@ type metadataIAMInstanceProfileSpecification struct {
 
 // String returns the string representation
 func (s IAMInstanceProfileSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16645,7 +16645,7 @@ type metadataICMPTypeCode struct {
 
 // String returns the string representation
 func (s ICMPTypeCode) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16694,7 +16694,7 @@ type metadataIPPermission struct {
 
 // String returns the string representation
 func (s IPPermission) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16717,7 +16717,7 @@ type metadataIPRange struct {
 
 // String returns the string representation
 func (s IPRange) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16812,7 +16812,7 @@ type metadataImage struct {
 
 // String returns the string representation
 func (s Image) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16852,7 +16852,7 @@ type metadataImageDiskContainer struct {
 
 // String returns the string representation
 func (s ImageDiskContainer) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16916,7 +16916,7 @@ type metadataImportImageInput struct {
 
 // String returns the string representation
 func (s ImportImageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -16967,7 +16967,7 @@ type metadataImportImageOutput struct {
 
 // String returns the string representation
 func (s ImportImageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17023,7 +17023,7 @@ type metadataImportImageTask struct {
 
 // String returns the string representation
 func (s ImportImageTask) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17059,7 +17059,7 @@ type metadataImportInstanceInput struct {
 
 // String returns the string representation
 func (s ImportInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17114,7 +17114,7 @@ type metadataImportInstanceLaunchSpecification struct {
 
 // String returns the string representation
 func (s ImportInstanceLaunchSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17135,7 +17135,7 @@ type metadataImportInstanceOutput struct {
 
 // String returns the string representation
 func (s ImportInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17166,7 +17166,7 @@ type metadataImportInstanceTaskDetails struct {
 
 // String returns the string representation
 func (s ImportInstanceTaskDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17206,7 +17206,7 @@ type metadataImportInstanceVolumeDetailItem struct {
 
 // String returns the string representation
 func (s ImportInstanceVolumeDetailItem) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17237,7 +17237,7 @@ type metadataImportKeyPairInput struct {
 
 // String returns the string representation
 func (s ImportKeyPairInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17261,7 +17261,7 @@ type metadataImportKeyPairOutput struct {
 
 // String returns the string representation
 func (s ImportKeyPairOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17300,7 +17300,7 @@ type metadataImportSnapshotInput struct {
 
 // String returns the string representation
 func (s ImportSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17327,7 +17327,7 @@ type metadataImportSnapshotOutput struct {
 
 // String returns the string representation
 func (s ImportSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17355,7 +17355,7 @@ type metadataImportSnapshotTask struct {
 
 // String returns the string representation
 func (s ImportSnapshotTask) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17391,7 +17391,7 @@ type metadataImportVolumeInput struct {
 
 // String returns the string representation
 func (s ImportVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17412,7 +17412,7 @@ type metadataImportVolumeOutput struct {
 
 // String returns the string representation
 func (s ImportVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17446,7 +17446,7 @@ type metadataImportVolumeTaskDetails struct {
 
 // String returns the string representation
 func (s ImportVolumeTaskDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17591,7 +17591,7 @@ type metadataInstance struct {
 
 // String returns the string representation
 func (s Instance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17617,7 +17617,7 @@ type metadataInstanceBlockDeviceMapping struct {
 
 // String returns the string representation
 func (s InstanceBlockDeviceMapping) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17649,7 +17649,7 @@ type metadataInstanceBlockDeviceMappingSpecification struct {
 
 // String returns the string representation
 func (s InstanceBlockDeviceMappingSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17674,7 +17674,7 @@ type metadataInstanceCount struct {
 
 // String returns the string representation
 func (s InstanceCount) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17699,7 +17699,7 @@ type metadataInstanceExportDetails struct {
 
 // String returns the string representation
 func (s InstanceExportDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17724,7 +17724,7 @@ type metadataInstanceMonitoring struct {
 
 // String returns the string representation
 func (s InstanceMonitoring) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17786,7 +17786,7 @@ type metadataInstanceNetworkInterface struct {
 
 // String returns the string representation
 func (s InstanceNetworkInterface) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17814,7 +17814,7 @@ type metadataInstanceNetworkInterfaceAssociation struct {
 
 // String returns the string representation
 func (s InstanceNetworkInterfaceAssociation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17848,7 +17848,7 @@ type metadataInstanceNetworkInterfaceAttachment struct {
 
 // String returns the string representation
 func (s InstanceNetworkInterfaceAttachment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17912,7 +17912,7 @@ type metadataInstanceNetworkInterfaceSpecification struct {
 
 // String returns the string representation
 func (s InstanceNetworkInterfaceSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17944,7 +17944,7 @@ type metadataInstancePrivateIPAddress struct {
 
 // String returns the string representation
 func (s InstancePrivateIPAddress) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -17982,7 +17982,7 @@ type metadataInstanceState struct {
 
 // String returns the string representation
 func (s InstanceState) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18010,7 +18010,7 @@ type metadataInstanceStateChange struct {
 
 // String returns the string representation
 func (s InstanceStateChange) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18051,7 +18051,7 @@ type metadataInstanceStatus struct {
 
 // String returns the string representation
 func (s InstanceStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18080,7 +18080,7 @@ type metadataInstanceStatusDetails struct {
 
 // String returns the string representation
 func (s InstanceStatusDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18115,7 +18115,7 @@ type metadataInstanceStatusEvent struct {
 
 // String returns the string representation
 func (s InstanceStatusEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18140,7 +18140,7 @@ type metadataInstanceStatusSummary struct {
 
 // String returns the string representation
 func (s InstanceStatusSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18168,7 +18168,7 @@ type metadataInternetGateway struct {
 
 // String returns the string representation
 func (s InternetGateway) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18193,7 +18193,7 @@ type metadataInternetGatewayAttachment struct {
 
 // String returns the string representation
 func (s InternetGatewayAttachment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18221,7 +18221,7 @@ type metadataKeyPairInfo struct {
 
 // String returns the string representation
 func (s KeyPairInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18246,7 +18246,7 @@ type metadataLaunchPermission struct {
 
 // String returns the string representation
 func (s LaunchPermission) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18272,7 +18272,7 @@ type metadataLaunchPermissionModifications struct {
 
 // String returns the string representation
 func (s LaunchPermissionModifications) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18345,7 +18345,7 @@ type metadataLaunchSpecification struct {
 
 // String returns the string representation
 func (s LaunchSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18400,7 +18400,7 @@ type metadataModifyImageAttributeInput struct {
 
 // String returns the string representation
 func (s ModifyImageAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18418,7 +18418,7 @@ type metadataModifyImageAttributeOutput struct {
 
 // String returns the string representation
 func (s ModifyImageAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18514,7 +18514,7 @@ type metadataModifyInstanceAttributeInput struct {
 
 // String returns the string representation
 func (s ModifyInstanceAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18532,7 +18532,7 @@ type metadataModifyInstanceAttributeOutput struct {
 
 // String returns the string representation
 func (s ModifyInstanceAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18579,7 +18579,7 @@ type metadataModifyNetworkInterfaceAttributeInput struct {
 
 // String returns the string representation
 func (s ModifyNetworkInterfaceAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18597,7 +18597,7 @@ type metadataModifyNetworkInterfaceAttributeOutput struct {
 
 // String returns the string representation
 func (s ModifyNetworkInterfaceAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18625,7 +18625,7 @@ type metadataModifyReservedInstancesInput struct {
 
 // String returns the string representation
 func (s ModifyReservedInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18646,7 +18646,7 @@ type metadataModifyReservedInstancesOutput struct {
 
 // String returns the string representation
 func (s ModifyReservedInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18688,7 +18688,7 @@ type metadataModifySnapshotAttributeInput struct {
 
 // String returns the string representation
 func (s ModifySnapshotAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18706,7 +18706,7 @@ type metadataModifySnapshotAttributeOutput struct {
 
 // String returns the string representation
 func (s ModifySnapshotAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18731,7 +18731,7 @@ type metadataModifySubnetAttributeInput struct {
 
 // String returns the string representation
 func (s ModifySubnetAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18749,7 +18749,7 @@ type metadataModifySubnetAttributeOutput struct {
 
 // String returns the string representation
 func (s ModifySubnetAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18783,7 +18783,7 @@ type metadataModifyVPCAttributeInput struct {
 
 // String returns the string representation
 func (s ModifyVPCAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18801,7 +18801,7 @@ type metadataModifyVPCAttributeOutput struct {
 
 // String returns the string representation
 func (s ModifyVPCAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18842,7 +18842,7 @@ type metadataModifyVPCEndpointInput struct {
 
 // String returns the string representation
 func (s ModifyVPCEndpointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18863,7 +18863,7 @@ type metadataModifyVPCEndpointOutput struct {
 
 // String returns the string representation
 func (s ModifyVPCEndpointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18893,7 +18893,7 @@ type metadataModifyVolumeAttributeInput struct {
 
 // String returns the string representation
 func (s ModifyVolumeAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18911,7 +18911,7 @@ type metadataModifyVolumeAttributeOutput struct {
 
 // String returns the string representation
 func (s ModifyVolumeAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18938,7 +18938,7 @@ type metadataMonitorInstancesInput struct {
 
 // String returns the string representation
 func (s MonitorInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18959,7 +18959,7 @@ type metadataMonitorInstancesOutput struct {
 
 // String returns the string representation
 func (s MonitorInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -18981,7 +18981,7 @@ type metadataMonitoring struct {
 
 // String returns the string representation
 func (s Monitoring) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19008,7 +19008,7 @@ type metadataMoveAddressToVPCInput struct {
 
 // String returns the string representation
 func (s MoveAddressToVPCInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19032,7 +19032,7 @@ type metadataMoveAddressToVPCOutput struct {
 
 // String returns the string representation
 func (s MoveAddressToVPCOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19058,7 +19058,7 @@ type metadataMovingAddressStatus struct {
 
 // String returns the string representation
 func (s MovingAddressStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19095,7 +19095,7 @@ type metadataNetworkACL struct {
 
 // String returns the string representation
 func (s NetworkACL) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19123,7 +19123,7 @@ type metadataNetworkACLAssociation struct {
 
 // String returns the string representation
 func (s NetworkACLAssociation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19165,7 +19165,7 @@ type metadataNetworkACLEntry struct {
 
 // String returns the string representation
 func (s NetworkACLEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19240,7 +19240,7 @@ type metadataNetworkInterface struct {
 
 // String returns the string representation
 func (s NetworkInterface) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19274,7 +19274,7 @@ type metadataNetworkInterfaceAssociation struct {
 
 // String returns the string representation
 func (s NetworkInterfaceAssociation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19314,7 +19314,7 @@ type metadataNetworkInterfaceAttachment struct {
 
 // String returns the string representation
 func (s NetworkInterfaceAttachment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19339,7 +19339,7 @@ type metadataNetworkInterfaceAttachmentChanges struct {
 
 // String returns the string representation
 func (s NetworkInterfaceAttachmentChanges) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19372,7 +19372,7 @@ type metadataNetworkInterfacePrivateIPAddress struct {
 
 // String returns the string representation
 func (s NetworkInterfacePrivateIPAddress) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19394,7 +19394,7 @@ type metadataNewDHCPConfiguration struct {
 
 // String returns the string representation
 func (s NewDHCPConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19423,7 +19423,7 @@ type metadataPlacement struct {
 
 // String returns the string representation
 func (s Placement) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19451,7 +19451,7 @@ type metadataPlacementGroup struct {
 
 // String returns the string representation
 func (s PlacementGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19476,7 +19476,7 @@ type metadataPortRange struct {
 
 // String returns the string representation
 func (s PortRange) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19504,7 +19504,7 @@ type metadataPrefixList struct {
 
 // String returns the string representation
 func (s PrefixList) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19526,7 +19526,7 @@ type metadataPrefixListID struct {
 
 // String returns the string representation
 func (s PrefixListID) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19568,7 +19568,7 @@ type metadataPriceSchedule struct {
 
 // String returns the string representation
 func (s PriceSchedule) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19598,7 +19598,7 @@ type metadataPriceScheduleSpecification struct {
 
 // String returns the string representation
 func (s PriceScheduleSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19623,7 +19623,7 @@ type metadataPricingDetail struct {
 
 // String returns the string representation
 func (s PricingDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19649,7 +19649,7 @@ type metadataPrivateIPAddressSpecification struct {
 
 // String returns the string representation
 func (s PrivateIPAddressSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19674,7 +19674,7 @@ type metadataProductCode struct {
 
 // String returns the string representation
 func (s ProductCode) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19696,7 +19696,7 @@ type metadataPropagatingVGW struct {
 
 // String returns the string representation
 func (s PropagatingVGW) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19731,7 +19731,7 @@ type metadataPurchaseReservedInstancesOfferingInput struct {
 
 // String returns the string representation
 func (s PurchaseReservedInstancesOfferingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19752,7 +19752,7 @@ type metadataPurchaseReservedInstancesOfferingOutput struct {
 
 // String returns the string representation
 func (s PurchaseReservedInstancesOfferingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19779,7 +19779,7 @@ type metadataRebootInstancesInput struct {
 
 // String returns the string representation
 func (s RebootInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19797,7 +19797,7 @@ type metadataRebootInstancesOutput struct {
 
 // String returns the string representation
 func (s RebootInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19822,7 +19822,7 @@ type metadataRecurringCharge struct {
 
 // String returns the string representation
 func (s RecurringCharge) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19847,7 +19847,7 @@ type metadataRegion struct {
 
 // String returns the string representation
 func (s Region) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19916,7 +19916,7 @@ type metadataRegisterImageInput struct {
 
 // String returns the string representation
 func (s RegisterImageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19937,7 +19937,7 @@ type metadataRegisterImageOutput struct {
 
 // String returns the string representation
 func (s RegisterImageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19964,7 +19964,7 @@ type metadataRejectVPCPeeringConnectionInput struct {
 
 // String returns the string representation
 func (s RejectVPCPeeringConnectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -19985,7 +19985,7 @@ type metadataRejectVPCPeeringConnectionOutput struct {
 
 // String returns the string representation
 func (s RejectVPCPeeringConnectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20015,7 +20015,7 @@ type metadataReleaseAddressInput struct {
 
 // String returns the string representation
 func (s ReleaseAddressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20033,7 +20033,7 @@ type metadataReleaseAddressOutput struct {
 
 // String returns the string representation
 func (s ReleaseAddressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20064,7 +20064,7 @@ type metadataReplaceNetworkACLAssociationInput struct {
 
 // String returns the string representation
 func (s ReplaceNetworkACLAssociationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20085,7 +20085,7 @@ type metadataReplaceNetworkACLAssociationOutput struct {
 
 // String returns the string representation
 func (s ReplaceNetworkACLAssociationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20137,7 +20137,7 @@ type metadataReplaceNetworkACLEntryInput struct {
 
 // String returns the string representation
 func (s ReplaceNetworkACLEntryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20155,7 +20155,7 @@ type metadataReplaceNetworkACLEntryOutput struct {
 
 // String returns the string representation
 func (s ReplaceNetworkACLEntryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20198,7 +20198,7 @@ type metadataReplaceRouteInput struct {
 
 // String returns the string representation
 func (s ReplaceRouteInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20216,7 +20216,7 @@ type metadataReplaceRouteOutput struct {
 
 // String returns the string representation
 func (s ReplaceRouteOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20246,7 +20246,7 @@ type metadataReplaceRouteTableAssociationInput struct {
 
 // String returns the string representation
 func (s ReplaceRouteTableAssociationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20267,7 +20267,7 @@ type metadataReplaceRouteTableAssociationOutput struct {
 
 // String returns the string representation
 func (s ReplaceRouteTableAssociationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20330,7 +20330,7 @@ type metadataReportInstanceStatusInput struct {
 
 // String returns the string representation
 func (s ReportInstanceStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20348,7 +20348,7 @@ type metadataReportInstanceStatusOutput struct {
 
 // String returns the string representation
 func (s ReportInstanceStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20376,7 +20376,7 @@ type metadataRequestSpotFleetInput struct {
 
 // String returns the string representation
 func (s RequestSpotFleetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20398,7 +20398,7 @@ type metadataRequestSpotFleetOutput struct {
 
 // String returns the string representation
 func (s RequestSpotFleetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20489,7 +20489,7 @@ type metadataRequestSpotInstancesInput struct {
 
 // String returns the string representation
 func (s RequestSpotInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20511,7 +20511,7 @@ type metadataRequestSpotInstancesOutput struct {
 
 // String returns the string representation
 func (s RequestSpotInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20582,7 +20582,7 @@ type metadataRequestSpotLaunchSpecification struct {
 
 // String returns the string representation
 func (s RequestSpotLaunchSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20617,7 +20617,7 @@ type metadataReservation struct {
 
 // String returns the string representation
 func (s Reservation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20644,7 +20644,7 @@ type metadataReservedInstanceLimitPrice struct {
 
 // String returns the string representation
 func (s ReservedInstanceLimitPrice) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20712,7 +20712,7 @@ type metadataReservedInstances struct {
 
 // String returns the string representation
 func (s ReservedInstances) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20744,7 +20744,7 @@ type metadataReservedInstancesConfiguration struct {
 
 // String returns the string representation
 func (s ReservedInstancesConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20766,7 +20766,7 @@ type metadataReservedInstancesID struct {
 
 // String returns the string representation
 func (s ReservedInstancesID) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20817,7 +20817,7 @@ type metadataReservedInstancesListing struct {
 
 // String returns the string representation
 func (s ReservedInstancesListing) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20865,7 +20865,7 @@ type metadataReservedInstancesModification struct {
 
 // String returns the string representation
 func (s ReservedInstancesModification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20891,7 +20891,7 @@ type metadataReservedInstancesModificationResult struct {
 
 // String returns the string representation
 func (s ReservedInstancesModificationResult) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20953,7 +20953,7 @@ type metadataReservedInstancesOffering struct {
 
 // String returns the string representation
 func (s ReservedInstancesOffering) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -20984,7 +20984,7 @@ type metadataResetImageAttributeInput struct {
 
 // String returns the string representation
 func (s ResetImageAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21002,7 +21002,7 @@ type metadataResetImageAttributeOutput struct {
 
 // String returns the string representation
 func (s ResetImageAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21032,7 +21032,7 @@ type metadataResetInstanceAttributeInput struct {
 
 // String returns the string representation
 func (s ResetInstanceAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21050,7 +21050,7 @@ type metadataResetInstanceAttributeOutput struct {
 
 // String returns the string representation
 func (s ResetInstanceAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21080,7 +21080,7 @@ type metadataResetNetworkInterfaceAttributeInput struct {
 
 // String returns the string representation
 func (s ResetNetworkInterfaceAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21098,7 +21098,7 @@ type metadataResetNetworkInterfaceAttributeOutput struct {
 
 // String returns the string representation
 func (s ResetNetworkInterfaceAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21129,7 +21129,7 @@ type metadataResetSnapshotAttributeInput struct {
 
 // String returns the string representation
 func (s ResetSnapshotAttributeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21147,7 +21147,7 @@ type metadataResetSnapshotAttributeOutput struct {
 
 // String returns the string representation
 func (s ResetSnapshotAttributeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21174,7 +21174,7 @@ type metadataRestoreAddressToClassicInput struct {
 
 // String returns the string representation
 func (s RestoreAddressToClassicInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21198,7 +21198,7 @@ type metadataRestoreAddressToClassicOutput struct {
 
 // String returns the string representation
 func (s RestoreAddressToClassicOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21253,7 +21253,7 @@ type metadataRevokeSecurityGroupEgressInput struct {
 
 // String returns the string representation
 func (s RevokeSecurityGroupEgressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21271,7 +21271,7 @@ type metadataRevokeSecurityGroupEgressOutput struct {
 
 // String returns the string representation
 func (s RevokeSecurityGroupEgressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21332,7 +21332,7 @@ type metadataRevokeSecurityGroupIngressInput struct {
 
 // String returns the string representation
 func (s RevokeSecurityGroupIngressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21350,7 +21350,7 @@ type metadataRevokeSecurityGroupIngressOutput struct {
 
 // String returns the string representation
 func (s RevokeSecurityGroupIngressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21403,7 +21403,7 @@ type metadataRoute struct {
 
 // String returns the string representation
 func (s Route) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21440,7 +21440,7 @@ type metadataRouteTable struct {
 
 // String returns the string representation
 func (s RouteTable) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21471,7 +21471,7 @@ type metadataRouteTableAssociation struct {
 
 // String returns the string representation
 func (s RouteTableAssociation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21622,7 +21622,7 @@ type metadataRunInstancesInput struct {
 
 // String returns the string representation
 func (s RunInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21644,7 +21644,7 @@ type metadataRunInstancesMonitoringEnabled struct {
 
 // String returns the string representation
 func (s RunInstancesMonitoringEnabled) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21684,7 +21684,7 @@ type metadataS3Storage struct {
 
 // String returns the string representation
 func (s S3Storage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21727,7 +21727,7 @@ type metadataSecurityGroup struct {
 
 // String returns the string representation
 func (s SecurityGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21784,7 +21784,7 @@ type metadataSnapshot struct {
 
 // String returns the string representation
 func (s Snapshot) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21833,7 +21833,7 @@ type metadataSnapshotDetail struct {
 
 // String returns the string representation
 func (s SnapshotDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21867,7 +21867,7 @@ type metadataSnapshotDiskContainer struct {
 
 // String returns the string representation
 func (s SnapshotDiskContainer) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21913,7 +21913,7 @@ type metadataSnapshotTaskDetail struct {
 
 // String returns the string representation
 func (s SnapshotTaskDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21947,7 +21947,7 @@ type metadataSpotDatafeedSubscription struct {
 
 // String returns the string representation
 func (s SpotDatafeedSubscription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -21975,7 +21975,7 @@ type metadataSpotFleetRequestConfig struct {
 
 // String returns the string representation
 func (s SpotFleetRequestConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22027,7 +22027,7 @@ type metadataSpotFleetRequestConfigData struct {
 
 // String returns the string representation
 func (s SpotFleetRequestConfigData) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22110,7 +22110,7 @@ type metadataSpotInstanceRequest struct {
 
 // String returns the string representation
 func (s SpotInstanceRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22135,7 +22135,7 @@ type metadataSpotInstanceStateFault struct {
 
 // String returns the string representation
 func (s SpotInstanceStateFault) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22164,7 +22164,7 @@ type metadataSpotInstanceStatus struct {
 
 // String returns the string representation
 func (s SpotInstanceStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22189,7 +22189,7 @@ type metadataSpotPlacement struct {
 
 // String returns the string representation
 func (s SpotPlacement) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22224,7 +22224,7 @@ type metadataSpotPrice struct {
 
 // String returns the string representation
 func (s SpotPrice) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22254,7 +22254,7 @@ type metadataStartInstancesInput struct {
 
 // String returns the string representation
 func (s StartInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22275,7 +22275,7 @@ type metadataStartInstancesOutput struct {
 
 // String returns the string representation
 func (s StartInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22322,7 +22322,7 @@ type metadataStateReason struct {
 
 // String returns the string representation
 func (s StateReason) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22357,7 +22357,7 @@ type metadataStopInstancesInput struct {
 
 // String returns the string representation
 func (s StopInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22378,7 +22378,7 @@ type metadataStopInstancesOutput struct {
 
 // String returns the string representation
 func (s StopInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22400,7 +22400,7 @@ type metadataStorage struct {
 
 // String returns the string representation
 func (s Storage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22447,7 +22447,7 @@ type metadataSubnet struct {
 
 // String returns the string representation
 func (s Subnet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22478,7 +22478,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22509,7 +22509,7 @@ type metadataTagDescription struct {
 
 // String returns the string representation
 func (s TagDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22536,7 +22536,7 @@ type metadataTerminateInstancesInput struct {
 
 // String returns the string representation
 func (s TerminateInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22557,7 +22557,7 @@ type metadataTerminateInstancesOutput struct {
 
 // String returns the string representation
 func (s TerminateInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22582,7 +22582,7 @@ type metadataUnassignPrivateIPAddressesInput struct {
 
 // String returns the string representation
 func (s UnassignPrivateIPAddressesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22600,7 +22600,7 @@ type metadataUnassignPrivateIPAddressesOutput struct {
 
 // String returns the string representation
 func (s UnassignPrivateIPAddressesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22627,7 +22627,7 @@ type metadataUnmonitorInstancesInput struct {
 
 // String returns the string representation
 func (s UnmonitorInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22648,7 +22648,7 @@ type metadataUnmonitorInstancesOutput struct {
 
 // String returns the string representation
 func (s UnmonitorInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22673,7 +22673,7 @@ type metadataUnsuccessfulItem struct {
 
 // String returns the string representation
 func (s UnsuccessfulItem) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22699,7 +22699,7 @@ type metadataUnsuccessfulItemError struct {
 
 // String returns the string representation
 func (s UnsuccessfulItemError) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22724,7 +22724,7 @@ type metadataUserBucket struct {
 
 // String returns the string representation
 func (s UserBucket) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22749,7 +22749,7 @@ type metadataUserBucketDetails struct {
 
 // String returns the string representation
 func (s UserBucketDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22771,7 +22771,7 @@ type metadataUserData struct {
 
 // String returns the string representation
 func (s UserData) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22801,7 +22801,7 @@ type metadataUserIDGroupPair struct {
 
 // String returns the string representation
 func (s UserIDGroupPair) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22836,7 +22836,7 @@ type metadataVGWTelemetry struct {
 
 // String returns the string representation
 func (s VGWTelemetry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22877,7 +22877,7 @@ type metadataVPC struct {
 
 // String returns the string representation
 func (s VPC) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22902,7 +22902,7 @@ type metadataVPCAttachment struct {
 
 // String returns the string representation
 func (s VPCAttachment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22930,7 +22930,7 @@ type metadataVPCClassicLink struct {
 
 // String returns the string representation
 func (s VPCClassicLink) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -22970,7 +22970,7 @@ type metadataVPCEndpoint struct {
 
 // String returns the string representation
 func (s VPCEndpoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23007,7 +23007,7 @@ type metadataVPCPeeringConnection struct {
 
 // String returns the string representation
 func (s VPCPeeringConnection) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23032,7 +23032,7 @@ type metadataVPCPeeringConnectionStateReason struct {
 
 // String returns the string representation
 func (s VPCPeeringConnectionStateReason) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23060,7 +23060,7 @@ type metadataVPCPeeringConnectionVPCInfo struct {
 
 // String returns the string representation
 func (s VPCPeeringConnectionVPCInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23112,7 +23112,7 @@ type metadataVPNConnection struct {
 
 // String returns the string representation
 func (s VPNConnection) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23135,7 +23135,7 @@ type metadataVPNConnectionOptions struct {
 
 // String returns the string representation
 func (s VPNConnectionOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23158,7 +23158,7 @@ type metadataVPNConnectionOptionsSpecification struct {
 
 // String returns the string representation
 func (s VPNConnectionOptionsSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23195,7 +23195,7 @@ type metadataVPNGateway struct {
 
 // String returns the string representation
 func (s VPNGateway) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23223,7 +23223,7 @@ type metadataVPNStaticRoute struct {
 
 // String returns the string representation
 func (s VPNStaticRoute) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23292,7 +23292,7 @@ type metadataVolume struct {
 
 // String returns the string representation
 func (s Volume) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23329,7 +23329,7 @@ type metadataVolumeAttachment struct {
 
 // String returns the string representation
 func (s VolumeAttachment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23351,7 +23351,7 @@ type metadataVolumeDetail struct {
 
 // String returns the string representation
 func (s VolumeDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23382,7 +23382,7 @@ type metadataVolumeStatusAction struct {
 
 // String returns the string representation
 func (s VolumeStatusAction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23407,7 +23407,7 @@ type metadataVolumeStatusDetails struct {
 
 // String returns the string representation
 func (s VolumeStatusDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23441,7 +23441,7 @@ type metadataVolumeStatusEvent struct {
 
 // String returns the string representation
 func (s VolumeStatusEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23466,7 +23466,7 @@ type metadataVolumeStatusInfo struct {
 
 // String returns the string representation
 func (s VolumeStatusInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -23500,7 +23500,7 @@ type metadataVolumeStatusItem struct {
 
 // String returns the string representation
 func (s VolumeStatusItem) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/ec2/customizations.go
+++ b/service/ec2/customizations.go
@@ -33,16 +33,16 @@ func fillPresignedURL(r *aws.Request) {
 
 	// Set destination region. Avoids infinite handler loop.
 	// Also needed to sign sub-request.
-	params.DestinationRegion = &r.Service.Config.Region
+	params.DestinationRegion = r.Service.Config.Region
 
 	// Create a new client pointing at source region.
 	// We will use this to presign the CopySnapshot request against
 	// the source region
-	config := r.Service.Config.Copy()
+	config := r.Service.Config.Copy().
+		WithEndpoint("").
+		WithRegion(*params.SourceRegion)
 
-	config.Endpoint = ""
-	config.Region = *params.SourceRegion
-	client := New(&config)
+	client := New(config)
 
 	// Presign a CopySnapshot request with modified params
 	req, _ := client.CopySnapshotRequest(params)

--- a/service/ec2/customizations_test.go
+++ b/service/ec2/customizations_test.go
@@ -14,7 +14,7 @@ import (
 var _ = unit.Imported
 
 func TestCopySnapshotPresignedURL(t *testing.T) {
-	svc := ec2.New(&aws.Config{Region: "us-west-2"})
+	svc := ec2.New(&aws.Config{Region: aws.String("us-west-2")})
 
 	assert.NotPanics(t, func() {
 		// Doesn't panic on nil input

--- a/service/ec2/examples_test.go
+++ b/service/ec2/examples_test.go
@@ -20,7 +20,7 @@ func ExampleEC2_AcceptVPCPeeringConnection() {
 	svc := ec2.New(nil)
 
 	params := &ec2.AcceptVPCPeeringConnectionInput{
-		DryRun:                 aws.Boolean(true),
+		DryRun:                 aws.Bool(true),
 		VPCPeeringConnectionID: aws.String("String"),
 	}
 	resp, err := svc.AcceptVPCPeeringConnection(params)
@@ -41,7 +41,7 @@ func ExampleEC2_AcceptVPCPeeringConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AllocateAddress() {
@@ -49,7 +49,7 @@ func ExampleEC2_AllocateAddress() {
 
 	params := &ec2.AllocateAddressInput{
 		Domain: aws.String("DomainType"),
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.AllocateAddress(params)
 
@@ -69,7 +69,7 @@ func ExampleEC2_AllocateAddress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AssignPrivateIPAddresses() {
@@ -77,12 +77,12 @@ func ExampleEC2_AssignPrivateIPAddresses() {
 
 	params := &ec2.AssignPrivateIPAddressesInput{
 		NetworkInterfaceID: aws.String("String"), // Required
-		AllowReassignment:  aws.Boolean(true),
+		AllowReassignment:  aws.Bool(true),
 		PrivateIPAddresses: []*string{
 			aws.String("String"), // Required
 			// More values...
 		},
-		SecondaryPrivateIPAddressCount: aws.Long(1),
+		SecondaryPrivateIPAddressCount: aws.Int64(1),
 	}
 	resp, err := svc.AssignPrivateIPAddresses(params)
 
@@ -102,7 +102,7 @@ func ExampleEC2_AssignPrivateIPAddresses() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AssociateAddress() {
@@ -110,8 +110,8 @@ func ExampleEC2_AssociateAddress() {
 
 	params := &ec2.AssociateAddressInput{
 		AllocationID:       aws.String("String"),
-		AllowReassociation: aws.Boolean(true),
-		DryRun:             aws.Boolean(true),
+		AllowReassociation: aws.Bool(true),
+		DryRun:             aws.Bool(true),
 		InstanceID:         aws.String("String"),
 		NetworkInterfaceID: aws.String("String"),
 		PrivateIPAddress:   aws.String("String"),
@@ -135,7 +135,7 @@ func ExampleEC2_AssociateAddress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AssociateDHCPOptions() {
@@ -144,7 +144,7 @@ func ExampleEC2_AssociateDHCPOptions() {
 	params := &ec2.AssociateDHCPOptionsInput{
 		DHCPOptionsID: aws.String("String"), // Required
 		VPCID:         aws.String("String"), // Required
-		DryRun:        aws.Boolean(true),
+		DryRun:        aws.Bool(true),
 	}
 	resp, err := svc.AssociateDHCPOptions(params)
 
@@ -164,7 +164,7 @@ func ExampleEC2_AssociateDHCPOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AssociateRouteTable() {
@@ -173,7 +173,7 @@ func ExampleEC2_AssociateRouteTable() {
 	params := &ec2.AssociateRouteTableInput{
 		RouteTableID: aws.String("String"), // Required
 		SubnetID:     aws.String("String"), // Required
-		DryRun:       aws.Boolean(true),
+		DryRun:       aws.Bool(true),
 	}
 	resp, err := svc.AssociateRouteTable(params)
 
@@ -193,7 +193,7 @@ func ExampleEC2_AssociateRouteTable() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AttachClassicLinkVPC() {
@@ -206,7 +206,7 @@ func ExampleEC2_AttachClassicLinkVPC() {
 		},
 		InstanceID: aws.String("String"), // Required
 		VPCID:      aws.String("String"), // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.AttachClassicLinkVPC(params)
 
@@ -226,7 +226,7 @@ func ExampleEC2_AttachClassicLinkVPC() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AttachInternetGateway() {
@@ -235,7 +235,7 @@ func ExampleEC2_AttachInternetGateway() {
 	params := &ec2.AttachInternetGatewayInput{
 		InternetGatewayID: aws.String("String"), // Required
 		VPCID:             aws.String("String"), // Required
-		DryRun:            aws.Boolean(true),
+		DryRun:            aws.Bool(true),
 	}
 	resp, err := svc.AttachInternetGateway(params)
 
@@ -255,17 +255,17 @@ func ExampleEC2_AttachInternetGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AttachNetworkInterface() {
 	svc := ec2.New(nil)
 
 	params := &ec2.AttachNetworkInterfaceInput{
-		DeviceIndex:        aws.Long(1),          // Required
+		DeviceIndex:        aws.Int64(1),         // Required
 		InstanceID:         aws.String("String"), // Required
 		NetworkInterfaceID: aws.String("String"), // Required
-		DryRun:             aws.Boolean(true),
+		DryRun:             aws.Bool(true),
 	}
 	resp, err := svc.AttachNetworkInterface(params)
 
@@ -285,7 +285,7 @@ func ExampleEC2_AttachNetworkInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AttachVPNGateway() {
@@ -294,7 +294,7 @@ func ExampleEC2_AttachVPNGateway() {
 	params := &ec2.AttachVPNGatewayInput{
 		VPCID:        aws.String("String"), // Required
 		VPNGatewayID: aws.String("String"), // Required
-		DryRun:       aws.Boolean(true),
+		DryRun:       aws.Bool(true),
 	}
 	resp, err := svc.AttachVPNGateway(params)
 
@@ -314,7 +314,7 @@ func ExampleEC2_AttachVPNGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AttachVolume() {
@@ -324,7 +324,7 @@ func ExampleEC2_AttachVolume() {
 		Device:     aws.String("String"), // Required
 		InstanceID: aws.String("String"), // Required
 		VolumeID:   aws.String("String"), // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.AttachVolume(params)
 
@@ -344,7 +344,7 @@ func ExampleEC2_AttachVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AuthorizeSecurityGroupEgress() {
@@ -353,11 +353,11 @@ func ExampleEC2_AuthorizeSecurityGroupEgress() {
 	params := &ec2.AuthorizeSecurityGroupEgressInput{
 		GroupID:  aws.String("String"), // Required
 		CIDRIP:   aws.String("String"),
-		DryRun:   aws.Boolean(true),
-		FromPort: aws.Long(1),
+		DryRun:   aws.Bool(true),
+		FromPort: aws.Int64(1),
 		IPPermissions: []*ec2.IPPermission{
 			{ // Required
-				FromPort:   aws.Long(1),
+				FromPort:   aws.Int64(1),
 				IPProtocol: aws.String("String"),
 				IPRanges: []*ec2.IPRange{
 					{ // Required
@@ -371,7 +371,7 @@ func ExampleEC2_AuthorizeSecurityGroupEgress() {
 					},
 					// More values...
 				},
-				ToPort: aws.Long(1),
+				ToPort: aws.Int64(1),
 				UserIDGroupPairs: []*ec2.UserIDGroupPair{
 					{ // Required
 						GroupID:   aws.String("String"),
@@ -386,7 +386,7 @@ func ExampleEC2_AuthorizeSecurityGroupEgress() {
 		IPProtocol:                 aws.String("String"),
 		SourceSecurityGroupName:    aws.String("String"),
 		SourceSecurityGroupOwnerID: aws.String("String"),
-		ToPort: aws.Long(1),
+		ToPort: aws.Int64(1),
 	}
 	resp, err := svc.AuthorizeSecurityGroupEgress(params)
 
@@ -406,7 +406,7 @@ func ExampleEC2_AuthorizeSecurityGroupEgress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_AuthorizeSecurityGroupIngress() {
@@ -414,13 +414,13 @@ func ExampleEC2_AuthorizeSecurityGroupIngress() {
 
 	params := &ec2.AuthorizeSecurityGroupIngressInput{
 		CIDRIP:    aws.String("String"),
-		DryRun:    aws.Boolean(true),
-		FromPort:  aws.Long(1),
+		DryRun:    aws.Bool(true),
+		FromPort:  aws.Int64(1),
 		GroupID:   aws.String("String"),
 		GroupName: aws.String("String"),
 		IPPermissions: []*ec2.IPPermission{
 			{ // Required
-				FromPort:   aws.Long(1),
+				FromPort:   aws.Int64(1),
 				IPProtocol: aws.String("String"),
 				IPRanges: []*ec2.IPRange{
 					{ // Required
@@ -434,7 +434,7 @@ func ExampleEC2_AuthorizeSecurityGroupIngress() {
 					},
 					// More values...
 				},
-				ToPort: aws.Long(1),
+				ToPort: aws.Int64(1),
 				UserIDGroupPairs: []*ec2.UserIDGroupPair{
 					{ // Required
 						GroupID:   aws.String("String"),
@@ -449,7 +449,7 @@ func ExampleEC2_AuthorizeSecurityGroupIngress() {
 		IPProtocol:                 aws.String("String"),
 		SourceSecurityGroupName:    aws.String("String"),
 		SourceSecurityGroupOwnerID: aws.String("String"),
-		ToPort: aws.Long(1),
+		ToPort: aws.Int64(1),
 	}
 	resp, err := svc.AuthorizeSecurityGroupIngress(params)
 
@@ -469,7 +469,7 @@ func ExampleEC2_AuthorizeSecurityGroupIngress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_BundleInstance() {
@@ -486,7 +486,7 @@ func ExampleEC2_BundleInstance() {
 				UploadPolicySignature: aws.String("String"),
 			},
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.BundleInstance(params)
 
@@ -506,7 +506,7 @@ func ExampleEC2_BundleInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CancelBundleTask() {
@@ -514,7 +514,7 @@ func ExampleEC2_CancelBundleTask() {
 
 	params := &ec2.CancelBundleTaskInput{
 		BundleID: aws.String("String"), // Required
-		DryRun:   aws.Boolean(true),
+		DryRun:   aws.Bool(true),
 	}
 	resp, err := svc.CancelBundleTask(params)
 
@@ -534,7 +534,7 @@ func ExampleEC2_CancelBundleTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CancelConversionTask() {
@@ -542,7 +542,7 @@ func ExampleEC2_CancelConversionTask() {
 
 	params := &ec2.CancelConversionTaskInput{
 		ConversionTaskID: aws.String("String"), // Required
-		DryRun:           aws.Boolean(true),
+		DryRun:           aws.Bool(true),
 		ReasonMessage:    aws.String("String"),
 	}
 	resp, err := svc.CancelConversionTask(params)
@@ -563,7 +563,7 @@ func ExampleEC2_CancelConversionTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CancelExportTask() {
@@ -590,7 +590,7 @@ func ExampleEC2_CancelExportTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CancelImportTask() {
@@ -598,7 +598,7 @@ func ExampleEC2_CancelImportTask() {
 
 	params := &ec2.CancelImportTaskInput{
 		CancelReason: aws.String("String"),
-		DryRun:       aws.Boolean(true),
+		DryRun:       aws.Bool(true),
 		ImportTaskID: aws.String("String"),
 	}
 	resp, err := svc.CancelImportTask(params)
@@ -619,7 +619,7 @@ func ExampleEC2_CancelImportTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CancelReservedInstancesListing() {
@@ -646,7 +646,7 @@ func ExampleEC2_CancelReservedInstancesListing() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CancelSpotFleetRequests() {
@@ -657,8 +657,8 @@ func ExampleEC2_CancelSpotFleetRequests() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		TerminateInstances: aws.Boolean(true), // Required
-		DryRun:             aws.Boolean(true),
+		TerminateInstances: aws.Bool(true), // Required
+		DryRun:             aws.Bool(true),
 	}
 	resp, err := svc.CancelSpotFleetRequests(params)
 
@@ -678,7 +678,7 @@ func ExampleEC2_CancelSpotFleetRequests() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CancelSpotInstanceRequests() {
@@ -689,7 +689,7 @@ func ExampleEC2_CancelSpotInstanceRequests() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.CancelSpotInstanceRequests(params)
 
@@ -709,7 +709,7 @@ func ExampleEC2_CancelSpotInstanceRequests() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ConfirmProductInstance() {
@@ -718,7 +718,7 @@ func ExampleEC2_ConfirmProductInstance() {
 	params := &ec2.ConfirmProductInstanceInput{
 		InstanceID:  aws.String("String"), // Required
 		ProductCode: aws.String("String"), // Required
-		DryRun:      aws.Boolean(true),
+		DryRun:      aws.Bool(true),
 	}
 	resp, err := svc.ConfirmProductInstance(params)
 
@@ -738,7 +738,7 @@ func ExampleEC2_ConfirmProductInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CopyImage() {
@@ -750,7 +750,7 @@ func ExampleEC2_CopyImage() {
 		SourceRegion:  aws.String("String"), // Required
 		ClientToken:   aws.String("String"),
 		Description:   aws.String("String"),
-		DryRun:        aws.Boolean(true),
+		DryRun:        aws.Bool(true),
 	}
 	resp, err := svc.CopyImage(params)
 
@@ -770,7 +770,7 @@ func ExampleEC2_CopyImage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CopySnapshot() {
@@ -781,8 +781,8 @@ func ExampleEC2_CopySnapshot() {
 		SourceSnapshotID:  aws.String("String"), // Required
 		Description:       aws.String("String"),
 		DestinationRegion: aws.String("String"),
-		DryRun:            aws.Boolean(true),
-		Encrypted:         aws.Boolean(true),
+		DryRun:            aws.Bool(true),
+		Encrypted:         aws.Bool(true),
 		KMSKeyID:          aws.String("String"),
 		PresignedURL:      aws.String("String"),
 	}
@@ -804,17 +804,17 @@ func ExampleEC2_CopySnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateCustomerGateway() {
 	svc := ec2.New(nil)
 
 	params := &ec2.CreateCustomerGatewayInput{
-		BGPASN:   aws.Long(1),               // Required
+		BGPASN:   aws.Int64(1),              // Required
 		PublicIP: aws.String("String"),      // Required
 		Type:     aws.String("GatewayType"), // Required
-		DryRun:   aws.Boolean(true),
+		DryRun:   aws.Bool(true),
 	}
 	resp, err := svc.CreateCustomerGateway(params)
 
@@ -834,7 +834,7 @@ func ExampleEC2_CreateCustomerGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateDHCPOptions() {
@@ -851,7 +851,7 @@ func ExampleEC2_CreateDHCPOptions() {
 			},
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.CreateDHCPOptions(params)
 
@@ -871,7 +871,7 @@ func ExampleEC2_CreateDHCPOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateFlowLogs() {
@@ -906,7 +906,7 @@ func ExampleEC2_CreateFlowLogs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateImage() {
@@ -919,11 +919,11 @@ func ExampleEC2_CreateImage() {
 			{ // Required
 				DeviceName: aws.String("String"),
 				EBS: &ec2.EBSBlockDevice{
-					DeleteOnTermination: aws.Boolean(true),
-					Encrypted:           aws.Boolean(true),
-					IOPS:                aws.Long(1),
+					DeleteOnTermination: aws.Bool(true),
+					Encrypted:           aws.Bool(true),
+					IOPS:                aws.Int64(1),
 					SnapshotID:          aws.String("String"),
-					VolumeSize:          aws.Long(1),
+					VolumeSize:          aws.Int64(1),
 					VolumeType:          aws.String("VolumeType"),
 				},
 				NoDevice:    aws.String("String"),
@@ -932,8 +932,8 @@ func ExampleEC2_CreateImage() {
 			// More values...
 		},
 		Description: aws.String("String"),
-		DryRun:      aws.Boolean(true),
-		NoReboot:    aws.Boolean(true),
+		DryRun:      aws.Bool(true),
+		NoReboot:    aws.Bool(true),
 	}
 	resp, err := svc.CreateImage(params)
 
@@ -953,7 +953,7 @@ func ExampleEC2_CreateImage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateInstanceExportTask() {
@@ -988,14 +988,14 @@ func ExampleEC2_CreateInstanceExportTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateInternetGateway() {
 	svc := ec2.New(nil)
 
 	params := &ec2.CreateInternetGatewayInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.CreateInternetGateway(params)
 
@@ -1015,7 +1015,7 @@ func ExampleEC2_CreateInternetGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateKeyPair() {
@@ -1023,7 +1023,7 @@ func ExampleEC2_CreateKeyPair() {
 
 	params := &ec2.CreateKeyPairInput{
 		KeyName: aws.String("String"), // Required
-		DryRun:  aws.Boolean(true),
+		DryRun:  aws.Bool(true),
 	}
 	resp, err := svc.CreateKeyPair(params)
 
@@ -1043,7 +1043,7 @@ func ExampleEC2_CreateKeyPair() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateNetworkACL() {
@@ -1051,7 +1051,7 @@ func ExampleEC2_CreateNetworkACL() {
 
 	params := &ec2.CreateNetworkACLInput{
 		VPCID:  aws.String("String"), // Required
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.CreateNetworkACL(params)
 
@@ -1071,7 +1071,7 @@ func ExampleEC2_CreateNetworkACL() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateNetworkACLEntry() {
@@ -1079,19 +1079,19 @@ func ExampleEC2_CreateNetworkACLEntry() {
 
 	params := &ec2.CreateNetworkACLEntryInput{
 		CIDRBlock:    aws.String("String"),     // Required
-		Egress:       aws.Boolean(true),        // Required
+		Egress:       aws.Bool(true),           // Required
 		NetworkACLID: aws.String("String"),     // Required
 		Protocol:     aws.String("String"),     // Required
 		RuleAction:   aws.String("RuleAction"), // Required
-		RuleNumber:   aws.Long(1),              // Required
-		DryRun:       aws.Boolean(true),
+		RuleNumber:   aws.Int64(1),             // Required
+		DryRun:       aws.Bool(true),
 		ICMPTypeCode: &ec2.ICMPTypeCode{
-			Code: aws.Long(1),
-			Type: aws.Long(1),
+			Code: aws.Int64(1),
+			Type: aws.Int64(1),
 		},
 		PortRange: &ec2.PortRange{
-			From: aws.Long(1),
-			To:   aws.Long(1),
+			From: aws.Int64(1),
+			To:   aws.Int64(1),
 		},
 	}
 	resp, err := svc.CreateNetworkACLEntry(params)
@@ -1112,7 +1112,7 @@ func ExampleEC2_CreateNetworkACLEntry() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateNetworkInterface() {
@@ -1121,7 +1121,7 @@ func ExampleEC2_CreateNetworkInterface() {
 	params := &ec2.CreateNetworkInterfaceInput{
 		SubnetID:    aws.String("String"), // Required
 		Description: aws.String("String"),
-		DryRun:      aws.Boolean(true),
+		DryRun:      aws.Bool(true),
 		Groups: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -1130,11 +1130,11 @@ func ExampleEC2_CreateNetworkInterface() {
 		PrivateIPAddresses: []*ec2.PrivateIPAddressSpecification{
 			{ // Required
 				PrivateIPAddress: aws.String("String"), // Required
-				Primary:          aws.Boolean(true),
+				Primary:          aws.Bool(true),
 			},
 			// More values...
 		},
-		SecondaryPrivateIPAddressCount: aws.Long(1),
+		SecondaryPrivateIPAddressCount: aws.Int64(1),
 	}
 	resp, err := svc.CreateNetworkInterface(params)
 
@@ -1154,7 +1154,7 @@ func ExampleEC2_CreateNetworkInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreatePlacementGroup() {
@@ -1163,7 +1163,7 @@ func ExampleEC2_CreatePlacementGroup() {
 	params := &ec2.CreatePlacementGroupInput{
 		GroupName: aws.String("String"),            // Required
 		Strategy:  aws.String("PlacementStrategy"), // Required
-		DryRun:    aws.Boolean(true),
+		DryRun:    aws.Bool(true),
 	}
 	resp, err := svc.CreatePlacementGroup(params)
 
@@ -1183,7 +1183,7 @@ func ExampleEC2_CreatePlacementGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateReservedInstancesListing() {
@@ -1191,12 +1191,12 @@ func ExampleEC2_CreateReservedInstancesListing() {
 
 	params := &ec2.CreateReservedInstancesListingInput{
 		ClientToken:   aws.String("String"), // Required
-		InstanceCount: aws.Long(1),          // Required
+		InstanceCount: aws.Int64(1),         // Required
 		PriceSchedules: []*ec2.PriceScheduleSpecification{ // Required
 			{ // Required
 				CurrencyCode: aws.String("CurrencyCodeValues"),
-				Price:        aws.Double(1.0),
-				Term:         aws.Long(1),
+				Price:        aws.Float64(1.0),
+				Term:         aws.Int64(1),
 			},
 			// More values...
 		},
@@ -1220,7 +1220,7 @@ func ExampleEC2_CreateReservedInstancesListing() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateRoute() {
@@ -1230,7 +1230,7 @@ func ExampleEC2_CreateRoute() {
 		DestinationCIDRBlock:   aws.String("String"), // Required
 		RouteTableID:           aws.String("String"), // Required
 		ClientToken:            aws.String("String"),
-		DryRun:                 aws.Boolean(true),
+		DryRun:                 aws.Bool(true),
 		GatewayID:              aws.String("String"),
 		InstanceID:             aws.String("String"),
 		NetworkInterfaceID:     aws.String("String"),
@@ -1254,7 +1254,7 @@ func ExampleEC2_CreateRoute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateRouteTable() {
@@ -1262,7 +1262,7 @@ func ExampleEC2_CreateRouteTable() {
 
 	params := &ec2.CreateRouteTableInput{
 		VPCID:  aws.String("String"), // Required
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.CreateRouteTable(params)
 
@@ -1282,7 +1282,7 @@ func ExampleEC2_CreateRouteTable() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateSecurityGroup() {
@@ -1291,7 +1291,7 @@ func ExampleEC2_CreateSecurityGroup() {
 	params := &ec2.CreateSecurityGroupInput{
 		Description: aws.String("String"), // Required
 		GroupName:   aws.String("String"), // Required
-		DryRun:      aws.Boolean(true),
+		DryRun:      aws.Bool(true),
 		VPCID:       aws.String("String"),
 	}
 	resp, err := svc.CreateSecurityGroup(params)
@@ -1312,7 +1312,7 @@ func ExampleEC2_CreateSecurityGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateSnapshot() {
@@ -1321,7 +1321,7 @@ func ExampleEC2_CreateSnapshot() {
 	params := &ec2.CreateSnapshotInput{
 		VolumeID:    aws.String("String"), // Required
 		Description: aws.String("String"),
-		DryRun:      aws.Boolean(true),
+		DryRun:      aws.Bool(true),
 	}
 	resp, err := svc.CreateSnapshot(params)
 
@@ -1341,7 +1341,7 @@ func ExampleEC2_CreateSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateSpotDatafeedSubscription() {
@@ -1349,7 +1349,7 @@ func ExampleEC2_CreateSpotDatafeedSubscription() {
 
 	params := &ec2.CreateSpotDatafeedSubscriptionInput{
 		Bucket: aws.String("String"), // Required
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Prefix: aws.String("String"),
 	}
 	resp, err := svc.CreateSpotDatafeedSubscription(params)
@@ -1370,7 +1370,7 @@ func ExampleEC2_CreateSpotDatafeedSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateSubnet() {
@@ -1380,7 +1380,7 @@ func ExampleEC2_CreateSubnet() {
 		CIDRBlock:        aws.String("String"), // Required
 		VPCID:            aws.String("String"), // Required
 		AvailabilityZone: aws.String("String"),
-		DryRun:           aws.Boolean(true),
+		DryRun:           aws.Bool(true),
 	}
 	resp, err := svc.CreateSubnet(params)
 
@@ -1400,7 +1400,7 @@ func ExampleEC2_CreateSubnet() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateTags() {
@@ -1418,7 +1418,7 @@ func ExampleEC2_CreateTags() {
 			},
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.CreateTags(params)
 
@@ -1438,7 +1438,7 @@ func ExampleEC2_CreateTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateVPC() {
@@ -1446,7 +1446,7 @@ func ExampleEC2_CreateVPC() {
 
 	params := &ec2.CreateVPCInput{
 		CIDRBlock:       aws.String("String"), // Required
-		DryRun:          aws.Boolean(true),
+		DryRun:          aws.Bool(true),
 		InstanceTenancy: aws.String("Tenancy"),
 	}
 	resp, err := svc.CreateVPC(params)
@@ -1467,7 +1467,7 @@ func ExampleEC2_CreateVPC() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateVPCEndpoint() {
@@ -1477,7 +1477,7 @@ func ExampleEC2_CreateVPCEndpoint() {
 		ServiceName:    aws.String("String"), // Required
 		VPCID:          aws.String("String"), // Required
 		ClientToken:    aws.String("String"),
-		DryRun:         aws.Boolean(true),
+		DryRun:         aws.Bool(true),
 		PolicyDocument: aws.String("String"),
 		RouteTableIDs: []*string{
 			aws.String("String"), // Required
@@ -1502,14 +1502,14 @@ func ExampleEC2_CreateVPCEndpoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateVPCPeeringConnection() {
 	svc := ec2.New(nil)
 
 	params := &ec2.CreateVPCPeeringConnectionInput{
-		DryRun:      aws.Boolean(true),
+		DryRun:      aws.Bool(true),
 		PeerOwnerID: aws.String("String"),
 		PeerVPCID:   aws.String("String"),
 		VPCID:       aws.String("String"),
@@ -1532,7 +1532,7 @@ func ExampleEC2_CreateVPCPeeringConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateVPNConnection() {
@@ -1542,9 +1542,9 @@ func ExampleEC2_CreateVPNConnection() {
 		CustomerGatewayID: aws.String("String"), // Required
 		Type:              aws.String("String"), // Required
 		VPNGatewayID:      aws.String("String"), // Required
-		DryRun:            aws.Boolean(true),
+		DryRun:            aws.Bool(true),
 		Options: &ec2.VPNConnectionOptionsSpecification{
-			StaticRoutesOnly: aws.Boolean(true),
+			StaticRoutesOnly: aws.Bool(true),
 		},
 	}
 	resp, err := svc.CreateVPNConnection(params)
@@ -1565,7 +1565,7 @@ func ExampleEC2_CreateVPNConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateVPNConnectionRoute() {
@@ -1593,7 +1593,7 @@ func ExampleEC2_CreateVPNConnectionRoute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateVPNGateway() {
@@ -1602,7 +1602,7 @@ func ExampleEC2_CreateVPNGateway() {
 	params := &ec2.CreateVPNGatewayInput{
 		Type:             aws.String("GatewayType"), // Required
 		AvailabilityZone: aws.String("String"),
-		DryRun:           aws.Boolean(true),
+		DryRun:           aws.Bool(true),
 	}
 	resp, err := svc.CreateVPNGateway(params)
 
@@ -1622,7 +1622,7 @@ func ExampleEC2_CreateVPNGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_CreateVolume() {
@@ -1630,11 +1630,11 @@ func ExampleEC2_CreateVolume() {
 
 	params := &ec2.CreateVolumeInput{
 		AvailabilityZone: aws.String("String"), // Required
-		DryRun:           aws.Boolean(true),
-		Encrypted:        aws.Boolean(true),
-		IOPS:             aws.Long(1),
+		DryRun:           aws.Bool(true),
+		Encrypted:        aws.Bool(true),
+		IOPS:             aws.Int64(1),
 		KMSKeyID:         aws.String("String"),
-		Size:             aws.Long(1),
+		Size:             aws.Int64(1),
 		SnapshotID:       aws.String("String"),
 		VolumeType:       aws.String("VolumeType"),
 	}
@@ -1656,7 +1656,7 @@ func ExampleEC2_CreateVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteCustomerGateway() {
@@ -1664,7 +1664,7 @@ func ExampleEC2_DeleteCustomerGateway() {
 
 	params := &ec2.DeleteCustomerGatewayInput{
 		CustomerGatewayID: aws.String("String"), // Required
-		DryRun:            aws.Boolean(true),
+		DryRun:            aws.Bool(true),
 	}
 	resp, err := svc.DeleteCustomerGateway(params)
 
@@ -1684,7 +1684,7 @@ func ExampleEC2_DeleteCustomerGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteDHCPOptions() {
@@ -1692,7 +1692,7 @@ func ExampleEC2_DeleteDHCPOptions() {
 
 	params := &ec2.DeleteDHCPOptionsInput{
 		DHCPOptionsID: aws.String("String"), // Required
-		DryRun:        aws.Boolean(true),
+		DryRun:        aws.Bool(true),
 	}
 	resp, err := svc.DeleteDHCPOptions(params)
 
@@ -1712,7 +1712,7 @@ func ExampleEC2_DeleteDHCPOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteFlowLogs() {
@@ -1742,7 +1742,7 @@ func ExampleEC2_DeleteFlowLogs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteInternetGateway() {
@@ -1750,7 +1750,7 @@ func ExampleEC2_DeleteInternetGateway() {
 
 	params := &ec2.DeleteInternetGatewayInput{
 		InternetGatewayID: aws.String("String"), // Required
-		DryRun:            aws.Boolean(true),
+		DryRun:            aws.Bool(true),
 	}
 	resp, err := svc.DeleteInternetGateway(params)
 
@@ -1770,7 +1770,7 @@ func ExampleEC2_DeleteInternetGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteKeyPair() {
@@ -1778,7 +1778,7 @@ func ExampleEC2_DeleteKeyPair() {
 
 	params := &ec2.DeleteKeyPairInput{
 		KeyName: aws.String("String"), // Required
-		DryRun:  aws.Boolean(true),
+		DryRun:  aws.Bool(true),
 	}
 	resp, err := svc.DeleteKeyPair(params)
 
@@ -1798,7 +1798,7 @@ func ExampleEC2_DeleteKeyPair() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteNetworkACL() {
@@ -1806,7 +1806,7 @@ func ExampleEC2_DeleteNetworkACL() {
 
 	params := &ec2.DeleteNetworkACLInput{
 		NetworkACLID: aws.String("String"), // Required
-		DryRun:       aws.Boolean(true),
+		DryRun:       aws.Bool(true),
 	}
 	resp, err := svc.DeleteNetworkACL(params)
 
@@ -1826,17 +1826,17 @@ func ExampleEC2_DeleteNetworkACL() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteNetworkACLEntry() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DeleteNetworkACLEntryInput{
-		Egress:       aws.Boolean(true),    // Required
+		Egress:       aws.Bool(true),       // Required
 		NetworkACLID: aws.String("String"), // Required
-		RuleNumber:   aws.Long(1),          // Required
-		DryRun:       aws.Boolean(true),
+		RuleNumber:   aws.Int64(1),         // Required
+		DryRun:       aws.Bool(true),
 	}
 	resp, err := svc.DeleteNetworkACLEntry(params)
 
@@ -1856,7 +1856,7 @@ func ExampleEC2_DeleteNetworkACLEntry() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteNetworkInterface() {
@@ -1864,7 +1864,7 @@ func ExampleEC2_DeleteNetworkInterface() {
 
 	params := &ec2.DeleteNetworkInterfaceInput{
 		NetworkInterfaceID: aws.String("String"), // Required
-		DryRun:             aws.Boolean(true),
+		DryRun:             aws.Bool(true),
 	}
 	resp, err := svc.DeleteNetworkInterface(params)
 
@@ -1884,7 +1884,7 @@ func ExampleEC2_DeleteNetworkInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeletePlacementGroup() {
@@ -1892,7 +1892,7 @@ func ExampleEC2_DeletePlacementGroup() {
 
 	params := &ec2.DeletePlacementGroupInput{
 		GroupName: aws.String("String"), // Required
-		DryRun:    aws.Boolean(true),
+		DryRun:    aws.Bool(true),
 	}
 	resp, err := svc.DeletePlacementGroup(params)
 
@@ -1912,7 +1912,7 @@ func ExampleEC2_DeletePlacementGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteRoute() {
@@ -1921,7 +1921,7 @@ func ExampleEC2_DeleteRoute() {
 	params := &ec2.DeleteRouteInput{
 		DestinationCIDRBlock: aws.String("String"), // Required
 		RouteTableID:         aws.String("String"), // Required
-		DryRun:               aws.Boolean(true),
+		DryRun:               aws.Bool(true),
 	}
 	resp, err := svc.DeleteRoute(params)
 
@@ -1941,7 +1941,7 @@ func ExampleEC2_DeleteRoute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteRouteTable() {
@@ -1949,7 +1949,7 @@ func ExampleEC2_DeleteRouteTable() {
 
 	params := &ec2.DeleteRouteTableInput{
 		RouteTableID: aws.String("String"), // Required
-		DryRun:       aws.Boolean(true),
+		DryRun:       aws.Bool(true),
 	}
 	resp, err := svc.DeleteRouteTable(params)
 
@@ -1969,14 +1969,14 @@ func ExampleEC2_DeleteRouteTable() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteSecurityGroup() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DeleteSecurityGroupInput{
-		DryRun:    aws.Boolean(true),
+		DryRun:    aws.Bool(true),
 		GroupID:   aws.String("String"),
 		GroupName: aws.String("String"),
 	}
@@ -1998,7 +1998,7 @@ func ExampleEC2_DeleteSecurityGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteSnapshot() {
@@ -2006,7 +2006,7 @@ func ExampleEC2_DeleteSnapshot() {
 
 	params := &ec2.DeleteSnapshotInput{
 		SnapshotID: aws.String("String"), // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.DeleteSnapshot(params)
 
@@ -2026,14 +2026,14 @@ func ExampleEC2_DeleteSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteSpotDatafeedSubscription() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DeleteSpotDatafeedSubscriptionInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.DeleteSpotDatafeedSubscription(params)
 
@@ -2053,7 +2053,7 @@ func ExampleEC2_DeleteSpotDatafeedSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteSubnet() {
@@ -2061,7 +2061,7 @@ func ExampleEC2_DeleteSubnet() {
 
 	params := &ec2.DeleteSubnetInput{
 		SubnetID: aws.String("String"), // Required
-		DryRun:   aws.Boolean(true),
+		DryRun:   aws.Bool(true),
 	}
 	resp, err := svc.DeleteSubnet(params)
 
@@ -2081,7 +2081,7 @@ func ExampleEC2_DeleteSubnet() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteTags() {
@@ -2092,7 +2092,7 @@ func ExampleEC2_DeleteTags() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Tags: []*ec2.Tag{
 			{ // Required
 				Key:   aws.String("String"),
@@ -2119,7 +2119,7 @@ func ExampleEC2_DeleteTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteVPC() {
@@ -2127,7 +2127,7 @@ func ExampleEC2_DeleteVPC() {
 
 	params := &ec2.DeleteVPCInput{
 		VPCID:  aws.String("String"), // Required
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.DeleteVPC(params)
 
@@ -2147,7 +2147,7 @@ func ExampleEC2_DeleteVPC() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteVPCEndpoints() {
@@ -2158,7 +2158,7 @@ func ExampleEC2_DeleteVPCEndpoints() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.DeleteVPCEndpoints(params)
 
@@ -2178,7 +2178,7 @@ func ExampleEC2_DeleteVPCEndpoints() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteVPCPeeringConnection() {
@@ -2186,7 +2186,7 @@ func ExampleEC2_DeleteVPCPeeringConnection() {
 
 	params := &ec2.DeleteVPCPeeringConnectionInput{
 		VPCPeeringConnectionID: aws.String("String"), // Required
-		DryRun:                 aws.Boolean(true),
+		DryRun:                 aws.Bool(true),
 	}
 	resp, err := svc.DeleteVPCPeeringConnection(params)
 
@@ -2206,7 +2206,7 @@ func ExampleEC2_DeleteVPCPeeringConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteVPNConnection() {
@@ -2214,7 +2214,7 @@ func ExampleEC2_DeleteVPNConnection() {
 
 	params := &ec2.DeleteVPNConnectionInput{
 		VPNConnectionID: aws.String("String"), // Required
-		DryRun:          aws.Boolean(true),
+		DryRun:          aws.Bool(true),
 	}
 	resp, err := svc.DeleteVPNConnection(params)
 
@@ -2234,7 +2234,7 @@ func ExampleEC2_DeleteVPNConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteVPNConnectionRoute() {
@@ -2262,7 +2262,7 @@ func ExampleEC2_DeleteVPNConnectionRoute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteVPNGateway() {
@@ -2270,7 +2270,7 @@ func ExampleEC2_DeleteVPNGateway() {
 
 	params := &ec2.DeleteVPNGatewayInput{
 		VPNGatewayID: aws.String("String"), // Required
-		DryRun:       aws.Boolean(true),
+		DryRun:       aws.Bool(true),
 	}
 	resp, err := svc.DeleteVPNGateway(params)
 
@@ -2290,7 +2290,7 @@ func ExampleEC2_DeleteVPNGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeleteVolume() {
@@ -2298,7 +2298,7 @@ func ExampleEC2_DeleteVolume() {
 
 	params := &ec2.DeleteVolumeInput{
 		VolumeID: aws.String("String"), // Required
-		DryRun:   aws.Boolean(true),
+		DryRun:   aws.Bool(true),
 	}
 	resp, err := svc.DeleteVolume(params)
 
@@ -2318,7 +2318,7 @@ func ExampleEC2_DeleteVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DeregisterImage() {
@@ -2326,7 +2326,7 @@ func ExampleEC2_DeregisterImage() {
 
 	params := &ec2.DeregisterImageInput{
 		ImageID: aws.String("String"), // Required
-		DryRun:  aws.Boolean(true),
+		DryRun:  aws.Bool(true),
 	}
 	resp, err := svc.DeregisterImage(params)
 
@@ -2346,7 +2346,7 @@ func ExampleEC2_DeregisterImage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeAccountAttributes() {
@@ -2357,7 +2357,7 @@ func ExampleEC2_DescribeAccountAttributes() {
 			aws.String("AccountAttributeName"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.DescribeAccountAttributes(params)
 
@@ -2377,7 +2377,7 @@ func ExampleEC2_DescribeAccountAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeAddresses() {
@@ -2388,7 +2388,7 @@ func ExampleEC2_DescribeAddresses() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2422,14 +2422,14 @@ func ExampleEC2_DescribeAddresses() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeAvailabilityZones() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeAvailabilityZonesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2463,7 +2463,7 @@ func ExampleEC2_DescribeAvailabilityZones() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeBundleTasks() {
@@ -2474,7 +2474,7 @@ func ExampleEC2_DescribeBundleTasks() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2504,14 +2504,14 @@ func ExampleEC2_DescribeBundleTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeClassicLinkInstances() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeClassicLinkInstancesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2526,7 +2526,7 @@ func ExampleEC2_DescribeClassicLinkInstances() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.DescribeClassicLinkInstances(params)
@@ -2547,7 +2547,7 @@ func ExampleEC2_DescribeClassicLinkInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeConversionTasks() {
@@ -2558,7 +2558,7 @@ func ExampleEC2_DescribeConversionTasks() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2588,7 +2588,7 @@ func ExampleEC2_DescribeConversionTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeCustomerGateways() {
@@ -2599,7 +2599,7 @@ func ExampleEC2_DescribeCustomerGateways() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2629,7 +2629,7 @@ func ExampleEC2_DescribeCustomerGateways() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeDHCPOptions() {
@@ -2640,7 +2640,7 @@ func ExampleEC2_DescribeDHCPOptions() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2670,7 +2670,7 @@ func ExampleEC2_DescribeDHCPOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeExportTasks() {
@@ -2700,7 +2700,7 @@ func ExampleEC2_DescribeExportTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeFlowLogs() {
@@ -2721,7 +2721,7 @@ func ExampleEC2_DescribeFlowLogs() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.DescribeFlowLogs(params)
@@ -2742,7 +2742,7 @@ func ExampleEC2_DescribeFlowLogs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeImageAttribute() {
@@ -2751,7 +2751,7 @@ func ExampleEC2_DescribeImageAttribute() {
 	params := &ec2.DescribeImageAttributeInput{
 		Attribute: aws.String("ImageAttributeName"), // Required
 		ImageID:   aws.String("String"),             // Required
-		DryRun:    aws.Boolean(true),
+		DryRun:    aws.Bool(true),
 	}
 	resp, err := svc.DescribeImageAttribute(params)
 
@@ -2771,14 +2771,14 @@ func ExampleEC2_DescribeImageAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeImages() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeImagesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		ExecutableUsers: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -2820,14 +2820,14 @@ func ExampleEC2_DescribeImages() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeImportImageTasks() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeImportImageTasksInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2842,7 +2842,7 @@ func ExampleEC2_DescribeImportImageTasks() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.DescribeImportImageTasks(params)
@@ -2863,14 +2863,14 @@ func ExampleEC2_DescribeImportImageTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeImportSnapshotTasks() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeImportSnapshotTasksInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2885,7 +2885,7 @@ func ExampleEC2_DescribeImportSnapshotTasks() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.DescribeImportSnapshotTasks(params)
@@ -2906,7 +2906,7 @@ func ExampleEC2_DescribeImportSnapshotTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeInstanceAttribute() {
@@ -2915,7 +2915,7 @@ func ExampleEC2_DescribeInstanceAttribute() {
 	params := &ec2.DescribeInstanceAttributeInput{
 		Attribute:  aws.String("InstanceAttributeName"), // Required
 		InstanceID: aws.String("String"),                // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.DescribeInstanceAttribute(params)
 
@@ -2935,14 +2935,14 @@ func ExampleEC2_DescribeInstanceAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeInstanceStatus() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeInstanceStatusInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -2953,12 +2953,12 @@ func ExampleEC2_DescribeInstanceStatus() {
 			},
 			// More values...
 		},
-		IncludeAllInstances: aws.Boolean(true),
+		IncludeAllInstances: aws.Bool(true),
 		InstanceIDs: []*string{
 			aws.String("String"), // Required
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.DescribeInstanceStatus(params)
@@ -2979,14 +2979,14 @@ func ExampleEC2_DescribeInstanceStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeInstances() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeInstancesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3001,7 +3001,7 @@ func ExampleEC2_DescribeInstances() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.DescribeInstances(params)
@@ -3022,14 +3022,14 @@ func ExampleEC2_DescribeInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeInternetGateways() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeInternetGatewaysInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3063,14 +3063,14 @@ func ExampleEC2_DescribeInternetGateways() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeKeyPairs() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeKeyPairsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3104,14 +3104,14 @@ func ExampleEC2_DescribeKeyPairs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeMovingAddresses() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeMovingAddressesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3122,7 +3122,7 @@ func ExampleEC2_DescribeMovingAddresses() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 		PublicIPs: []*string{
 			aws.String("String"), // Required
@@ -3147,14 +3147,14 @@ func ExampleEC2_DescribeMovingAddresses() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeNetworkACLs() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeNetworkACLsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3188,7 +3188,7 @@ func ExampleEC2_DescribeNetworkACLs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeNetworkInterfaceAttribute() {
@@ -3197,7 +3197,7 @@ func ExampleEC2_DescribeNetworkInterfaceAttribute() {
 	params := &ec2.DescribeNetworkInterfaceAttributeInput{
 		NetworkInterfaceID: aws.String("String"), // Required
 		Attribute:          aws.String("NetworkInterfaceAttribute"),
-		DryRun:             aws.Boolean(true),
+		DryRun:             aws.Bool(true),
 	}
 	resp, err := svc.DescribeNetworkInterfaceAttribute(params)
 
@@ -3217,14 +3217,14 @@ func ExampleEC2_DescribeNetworkInterfaceAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeNetworkInterfaces() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeNetworkInterfacesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3258,14 +3258,14 @@ func ExampleEC2_DescribeNetworkInterfaces() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribePlacementGroups() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribePlacementGroupsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3299,14 +3299,14 @@ func ExampleEC2_DescribePlacementGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribePrefixLists() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribePrefixListsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3317,7 +3317,7 @@ func ExampleEC2_DescribePrefixLists() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 		PrefixListIDs: []*string{
 			aws.String("String"), // Required
@@ -3342,14 +3342,14 @@ func ExampleEC2_DescribePrefixLists() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeRegions() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeRegionsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3383,14 +3383,14 @@ func ExampleEC2_DescribeRegions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeReservedInstances() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeReservedInstancesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3425,7 +3425,7 @@ func ExampleEC2_DescribeReservedInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeReservedInstancesListings() {
@@ -3463,7 +3463,7 @@ func ExampleEC2_DescribeReservedInstancesListings() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeReservedInstancesModifications() {
@@ -3504,7 +3504,7 @@ func ExampleEC2_DescribeReservedInstancesModifications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeReservedInstancesOfferings() {
@@ -3512,7 +3512,7 @@ func ExampleEC2_DescribeReservedInstancesOfferings() {
 
 	params := &ec2.DescribeReservedInstancesOfferingsInput{
 		AvailabilityZone: aws.String("String"),
-		DryRun:           aws.Boolean(true),
+		DryRun:           aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3523,13 +3523,13 @@ func ExampleEC2_DescribeReservedInstancesOfferings() {
 			},
 			// More values...
 		},
-		IncludeMarketplace: aws.Boolean(true),
+		IncludeMarketplace: aws.Bool(true),
 		InstanceTenancy:    aws.String("Tenancy"),
 		InstanceType:       aws.String("InstanceType"),
-		MaxDuration:        aws.Long(1),
-		MaxInstanceCount:   aws.Long(1),
-		MaxResults:         aws.Long(1),
-		MinDuration:        aws.Long(1),
+		MaxDuration:        aws.Int64(1),
+		MaxInstanceCount:   aws.Int64(1),
+		MaxResults:         aws.Int64(1),
+		MinDuration:        aws.Int64(1),
 		NextToken:          aws.String("String"),
 		OfferingType:       aws.String("OfferingTypeValues"),
 		ProductDescription: aws.String("RIProductDescription"),
@@ -3556,14 +3556,14 @@ func ExampleEC2_DescribeReservedInstancesOfferings() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeRouteTables() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeRouteTablesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3597,14 +3597,14 @@ func ExampleEC2_DescribeRouteTables() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSecurityGroups() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeSecurityGroupsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3642,7 +3642,7 @@ func ExampleEC2_DescribeSecurityGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSnapshotAttribute() {
@@ -3651,7 +3651,7 @@ func ExampleEC2_DescribeSnapshotAttribute() {
 	params := &ec2.DescribeSnapshotAttributeInput{
 		Attribute:  aws.String("SnapshotAttributeName"), // Required
 		SnapshotID: aws.String("String"),                // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.DescribeSnapshotAttribute(params)
 
@@ -3671,14 +3671,14 @@ func ExampleEC2_DescribeSnapshotAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSnapshots() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeSnapshotsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3689,7 +3689,7 @@ func ExampleEC2_DescribeSnapshots() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 		OwnerIDs: []*string{
 			aws.String("String"), // Required
@@ -3722,14 +3722,14 @@ func ExampleEC2_DescribeSnapshots() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSpotDatafeedSubscription() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeSpotDatafeedSubscriptionInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.DescribeSpotDatafeedSubscription(params)
 
@@ -3749,7 +3749,7 @@ func ExampleEC2_DescribeSpotDatafeedSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSpotFleetInstances() {
@@ -3757,8 +3757,8 @@ func ExampleEC2_DescribeSpotFleetInstances() {
 
 	params := &ec2.DescribeSpotFleetInstancesInput{
 		SpotFleetRequestID: aws.String("String"), // Required
-		DryRun:             aws.Boolean(true),
-		MaxResults:         aws.Long(1),
+		DryRun:             aws.Bool(true),
+		MaxResults:         aws.Int64(1),
 		NextToken:          aws.String("String"),
 	}
 	resp, err := svc.DescribeSpotFleetInstances(params)
@@ -3779,7 +3779,7 @@ func ExampleEC2_DescribeSpotFleetInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSpotFleetRequestHistory() {
@@ -3788,9 +3788,9 @@ func ExampleEC2_DescribeSpotFleetRequestHistory() {
 	params := &ec2.DescribeSpotFleetRequestHistoryInput{
 		SpotFleetRequestID: aws.String("String"), // Required
 		StartTime:          aws.Time(time.Now()), // Required
-		DryRun:             aws.Boolean(true),
+		DryRun:             aws.Bool(true),
 		EventType:          aws.String("EventType"),
-		MaxResults:         aws.Long(1),
+		MaxResults:         aws.Int64(1),
 		NextToken:          aws.String("String"),
 	}
 	resp, err := svc.DescribeSpotFleetRequestHistory(params)
@@ -3811,15 +3811,15 @@ func ExampleEC2_DescribeSpotFleetRequestHistory() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSpotFleetRequests() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeSpotFleetRequestsInput{
-		DryRun:     aws.Boolean(true),
-		MaxResults: aws.Long(1),
+		DryRun:     aws.Bool(true),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 		SpotFleetRequestIDs: []*string{
 			aws.String("String"), // Required
@@ -3844,14 +3844,14 @@ func ExampleEC2_DescribeSpotFleetRequests() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSpotInstanceRequests() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeSpotInstanceRequestsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3885,7 +3885,7 @@ func ExampleEC2_DescribeSpotInstanceRequests() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSpotPriceHistory() {
@@ -3893,7 +3893,7 @@ func ExampleEC2_DescribeSpotPriceHistory() {
 
 	params := &ec2.DescribeSpotPriceHistoryInput{
 		AvailabilityZone: aws.String("String"),
-		DryRun:           aws.Boolean(true),
+		DryRun:           aws.Bool(true),
 		EndTime:          aws.Time(time.Now()),
 		Filters: []*ec2.Filter{
 			{ // Required
@@ -3909,7 +3909,7 @@ func ExampleEC2_DescribeSpotPriceHistory() {
 			aws.String("InstanceType"), // Required
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 		ProductDescriptions: []*string{
 			aws.String("String"), // Required
@@ -3935,14 +3935,14 @@ func ExampleEC2_DescribeSpotPriceHistory() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeSubnets() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeSubnetsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3976,14 +3976,14 @@ func ExampleEC2_DescribeSubnets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeTags() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeTagsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -3994,7 +3994,7 @@ func ExampleEC2_DescribeTags() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.DescribeTags(params)
@@ -4015,7 +4015,7 @@ func ExampleEC2_DescribeTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVPCAttribute() {
@@ -4024,7 +4024,7 @@ func ExampleEC2_DescribeVPCAttribute() {
 	params := &ec2.DescribeVPCAttributeInput{
 		VPCID:     aws.String("String"), // Required
 		Attribute: aws.String("VpcAttributeName"),
-		DryRun:    aws.Boolean(true),
+		DryRun:    aws.Bool(true),
 	}
 	resp, err := svc.DescribeVPCAttribute(params)
 
@@ -4044,14 +4044,14 @@ func ExampleEC2_DescribeVPCAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVPCClassicLink() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVPCClassicLinkInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -4085,15 +4085,15 @@ func ExampleEC2_DescribeVPCClassicLink() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVPCEndpointServices() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVPCEndpointServicesInput{
-		DryRun:     aws.Boolean(true),
-		MaxResults: aws.Long(1),
+		DryRun:     aws.Bool(true),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.DescribeVPCEndpointServices(params)
@@ -4114,14 +4114,14 @@ func ExampleEC2_DescribeVPCEndpointServices() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVPCEndpoints() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVPCEndpointsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -4132,7 +4132,7 @@ func ExampleEC2_DescribeVPCEndpoints() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 		VPCEndpointIDs: []*string{
 			aws.String("String"), // Required
@@ -4157,14 +4157,14 @@ func ExampleEC2_DescribeVPCEndpoints() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVPCPeeringConnections() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVPCPeeringConnectionsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -4198,14 +4198,14 @@ func ExampleEC2_DescribeVPCPeeringConnections() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVPCs() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVPCsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -4239,14 +4239,14 @@ func ExampleEC2_DescribeVPCs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVPNConnections() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVPNConnectionsInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -4280,14 +4280,14 @@ func ExampleEC2_DescribeVPNConnections() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVPNGateways() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVPNGatewaysInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -4321,7 +4321,7 @@ func ExampleEC2_DescribeVPNGateways() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVolumeAttribute() {
@@ -4330,7 +4330,7 @@ func ExampleEC2_DescribeVolumeAttribute() {
 	params := &ec2.DescribeVolumeAttributeInput{
 		VolumeID:  aws.String("String"), // Required
 		Attribute: aws.String("VolumeAttributeName"),
-		DryRun:    aws.Boolean(true),
+		DryRun:    aws.Bool(true),
 	}
 	resp, err := svc.DescribeVolumeAttribute(params)
 
@@ -4350,14 +4350,14 @@ func ExampleEC2_DescribeVolumeAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVolumeStatus() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVolumeStatusInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -4368,7 +4368,7 @@ func ExampleEC2_DescribeVolumeStatus() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 		VolumeIDs: []*string{
 			aws.String("String"), // Required
@@ -4393,14 +4393,14 @@ func ExampleEC2_DescribeVolumeStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DescribeVolumes() {
 	svc := ec2.New(nil)
 
 	params := &ec2.DescribeVolumesInput{
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Filters: []*ec2.Filter{
 			{ // Required
 				Name: aws.String("String"),
@@ -4411,7 +4411,7 @@ func ExampleEC2_DescribeVolumes() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 		VolumeIDs: []*string{
 			aws.String("String"), // Required
@@ -4436,7 +4436,7 @@ func ExampleEC2_DescribeVolumes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DetachClassicLinkVPC() {
@@ -4445,7 +4445,7 @@ func ExampleEC2_DetachClassicLinkVPC() {
 	params := &ec2.DetachClassicLinkVPCInput{
 		InstanceID: aws.String("String"), // Required
 		VPCID:      aws.String("String"), // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.DetachClassicLinkVPC(params)
 
@@ -4465,7 +4465,7 @@ func ExampleEC2_DetachClassicLinkVPC() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DetachInternetGateway() {
@@ -4474,7 +4474,7 @@ func ExampleEC2_DetachInternetGateway() {
 	params := &ec2.DetachInternetGatewayInput{
 		InternetGatewayID: aws.String("String"), // Required
 		VPCID:             aws.String("String"), // Required
-		DryRun:            aws.Boolean(true),
+		DryRun:            aws.Bool(true),
 	}
 	resp, err := svc.DetachInternetGateway(params)
 
@@ -4494,7 +4494,7 @@ func ExampleEC2_DetachInternetGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DetachNetworkInterface() {
@@ -4502,8 +4502,8 @@ func ExampleEC2_DetachNetworkInterface() {
 
 	params := &ec2.DetachNetworkInterfaceInput{
 		AttachmentID: aws.String("String"), // Required
-		DryRun:       aws.Boolean(true),
-		Force:        aws.Boolean(true),
+		DryRun:       aws.Bool(true),
+		Force:        aws.Bool(true),
 	}
 	resp, err := svc.DetachNetworkInterface(params)
 
@@ -4523,7 +4523,7 @@ func ExampleEC2_DetachNetworkInterface() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DetachVPNGateway() {
@@ -4532,7 +4532,7 @@ func ExampleEC2_DetachVPNGateway() {
 	params := &ec2.DetachVPNGatewayInput{
 		VPCID:        aws.String("String"), // Required
 		VPNGatewayID: aws.String("String"), // Required
-		DryRun:       aws.Boolean(true),
+		DryRun:       aws.Bool(true),
 	}
 	resp, err := svc.DetachVPNGateway(params)
 
@@ -4552,7 +4552,7 @@ func ExampleEC2_DetachVPNGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DetachVolume() {
@@ -4561,8 +4561,8 @@ func ExampleEC2_DetachVolume() {
 	params := &ec2.DetachVolumeInput{
 		VolumeID:   aws.String("String"), // Required
 		Device:     aws.String("String"),
-		DryRun:     aws.Boolean(true),
-		Force:      aws.Boolean(true),
+		DryRun:     aws.Bool(true),
+		Force:      aws.Bool(true),
 		InstanceID: aws.String("String"),
 	}
 	resp, err := svc.DetachVolume(params)
@@ -4583,7 +4583,7 @@ func ExampleEC2_DetachVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DisableVGWRoutePropagation() {
@@ -4611,7 +4611,7 @@ func ExampleEC2_DisableVGWRoutePropagation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DisableVPCClassicLink() {
@@ -4619,7 +4619,7 @@ func ExampleEC2_DisableVPCClassicLink() {
 
 	params := &ec2.DisableVPCClassicLinkInput{
 		VPCID:  aws.String("String"), // Required
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.DisableVPCClassicLink(params)
 
@@ -4639,7 +4639,7 @@ func ExampleEC2_DisableVPCClassicLink() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DisassociateAddress() {
@@ -4647,7 +4647,7 @@ func ExampleEC2_DisassociateAddress() {
 
 	params := &ec2.DisassociateAddressInput{
 		AssociationID: aws.String("String"),
-		DryRun:        aws.Boolean(true),
+		DryRun:        aws.Bool(true),
 		PublicIP:      aws.String("String"),
 	}
 	resp, err := svc.DisassociateAddress(params)
@@ -4668,7 +4668,7 @@ func ExampleEC2_DisassociateAddress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_DisassociateRouteTable() {
@@ -4676,7 +4676,7 @@ func ExampleEC2_DisassociateRouteTable() {
 
 	params := &ec2.DisassociateRouteTableInput{
 		AssociationID: aws.String("String"), // Required
-		DryRun:        aws.Boolean(true),
+		DryRun:        aws.Bool(true),
 	}
 	resp, err := svc.DisassociateRouteTable(params)
 
@@ -4696,7 +4696,7 @@ func ExampleEC2_DisassociateRouteTable() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_EnableVGWRoutePropagation() {
@@ -4724,7 +4724,7 @@ func ExampleEC2_EnableVGWRoutePropagation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_EnableVPCClassicLink() {
@@ -4732,7 +4732,7 @@ func ExampleEC2_EnableVPCClassicLink() {
 
 	params := &ec2.EnableVPCClassicLinkInput{
 		VPCID:  aws.String("String"), // Required
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.EnableVPCClassicLink(params)
 
@@ -4752,7 +4752,7 @@ func ExampleEC2_EnableVPCClassicLink() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_EnableVolumeIO() {
@@ -4760,7 +4760,7 @@ func ExampleEC2_EnableVolumeIO() {
 
 	params := &ec2.EnableVolumeIOInput{
 		VolumeID: aws.String("String"), // Required
-		DryRun:   aws.Boolean(true),
+		DryRun:   aws.Bool(true),
 	}
 	resp, err := svc.EnableVolumeIO(params)
 
@@ -4780,7 +4780,7 @@ func ExampleEC2_EnableVolumeIO() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_GetConsoleOutput() {
@@ -4788,7 +4788,7 @@ func ExampleEC2_GetConsoleOutput() {
 
 	params := &ec2.GetConsoleOutputInput{
 		InstanceID: aws.String("String"), // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.GetConsoleOutput(params)
 
@@ -4808,7 +4808,7 @@ func ExampleEC2_GetConsoleOutput() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_GetPasswordData() {
@@ -4816,7 +4816,7 @@ func ExampleEC2_GetPasswordData() {
 
 	params := &ec2.GetPasswordDataInput{
 		InstanceID: aws.String("String"), // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.GetPasswordData(params)
 
@@ -4836,7 +4836,7 @@ func ExampleEC2_GetPasswordData() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ImportImage() {
@@ -4847,7 +4847,7 @@ func ExampleEC2_ImportImage() {
 		ClientData: &ec2.ClientData{
 			Comment:     aws.String("String"),
 			UploadEnd:   aws.Time(time.Now()),
-			UploadSize:  aws.Double(1.0),
+			UploadSize:  aws.Float64(1.0),
 			UploadStart: aws.Time(time.Now()),
 		},
 		ClientToken: aws.String("String"),
@@ -4866,7 +4866,7 @@ func ExampleEC2_ImportImage() {
 			},
 			// More values...
 		},
-		DryRun:      aws.Boolean(true),
+		DryRun:      aws.Bool(true),
 		Hypervisor:  aws.String("String"),
 		LicenseType: aws.String("String"),
 		Platform:    aws.String("String"),
@@ -4890,7 +4890,7 @@ func ExampleEC2_ImportImage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ImportInstance() {
@@ -4903,17 +4903,17 @@ func ExampleEC2_ImportInstance() {
 			{ // Required
 				Description: aws.String("String"),
 				Image: &ec2.DiskImageDetail{
-					Bytes:             aws.Long(1),                   // Required
+					Bytes:             aws.Int64(1),                  // Required
 					Format:            aws.String("DiskImageFormat"), // Required
 					ImportManifestURL: aws.String("String"),          // Required
 				},
 				Volume: &ec2.VolumeDetail{
-					Size: aws.Long(1), // Required
+					Size: aws.Int64(1), // Required
 				},
 			},
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		LaunchSpecification: &ec2.ImportInstanceLaunchSpecification{
 			AdditionalInfo: aws.String("String"),
 			Architecture:   aws.String("ArchitectureValues"),
@@ -4927,7 +4927,7 @@ func ExampleEC2_ImportInstance() {
 			},
 			InstanceInitiatedShutdownBehavior: aws.String("ShutdownBehavior"),
 			InstanceType:                      aws.String("InstanceType"),
-			Monitoring:                        aws.Boolean(true),
+			Monitoring:                        aws.Bool(true),
 			Placement: &ec2.Placement{
 				AvailabilityZone: aws.String("String"),
 				GroupName:        aws.String("String"),
@@ -4958,7 +4958,7 @@ func ExampleEC2_ImportInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ImportKeyPair() {
@@ -4967,7 +4967,7 @@ func ExampleEC2_ImportKeyPair() {
 	params := &ec2.ImportKeyPairInput{
 		KeyName:           aws.String("String"), // Required
 		PublicKeyMaterial: []byte("PAYLOAD"),    // Required
-		DryRun:            aws.Boolean(true),
+		DryRun:            aws.Bool(true),
 	}
 	resp, err := svc.ImportKeyPair(params)
 
@@ -4987,7 +4987,7 @@ func ExampleEC2_ImportKeyPair() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ImportSnapshot() {
@@ -4997,7 +4997,7 @@ func ExampleEC2_ImportSnapshot() {
 		ClientData: &ec2.ClientData{
 			Comment:     aws.String("String"),
 			UploadEnd:   aws.Time(time.Now()),
-			UploadSize:  aws.Double(1.0),
+			UploadSize:  aws.Float64(1.0),
 			UploadStart: aws.Time(time.Now()),
 		},
 		ClientToken: aws.String("String"),
@@ -5011,7 +5011,7 @@ func ExampleEC2_ImportSnapshot() {
 				S3Key:    aws.String("String"),
 			},
 		},
-		DryRun:   aws.Boolean(true),
+		DryRun:   aws.Bool(true),
 		RoleName: aws.String("String"),
 	}
 	resp, err := svc.ImportSnapshot(params)
@@ -5032,7 +5032,7 @@ func ExampleEC2_ImportSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ImportVolume() {
@@ -5041,15 +5041,15 @@ func ExampleEC2_ImportVolume() {
 	params := &ec2.ImportVolumeInput{
 		AvailabilityZone: aws.String("String"), // Required
 		Image: &ec2.DiskImageDetail{ // Required
-			Bytes:             aws.Long(1),                   // Required
+			Bytes:             aws.Int64(1),                  // Required
 			Format:            aws.String("DiskImageFormat"), // Required
 			ImportManifestURL: aws.String("String"),          // Required
 		},
 		Volume: &ec2.VolumeDetail{ // Required
-			Size: aws.Long(1), // Required
+			Size: aws.Int64(1), // Required
 		},
 		Description: aws.String("String"),
-		DryRun:      aws.Boolean(true),
+		DryRun:      aws.Bool(true),
 	}
 	resp, err := svc.ImportVolume(params)
 
@@ -5069,7 +5069,7 @@ func ExampleEC2_ImportVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifyImageAttribute() {
@@ -5081,7 +5081,7 @@ func ExampleEC2_ModifyImageAttribute() {
 		Description: &ec2.AttributeValue{
 			Value: aws.String("String"),
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		LaunchPermission: &ec2.LaunchPermissionModifications{
 			Add: []*ec2.LaunchPermission{
 				{ // Required
@@ -5131,7 +5131,7 @@ func ExampleEC2_ModifyImageAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifyInstanceAttribute() {
@@ -5144,7 +5144,7 @@ func ExampleEC2_ModifyInstanceAttribute() {
 			{ // Required
 				DeviceName: aws.String("String"),
 				EBS: &ec2.EBSInstanceBlockDeviceSpecification{
-					DeleteOnTermination: aws.Boolean(true),
+					DeleteOnTermination: aws.Bool(true),
 					VolumeID:            aws.String("String"),
 				},
 				NoDevice:    aws.String("String"),
@@ -5153,11 +5153,11 @@ func ExampleEC2_ModifyInstanceAttribute() {
 			// More values...
 		},
 		DisableAPITermination: &ec2.AttributeBooleanValue{
-			Value: aws.Boolean(true),
+			Value: aws.Bool(true),
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		EBSOptimized: &ec2.AttributeBooleanValue{
-			Value: aws.Boolean(true),
+			Value: aws.Bool(true),
 		},
 		Groups: []*string{
 			aws.String("String"), // Required
@@ -5179,7 +5179,7 @@ func ExampleEC2_ModifyInstanceAttribute() {
 			Value: aws.String("String"),
 		},
 		SourceDestCheck: &ec2.AttributeBooleanValue{
-			Value: aws.Boolean(true),
+			Value: aws.Bool(true),
 		},
 		UserData: &ec2.BlobAttributeValue{
 			Value: []byte("PAYLOAD"),
@@ -5204,7 +5204,7 @@ func ExampleEC2_ModifyInstanceAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifyNetworkInterfaceAttribute() {
@@ -5214,18 +5214,18 @@ func ExampleEC2_ModifyNetworkInterfaceAttribute() {
 		NetworkInterfaceID: aws.String("String"), // Required
 		Attachment: &ec2.NetworkInterfaceAttachmentChanges{
 			AttachmentID:        aws.String("String"),
-			DeleteOnTermination: aws.Boolean(true),
+			DeleteOnTermination: aws.Bool(true),
 		},
 		Description: &ec2.AttributeValue{
 			Value: aws.String("String"),
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		Groups: []*string{
 			aws.String("String"), // Required
 			// More values...
 		},
 		SourceDestCheck: &ec2.AttributeBooleanValue{
-			Value: aws.Boolean(true),
+			Value: aws.Bool(true),
 		},
 	}
 	resp, err := svc.ModifyNetworkInterfaceAttribute(params)
@@ -5246,7 +5246,7 @@ func ExampleEC2_ModifyNetworkInterfaceAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifyReservedInstances() {
@@ -5260,7 +5260,7 @@ func ExampleEC2_ModifyReservedInstances() {
 		TargetConfigurations: []*ec2.ReservedInstancesConfiguration{ // Required
 			{ // Required
 				AvailabilityZone: aws.String("String"),
-				InstanceCount:    aws.Long(1),
+				InstanceCount:    aws.Int64(1),
 				InstanceType:     aws.String("InstanceType"),
 				Platform:         aws.String("String"),
 			},
@@ -5286,7 +5286,7 @@ func ExampleEC2_ModifyReservedInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifySnapshotAttribute() {
@@ -5311,7 +5311,7 @@ func ExampleEC2_ModifySnapshotAttribute() {
 				// More values...
 			},
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		GroupNames: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -5340,7 +5340,7 @@ func ExampleEC2_ModifySnapshotAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifySubnetAttribute() {
@@ -5349,7 +5349,7 @@ func ExampleEC2_ModifySubnetAttribute() {
 	params := &ec2.ModifySubnetAttributeInput{
 		SubnetID: aws.String("String"), // Required
 		MapPublicIPOnLaunch: &ec2.AttributeBooleanValue{
-			Value: aws.Boolean(true),
+			Value: aws.Bool(true),
 		},
 	}
 	resp, err := svc.ModifySubnetAttribute(params)
@@ -5370,7 +5370,7 @@ func ExampleEC2_ModifySubnetAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifyVPCAttribute() {
@@ -5379,10 +5379,10 @@ func ExampleEC2_ModifyVPCAttribute() {
 	params := &ec2.ModifyVPCAttributeInput{
 		VPCID: aws.String("String"), // Required
 		EnableDNSHostnames: &ec2.AttributeBooleanValue{
-			Value: aws.Boolean(true),
+			Value: aws.Bool(true),
 		},
 		EnableDNSSupport: &ec2.AttributeBooleanValue{
-			Value: aws.Boolean(true),
+			Value: aws.Bool(true),
 		},
 	}
 	resp, err := svc.ModifyVPCAttribute(params)
@@ -5403,7 +5403,7 @@ func ExampleEC2_ModifyVPCAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifyVPCEndpoint() {
@@ -5415,13 +5415,13 @@ func ExampleEC2_ModifyVPCEndpoint() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun:         aws.Boolean(true),
+		DryRun:         aws.Bool(true),
 		PolicyDocument: aws.String("String"),
 		RemoveRouteTableIDs: []*string{
 			aws.String("String"), // Required
 			// More values...
 		},
-		ResetPolicy: aws.Boolean(true),
+		ResetPolicy: aws.Bool(true),
 	}
 	resp, err := svc.ModifyVPCEndpoint(params)
 
@@ -5441,7 +5441,7 @@ func ExampleEC2_ModifyVPCEndpoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ModifyVolumeAttribute() {
@@ -5450,9 +5450,9 @@ func ExampleEC2_ModifyVolumeAttribute() {
 	params := &ec2.ModifyVolumeAttributeInput{
 		VolumeID: aws.String("String"), // Required
 		AutoEnableIO: &ec2.AttributeBooleanValue{
-			Value: aws.Boolean(true),
+			Value: aws.Bool(true),
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.ModifyVolumeAttribute(params)
 
@@ -5472,7 +5472,7 @@ func ExampleEC2_ModifyVolumeAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_MonitorInstances() {
@@ -5483,7 +5483,7 @@ func ExampleEC2_MonitorInstances() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.MonitorInstances(params)
 
@@ -5503,7 +5503,7 @@ func ExampleEC2_MonitorInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_MoveAddressToVPC() {
@@ -5511,7 +5511,7 @@ func ExampleEC2_MoveAddressToVPC() {
 
 	params := &ec2.MoveAddressToVPCInput{
 		PublicIP: aws.String("String"), // Required
-		DryRun:   aws.Boolean(true),
+		DryRun:   aws.Bool(true),
 	}
 	resp, err := svc.MoveAddressToVPC(params)
 
@@ -5531,18 +5531,18 @@ func ExampleEC2_MoveAddressToVPC() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_PurchaseReservedInstancesOffering() {
 	svc := ec2.New(nil)
 
 	params := &ec2.PurchaseReservedInstancesOfferingInput{
-		InstanceCount:               aws.Long(1),          // Required
+		InstanceCount:               aws.Int64(1),         // Required
 		ReservedInstancesOfferingID: aws.String("String"), // Required
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 		LimitPrice: &ec2.ReservedInstanceLimitPrice{
-			Amount:       aws.Double(1.0),
+			Amount:       aws.Float64(1.0),
 			CurrencyCode: aws.String("CurrencyCodeValues"),
 		},
 	}
@@ -5564,7 +5564,7 @@ func ExampleEC2_PurchaseReservedInstancesOffering() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RebootInstances() {
@@ -5575,7 +5575,7 @@ func ExampleEC2_RebootInstances() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.RebootInstances(params)
 
@@ -5595,7 +5595,7 @@ func ExampleEC2_RebootInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RegisterImage() {
@@ -5608,11 +5608,11 @@ func ExampleEC2_RegisterImage() {
 			{ // Required
 				DeviceName: aws.String("String"),
 				EBS: &ec2.EBSBlockDevice{
-					DeleteOnTermination: aws.Boolean(true),
-					Encrypted:           aws.Boolean(true),
-					IOPS:                aws.Long(1),
+					DeleteOnTermination: aws.Bool(true),
+					Encrypted:           aws.Bool(true),
+					IOPS:                aws.Int64(1),
 					SnapshotID:          aws.String("String"),
-					VolumeSize:          aws.Long(1),
+					VolumeSize:          aws.Int64(1),
 					VolumeType:          aws.String("VolumeType"),
 				},
 				NoDevice:    aws.String("String"),
@@ -5621,7 +5621,7 @@ func ExampleEC2_RegisterImage() {
 			// More values...
 		},
 		Description:        aws.String("String"),
-		DryRun:             aws.Boolean(true),
+		DryRun:             aws.Bool(true),
 		ImageLocation:      aws.String("String"),
 		KernelID:           aws.String("String"),
 		RAMDiskID:          aws.String("String"),
@@ -5647,7 +5647,7 @@ func ExampleEC2_RegisterImage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RejectVPCPeeringConnection() {
@@ -5655,7 +5655,7 @@ func ExampleEC2_RejectVPCPeeringConnection() {
 
 	params := &ec2.RejectVPCPeeringConnectionInput{
 		VPCPeeringConnectionID: aws.String("String"), // Required
-		DryRun:                 aws.Boolean(true),
+		DryRun:                 aws.Bool(true),
 	}
 	resp, err := svc.RejectVPCPeeringConnection(params)
 
@@ -5675,7 +5675,7 @@ func ExampleEC2_RejectVPCPeeringConnection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ReleaseAddress() {
@@ -5683,7 +5683,7 @@ func ExampleEC2_ReleaseAddress() {
 
 	params := &ec2.ReleaseAddressInput{
 		AllocationID: aws.String("String"),
-		DryRun:       aws.Boolean(true),
+		DryRun:       aws.Bool(true),
 		PublicIP:     aws.String("String"),
 	}
 	resp, err := svc.ReleaseAddress(params)
@@ -5704,7 +5704,7 @@ func ExampleEC2_ReleaseAddress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ReplaceNetworkACLAssociation() {
@@ -5713,7 +5713,7 @@ func ExampleEC2_ReplaceNetworkACLAssociation() {
 	params := &ec2.ReplaceNetworkACLAssociationInput{
 		AssociationID: aws.String("String"), // Required
 		NetworkACLID:  aws.String("String"), // Required
-		DryRun:        aws.Boolean(true),
+		DryRun:        aws.Bool(true),
 	}
 	resp, err := svc.ReplaceNetworkACLAssociation(params)
 
@@ -5733,7 +5733,7 @@ func ExampleEC2_ReplaceNetworkACLAssociation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ReplaceNetworkACLEntry() {
@@ -5741,19 +5741,19 @@ func ExampleEC2_ReplaceNetworkACLEntry() {
 
 	params := &ec2.ReplaceNetworkACLEntryInput{
 		CIDRBlock:    aws.String("String"),     // Required
-		Egress:       aws.Boolean(true),        // Required
+		Egress:       aws.Bool(true),           // Required
 		NetworkACLID: aws.String("String"),     // Required
 		Protocol:     aws.String("String"),     // Required
 		RuleAction:   aws.String("RuleAction"), // Required
-		RuleNumber:   aws.Long(1),              // Required
-		DryRun:       aws.Boolean(true),
+		RuleNumber:   aws.Int64(1),             // Required
+		DryRun:       aws.Bool(true),
 		ICMPTypeCode: &ec2.ICMPTypeCode{
-			Code: aws.Long(1),
-			Type: aws.Long(1),
+			Code: aws.Int64(1),
+			Type: aws.Int64(1),
 		},
 		PortRange: &ec2.PortRange{
-			From: aws.Long(1),
-			To:   aws.Long(1),
+			From: aws.Int64(1),
+			To:   aws.Int64(1),
 		},
 	}
 	resp, err := svc.ReplaceNetworkACLEntry(params)
@@ -5774,7 +5774,7 @@ func ExampleEC2_ReplaceNetworkACLEntry() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ReplaceRoute() {
@@ -5783,7 +5783,7 @@ func ExampleEC2_ReplaceRoute() {
 	params := &ec2.ReplaceRouteInput{
 		DestinationCIDRBlock:   aws.String("String"), // Required
 		RouteTableID:           aws.String("String"), // Required
-		DryRun:                 aws.Boolean(true),
+		DryRun:                 aws.Bool(true),
 		GatewayID:              aws.String("String"),
 		InstanceID:             aws.String("String"),
 		NetworkInterfaceID:     aws.String("String"),
@@ -5807,7 +5807,7 @@ func ExampleEC2_ReplaceRoute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ReplaceRouteTableAssociation() {
@@ -5816,7 +5816,7 @@ func ExampleEC2_ReplaceRouteTableAssociation() {
 	params := &ec2.ReplaceRouteTableAssociationInput{
 		AssociationID: aws.String("String"), // Required
 		RouteTableID:  aws.String("String"), // Required
-		DryRun:        aws.Boolean(true),
+		DryRun:        aws.Bool(true),
 	}
 	resp, err := svc.ReplaceRouteTableAssociation(params)
 
@@ -5836,7 +5836,7 @@ func ExampleEC2_ReplaceRouteTableAssociation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ReportInstanceStatus() {
@@ -5853,7 +5853,7 @@ func ExampleEC2_ReportInstanceStatus() {
 		},
 		Status:      aws.String("ReportStatusType"), // Required
 		Description: aws.String("String"),
-		DryRun:      aws.Boolean(true),
+		DryRun:      aws.Bool(true),
 		EndTime:     aws.Time(time.Now()),
 		StartTime:   aws.Time(time.Now()),
 	}
@@ -5875,7 +5875,7 @@ func ExampleEC2_ReportInstanceStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RequestSpotFleet() {
@@ -5891,11 +5891,11 @@ func ExampleEC2_RequestSpotFleet() {
 						{ // Required
 							DeviceName: aws.String("String"),
 							EBS: &ec2.EBSBlockDevice{
-								DeleteOnTermination: aws.Boolean(true),
-								Encrypted:           aws.Boolean(true),
-								IOPS:                aws.Long(1),
+								DeleteOnTermination: aws.Bool(true),
+								Encrypted:           aws.Bool(true),
+								IOPS:                aws.Int64(1),
 								SnapshotID:          aws.String("String"),
-								VolumeSize:          aws.Long(1),
+								VolumeSize:          aws.Int64(1),
 								VolumeType:          aws.String("VolumeType"),
 							},
 							NoDevice:    aws.String("String"),
@@ -5903,7 +5903,7 @@ func ExampleEC2_RequestSpotFleet() {
 						},
 						// More values...
 					},
-					EBSOptimized: aws.Boolean(true),
+					EBSOptimized: aws.Bool(true),
 					IAMInstanceProfile: &ec2.IAMInstanceProfileSpecification{
 						ARN:  aws.String("String"),
 						Name: aws.String("String"),
@@ -5913,14 +5913,14 @@ func ExampleEC2_RequestSpotFleet() {
 					KernelID:     aws.String("String"),
 					KeyName:      aws.String("String"),
 					Monitoring: &ec2.RunInstancesMonitoringEnabled{
-						Enabled: aws.Boolean(true), // Required
+						Enabled: aws.Bool(true), // Required
 					},
 					NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 						{ // Required
-							AssociatePublicIPAddress: aws.Boolean(true),
-							DeleteOnTermination:      aws.Boolean(true),
+							AssociatePublicIPAddress: aws.Bool(true),
+							DeleteOnTermination:      aws.Bool(true),
 							Description:              aws.String("String"),
-							DeviceIndex:              aws.Long(1),
+							DeviceIndex:              aws.Int64(1),
 							Groups: []*string{
 								aws.String("String"), // Required
 								// More values...
@@ -5930,11 +5930,11 @@ func ExampleEC2_RequestSpotFleet() {
 							PrivateIPAddresses: []*ec2.PrivateIPAddressSpecification{
 								{ // Required
 									PrivateIPAddress: aws.String("String"), // Required
-									Primary:          aws.Boolean(true),
+									Primary:          aws.Bool(true),
 								},
 								// More values...
 							},
-							SecondaryPrivateIPAddressCount: aws.Long(1),
+							SecondaryPrivateIPAddressCount: aws.Int64(1),
 							SubnetID:                       aws.String("String"),
 						},
 						// More values...
@@ -5957,13 +5957,13 @@ func ExampleEC2_RequestSpotFleet() {
 				// More values...
 			},
 			SpotPrice:                        aws.String("String"), // Required
-			TargetCapacity:                   aws.Long(1),          // Required
+			TargetCapacity:                   aws.Int64(1),         // Required
 			ClientToken:                      aws.String("String"),
-			TerminateInstancesWithExpiration: aws.Boolean(true),
+			TerminateInstancesWithExpiration: aws.Bool(true),
 			ValidFrom:                        aws.Time(time.Now()),
 			ValidUntil:                       aws.Time(time.Now()),
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.RequestSpotFleet(params)
 
@@ -5983,7 +5983,7 @@ func ExampleEC2_RequestSpotFleet() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RequestSpotInstances() {
@@ -5993,8 +5993,8 @@ func ExampleEC2_RequestSpotInstances() {
 		SpotPrice:             aws.String("String"), // Required
 		AvailabilityZoneGroup: aws.String("String"),
 		ClientToken:           aws.String("String"),
-		DryRun:                aws.Boolean(true),
-		InstanceCount:         aws.Long(1),
+		DryRun:                aws.Bool(true),
+		InstanceCount:         aws.Int64(1),
 		LaunchGroup:           aws.String("String"),
 		LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
 			AddressingType: aws.String("String"),
@@ -6002,11 +6002,11 @@ func ExampleEC2_RequestSpotInstances() {
 				{ // Required
 					DeviceName: aws.String("String"),
 					EBS: &ec2.EBSBlockDevice{
-						DeleteOnTermination: aws.Boolean(true),
-						Encrypted:           aws.Boolean(true),
-						IOPS:                aws.Long(1),
+						DeleteOnTermination: aws.Bool(true),
+						Encrypted:           aws.Bool(true),
+						IOPS:                aws.Int64(1),
 						SnapshotID:          aws.String("String"),
-						VolumeSize:          aws.Long(1),
+						VolumeSize:          aws.Int64(1),
 						VolumeType:          aws.String("VolumeType"),
 					},
 					NoDevice:    aws.String("String"),
@@ -6014,7 +6014,7 @@ func ExampleEC2_RequestSpotInstances() {
 				},
 				// More values...
 			},
-			EBSOptimized: aws.Boolean(true),
+			EBSOptimized: aws.Bool(true),
 			IAMInstanceProfile: &ec2.IAMInstanceProfileSpecification{
 				ARN:  aws.String("String"),
 				Name: aws.String("String"),
@@ -6024,14 +6024,14 @@ func ExampleEC2_RequestSpotInstances() {
 			KernelID:     aws.String("String"),
 			KeyName:      aws.String("String"),
 			Monitoring: &ec2.RunInstancesMonitoringEnabled{
-				Enabled: aws.Boolean(true), // Required
+				Enabled: aws.Bool(true), // Required
 			},
 			NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 				{ // Required
-					AssociatePublicIPAddress: aws.Boolean(true),
-					DeleteOnTermination:      aws.Boolean(true),
+					AssociatePublicIPAddress: aws.Bool(true),
+					DeleteOnTermination:      aws.Bool(true),
 					Description:              aws.String("String"),
-					DeviceIndex:              aws.Long(1),
+					DeviceIndex:              aws.Int64(1),
 					Groups: []*string{
 						aws.String("String"), // Required
 						// More values...
@@ -6041,11 +6041,11 @@ func ExampleEC2_RequestSpotInstances() {
 					PrivateIPAddresses: []*ec2.PrivateIPAddressSpecification{
 						{ // Required
 							PrivateIPAddress: aws.String("String"), // Required
-							Primary:          aws.Boolean(true),
+							Primary:          aws.Bool(true),
 						},
 						// More values...
 					},
-					SecondaryPrivateIPAddressCount: aws.Long(1),
+					SecondaryPrivateIPAddressCount: aws.Int64(1),
 					SubnetID:                       aws.String("String"),
 				},
 				// More values...
@@ -6088,7 +6088,7 @@ func ExampleEC2_RequestSpotInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ResetImageAttribute() {
@@ -6097,7 +6097,7 @@ func ExampleEC2_ResetImageAttribute() {
 	params := &ec2.ResetImageAttributeInput{
 		Attribute: aws.String("ResetImageAttributeName"), // Required
 		ImageID:   aws.String("String"),                  // Required
-		DryRun:    aws.Boolean(true),
+		DryRun:    aws.Bool(true),
 	}
 	resp, err := svc.ResetImageAttribute(params)
 
@@ -6117,7 +6117,7 @@ func ExampleEC2_ResetImageAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ResetInstanceAttribute() {
@@ -6126,7 +6126,7 @@ func ExampleEC2_ResetInstanceAttribute() {
 	params := &ec2.ResetInstanceAttributeInput{
 		Attribute:  aws.String("InstanceAttributeName"), // Required
 		InstanceID: aws.String("String"),                // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.ResetInstanceAttribute(params)
 
@@ -6146,7 +6146,7 @@ func ExampleEC2_ResetInstanceAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ResetNetworkInterfaceAttribute() {
@@ -6154,7 +6154,7 @@ func ExampleEC2_ResetNetworkInterfaceAttribute() {
 
 	params := &ec2.ResetNetworkInterfaceAttributeInput{
 		NetworkInterfaceID: aws.String("String"), // Required
-		DryRun:             aws.Boolean(true),
+		DryRun:             aws.Bool(true),
 		SourceDestCheck:    aws.String("String"),
 	}
 	resp, err := svc.ResetNetworkInterfaceAttribute(params)
@@ -6175,7 +6175,7 @@ func ExampleEC2_ResetNetworkInterfaceAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_ResetSnapshotAttribute() {
@@ -6184,7 +6184,7 @@ func ExampleEC2_ResetSnapshotAttribute() {
 	params := &ec2.ResetSnapshotAttributeInput{
 		Attribute:  aws.String("ModifySnapshotAttributeName"), // Required
 		SnapshotID: aws.String("String"),                      // Required
-		DryRun:     aws.Boolean(true),
+		DryRun:     aws.Bool(true),
 	}
 	resp, err := svc.ResetSnapshotAttribute(params)
 
@@ -6204,7 +6204,7 @@ func ExampleEC2_ResetSnapshotAttribute() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RestoreAddressToClassic() {
@@ -6212,7 +6212,7 @@ func ExampleEC2_RestoreAddressToClassic() {
 
 	params := &ec2.RestoreAddressToClassicInput{
 		PublicIP: aws.String("String"), // Required
-		DryRun:   aws.Boolean(true),
+		DryRun:   aws.Bool(true),
 	}
 	resp, err := svc.RestoreAddressToClassic(params)
 
@@ -6232,7 +6232,7 @@ func ExampleEC2_RestoreAddressToClassic() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RevokeSecurityGroupEgress() {
@@ -6241,11 +6241,11 @@ func ExampleEC2_RevokeSecurityGroupEgress() {
 	params := &ec2.RevokeSecurityGroupEgressInput{
 		GroupID:  aws.String("String"), // Required
 		CIDRIP:   aws.String("String"),
-		DryRun:   aws.Boolean(true),
-		FromPort: aws.Long(1),
+		DryRun:   aws.Bool(true),
+		FromPort: aws.Int64(1),
 		IPPermissions: []*ec2.IPPermission{
 			{ // Required
-				FromPort:   aws.Long(1),
+				FromPort:   aws.Int64(1),
 				IPProtocol: aws.String("String"),
 				IPRanges: []*ec2.IPRange{
 					{ // Required
@@ -6259,7 +6259,7 @@ func ExampleEC2_RevokeSecurityGroupEgress() {
 					},
 					// More values...
 				},
-				ToPort: aws.Long(1),
+				ToPort: aws.Int64(1),
 				UserIDGroupPairs: []*ec2.UserIDGroupPair{
 					{ // Required
 						GroupID:   aws.String("String"),
@@ -6274,7 +6274,7 @@ func ExampleEC2_RevokeSecurityGroupEgress() {
 		IPProtocol:                 aws.String("String"),
 		SourceSecurityGroupName:    aws.String("String"),
 		SourceSecurityGroupOwnerID: aws.String("String"),
-		ToPort: aws.Long(1),
+		ToPort: aws.Int64(1),
 	}
 	resp, err := svc.RevokeSecurityGroupEgress(params)
 
@@ -6294,7 +6294,7 @@ func ExampleEC2_RevokeSecurityGroupEgress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RevokeSecurityGroupIngress() {
@@ -6302,13 +6302,13 @@ func ExampleEC2_RevokeSecurityGroupIngress() {
 
 	params := &ec2.RevokeSecurityGroupIngressInput{
 		CIDRIP:    aws.String("String"),
-		DryRun:    aws.Boolean(true),
-		FromPort:  aws.Long(1),
+		DryRun:    aws.Bool(true),
+		FromPort:  aws.Int64(1),
 		GroupID:   aws.String("String"),
 		GroupName: aws.String("String"),
 		IPPermissions: []*ec2.IPPermission{
 			{ // Required
-				FromPort:   aws.Long(1),
+				FromPort:   aws.Int64(1),
 				IPProtocol: aws.String("String"),
 				IPRanges: []*ec2.IPRange{
 					{ // Required
@@ -6322,7 +6322,7 @@ func ExampleEC2_RevokeSecurityGroupIngress() {
 					},
 					// More values...
 				},
-				ToPort: aws.Long(1),
+				ToPort: aws.Int64(1),
 				UserIDGroupPairs: []*ec2.UserIDGroupPair{
 					{ // Required
 						GroupID:   aws.String("String"),
@@ -6337,7 +6337,7 @@ func ExampleEC2_RevokeSecurityGroupIngress() {
 		IPProtocol:                 aws.String("String"),
 		SourceSecurityGroupName:    aws.String("String"),
 		SourceSecurityGroupOwnerID: aws.String("String"),
-		ToPort: aws.Long(1),
+		ToPort: aws.Int64(1),
 	}
 	resp, err := svc.RevokeSecurityGroupIngress(params)
 
@@ -6357,7 +6357,7 @@ func ExampleEC2_RevokeSecurityGroupIngress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_RunInstances() {
@@ -6365,18 +6365,18 @@ func ExampleEC2_RunInstances() {
 
 	params := &ec2.RunInstancesInput{
 		ImageID:        aws.String("String"), // Required
-		MaxCount:       aws.Long(1),          // Required
-		MinCount:       aws.Long(1),          // Required
+		MaxCount:       aws.Int64(1),         // Required
+		MinCount:       aws.Int64(1),         // Required
 		AdditionalInfo: aws.String("String"),
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 			{ // Required
 				DeviceName: aws.String("String"),
 				EBS: &ec2.EBSBlockDevice{
-					DeleteOnTermination: aws.Boolean(true),
-					Encrypted:           aws.Boolean(true),
-					IOPS:                aws.Long(1),
+					DeleteOnTermination: aws.Bool(true),
+					Encrypted:           aws.Bool(true),
+					IOPS:                aws.Int64(1),
 					SnapshotID:          aws.String("String"),
-					VolumeSize:          aws.Long(1),
+					VolumeSize:          aws.Int64(1),
 					VolumeType:          aws.String("VolumeType"),
 				},
 				NoDevice:    aws.String("String"),
@@ -6385,9 +6385,9 @@ func ExampleEC2_RunInstances() {
 			// More values...
 		},
 		ClientToken:           aws.String("String"),
-		DisableAPITermination: aws.Boolean(true),
-		DryRun:                aws.Boolean(true),
-		EBSOptimized:          aws.Boolean(true),
+		DisableAPITermination: aws.Bool(true),
+		DryRun:                aws.Bool(true),
+		EBSOptimized:          aws.Bool(true),
 		IAMInstanceProfile: &ec2.IAMInstanceProfileSpecification{
 			ARN:  aws.String("String"),
 			Name: aws.String("String"),
@@ -6397,14 +6397,14 @@ func ExampleEC2_RunInstances() {
 		KernelID:                          aws.String("String"),
 		KeyName:                           aws.String("String"),
 		Monitoring: &ec2.RunInstancesMonitoringEnabled{
-			Enabled: aws.Boolean(true), // Required
+			Enabled: aws.Bool(true), // Required
 		},
 		NetworkInterfaces: []*ec2.InstanceNetworkInterfaceSpecification{
 			{ // Required
-				AssociatePublicIPAddress: aws.Boolean(true),
-				DeleteOnTermination:      aws.Boolean(true),
+				AssociatePublicIPAddress: aws.Bool(true),
+				DeleteOnTermination:      aws.Bool(true),
 				Description:              aws.String("String"),
-				DeviceIndex:              aws.Long(1),
+				DeviceIndex:              aws.Int64(1),
 				Groups: []*string{
 					aws.String("String"), // Required
 					// More values...
@@ -6414,11 +6414,11 @@ func ExampleEC2_RunInstances() {
 				PrivateIPAddresses: []*ec2.PrivateIPAddressSpecification{
 					{ // Required
 						PrivateIPAddress: aws.String("String"), // Required
-						Primary:          aws.Boolean(true),
+						Primary:          aws.Bool(true),
 					},
 					// More values...
 				},
-				SecondaryPrivateIPAddressCount: aws.Long(1),
+				SecondaryPrivateIPAddressCount: aws.Int64(1),
 				SubnetID:                       aws.String("String"),
 			},
 			// More values...
@@ -6459,7 +6459,7 @@ func ExampleEC2_RunInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_StartInstances() {
@@ -6471,7 +6471,7 @@ func ExampleEC2_StartInstances() {
 			// More values...
 		},
 		AdditionalInfo: aws.String("String"),
-		DryRun:         aws.Boolean(true),
+		DryRun:         aws.Bool(true),
 	}
 	resp, err := svc.StartInstances(params)
 
@@ -6491,7 +6491,7 @@ func ExampleEC2_StartInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_StopInstances() {
@@ -6502,8 +6502,8 @@ func ExampleEC2_StopInstances() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
-		Force:  aws.Boolean(true),
+		DryRun: aws.Bool(true),
+		Force:  aws.Bool(true),
 	}
 	resp, err := svc.StopInstances(params)
 
@@ -6523,7 +6523,7 @@ func ExampleEC2_StopInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_TerminateInstances() {
@@ -6534,7 +6534,7 @@ func ExampleEC2_TerminateInstances() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.TerminateInstances(params)
 
@@ -6554,7 +6554,7 @@ func ExampleEC2_TerminateInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_UnassignPrivateIPAddresses() {
@@ -6585,7 +6585,7 @@ func ExampleEC2_UnassignPrivateIPAddresses() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEC2_UnmonitorInstances() {
@@ -6596,7 +6596,7 @@ func ExampleEC2_UnmonitorInstances() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		DryRun: aws.Boolean(true),
+		DryRun: aws.Bool(true),
 	}
 	resp, err := svc.UnmonitorInstances(params)
 
@@ -6616,5 +6616,5 @@ func ExampleEC2_UnmonitorInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -948,7 +948,7 @@ type metadataCluster struct {
 
 // String returns the string representation
 func (s Cluster) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -989,7 +989,7 @@ type metadataContainer struct {
 
 // String returns the string representation
 func (s Container) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1099,7 +1099,7 @@ type metadataContainerDefinition struct {
 
 // String returns the string representation
 func (s ContainerDefinition) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1160,7 +1160,7 @@ type metadataContainerInstance struct {
 
 // String returns the string representation
 func (s ContainerInstance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1191,7 +1191,7 @@ type metadataContainerOverride struct {
 
 // String returns the string representation
 func (s ContainerOverride) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1214,7 +1214,7 @@ type metadataCreateClusterInput struct {
 
 // String returns the string representation
 func (s CreateClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1235,7 +1235,7 @@ type metadataCreateClusterOutput struct {
 
 // String returns the string representation
 func (s CreateClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1288,7 +1288,7 @@ type metadataCreateServiceInput struct {
 
 // String returns the string representation
 func (s CreateServiceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1309,7 +1309,7 @@ type metadataCreateServiceOutput struct {
 
 // String returns the string representation
 func (s CreateServiceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1331,7 +1331,7 @@ type metadataDeleteClusterInput struct {
 
 // String returns the string representation
 func (s DeleteClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1352,7 +1352,7 @@ type metadataDeleteClusterOutput struct {
 
 // String returns the string representation
 func (s DeleteClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1376,7 +1376,7 @@ type metadataDeleteServiceInput struct {
 
 // String returns the string representation
 func (s DeleteServiceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1397,7 +1397,7 @@ type metadataDeleteServiceOutput struct {
 
 // String returns the string representation
 func (s DeleteServiceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1444,7 +1444,7 @@ type metadataDeployment struct {
 
 // String returns the string representation
 func (s Deployment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1484,7 +1484,7 @@ type metadataDeregisterContainerInstanceInput struct {
 
 // String returns the string representation
 func (s DeregisterContainerInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1506,7 +1506,7 @@ type metadataDeregisterContainerInstanceOutput struct {
 
 // String returns the string representation
 func (s DeregisterContainerInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1528,7 +1528,7 @@ type metadataDeregisterTaskDefinitionInput struct {
 
 // String returns the string representation
 func (s DeregisterTaskDefinitionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1549,7 +1549,7 @@ type metadataDeregisterTaskDefinitionOutput struct {
 
 // String returns the string representation
 func (s DeregisterTaskDefinitionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1571,7 +1571,7 @@ type metadataDescribeClustersInput struct {
 
 // String returns the string representation
 func (s DescribeClustersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1594,7 +1594,7 @@ type metadataDescribeClustersOutput struct {
 
 // String returns the string representation
 func (s DescribeClustersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1621,7 +1621,7 @@ type metadataDescribeContainerInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeContainerInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1644,7 +1644,7 @@ type metadataDescribeContainerInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeContainerInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1668,7 +1668,7 @@ type metadataDescribeServicesInput struct {
 
 // String returns the string representation
 func (s DescribeServicesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1692,7 +1692,7 @@ type metadataDescribeServicesOutput struct {
 
 // String returns the string representation
 func (s DescribeServicesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1715,7 +1715,7 @@ type metadataDescribeTaskDefinitionInput struct {
 
 // String returns the string representation
 func (s DescribeTaskDefinitionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1736,7 +1736,7 @@ type metadataDescribeTaskDefinitionOutput struct {
 
 // String returns the string representation
 func (s DescribeTaskDefinitionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1762,7 +1762,7 @@ type metadataDescribeTasksInput struct {
 
 // String returns the string representation
 func (s DescribeTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1785,7 +1785,7 @@ type metadataDescribeTasksOutput struct {
 
 // String returns the string representation
 func (s DescribeTasksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1813,7 +1813,7 @@ type metadataDiscoverPollEndpointInput struct {
 
 // String returns the string representation
 func (s DiscoverPollEndpointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1837,7 +1837,7 @@ type metadataDiscoverPollEndpointOutput struct {
 
 // String returns the string representation
 func (s DiscoverPollEndpointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1862,7 +1862,7 @@ type metadataFailure struct {
 
 // String returns the string representation
 func (s Failure) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1886,7 +1886,7 @@ type metadataHostVolumeProperties struct {
 
 // String returns the string representation
 func (s HostVolumeProperties) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1913,7 +1913,7 @@ type metadataKeyValuePair struct {
 
 // String returns the string representation
 func (s KeyValuePair) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1946,7 +1946,7 @@ type metadataListClustersInput struct {
 
 // String returns the string representation
 func (s ListClustersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1974,7 +1974,7 @@ type metadataListClustersOutput struct {
 
 // String returns the string representation
 func (s ListClustersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2014,7 +2014,7 @@ type metadataListContainerInstancesInput struct {
 
 // String returns the string representation
 func (s ListContainerInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2042,7 +2042,7 @@ type metadataListContainerInstancesOutput struct {
 
 // String returns the string representation
 func (s ListContainerInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2080,7 +2080,7 @@ type metadataListServicesInput struct {
 
 // String returns the string representation
 func (s ListServicesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2108,7 +2108,7 @@ type metadataListServicesOutput struct {
 
 // String returns the string representation
 func (s ListServicesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2148,7 +2148,7 @@ type metadataListTaskDefinitionFamiliesInput struct {
 
 // String returns the string representation
 func (s ListTaskDefinitionFamiliesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2176,7 +2176,7 @@ type metadataListTaskDefinitionFamiliesOutput struct {
 
 // String returns the string representation
 func (s ListTaskDefinitionFamiliesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2231,7 +2231,7 @@ type metadataListTaskDefinitionsInput struct {
 
 // String returns the string representation
 func (s ListTaskDefinitionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2259,7 +2259,7 @@ type metadataListTaskDefinitionsOutput struct {
 
 // String returns the string representation
 func (s ListTaskDefinitionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2323,7 +2323,7 @@ type metadataListTasksInput struct {
 
 // String returns the string representation
 func (s ListTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2350,7 +2350,7 @@ type metadataListTasksOutput struct {
 
 // String returns the string representation
 func (s ListTasksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2381,7 +2381,7 @@ type metadataLoadBalancer struct {
 
 // String returns the string representation
 func (s LoadBalancer) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2411,7 +2411,7 @@ type metadataMountPoint struct {
 
 // String returns the string representation
 func (s MountPoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2443,7 +2443,7 @@ type metadataNetworkBinding struct {
 
 // String returns the string representation
 func (s NetworkBinding) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2497,7 +2497,7 @@ type metadataPortMapping struct {
 
 // String returns the string representation
 func (s PortMapping) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2541,7 +2541,7 @@ type metadataRegisterContainerInstanceInput struct {
 
 // String returns the string representation
 func (s RegisterContainerInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2563,7 +2563,7 @@ type metadataRegisterContainerInstanceOutput struct {
 
 // String returns the string representation
 func (s RegisterContainerInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2595,7 +2595,7 @@ type metadataRegisterTaskDefinitionInput struct {
 
 // String returns the string representation
 func (s RegisterTaskDefinitionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2616,7 +2616,7 @@ type metadataRegisterTaskDefinitionOutput struct {
 
 // String returns the string representation
 func (s RegisterTaskDefinitionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2656,7 +2656,7 @@ type metadataResource struct {
 
 // String returns the string representation
 func (s Resource) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2712,7 +2712,7 @@ type metadataRunTaskInput struct {
 
 // String returns the string representation
 func (s RunTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2737,7 +2737,7 @@ type metadataRunTaskOutput struct {
 
 // String returns the string representation
 func (s RunTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2804,7 +2804,7 @@ type metadataService struct {
 
 // String returns the string representation
 func (s Service) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2832,7 +2832,7 @@ type metadataServiceEvent struct {
 
 // String returns the string representation
 func (s ServiceEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2888,7 +2888,7 @@ type metadataStartTaskInput struct {
 
 // String returns the string representation
 func (s StartTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2913,7 +2913,7 @@ type metadataStartTaskOutput struct {
 
 // String returns the string representation
 func (s StartTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2940,7 +2940,7 @@ type metadataStopTaskInput struct {
 
 // String returns the string representation
 func (s StopTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2961,7 +2961,7 @@ type metadataStopTaskOutput struct {
 
 // String returns the string representation
 func (s StopTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3002,7 +3002,7 @@ type metadataSubmitContainerStateChangeInput struct {
 
 // String returns the string representation
 func (s SubmitContainerStateChangeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3023,7 +3023,7 @@ type metadataSubmitContainerStateChangeOutput struct {
 
 // String returns the string representation
 func (s SubmitContainerStateChangeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3055,7 +3055,7 @@ type metadataSubmitTaskStateChangeInput struct {
 
 // String returns the string representation
 func (s SubmitTaskStateChangeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3076,7 +3076,7 @@ type metadataSubmitTaskStateChangeOutput struct {
 
 // String returns the string representation
 func (s SubmitTaskStateChangeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3125,7 +3125,7 @@ type metadataTask struct {
 
 // String returns the string representation
 func (s Task) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3173,7 +3173,7 @@ type metadataTaskDefinition struct {
 
 // String returns the string representation
 func (s TaskDefinition) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3195,7 +3195,7 @@ type metadataTaskOverride struct {
 
 // String returns the string representation
 func (s TaskOverride) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3223,7 +3223,7 @@ type metadataUpdateContainerAgentInput struct {
 
 // String returns the string representation
 func (s UpdateContainerAgentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3245,7 +3245,7 @@ type metadataUpdateContainerAgentOutput struct {
 
 // String returns the string representation
 func (s UpdateContainerAgentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3283,7 +3283,7 @@ type metadataUpdateServiceInput struct {
 
 // String returns the string representation
 func (s UpdateServiceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3304,7 +3304,7 @@ type metadataUpdateServiceOutput struct {
 
 // String returns the string representation
 func (s UpdateServiceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3334,7 +3334,7 @@ type metadataVersionInfo struct {
 
 // String returns the string representation
 func (s VersionInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3362,7 +3362,7 @@ type metadataVolume struct {
 
 // String returns the string representation
 func (s Volume) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3389,7 +3389,7 @@ type metadataVolumeFrom struct {
 
 // String returns the string representation
 func (s VolumeFrom) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/ecs/examples_test.go
+++ b/service/ecs/examples_test.go
@@ -40,14 +40,14 @@ func ExampleECS_CreateCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_CreateService() {
 	svc := ecs.New(nil)
 
 	params := &ecs.CreateServiceInput{
-		DesiredCount:   aws.Long(1),          // Required
+		DesiredCount:   aws.Int64(1),         // Required
 		ServiceName:    aws.String("String"), // Required
 		TaskDefinition: aws.String("String"), // Required
 		ClientToken:    aws.String("String"),
@@ -55,7 +55,7 @@ func ExampleECS_CreateService() {
 		LoadBalancers: []*ecs.LoadBalancer{
 			{ // Required
 				ContainerName:    aws.String("String"),
-				ContainerPort:    aws.Long(1),
+				ContainerPort:    aws.Int64(1),
 				LoadBalancerName: aws.String("String"),
 			},
 			// More values...
@@ -80,7 +80,7 @@ func ExampleECS_CreateService() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DeleteCluster() {
@@ -107,7 +107,7 @@ func ExampleECS_DeleteCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DeleteService() {
@@ -135,7 +135,7 @@ func ExampleECS_DeleteService() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DeregisterContainerInstance() {
@@ -144,7 +144,7 @@ func ExampleECS_DeregisterContainerInstance() {
 	params := &ecs.DeregisterContainerInstanceInput{
 		ContainerInstance: aws.String("String"), // Required
 		Cluster:           aws.String("String"),
-		Force:             aws.Boolean(true),
+		Force:             aws.Bool(true),
 	}
 	resp, err := svc.DeregisterContainerInstance(params)
 
@@ -164,7 +164,7 @@ func ExampleECS_DeregisterContainerInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DeregisterTaskDefinition() {
@@ -191,7 +191,7 @@ func ExampleECS_DeregisterTaskDefinition() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DescribeClusters() {
@@ -221,7 +221,7 @@ func ExampleECS_DescribeClusters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DescribeContainerInstances() {
@@ -252,7 +252,7 @@ func ExampleECS_DescribeContainerInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DescribeServices() {
@@ -283,7 +283,7 @@ func ExampleECS_DescribeServices() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DescribeTaskDefinition() {
@@ -310,7 +310,7 @@ func ExampleECS_DescribeTaskDefinition() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DescribeTasks() {
@@ -341,7 +341,7 @@ func ExampleECS_DescribeTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_DiscoverPollEndpoint() {
@@ -369,14 +369,14 @@ func ExampleECS_DiscoverPollEndpoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_ListClusters() {
 	svc := ecs.New(nil)
 
 	params := &ecs.ListClustersInput{
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.ListClusters(params)
@@ -397,7 +397,7 @@ func ExampleECS_ListClusters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_ListContainerInstances() {
@@ -405,7 +405,7 @@ func ExampleECS_ListContainerInstances() {
 
 	params := &ecs.ListContainerInstancesInput{
 		Cluster:    aws.String("String"),
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.ListContainerInstances(params)
@@ -426,7 +426,7 @@ func ExampleECS_ListContainerInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_ListServices() {
@@ -434,7 +434,7 @@ func ExampleECS_ListServices() {
 
 	params := &ecs.ListServicesInput{
 		Cluster:    aws.String("String"),
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("String"),
 	}
 	resp, err := svc.ListServices(params)
@@ -455,7 +455,7 @@ func ExampleECS_ListServices() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_ListTaskDefinitionFamilies() {
@@ -463,7 +463,7 @@ func ExampleECS_ListTaskDefinitionFamilies() {
 
 	params := &ecs.ListTaskDefinitionFamiliesInput{
 		FamilyPrefix: aws.String("String"),
-		MaxResults:   aws.Long(1),
+		MaxResults:   aws.Int64(1),
 		NextToken:    aws.String("String"),
 	}
 	resp, err := svc.ListTaskDefinitionFamilies(params)
@@ -484,7 +484,7 @@ func ExampleECS_ListTaskDefinitionFamilies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_ListTaskDefinitions() {
@@ -492,7 +492,7 @@ func ExampleECS_ListTaskDefinitions() {
 
 	params := &ecs.ListTaskDefinitionsInput{
 		FamilyPrefix: aws.String("String"),
-		MaxResults:   aws.Long(1),
+		MaxResults:   aws.Int64(1),
 		NextToken:    aws.String("String"),
 		Sort:         aws.String("SortOrder"),
 		Status:       aws.String("TaskDefinitionStatus"),
@@ -515,7 +515,7 @@ func ExampleECS_ListTaskDefinitions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_ListTasks() {
@@ -526,7 +526,7 @@ func ExampleECS_ListTasks() {
 		ContainerInstance: aws.String("String"),
 		DesiredStatus:     aws.String("DesiredStatus"),
 		Family:            aws.String("String"),
-		MaxResults:        aws.Long(1),
+		MaxResults:        aws.Int64(1),
 		NextToken:         aws.String("String"),
 		ServiceName:       aws.String("String"),
 		StartedBy:         aws.String("String"),
@@ -549,7 +549,7 @@ func ExampleECS_ListTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_RegisterContainerInstance() {
@@ -562,9 +562,9 @@ func ExampleECS_RegisterContainerInstance() {
 		InstanceIdentityDocumentSignature: aws.String("String"),
 		TotalResources: []*ecs.Resource{
 			{ // Required
-				DoubleValue:  aws.Double(1.0),
-				IntegerValue: aws.Long(1),
-				LongValue:    aws.Long(1),
+				DoubleValue:  aws.Float64(1.0),
+				IntegerValue: aws.Int64(1),
+				LongValue:    aws.Int64(1),
 				Name:         aws.String("String"),
 				StringSetValue: []*string{
 					aws.String("String"), // Required
@@ -598,7 +598,7 @@ func ExampleECS_RegisterContainerInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_RegisterTaskDefinition() {
@@ -607,7 +607,7 @@ func ExampleECS_RegisterTaskDefinition() {
 	params := &ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: []*ecs.ContainerDefinition{ // Required
 			{ // Required
-				CPU: aws.Long(1),
+				CPU: aws.Int64(1),
 				Command: []*string{
 					aws.String("String"), // Required
 					// More values...
@@ -623,17 +623,17 @@ func ExampleECS_RegisterTaskDefinition() {
 					},
 					// More values...
 				},
-				Essential: aws.Boolean(true),
+				Essential: aws.Bool(true),
 				Image:     aws.String("String"),
 				Links: []*string{
 					aws.String("String"), // Required
 					// More values...
 				},
-				Memory: aws.Long(1),
+				Memory: aws.Int64(1),
 				MountPoints: []*ecs.MountPoint{
 					{ // Required
 						ContainerPath: aws.String("String"),
-						ReadOnly:      aws.Boolean(true),
+						ReadOnly:      aws.Bool(true),
 						SourceVolume:  aws.String("String"),
 					},
 					// More values...
@@ -641,15 +641,15 @@ func ExampleECS_RegisterTaskDefinition() {
 				Name: aws.String("String"),
 				PortMappings: []*ecs.PortMapping{
 					{ // Required
-						ContainerPort: aws.Long(1),
-						HostPort:      aws.Long(1),
+						ContainerPort: aws.Int64(1),
+						HostPort:      aws.Int64(1),
 						Protocol:      aws.String("TransportProtocol"),
 					},
 					// More values...
 				},
 				VolumesFrom: []*ecs.VolumeFrom{
 					{ // Required
-						ReadOnly:        aws.Boolean(true),
+						ReadOnly:        aws.Bool(true),
 						SourceContainer: aws.String("String"),
 					},
 					// More values...
@@ -686,7 +686,7 @@ func ExampleECS_RegisterTaskDefinition() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_RunTask() {
@@ -695,7 +695,7 @@ func ExampleECS_RunTask() {
 	params := &ecs.RunTaskInput{
 		TaskDefinition: aws.String("String"), // Required
 		Cluster:        aws.String("String"),
-		Count:          aws.Long(1),
+		Count:          aws.Int64(1),
 		Overrides: &ecs.TaskOverride{
 			ContainerOverrides: []*ecs.ContainerOverride{
 				{ // Required
@@ -735,7 +735,7 @@ func ExampleECS_RunTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_StartTask() {
@@ -787,7 +787,7 @@ func ExampleECS_StartTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_StopTask() {
@@ -815,7 +815,7 @@ func ExampleECS_StopTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_SubmitContainerStateChange() {
@@ -824,12 +824,12 @@ func ExampleECS_SubmitContainerStateChange() {
 	params := &ecs.SubmitContainerStateChangeInput{
 		Cluster:       aws.String("String"),
 		ContainerName: aws.String("String"),
-		ExitCode:      aws.Long(1),
+		ExitCode:      aws.Int64(1),
 		NetworkBindings: []*ecs.NetworkBinding{
 			{ // Required
 				BindIP:        aws.String("String"),
-				ContainerPort: aws.Long(1),
-				HostPort:      aws.Long(1),
+				ContainerPort: aws.Int64(1),
+				HostPort:      aws.Int64(1),
 				Protocol:      aws.String("TransportProtocol"),
 			},
 			// More values...
@@ -856,7 +856,7 @@ func ExampleECS_SubmitContainerStateChange() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_SubmitTaskStateChange() {
@@ -886,7 +886,7 @@ func ExampleECS_SubmitTaskStateChange() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_UpdateContainerAgent() {
@@ -914,7 +914,7 @@ func ExampleECS_UpdateContainerAgent() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleECS_UpdateService() {
@@ -923,7 +923,7 @@ func ExampleECS_UpdateService() {
 	params := &ecs.UpdateServiceInput{
 		Service:        aws.String("String"), // Required
 		Cluster:        aws.String("String"),
-		DesiredCount:   aws.Long(1),
+		DesiredCount:   aws.Int64(1),
 		TaskDefinition: aws.String("String"),
 	}
 	resp, err := svc.UpdateService(params)
@@ -944,5 +944,5 @@ func ExampleECS_UpdateService() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -530,7 +530,7 @@ type metadataCreateFileSystemInput struct {
 
 // String returns the string representation
 func (s CreateFileSystemInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -561,7 +561,7 @@ type metadataCreateMountTargetInput struct {
 
 // String returns the string representation
 func (s CreateMountTargetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -586,7 +586,7 @@ type metadataCreateTagsInput struct {
 
 // String returns the string representation
 func (s CreateTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -604,7 +604,7 @@ type metadataCreateTagsOutput struct {
 
 // String returns the string representation
 func (s CreateTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -625,7 +625,7 @@ type metadataDeleteFileSystemInput struct {
 
 // String returns the string representation
 func (s DeleteFileSystemInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -643,7 +643,7 @@ type metadataDeleteFileSystemOutput struct {
 
 // String returns the string representation
 func (s DeleteFileSystemOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -664,7 +664,7 @@ type metadataDeleteMountTargetInput struct {
 
 // String returns the string representation
 func (s DeleteMountTargetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -682,7 +682,7 @@ type metadataDeleteMountTargetOutput struct {
 
 // String returns the string representation
 func (s DeleteMountTargetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -706,7 +706,7 @@ type metadataDeleteTagsInput struct {
 
 // String returns the string representation
 func (s DeleteTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -724,7 +724,7 @@ type metadataDeleteTagsOutput struct {
 
 // String returns the string representation
 func (s DeleteTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -762,7 +762,7 @@ type metadataDescribeFileSystemsInput struct {
 
 // String returns the string representation
 func (s DescribeFileSystemsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -790,7 +790,7 @@ type metadataDescribeFileSystemsOutput struct {
 
 // String returns the string representation
 func (s DescribeFileSystemsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -811,7 +811,7 @@ type metadataDescribeMountTargetSecurityGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeMountTargetSecurityGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -832,7 +832,7 @@ type metadataDescribeMountTargetSecurityGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeMountTargetSecurityGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -862,7 +862,7 @@ type metadataDescribeMountTargetsInput struct {
 
 // String returns the string representation
 func (s DescribeMountTargetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -893,7 +893,7 @@ type metadataDescribeMountTargetsOutput struct {
 
 // String returns the string representation
 func (s DescribeMountTargetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -923,7 +923,7 @@ type metadataDescribeTagsInput struct {
 
 // String returns the string representation
 func (s DescribeTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -953,7 +953,7 @@ type metadataDescribeTagsOutput struct {
 
 // String returns the string representation
 func (s DescribeTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1009,7 +1009,7 @@ type metadataFileSystemDescription struct {
 
 // String returns the string representation
 func (s FileSystemDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1042,7 +1042,7 @@ type metadataFileSystemSize struct {
 
 // String returns the string representation
 func (s FileSystemSize) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1066,7 +1066,7 @@ type metadataModifyMountTargetSecurityGroupsInput struct {
 
 // String returns the string representation
 func (s ModifyMountTargetSecurityGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1084,7 +1084,7 @@ type metadataModifyMountTargetSecurityGroupsOutput struct {
 
 // String returns the string representation
 func (s ModifyMountTargetSecurityGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1125,7 +1125,7 @@ type metadataMountTargetDescription struct {
 
 // String returns the string representation
 func (s MountTargetDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1152,7 +1152,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/efs/examples_test.go
+++ b/service/efs/examples_test.go
@@ -40,7 +40,7 @@ func ExampleEFS_CreateFileSystem() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_CreateMountTarget() {
@@ -73,7 +73,7 @@ func ExampleEFS_CreateMountTarget() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_CreateTags() {
@@ -107,7 +107,7 @@ func ExampleEFS_CreateTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_DeleteFileSystem() {
@@ -134,7 +134,7 @@ func ExampleEFS_DeleteFileSystem() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_DeleteMountTarget() {
@@ -161,7 +161,7 @@ func ExampleEFS_DeleteMountTarget() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_DeleteTags() {
@@ -192,7 +192,7 @@ func ExampleEFS_DeleteTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_DescribeFileSystems() {
@@ -202,7 +202,7 @@ func ExampleEFS_DescribeFileSystems() {
 		CreationToken: aws.String("CreationToken"),
 		FileSystemID:  aws.String("FileSystemId"),
 		Marker:        aws.String("Marker"),
-		MaxItems:      aws.Long(1),
+		MaxItems:      aws.Int64(1),
 	}
 	resp, err := svc.DescribeFileSystems(params)
 
@@ -222,7 +222,7 @@ func ExampleEFS_DescribeFileSystems() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_DescribeMountTargetSecurityGroups() {
@@ -249,7 +249,7 @@ func ExampleEFS_DescribeMountTargetSecurityGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_DescribeMountTargets() {
@@ -258,7 +258,7 @@ func ExampleEFS_DescribeMountTargets() {
 	params := &efs.DescribeMountTargetsInput{
 		FileSystemID: aws.String("FileSystemId"), // Required
 		Marker:       aws.String("Marker"),
-		MaxItems:     aws.Long(1),
+		MaxItems:     aws.Int64(1),
 	}
 	resp, err := svc.DescribeMountTargets(params)
 
@@ -278,7 +278,7 @@ func ExampleEFS_DescribeMountTargets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_DescribeTags() {
@@ -287,7 +287,7 @@ func ExampleEFS_DescribeTags() {
 	params := &efs.DescribeTagsInput{
 		FileSystemID: aws.String("FileSystemId"), // Required
 		Marker:       aws.String("Marker"),
-		MaxItems:     aws.Long(1),
+		MaxItems:     aws.Int64(1),
 	}
 	resp, err := svc.DescribeTags(params)
 
@@ -307,7 +307,7 @@ func ExampleEFS_DescribeTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEFS_ModifyMountTargetSecurityGroups() {
@@ -338,5 +338,5 @@ func ExampleEFS_ModifyMountTargetSecurityGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -1317,7 +1317,7 @@ type metadataAddTagsToResourceInput struct {
 
 // String returns the string representation
 func (s AddTagsToResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1348,7 +1348,7 @@ type metadataAuthorizeCacheSecurityGroupIngressInput struct {
 
 // String returns the string representation
 func (s AuthorizeCacheSecurityGroupIngressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1371,7 +1371,7 @@ type metadataAuthorizeCacheSecurityGroupIngressOutput struct {
 
 // String returns the string representation
 func (s AuthorizeCacheSecurityGroupIngressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1393,7 +1393,7 @@ type metadataAvailabilityZone struct {
 
 // String returns the string representation
 func (s AvailabilityZone) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1524,7 +1524,7 @@ type metadataCacheCluster struct {
 
 // String returns the string representation
 func (s CacheCluster) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1558,7 +1558,7 @@ type metadataCacheEngineVersion struct {
 
 // String returns the string representation
 func (s CacheEngineVersion) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1622,7 +1622,7 @@ type metadataCacheNode struct {
 
 // String returns the string representation
 func (s CacheNode) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1669,7 +1669,7 @@ type metadataCacheNodeTypeSpecificParameter struct {
 
 // String returns the string representation
 func (s CacheNodeTypeSpecificParameter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1694,7 +1694,7 @@ type metadataCacheNodeTypeSpecificValue struct {
 
 // String returns the string representation
 func (s CacheNodeTypeSpecificValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1723,7 +1723,7 @@ type metadataCacheParameterGroup struct {
 
 // String returns the string representation
 func (s CacheParameterGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1747,7 +1747,7 @@ type metadataCacheParameterGroupNameMessage struct {
 
 // String returns the string representation
 func (s CacheParameterGroupNameMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1776,7 +1776,7 @@ type metadataCacheParameterGroupStatus struct {
 
 // String returns the string representation
 func (s CacheParameterGroupStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1810,7 +1810,7 @@ type metadataCacheSecurityGroup struct {
 
 // String returns the string representation
 func (s CacheSecurityGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1837,7 +1837,7 @@ type metadataCacheSecurityGroupMembership struct {
 
 // String returns the string representation
 func (s CacheSecurityGroupMembership) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1871,7 +1871,7 @@ type metadataCacheSubnetGroup struct {
 
 // String returns the string representation
 func (s CacheSubnetGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1896,7 +1896,7 @@ type metadataCopySnapshotInput struct {
 
 // String returns the string representation
 func (s CopySnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1918,7 +1918,7 @@ type metadataCopySnapshotOutput struct {
 
 // String returns the string representation
 func (s CopySnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2127,7 +2127,7 @@ type metadataCreateCacheClusterInput struct {
 
 // String returns the string representation
 func (s CreateCacheClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2148,7 +2148,7 @@ type metadataCreateCacheClusterOutput struct {
 
 // String returns the string representation
 func (s CreateCacheClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2179,7 +2179,7 @@ type metadataCreateCacheParameterGroupInput struct {
 
 // String returns the string representation
 func (s CreateCacheParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2200,7 +2200,7 @@ type metadataCreateCacheParameterGroupOutput struct {
 
 // String returns the string representation
 func (s CreateCacheParameterGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2231,7 +2231,7 @@ type metadataCreateCacheSecurityGroupInput struct {
 
 // String returns the string representation
 func (s CreateCacheSecurityGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2254,7 +2254,7 @@ type metadataCreateCacheSecurityGroupOutput struct {
 
 // String returns the string representation
 func (s CreateCacheSecurityGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2286,7 +2286,7 @@ type metadataCreateCacheSubnetGroupInput struct {
 
 // String returns the string representation
 func (s CreateCacheSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2309,7 +2309,7 @@ type metadataCreateCacheSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s CreateCacheSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2497,7 +2497,7 @@ type metadataCreateReplicationGroupInput struct {
 
 // String returns the string representation
 func (s CreateReplicationGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2518,7 +2518,7 @@ type metadataCreateReplicationGroupOutput struct {
 
 // String returns the string representation
 func (s CreateReplicationGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2544,7 +2544,7 @@ type metadataCreateSnapshotInput struct {
 
 // String returns the string representation
 func (s CreateSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2566,7 +2566,7 @@ type metadataCreateSnapshotOutput struct {
 
 // String returns the string representation
 func (s CreateSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2594,7 +2594,7 @@ type metadataDeleteCacheClusterInput struct {
 
 // String returns the string representation
 func (s DeleteCacheClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2615,7 +2615,7 @@ type metadataDeleteCacheClusterOutput struct {
 
 // String returns the string representation
 func (s DeleteCacheClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2640,7 +2640,7 @@ type metadataDeleteCacheParameterGroupInput struct {
 
 // String returns the string representation
 func (s DeleteCacheParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2658,7 +2658,7 @@ type metadataDeleteCacheParameterGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteCacheParameterGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2682,7 +2682,7 @@ type metadataDeleteCacheSecurityGroupInput struct {
 
 // String returns the string representation
 func (s DeleteCacheSecurityGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2700,7 +2700,7 @@ type metadataDeleteCacheSecurityGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteCacheSecurityGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2724,7 +2724,7 @@ type metadataDeleteCacheSubnetGroupInput struct {
 
 // String returns the string representation
 func (s DeleteCacheSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2742,7 +2742,7 @@ type metadataDeleteCacheSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteCacheSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2775,7 +2775,7 @@ type metadataDeleteReplicationGroupInput struct {
 
 // String returns the string representation
 func (s DeleteReplicationGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2796,7 +2796,7 @@ type metadataDeleteReplicationGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteReplicationGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2818,7 +2818,7 @@ type metadataDeleteSnapshotInput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2840,7 +2840,7 @@ type metadataDeleteSnapshotOutput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2882,7 +2882,7 @@ type metadataDescribeCacheClustersInput struct {
 
 // String returns the string representation
 func (s DescribeCacheClustersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2908,7 +2908,7 @@ type metadataDescribeCacheClustersOutput struct {
 
 // String returns the string representation
 func (s DescribeCacheClustersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2961,7 +2961,7 @@ type metadataDescribeCacheEngineVersionsInput struct {
 
 // String returns the string representation
 func (s DescribeCacheEngineVersionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2987,7 +2987,7 @@ type metadataDescribeCacheEngineVersionsOutput struct {
 
 // String returns the string representation
 func (s DescribeCacheEngineVersionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3023,7 +3023,7 @@ type metadataDescribeCacheParameterGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeCacheParameterGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3049,7 +3049,7 @@ type metadataDescribeCacheParameterGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeCacheParameterGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3090,7 +3090,7 @@ type metadataDescribeCacheParametersInput struct {
 
 // String returns the string representation
 func (s DescribeCacheParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3119,7 +3119,7 @@ type metadataDescribeCacheParametersOutput struct {
 
 // String returns the string representation
 func (s DescribeCacheParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3155,7 +3155,7 @@ type metadataDescribeCacheSecurityGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeCacheSecurityGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3181,7 +3181,7 @@ type metadataDescribeCacheSecurityGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeCacheSecurityGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3217,7 +3217,7 @@ type metadataDescribeCacheSubnetGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeCacheSubnetGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3243,7 +3243,7 @@ type metadataDescribeCacheSubnetGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeCacheSubnetGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3280,7 +3280,7 @@ type metadataDescribeEngineDefaultParametersInput struct {
 
 // String returns the string representation
 func (s DescribeEngineDefaultParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3301,7 +3301,7 @@ type metadataDescribeEngineDefaultParametersOutput struct {
 
 // String returns the string representation
 func (s DescribeEngineDefaultParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3356,7 +3356,7 @@ type metadataDescribeEventsInput struct {
 
 // String returns the string representation
 func (s DescribeEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3382,7 +3382,7 @@ type metadataDescribeEventsOutput struct {
 
 // String returns the string representation
 func (s DescribeEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3422,7 +3422,7 @@ type metadataDescribeReplicationGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeReplicationGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3448,7 +3448,7 @@ type metadataDescribeReplicationGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeReplicationGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3527,7 +3527,7 @@ type metadataDescribeReservedCacheNodesInput struct {
 
 // String returns the string representation
 func (s DescribeReservedCacheNodesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3604,7 +3604,7 @@ type metadataDescribeReservedCacheNodesOfferingsInput struct {
 
 // String returns the string representation
 func (s DescribeReservedCacheNodesOfferingsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3630,7 +3630,7 @@ type metadataDescribeReservedCacheNodesOfferingsOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedCacheNodesOfferingsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3656,7 +3656,7 @@ type metadataDescribeReservedCacheNodesOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedCacheNodesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3703,7 +3703,7 @@ type metadataDescribeSnapshotsInput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3731,7 +3731,7 @@ type metadataDescribeSnapshotsOutput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3759,7 +3759,7 @@ type metadataEC2SecurityGroup struct {
 
 // String returns the string representation
 func (s EC2SecurityGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3785,7 +3785,7 @@ type metadataEndpoint struct {
 
 // String returns the string representation
 func (s Endpoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3818,7 +3818,7 @@ type metadataEngineDefaults struct {
 
 // String returns the string representation
 func (s EngineDefaults) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3854,7 +3854,7 @@ type metadataEvent struct {
 
 // String returns the string representation
 func (s Event) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3877,7 +3877,7 @@ type metadataListTagsForResourceInput struct {
 
 // String returns the string representation
 func (s ListTagsForResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4074,7 +4074,7 @@ type metadataModifyCacheClusterInput struct {
 
 // String returns the string representation
 func (s ModifyCacheClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4095,7 +4095,7 @@ type metadataModifyCacheClusterOutput struct {
 
 // String returns the string representation
 func (s ModifyCacheClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4122,7 +4122,7 @@ type metadataModifyCacheParameterGroupInput struct {
 
 // String returns the string representation
 func (s ModifyCacheParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4155,7 +4155,7 @@ type metadataModifyCacheSubnetGroupInput struct {
 
 // String returns the string representation
 func (s ModifyCacheSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4178,7 +4178,7 @@ type metadataModifyCacheSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s ModifyCacheSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4304,7 +4304,7 @@ type metadataModifyReplicationGroupInput struct {
 
 // String returns the string representation
 func (s ModifyReplicationGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4325,7 +4325,7 @@ type metadataModifyReplicationGroupOutput struct {
 
 // String returns the string representation
 func (s ModifyReplicationGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4358,7 +4358,7 @@ type metadataNodeGroup struct {
 
 // String returns the string representation
 func (s NodeGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4394,7 +4394,7 @@ type metadataNodeGroupMember struct {
 
 // String returns the string representation
 func (s NodeGroupMember) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4426,7 +4426,7 @@ type metadataNodeSnapshot struct {
 
 // String returns the string representation
 func (s NodeSnapshot) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4453,7 +4453,7 @@ type metadataNotificationConfiguration struct {
 
 // String returns the string representation
 func (s NotificationConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4499,7 +4499,7 @@ type metadataParameter struct {
 
 // String returns the string representation
 func (s Parameter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4524,7 +4524,7 @@ type metadataParameterNameValue struct {
 
 // String returns the string representation
 func (s ParameterNameValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4557,7 +4557,7 @@ type metadataPendingModifiedValues struct {
 
 // String returns the string representation
 func (s PendingModifiedValues) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4591,7 +4591,7 @@ type metadataPurchaseReservedCacheNodesOfferingInput struct {
 
 // String returns the string representation
 func (s PurchaseReservedCacheNodesOfferingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4612,7 +4612,7 @@ type metadataPurchaseReservedCacheNodesOfferingOutput struct {
 
 // String returns the string representation
 func (s PurchaseReservedCacheNodesOfferingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4639,7 +4639,7 @@ type metadataRebootCacheClusterInput struct {
 
 // String returns the string representation
 func (s RebootCacheClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4660,7 +4660,7 @@ type metadataRebootCacheClusterOutput struct {
 
 // String returns the string representation
 func (s RebootCacheClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4686,7 +4686,7 @@ type metadataRecurringCharge struct {
 
 // String returns the string representation
 func (s RecurringCharge) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4714,7 +4714,7 @@ type metadataRemoveTagsFromResourceInput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4764,7 +4764,7 @@ type metadataReplicationGroup struct {
 
 // String returns the string representation
 func (s ReplicationGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4795,7 +4795,7 @@ type metadataReplicationGroupPendingModifiedValues struct {
 
 // String returns the string representation
 func (s ReplicationGroupPendingModifiedValues) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4868,7 +4868,7 @@ type metadataReservedCacheNode struct {
 
 // String returns the string representation
 func (s ReservedCacheNode) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4929,7 +4929,7 @@ type metadataReservedCacheNodesOffering struct {
 
 // String returns the string representation
 func (s ReservedCacheNodesOffering) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4961,7 +4961,7 @@ type metadataResetCacheParameterGroupInput struct {
 
 // String returns the string representation
 func (s ResetCacheParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4991,7 +4991,7 @@ type metadataRevokeCacheSecurityGroupIngressInput struct {
 
 // String returns the string representation
 func (s RevokeCacheSecurityGroupIngressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5014,7 +5014,7 @@ type metadataRevokeCacheSecurityGroupIngressOutput struct {
 
 // String returns the string representation
 func (s RevokeCacheSecurityGroupIngressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5041,7 +5041,7 @@ type metadataSecurityGroupMembership struct {
 
 // String returns the string representation
 func (s SecurityGroupMembership) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5165,7 +5165,7 @@ type metadataSnapshot struct {
 
 // String returns the string representation
 func (s Snapshot) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5192,7 +5192,7 @@ type metadataSubnet struct {
 
 // String returns the string representation
 func (s Subnet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5219,7 +5219,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5242,7 +5242,7 @@ type metadataTagListMessage struct {
 
 // String returns the string representation
 func (s TagListMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/elasticache/examples_test.go
+++ b/service/elasticache/examples_test.go
@@ -47,7 +47,7 @@ func ExampleElastiCache_AddTagsToResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_AuthorizeCacheSecurityGroupIngress() {
@@ -76,7 +76,7 @@ func ExampleElastiCache_AuthorizeCacheSecurityGroupIngress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_CopySnapshot() {
@@ -104,7 +104,7 @@ func ExampleElastiCache_CopySnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_CreateCacheCluster() {
@@ -113,7 +113,7 @@ func ExampleElastiCache_CreateCacheCluster() {
 	params := &elasticache.CreateCacheClusterInput{
 		CacheClusterID:          aws.String("String"), // Required
 		AZMode:                  aws.String("AZMode"),
-		AutoMinorVersionUpgrade: aws.Boolean(true),
+		AutoMinorVersionUpgrade: aws.Bool(true),
 		CacheNodeType:           aws.String("String"),
 		CacheParameterGroupName: aws.String("String"),
 		CacheSecurityGroupNames: []*string{
@@ -124,8 +124,8 @@ func ExampleElastiCache_CreateCacheCluster() {
 		Engine:               aws.String("String"),
 		EngineVersion:        aws.String("String"),
 		NotificationTopicARN: aws.String("String"),
-		NumCacheNodes:        aws.Long(1),
-		Port:                 aws.Long(1),
+		NumCacheNodes:        aws.Int64(1),
+		Port:                 aws.Int64(1),
 		PreferredAvailabilityZone: aws.String("String"),
 		PreferredAvailabilityZones: []*string{
 			aws.String("String"), // Required
@@ -142,7 +142,7 @@ func ExampleElastiCache_CreateCacheCluster() {
 			// More values...
 		},
 		SnapshotName:           aws.String("String"),
-		SnapshotRetentionLimit: aws.Long(1),
+		SnapshotRetentionLimit: aws.Int64(1),
 		SnapshotWindow:         aws.String("String"),
 		Tags: []*elasticache.Tag{
 			{ // Required
@@ -170,7 +170,7 @@ func ExampleElastiCache_CreateCacheCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_CreateCacheParameterGroup() {
@@ -199,7 +199,7 @@ func ExampleElastiCache_CreateCacheParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_CreateCacheSecurityGroup() {
@@ -227,7 +227,7 @@ func ExampleElastiCache_CreateCacheSecurityGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_CreateCacheSubnetGroup() {
@@ -259,7 +259,7 @@ func ExampleElastiCache_CreateCacheSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_CreateReplicationGroup() {
@@ -268,8 +268,8 @@ func ExampleElastiCache_CreateReplicationGroup() {
 	params := &elasticache.CreateReplicationGroupInput{
 		ReplicationGroupDescription: aws.String("String"), // Required
 		ReplicationGroupID:          aws.String("String"), // Required
-		AutoMinorVersionUpgrade:     aws.Boolean(true),
-		AutomaticFailoverEnabled:    aws.Boolean(true),
+		AutoMinorVersionUpgrade:     aws.Bool(true),
+		AutomaticFailoverEnabled:    aws.Bool(true),
 		CacheNodeType:               aws.String("String"),
 		CacheParameterGroupName:     aws.String("String"),
 		CacheSecurityGroupNames: []*string{
@@ -280,8 +280,8 @@ func ExampleElastiCache_CreateReplicationGroup() {
 		Engine:               aws.String("String"),
 		EngineVersion:        aws.String("String"),
 		NotificationTopicARN: aws.String("String"),
-		NumCacheClusters:     aws.Long(1),
-		Port:                 aws.Long(1),
+		NumCacheClusters:     aws.Int64(1),
+		Port:                 aws.Int64(1),
 		PreferredCacheClusterAZs: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -297,7 +297,7 @@ func ExampleElastiCache_CreateReplicationGroup() {
 			// More values...
 		},
 		SnapshotName:           aws.String("String"),
-		SnapshotRetentionLimit: aws.Long(1),
+		SnapshotRetentionLimit: aws.Int64(1),
 		SnapshotWindow:         aws.String("String"),
 		Tags: []*elasticache.Tag{
 			{ // Required
@@ -325,7 +325,7 @@ func ExampleElastiCache_CreateReplicationGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_CreateSnapshot() {
@@ -353,7 +353,7 @@ func ExampleElastiCache_CreateSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DeleteCacheCluster() {
@@ -381,7 +381,7 @@ func ExampleElastiCache_DeleteCacheCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DeleteCacheParameterGroup() {
@@ -408,7 +408,7 @@ func ExampleElastiCache_DeleteCacheParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DeleteCacheSecurityGroup() {
@@ -435,7 +435,7 @@ func ExampleElastiCache_DeleteCacheSecurityGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DeleteCacheSubnetGroup() {
@@ -462,7 +462,7 @@ func ExampleElastiCache_DeleteCacheSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DeleteReplicationGroup() {
@@ -471,7 +471,7 @@ func ExampleElastiCache_DeleteReplicationGroup() {
 	params := &elasticache.DeleteReplicationGroupInput{
 		ReplicationGroupID:      aws.String("String"), // Required
 		FinalSnapshotIdentifier: aws.String("String"),
-		RetainPrimaryCluster:    aws.Boolean(true),
+		RetainPrimaryCluster:    aws.Bool(true),
 	}
 	resp, err := svc.DeleteReplicationGroup(params)
 
@@ -491,7 +491,7 @@ func ExampleElastiCache_DeleteReplicationGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DeleteSnapshot() {
@@ -518,7 +518,7 @@ func ExampleElastiCache_DeleteSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeCacheClusters() {
@@ -527,8 +527,8 @@ func ExampleElastiCache_DescribeCacheClusters() {
 	params := &elasticache.DescribeCacheClustersInput{
 		CacheClusterID:    aws.String("String"),
 		Marker:            aws.String("String"),
-		MaxRecords:        aws.Long(1),
-		ShowCacheNodeInfo: aws.Boolean(true),
+		MaxRecords:        aws.Int64(1),
+		ShowCacheNodeInfo: aws.Bool(true),
 	}
 	resp, err := svc.DescribeCacheClusters(params)
 
@@ -548,7 +548,7 @@ func ExampleElastiCache_DescribeCacheClusters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeCacheEngineVersions() {
@@ -556,11 +556,11 @@ func ExampleElastiCache_DescribeCacheEngineVersions() {
 
 	params := &elasticache.DescribeCacheEngineVersionsInput{
 		CacheParameterGroupFamily: aws.String("String"),
-		DefaultOnly:               aws.Boolean(true),
+		DefaultOnly:               aws.Bool(true),
 		Engine:                    aws.String("String"),
 		EngineVersion:             aws.String("String"),
 		Marker:                    aws.String("String"),
-		MaxRecords:                aws.Long(1),
+		MaxRecords:                aws.Int64(1),
 	}
 	resp, err := svc.DescribeCacheEngineVersions(params)
 
@@ -580,7 +580,7 @@ func ExampleElastiCache_DescribeCacheEngineVersions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeCacheParameterGroups() {
@@ -589,7 +589,7 @@ func ExampleElastiCache_DescribeCacheParameterGroups() {
 	params := &elasticache.DescribeCacheParameterGroupsInput{
 		CacheParameterGroupName: aws.String("String"),
 		Marker:                  aws.String("String"),
-		MaxRecords:              aws.Long(1),
+		MaxRecords:              aws.Int64(1),
 	}
 	resp, err := svc.DescribeCacheParameterGroups(params)
 
@@ -609,7 +609,7 @@ func ExampleElastiCache_DescribeCacheParameterGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeCacheParameters() {
@@ -618,7 +618,7 @@ func ExampleElastiCache_DescribeCacheParameters() {
 	params := &elasticache.DescribeCacheParametersInput{
 		CacheParameterGroupName: aws.String("String"), // Required
 		Marker:                  aws.String("String"),
-		MaxRecords:              aws.Long(1),
+		MaxRecords:              aws.Int64(1),
 		Source:                  aws.String("String"),
 	}
 	resp, err := svc.DescribeCacheParameters(params)
@@ -639,7 +639,7 @@ func ExampleElastiCache_DescribeCacheParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeCacheSecurityGroups() {
@@ -648,7 +648,7 @@ func ExampleElastiCache_DescribeCacheSecurityGroups() {
 	params := &elasticache.DescribeCacheSecurityGroupsInput{
 		CacheSecurityGroupName: aws.String("String"),
 		Marker:                 aws.String("String"),
-		MaxRecords:             aws.Long(1),
+		MaxRecords:             aws.Int64(1),
 	}
 	resp, err := svc.DescribeCacheSecurityGroups(params)
 
@@ -668,7 +668,7 @@ func ExampleElastiCache_DescribeCacheSecurityGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeCacheSubnetGroups() {
@@ -677,7 +677,7 @@ func ExampleElastiCache_DescribeCacheSubnetGroups() {
 	params := &elasticache.DescribeCacheSubnetGroupsInput{
 		CacheSubnetGroupName: aws.String("String"),
 		Marker:               aws.String("String"),
-		MaxRecords:           aws.Long(1),
+		MaxRecords:           aws.Int64(1),
 	}
 	resp, err := svc.DescribeCacheSubnetGroups(params)
 
@@ -697,7 +697,7 @@ func ExampleElastiCache_DescribeCacheSubnetGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeEngineDefaultParameters() {
@@ -706,7 +706,7 @@ func ExampleElastiCache_DescribeEngineDefaultParameters() {
 	params := &elasticache.DescribeEngineDefaultParametersInput{
 		CacheParameterGroupFamily: aws.String("String"), // Required
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeEngineDefaultParameters(params)
 
@@ -726,17 +726,17 @@ func ExampleElastiCache_DescribeEngineDefaultParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeEvents() {
 	svc := elasticache.New(nil)
 
 	params := &elasticache.DescribeEventsInput{
-		Duration:         aws.Long(1),
+		Duration:         aws.Int64(1),
 		EndTime:          aws.Time(time.Now()),
 		Marker:           aws.String("String"),
-		MaxRecords:       aws.Long(1),
+		MaxRecords:       aws.Int64(1),
 		SourceIdentifier: aws.String("String"),
 		SourceType:       aws.String("SourceType"),
 		StartTime:        aws.Time(time.Now()),
@@ -759,7 +759,7 @@ func ExampleElastiCache_DescribeEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeReplicationGroups() {
@@ -767,7 +767,7 @@ func ExampleElastiCache_DescribeReplicationGroups() {
 
 	params := &elasticache.DescribeReplicationGroupsInput{
 		Marker:             aws.String("String"),
-		MaxRecords:         aws.Long(1),
+		MaxRecords:         aws.Int64(1),
 		ReplicationGroupID: aws.String("String"),
 	}
 	resp, err := svc.DescribeReplicationGroups(params)
@@ -788,7 +788,7 @@ func ExampleElastiCache_DescribeReplicationGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeReservedCacheNodes() {
@@ -798,7 +798,7 @@ func ExampleElastiCache_DescribeReservedCacheNodes() {
 		CacheNodeType:                aws.String("String"),
 		Duration:                     aws.String("String"),
 		Marker:                       aws.String("String"),
-		MaxRecords:                   aws.Long(1),
+		MaxRecords:                   aws.Int64(1),
 		OfferingType:                 aws.String("String"),
 		ProductDescription:           aws.String("String"),
 		ReservedCacheNodeID:          aws.String("String"),
@@ -822,7 +822,7 @@ func ExampleElastiCache_DescribeReservedCacheNodes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeReservedCacheNodesOfferings() {
@@ -832,7 +832,7 @@ func ExampleElastiCache_DescribeReservedCacheNodesOfferings() {
 		CacheNodeType:                aws.String("String"),
 		Duration:                     aws.String("String"),
 		Marker:                       aws.String("String"),
-		MaxRecords:                   aws.Long(1),
+		MaxRecords:                   aws.Int64(1),
 		OfferingType:                 aws.String("String"),
 		ProductDescription:           aws.String("String"),
 		ReservedCacheNodesOfferingID: aws.String("String"),
@@ -855,7 +855,7 @@ func ExampleElastiCache_DescribeReservedCacheNodesOfferings() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_DescribeSnapshots() {
@@ -864,7 +864,7 @@ func ExampleElastiCache_DescribeSnapshots() {
 	params := &elasticache.DescribeSnapshotsInput{
 		CacheClusterID: aws.String("String"),
 		Marker:         aws.String("String"),
-		MaxRecords:     aws.Long(1),
+		MaxRecords:     aws.Int64(1),
 		SnapshotName:   aws.String("String"),
 		SnapshotSource: aws.String("String"),
 	}
@@ -886,7 +886,7 @@ func ExampleElastiCache_DescribeSnapshots() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_ListTagsForResource() {
@@ -913,7 +913,7 @@ func ExampleElastiCache_ListTagsForResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_ModifyCacheCluster() {
@@ -922,8 +922,8 @@ func ExampleElastiCache_ModifyCacheCluster() {
 	params := &elasticache.ModifyCacheClusterInput{
 		CacheClusterID:          aws.String("String"), // Required
 		AZMode:                  aws.String("AZMode"),
-		ApplyImmediately:        aws.Boolean(true),
-		AutoMinorVersionUpgrade: aws.Boolean(true),
+		ApplyImmediately:        aws.Bool(true),
+		AutoMinorVersionUpgrade: aws.Bool(true),
 		CacheNodeIDsToRemove: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -940,13 +940,13 @@ func ExampleElastiCache_ModifyCacheCluster() {
 		},
 		NotificationTopicARN:       aws.String("String"),
 		NotificationTopicStatus:    aws.String("String"),
-		NumCacheNodes:              aws.Long(1),
+		NumCacheNodes:              aws.Int64(1),
 		PreferredMaintenanceWindow: aws.String("String"),
 		SecurityGroupIDs: []*string{
 			aws.String("String"), // Required
 			// More values...
 		},
-		SnapshotRetentionLimit: aws.Long(1),
+		SnapshotRetentionLimit: aws.Int64(1),
 		SnapshotWindow:         aws.String("String"),
 	}
 	resp, err := svc.ModifyCacheCluster(params)
@@ -967,7 +967,7 @@ func ExampleElastiCache_ModifyCacheCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_ModifyCacheParameterGroup() {
@@ -1001,7 +1001,7 @@ func ExampleElastiCache_ModifyCacheParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_ModifyCacheSubnetGroup() {
@@ -1033,7 +1033,7 @@ func ExampleElastiCache_ModifyCacheSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_ModifyReplicationGroup() {
@@ -1041,9 +1041,9 @@ func ExampleElastiCache_ModifyReplicationGroup() {
 
 	params := &elasticache.ModifyReplicationGroupInput{
 		ReplicationGroupID:       aws.String("String"), // Required
-		ApplyImmediately:         aws.Boolean(true),
-		AutoMinorVersionUpgrade:  aws.Boolean(true),
-		AutomaticFailoverEnabled: aws.Boolean(true),
+		ApplyImmediately:         aws.Bool(true),
+		AutoMinorVersionUpgrade:  aws.Bool(true),
+		AutomaticFailoverEnabled: aws.Bool(true),
 		CacheParameterGroupName:  aws.String("String"),
 		CacheSecurityGroupNames: []*string{
 			aws.String("String"), // Required
@@ -1059,7 +1059,7 @@ func ExampleElastiCache_ModifyReplicationGroup() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		SnapshotRetentionLimit: aws.Long(1),
+		SnapshotRetentionLimit: aws.Int64(1),
 		SnapshotWindow:         aws.String("String"),
 		SnapshottingClusterID:  aws.String("String"),
 	}
@@ -1081,7 +1081,7 @@ func ExampleElastiCache_ModifyReplicationGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_PurchaseReservedCacheNodesOffering() {
@@ -1089,7 +1089,7 @@ func ExampleElastiCache_PurchaseReservedCacheNodesOffering() {
 
 	params := &elasticache.PurchaseReservedCacheNodesOfferingInput{
 		ReservedCacheNodesOfferingID: aws.String("String"), // Required
-		CacheNodeCount:               aws.Long(1),
+		CacheNodeCount:               aws.Int64(1),
 		ReservedCacheNodeID:          aws.String("String"),
 	}
 	resp, err := svc.PurchaseReservedCacheNodesOffering(params)
@@ -1110,7 +1110,7 @@ func ExampleElastiCache_PurchaseReservedCacheNodesOffering() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_RebootCacheCluster() {
@@ -1141,7 +1141,7 @@ func ExampleElastiCache_RebootCacheCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_RemoveTagsFromResource() {
@@ -1172,7 +1172,7 @@ func ExampleElastiCache_RemoveTagsFromResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_ResetCacheParameterGroup() {
@@ -1187,7 +1187,7 @@ func ExampleElastiCache_ResetCacheParameterGroup() {
 			},
 			// More values...
 		},
-		ResetAllParameters: aws.Boolean(true),
+		ResetAllParameters: aws.Bool(true),
 	}
 	resp, err := svc.ResetCacheParameterGroup(params)
 
@@ -1207,7 +1207,7 @@ func ExampleElastiCache_ResetCacheParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElastiCache_RevokeCacheSecurityGroupIngress() {
@@ -1236,5 +1236,5 @@ func ExampleElastiCache_RevokeCacheSecurityGroupIngress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -950,7 +950,7 @@ type metadataAbortEnvironmentUpdateInput struct {
 
 // String returns the string representation
 func (s AbortEnvironmentUpdateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -968,7 +968,7 @@ type metadataAbortEnvironmentUpdateOutput struct {
 
 // String returns the string representation
 func (s AbortEnvironmentUpdateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1005,7 +1005,7 @@ type metadataApplicationDescription struct {
 
 // String returns the string representation
 func (s ApplicationDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1027,7 +1027,7 @@ type metadataApplicationDescriptionMessage struct {
 
 // String returns the string representation
 func (s ApplicationDescriptionMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1064,7 +1064,7 @@ type metadataApplicationVersionDescription struct {
 
 // String returns the string representation
 func (s ApplicationVersionDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1086,7 +1086,7 @@ type metadataApplicationVersionDescriptionMessage struct {
 
 // String returns the string representation
 func (s ApplicationVersionDescriptionMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1108,7 +1108,7 @@ type metadataAutoScalingGroup struct {
 
 // String returns the string representation
 func (s AutoScalingGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1130,7 +1130,7 @@ type metadataCheckDNSAvailabilityInput struct {
 
 // String returns the string representation
 func (s CheckDNSAvailabilityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1162,7 +1162,7 @@ type metadataCheckDNSAvailabilityOutput struct {
 
 // String returns the string representation
 func (s CheckDNSAvailabilityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1269,7 +1269,7 @@ type metadataConfigurationOptionDescription struct {
 
 // String returns the string representation
 func (s ConfigurationOptionDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1303,7 +1303,7 @@ type metadataConfigurationOptionSetting struct {
 
 // String returns the string representation
 func (s ConfigurationOptionSetting) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1368,7 +1368,7 @@ type metadataConfigurationSettingsDescription struct {
 
 // String returns the string representation
 func (s ConfigurationSettingsDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1396,7 +1396,7 @@ type metadataCreateApplicationInput struct {
 
 // String returns the string representation
 func (s CreateApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1458,7 +1458,7 @@ type metadataCreateApplicationVersionInput struct {
 
 // String returns the string representation
 func (s CreateApplicationVersionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1532,7 +1532,7 @@ type metadataCreateConfigurationTemplateInput struct {
 
 // String returns the string representation
 func (s CreateConfigurationTemplateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1620,7 +1620,7 @@ type metadataCreateEnvironmentInput struct {
 
 // String returns the string representation
 func (s CreateEnvironmentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1638,7 +1638,7 @@ type metadataCreateStorageLocationInput struct {
 
 // String returns the string representation
 func (s CreateStorageLocationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1660,7 +1660,7 @@ type metadataCreateStorageLocationOutput struct {
 
 // String returns the string representation
 func (s CreateStorageLocationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1686,7 +1686,7 @@ type metadataDeleteApplicationInput struct {
 
 // String returns the string representation
 func (s DeleteApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1704,7 +1704,7 @@ type metadataDeleteApplicationOutput struct {
 
 // String returns the string representation
 func (s DeleteApplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1736,7 +1736,7 @@ type metadataDeleteApplicationVersionInput struct {
 
 // String returns the string representation
 func (s DeleteApplicationVersionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1754,7 +1754,7 @@ type metadataDeleteApplicationVersionOutput struct {
 
 // String returns the string representation
 func (s DeleteApplicationVersionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1779,7 +1779,7 @@ type metadataDeleteConfigurationTemplateInput struct {
 
 // String returns the string representation
 func (s DeleteConfigurationTemplateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1797,7 +1797,7 @@ type metadataDeleteConfigurationTemplateOutput struct {
 
 // String returns the string representation
 func (s DeleteConfigurationTemplateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1822,7 +1822,7 @@ type metadataDeleteEnvironmentConfigurationInput struct {
 
 // String returns the string representation
 func (s DeleteEnvironmentConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1840,7 +1840,7 @@ type metadataDeleteEnvironmentConfigurationOutput struct {
 
 // String returns the string representation
 func (s DeleteEnvironmentConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1867,7 +1867,7 @@ type metadataDescribeApplicationVersionsInput struct {
 
 // String returns the string representation
 func (s DescribeApplicationVersionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1889,7 +1889,7 @@ type metadataDescribeApplicationVersionsOutput struct {
 
 // String returns the string representation
 func (s DescribeApplicationVersionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1912,7 +1912,7 @@ type metadataDescribeApplicationsInput struct {
 
 // String returns the string representation
 func (s DescribeApplicationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1934,7 +1934,7 @@ type metadataDescribeApplicationsOutput struct {
 
 // String returns the string representation
 func (s DescribeApplicationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1971,7 +1971,7 @@ type metadataDescribeConfigurationOptionsInput struct {
 
 // String returns the string representation
 func (s DescribeConfigurationOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1996,7 +1996,7 @@ type metadataDescribeConfigurationOptionsOutput struct {
 
 // String returns the string representation
 func (s DescribeConfigurationOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2035,7 +2035,7 @@ type metadataDescribeConfigurationSettingsInput struct {
 
 // String returns the string representation
 func (s DescribeConfigurationSettingsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2057,7 +2057,7 @@ type metadataDescribeConfigurationSettingsOutput struct {
 
 // String returns the string representation
 func (s DescribeConfigurationSettingsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2090,7 +2090,7 @@ type metadataDescribeEnvironmentResourcesInput struct {
 
 // String returns the string representation
 func (s DescribeEnvironmentResourcesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2112,7 +2112,7 @@ type metadataDescribeEnvironmentResourcesOutput struct {
 
 // String returns the string representation
 func (s DescribeEnvironmentResourcesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2159,7 +2159,7 @@ type metadataDescribeEnvironmentsInput struct {
 
 // String returns the string representation
 func (s DescribeEnvironmentsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2181,7 +2181,7 @@ type metadataDescribeEnvironmentsOutput struct {
 
 // String returns the string representation
 func (s DescribeEnvironmentsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2243,7 +2243,7 @@ type metadataDescribeEventsInput struct {
 
 // String returns the string representation
 func (s DescribeEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2269,7 +2269,7 @@ type metadataDescribeEventsOutput struct {
 
 // String returns the string representation
 func (s DescribeEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2364,7 +2364,7 @@ type metadataEnvironmentDescription struct {
 
 // String returns the string representation
 func (s EnvironmentDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2395,7 +2395,7 @@ type metadataEnvironmentInfoDescription struct {
 
 // String returns the string representation
 func (s EnvironmentInfoDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2435,7 +2435,7 @@ type metadataEnvironmentResourceDescription struct {
 
 // String returns the string representation
 func (s EnvironmentResourceDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2458,7 +2458,7 @@ type metadataEnvironmentResourcesDescription struct {
 
 // String returns the string representation
 func (s EnvironmentResourcesDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2486,7 +2486,7 @@ type metadataEnvironmentTier struct {
 
 // String returns the string representation
 func (s EnvironmentTier) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2529,7 +2529,7 @@ type metadataEventDescription struct {
 
 // String returns the string representation
 func (s EventDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2551,7 +2551,7 @@ type metadataInstance struct {
 
 // String returns the string representation
 func (s Instance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2573,7 +2573,7 @@ type metadataLaunchConfiguration struct {
 
 // String returns the string representation
 func (s LaunchConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2591,7 +2591,7 @@ type metadataListAvailableSolutionStacksInput struct {
 
 // String returns the string representation
 func (s ListAvailableSolutionStacksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2616,7 +2616,7 @@ type metadataListAvailableSolutionStacksOutput struct {
 
 // String returns the string representation
 func (s ListAvailableSolutionStacksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2641,7 +2641,7 @@ type metadataListener struct {
 
 // String returns the string representation
 func (s Listener) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2663,7 +2663,7 @@ type metadataLoadBalancer struct {
 
 // String returns the string representation
 func (s LoadBalancer) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2691,7 +2691,7 @@ type metadataLoadBalancerDescription struct {
 
 // String returns the string representation
 func (s LoadBalancerDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2718,7 +2718,7 @@ type metadataOptionRestrictionRegex struct {
 
 // String returns the string representation
 func (s OptionRestrictionRegex) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2746,7 +2746,7 @@ type metadataOptionSpecification struct {
 
 // String returns the string representation
 func (s OptionSpecification) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2771,7 +2771,7 @@ type metadataQueue struct {
 
 // String returns the string representation
 func (s Queue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2803,7 +2803,7 @@ type metadataRebuildEnvironmentInput struct {
 
 // String returns the string representation
 func (s RebuildEnvironmentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2821,7 +2821,7 @@ type metadataRebuildEnvironmentOutput struct {
 
 // String returns the string representation
 func (s RebuildEnvironmentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2863,7 +2863,7 @@ type metadataRequestEnvironmentInfoInput struct {
 
 // String returns the string representation
 func (s RequestEnvironmentInfoInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2881,7 +2881,7 @@ type metadataRequestEnvironmentInfoOutput struct {
 
 // String returns the string representation
 func (s RequestEnvironmentInfoOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2913,7 +2913,7 @@ type metadataRestartAppServerInput struct {
 
 // String returns the string representation
 func (s RestartAppServerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2931,7 +2931,7 @@ type metadataRestartAppServerOutput struct {
 
 // String returns the string representation
 func (s RestartAppServerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2971,7 +2971,7 @@ type metadataRetrieveEnvironmentInfoInput struct {
 
 // String returns the string representation
 func (s RetrieveEnvironmentInfoInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2993,7 +2993,7 @@ type metadataRetrieveEnvironmentInfoOutput struct {
 
 // String returns the string representation
 func (s RetrieveEnvironmentInfoOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3018,7 +3018,7 @@ type metadataS3Location struct {
 
 // String returns the string representation
 func (s S3Location) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3043,7 +3043,7 @@ type metadataSolutionStackDescription struct {
 
 // String returns the string representation
 func (s SolutionStackDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3068,7 +3068,7 @@ type metadataSourceConfiguration struct {
 
 // String returns the string representation
 func (s SourceConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3115,7 +3115,7 @@ type metadataSwapEnvironmentCNAMEsInput struct {
 
 // String returns the string representation
 func (s SwapEnvironmentCNAMEsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3133,7 +3133,7 @@ type metadataSwapEnvironmentCNAMEsOutput struct {
 
 // String returns the string representation
 func (s SwapEnvironmentCNAMEsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3158,7 +3158,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3211,7 +3211,7 @@ type metadataTerminateEnvironmentInput struct {
 
 // String returns the string representation
 func (s TerminateEnvironmentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3233,7 +3233,7 @@ type metadataTrigger struct {
 
 // String returns the string representation
 func (s Trigger) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3261,7 +3261,7 @@ type metadataUpdateApplicationInput struct {
 
 // String returns the string representation
 func (s UpdateApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3294,7 +3294,7 @@ type metadataUpdateApplicationVersionInput struct {
 
 // String returns the string representation
 func (s UpdateApplicationVersionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3338,7 +3338,7 @@ type metadataUpdateConfigurationTemplateInput struct {
 
 // String returns the string representation
 func (s UpdateConfigurationTemplateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3408,7 +3408,7 @@ type metadataUpdateEnvironmentInput struct {
 
 // String returns the string representation
 func (s UpdateEnvironmentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3444,7 +3444,7 @@ type metadataValidateConfigurationSettingsInput struct {
 
 // String returns the string representation
 func (s ValidateConfigurationSettingsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3466,7 +3466,7 @@ type metadataValidateConfigurationSettingsOutput struct {
 
 // String returns the string representation
 func (s ValidateConfigurationSettingsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3504,7 +3504,7 @@ type metadataValidationMessage struct {
 
 // String returns the string representation
 func (s ValidationMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/elasticbeanstalk/examples_test.go
+++ b/service/elasticbeanstalk/examples_test.go
@@ -41,7 +41,7 @@ func ExampleElasticBeanstalk_AbortEnvironmentUpdate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_CheckDNSAvailability() {
@@ -68,7 +68,7 @@ func ExampleElasticBeanstalk_CheckDNSAvailability() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_CreateApplication() {
@@ -96,7 +96,7 @@ func ExampleElasticBeanstalk_CreateApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_CreateApplicationVersion() {
@@ -105,7 +105,7 @@ func ExampleElasticBeanstalk_CreateApplicationVersion() {
 	params := &elasticbeanstalk.CreateApplicationVersionInput{
 		ApplicationName:       aws.String("ApplicationName"), // Required
 		VersionLabel:          aws.String("VersionLabel"),    // Required
-		AutoCreateApplication: aws.Boolean(true),
+		AutoCreateApplication: aws.Bool(true),
 		Description:           aws.String("Description"),
 		SourceBundle: &elasticbeanstalk.S3Location{
 			S3Bucket: aws.String("S3Bucket"),
@@ -130,7 +130,7 @@ func ExampleElasticBeanstalk_CreateApplicationVersion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_CreateConfigurationTemplate() {
@@ -174,7 +174,7 @@ func ExampleElasticBeanstalk_CreateConfigurationTemplate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_CreateEnvironment() {
@@ -236,7 +236,7 @@ func ExampleElasticBeanstalk_CreateEnvironment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_CreateStorageLocation() {
@@ -261,7 +261,7 @@ func ExampleElasticBeanstalk_CreateStorageLocation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DeleteApplication() {
@@ -269,7 +269,7 @@ func ExampleElasticBeanstalk_DeleteApplication() {
 
 	params := &elasticbeanstalk.DeleteApplicationInput{
 		ApplicationName:     aws.String("ApplicationName"), // Required
-		TerminateEnvByForce: aws.Boolean(true),
+		TerminateEnvByForce: aws.Bool(true),
 	}
 	resp, err := svc.DeleteApplication(params)
 
@@ -289,7 +289,7 @@ func ExampleElasticBeanstalk_DeleteApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DeleteApplicationVersion() {
@@ -298,7 +298,7 @@ func ExampleElasticBeanstalk_DeleteApplicationVersion() {
 	params := &elasticbeanstalk.DeleteApplicationVersionInput{
 		ApplicationName:    aws.String("ApplicationName"), // Required
 		VersionLabel:       aws.String("VersionLabel"),    // Required
-		DeleteSourceBundle: aws.Boolean(true),
+		DeleteSourceBundle: aws.Bool(true),
 	}
 	resp, err := svc.DeleteApplicationVersion(params)
 
@@ -318,7 +318,7 @@ func ExampleElasticBeanstalk_DeleteApplicationVersion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DeleteConfigurationTemplate() {
@@ -346,7 +346,7 @@ func ExampleElasticBeanstalk_DeleteConfigurationTemplate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DeleteEnvironmentConfiguration() {
@@ -374,7 +374,7 @@ func ExampleElasticBeanstalk_DeleteEnvironmentConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DescribeApplicationVersions() {
@@ -405,7 +405,7 @@ func ExampleElasticBeanstalk_DescribeApplicationVersions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DescribeApplications() {
@@ -435,7 +435,7 @@ func ExampleElasticBeanstalk_DescribeApplications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DescribeConfigurationOptions() {
@@ -473,7 +473,7 @@ func ExampleElasticBeanstalk_DescribeConfigurationOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DescribeConfigurationSettings() {
@@ -502,7 +502,7 @@ func ExampleElasticBeanstalk_DescribeConfigurationSettings() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DescribeEnvironmentResources() {
@@ -530,7 +530,7 @@ func ExampleElasticBeanstalk_DescribeEnvironmentResources() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DescribeEnvironments() {
@@ -546,7 +546,7 @@ func ExampleElasticBeanstalk_DescribeEnvironments() {
 			aws.String("EnvironmentName"), // Required
 			// More values...
 		},
-		IncludeDeleted:        aws.Boolean(true),
+		IncludeDeleted:        aws.Bool(true),
 		IncludedDeletedBackTo: aws.Time(time.Now()),
 		VersionLabel:          aws.String("VersionLabel"),
 	}
@@ -568,7 +568,7 @@ func ExampleElasticBeanstalk_DescribeEnvironments() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_DescribeEvents() {
@@ -579,7 +579,7 @@ func ExampleElasticBeanstalk_DescribeEvents() {
 		EndTime:         aws.Time(time.Now()),
 		EnvironmentID:   aws.String("EnvironmentId"),
 		EnvironmentName: aws.String("EnvironmentName"),
-		MaxRecords:      aws.Long(1),
+		MaxRecords:      aws.Int64(1),
 		NextToken:       aws.String("Token"),
 		RequestID:       aws.String("RequestId"),
 		Severity:        aws.String("EventSeverity"),
@@ -605,7 +605,7 @@ func ExampleElasticBeanstalk_DescribeEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_ListAvailableSolutionStacks() {
@@ -630,7 +630,7 @@ func ExampleElasticBeanstalk_ListAvailableSolutionStacks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_RebuildEnvironment() {
@@ -658,7 +658,7 @@ func ExampleElasticBeanstalk_RebuildEnvironment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_RequestEnvironmentInfo() {
@@ -687,7 +687,7 @@ func ExampleElasticBeanstalk_RequestEnvironmentInfo() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_RestartAppServer() {
@@ -715,7 +715,7 @@ func ExampleElasticBeanstalk_RestartAppServer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_RetrieveEnvironmentInfo() {
@@ -744,7 +744,7 @@ func ExampleElasticBeanstalk_RetrieveEnvironmentInfo() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_SwapEnvironmentCNAMEs() {
@@ -774,7 +774,7 @@ func ExampleElasticBeanstalk_SwapEnvironmentCNAMEs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_TerminateEnvironment() {
@@ -783,7 +783,7 @@ func ExampleElasticBeanstalk_TerminateEnvironment() {
 	params := &elasticbeanstalk.TerminateEnvironmentInput{
 		EnvironmentID:      aws.String("EnvironmentId"),
 		EnvironmentName:    aws.String("EnvironmentName"),
-		TerminateResources: aws.Boolean(true),
+		TerminateResources: aws.Bool(true),
 	}
 	resp, err := svc.TerminateEnvironment(params)
 
@@ -803,7 +803,7 @@ func ExampleElasticBeanstalk_TerminateEnvironment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_UpdateApplication() {
@@ -831,7 +831,7 @@ func ExampleElasticBeanstalk_UpdateApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_UpdateApplicationVersion() {
@@ -860,7 +860,7 @@ func ExampleElasticBeanstalk_UpdateApplicationVersion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_UpdateConfigurationTemplate() {
@@ -906,7 +906,7 @@ func ExampleElasticBeanstalk_UpdateConfigurationTemplate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_UpdateEnvironment() {
@@ -960,7 +960,7 @@ func ExampleElasticBeanstalk_UpdateEnvironment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticBeanstalk_ValidateConfigurationSettings() {
@@ -998,5 +998,5 @@ func ExampleElasticBeanstalk_ValidateConfigurationSettings() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -653,7 +653,7 @@ type metadataArtwork struct {
 
 // String returns the string representation
 func (s Artwork) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -720,7 +720,7 @@ type metadataAudioCodecOptions struct {
 
 // String returns the string representation
 func (s AudioCodecOptions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -851,7 +851,7 @@ type metadataAudioParameters struct {
 
 // String returns the string representation
 func (s AudioParameters) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -876,7 +876,7 @@ type metadataCancelJobInput struct {
 
 // String returns the string representation
 func (s CancelJobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -896,7 +896,7 @@ type metadataCancelJobOutput struct {
 
 // String returns the string representation
 func (s CancelJobOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -962,7 +962,7 @@ type metadataCaptionFormat struct {
 
 // String returns the string representation
 func (s CaptionFormat) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1013,7 +1013,7 @@ type metadataCaptionSource struct {
 
 // String returns the string representation
 func (s CaptionSource) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1060,7 +1060,7 @@ type metadataCaptions struct {
 
 // String returns the string representation
 func (s Captions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1083,7 +1083,7 @@ type metadataClip struct {
 
 // String returns the string representation
 func (s Clip) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1138,7 +1138,7 @@ type metadataCreateJobInput struct {
 
 // String returns the string representation
 func (s CreateJobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1295,7 +1295,7 @@ type metadataCreateJobOutput struct {
 
 // String returns the string representation
 func (s CreateJobOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1377,7 +1377,7 @@ type metadataCreateJobPlaylist struct {
 
 // String returns the string representation
 func (s CreateJobPlaylist) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1400,7 +1400,7 @@ type metadataCreateJobResponse struct {
 
 // String returns the string representation
 func (s CreateJobResponse) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1570,7 +1570,7 @@ type metadataCreatePipelineInput struct {
 
 // String returns the string representation
 func (s CreatePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1602,7 +1602,7 @@ type metadataCreatePipelineOutput struct {
 
 // String returns the string representation
 func (s CreatePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1642,7 +1642,7 @@ type metadataCreatePresetInput struct {
 
 // String returns the string representation
 func (s CreatePresetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1671,7 +1671,7 @@ type metadataCreatePresetOutput struct {
 
 // String returns the string representation
 func (s CreatePresetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1693,7 +1693,7 @@ type metadataDeletePipelineInput struct {
 
 // String returns the string representation
 func (s DeletePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1712,7 +1712,7 @@ type metadataDeletePipelineOutput struct {
 
 // String returns the string representation
 func (s DeletePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1734,7 +1734,7 @@ type metadataDeletePresetInput struct {
 
 // String returns the string representation
 func (s DeletePresetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1753,7 +1753,7 @@ type metadataDeletePresetOutput struct {
 
 // String returns the string representation
 func (s DeletePresetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1788,7 +1788,7 @@ type metadataDetectedProperties struct {
 
 // String returns the string representation
 func (s DetectedProperties) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1870,7 +1870,7 @@ type metadataEncryption struct {
 
 // String returns the string representation
 func (s Encryption) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1935,7 +1935,7 @@ type metadataHLSContentProtection struct {
 
 // String returns the string representation
 func (s HLSContentProtection) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2026,7 +2026,7 @@ type metadataJob struct {
 
 // String returns the string representation
 func (s Job) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2061,7 +2061,7 @@ type metadataJobAlbumArt struct {
 
 // String returns the string representation
 func (s JobAlbumArt) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2142,7 +2142,7 @@ type metadataJobInput struct {
 
 // String returns the string representation
 func (s JobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2361,7 +2361,7 @@ type metadataJobOutput struct {
 
 // String returns the string representation
 func (s JobOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2401,7 +2401,7 @@ type metadataJobWatermark struct {
 
 // String returns the string representation
 func (s JobWatermark) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2431,7 +2431,7 @@ type metadataListJobsByPipelineInput struct {
 
 // String returns the string representation
 func (s ListJobsByPipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2458,7 +2458,7 @@ type metadataListJobsByPipelineOutput struct {
 
 // String returns the string representation
 func (s ListJobsByPipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2490,7 +2490,7 @@ type metadataListJobsByStatusInput struct {
 
 // String returns the string representation
 func (s ListJobsByStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2517,7 +2517,7 @@ type metadataListJobsByStatusOutput struct {
 
 // String returns the string representation
 func (s ListJobsByStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2545,7 +2545,7 @@ type metadataListPipelinesInput struct {
 
 // String returns the string representation
 func (s ListPipelinesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2572,7 +2572,7 @@ type metadataListPipelinesOutput struct {
 
 // String returns the string representation
 func (s ListPipelinesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2600,7 +2600,7 @@ type metadataListPresetsInput struct {
 
 // String returns the string representation
 func (s ListPresetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2627,7 +2627,7 @@ type metadataListPresetsOutput struct {
 
 // String returns the string representation
 func (s ListPresetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2666,7 +2666,7 @@ type metadataNotifications struct {
 
 // String returns the string representation
 func (s Notifications) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2710,7 +2710,7 @@ type metadataPermission struct {
 
 // String returns the string representation
 func (s Permission) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2840,7 +2840,7 @@ type metadataPipeline struct {
 
 // String returns the string representation
 func (s Pipeline) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2893,7 +2893,7 @@ type metadataPipelineOutputConfig struct {
 
 // String returns the string representation
 func (s PipelineOutputConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2959,7 +2959,7 @@ type metadataPlayReadyDRM struct {
 
 // String returns the string representation
 func (s PlayReadyDRM) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3051,7 +3051,7 @@ type metadataPlaylist struct {
 
 // String returns the string representation
 func (s Playlist) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3108,7 +3108,7 @@ type metadataPreset struct {
 
 // String returns the string representation
 func (s Preset) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3251,7 +3251,7 @@ type metadataPresetWatermark struct {
 
 // String returns the string representation
 func (s PresetWatermark) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3273,7 +3273,7 @@ type metadataReadJobInput struct {
 
 // String returns the string representation
 func (s ReadJobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3295,7 +3295,7 @@ type metadataReadJobOutput struct {
 
 // String returns the string representation
 func (s ReadJobOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3317,7 +3317,7 @@ type metadataReadPipelineInput struct {
 
 // String returns the string representation
 func (s ReadPipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3347,7 +3347,7 @@ type metadataReadPipelineOutput struct {
 
 // String returns the string representation
 func (s ReadPipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3369,7 +3369,7 @@ type metadataReadPresetInput struct {
 
 // String returns the string representation
 func (s ReadPresetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3391,7 +3391,7 @@ type metadataReadPresetOutput struct {
 
 // String returns the string representation
 func (s ReadPresetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3426,7 +3426,7 @@ type metadataTestRoleInput struct {
 
 // String returns the string representation
 func (s TestRoleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3453,7 +3453,7 @@ type metadataTestRoleOutput struct {
 
 // String returns the string representation
 func (s TestRoleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3545,7 +3545,7 @@ type metadataThumbnails struct {
 
 // String returns the string representation
 func (s Thumbnails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3579,7 +3579,7 @@ type metadataTimeSpan struct {
 
 // String returns the string representation
 func (s TimeSpan) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3607,7 +3607,7 @@ type metadataTiming struct {
 
 // String returns the string representation
 func (s Timing) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3748,7 +3748,7 @@ type metadataUpdatePipelineInput struct {
 
 // String returns the string representation
 func (s UpdatePipelineInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3789,7 +3789,7 @@ type metadataUpdatePipelineNotificationsInput struct {
 
 // String returns the string representation
 func (s UpdatePipelineNotificationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3811,7 +3811,7 @@ type metadataUpdatePipelineNotificationsOutput struct {
 
 // String returns the string representation
 func (s UpdatePipelineNotificationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3842,7 +3842,7 @@ type metadataUpdatePipelineOutput struct {
 
 // String returns the string representation
 func (s UpdatePipelineOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3870,7 +3870,7 @@ type metadataUpdatePipelineStatusInput struct {
 
 // String returns the string representation
 func (s UpdatePipelineStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3893,7 +3893,7 @@ type metadataUpdatePipelineStatusOutput struct {
 
 // String returns the string representation
 func (s UpdatePipelineStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4207,7 +4207,7 @@ type metadataVideoParameters struct {
 
 // String returns the string representation
 func (s VideoParameters) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4240,7 +4240,7 @@ type metadataWarning struct {
 
 // String returns the string representation
 func (s Warning) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/elastictranscoder/examples_test.go
+++ b/service/elastictranscoder/examples_test.go
@@ -40,7 +40,7 @@ func ExampleElasticTranscoder_CancelJob() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_CreateJob() {
@@ -51,11 +51,11 @@ func ExampleElasticTranscoder_CreateJob() {
 			AspectRatio: aws.String("AspectRatio"),
 			Container:   aws.String("JobContainer"),
 			DetectedProperties: &elastictranscoder.DetectedProperties{
-				DurationMillis: aws.Long(1),
-				FileSize:       aws.Long(1),
+				DurationMillis: aws.Int64(1),
+				FileSize:       aws.Int64(1),
 				FrameRate:      aws.String("FloatString"),
-				Height:         aws.Long(1),
-				Width:          aws.Long(1),
+				Height:         aws.Int64(1),
+				Width:          aws.Int64(1),
 			},
 			Encryption: &elastictranscoder.Encryption{
 				InitializationVector: aws.String("ZeroTo255String"),
@@ -307,7 +307,7 @@ func ExampleElasticTranscoder_CreateJob() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_CreatePipeline() {
@@ -374,7 +374,7 @@ func ExampleElasticTranscoder_CreatePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_CreatePreset() {
@@ -460,7 +460,7 @@ func ExampleElasticTranscoder_CreatePreset() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_DeletePipeline() {
@@ -487,7 +487,7 @@ func ExampleElasticTranscoder_DeletePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_DeletePreset() {
@@ -514,7 +514,7 @@ func ExampleElasticTranscoder_DeletePreset() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_ListJobsByPipeline() {
@@ -543,7 +543,7 @@ func ExampleElasticTranscoder_ListJobsByPipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_ListJobsByStatus() {
@@ -572,7 +572,7 @@ func ExampleElasticTranscoder_ListJobsByStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_ListPipelines() {
@@ -600,7 +600,7 @@ func ExampleElasticTranscoder_ListPipelines() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_ListPresets() {
@@ -628,7 +628,7 @@ func ExampleElasticTranscoder_ListPresets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_ReadJob() {
@@ -655,7 +655,7 @@ func ExampleElasticTranscoder_ReadJob() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_ReadPipeline() {
@@ -682,7 +682,7 @@ func ExampleElasticTranscoder_ReadPipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_ReadPreset() {
@@ -709,7 +709,7 @@ func ExampleElasticTranscoder_ReadPreset() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_TestRole() {
@@ -742,7 +742,7 @@ func ExampleElasticTranscoder_TestRole() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_UpdatePipeline() {
@@ -809,7 +809,7 @@ func ExampleElasticTranscoder_UpdatePipeline() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_UpdatePipelineNotifications() {
@@ -842,7 +842,7 @@ func ExampleElasticTranscoder_UpdatePipelineNotifications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleElasticTranscoder_UpdatePipelineStatus() {
@@ -870,5 +870,5 @@ func ExampleElasticTranscoder_UpdatePipelineStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -991,7 +991,7 @@ type metadataAccessLog struct {
 
 // String returns the string representation
 func (s AccessLog) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1015,7 +1015,7 @@ type metadataAddTagsInput struct {
 
 // String returns the string representation
 func (s AddTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1033,7 +1033,7 @@ type metadataAddTagsOutput struct {
 
 // String returns the string representation
 func (s AddTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1058,7 +1058,7 @@ type metadataAdditionalAttribute struct {
 
 // String returns the string representation
 func (s AdditionalAttribute) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1084,7 +1084,7 @@ type metadataAppCookieStickinessPolicy struct {
 
 // String returns the string representation
 func (s AppCookieStickinessPolicy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1109,7 +1109,7 @@ type metadataApplySecurityGroupsToLoadBalancerInput struct {
 
 // String returns the string representation
 func (s ApplySecurityGroupsToLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1130,7 +1130,7 @@ type metadataApplySecurityGroupsToLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s ApplySecurityGroupsToLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1155,7 +1155,7 @@ type metadataAttachLoadBalancerToSubnetsInput struct {
 
 // String returns the string representation
 func (s AttachLoadBalancerToSubnetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1176,7 +1176,7 @@ type metadataAttachLoadBalancerToSubnetsOutput struct {
 
 // String returns the string representation
 func (s AttachLoadBalancerToSubnetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1201,7 +1201,7 @@ type metadataBackendServerDescription struct {
 
 // String returns the string representation
 func (s BackendServerDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1225,7 +1225,7 @@ type metadataConfigureHealthCheckInput struct {
 
 // String returns the string representation
 func (s ConfigureHealthCheckInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1246,7 +1246,7 @@ type metadataConfigureHealthCheckOutput struct {
 
 // String returns the string representation
 func (s ConfigureHealthCheckOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1272,7 +1272,7 @@ type metadataConnectionDraining struct {
 
 // String returns the string representation
 func (s ConnectionDraining) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1295,7 +1295,7 @@ type metadataConnectionSettings struct {
 
 // String returns the string representation
 func (s ConnectionSettings) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1323,7 +1323,7 @@ type metadataCreateAppCookieStickinessPolicyInput struct {
 
 // String returns the string representation
 func (s CreateAppCookieStickinessPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1341,7 +1341,7 @@ type metadataCreateAppCookieStickinessPolicyOutput struct {
 
 // String returns the string representation
 func (s CreateAppCookieStickinessPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1371,7 +1371,7 @@ type metadataCreateLBCookieStickinessPolicyInput struct {
 
 // String returns the string representation
 func (s CreateLBCookieStickinessPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1389,7 +1389,7 @@ type metadataCreateLBCookieStickinessPolicyOutput struct {
 
 // String returns the string representation
 func (s CreateLBCookieStickinessPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1454,7 +1454,7 @@ type metadataCreateLoadBalancerInput struct {
 
 // String returns the string representation
 func (s CreateLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1478,7 +1478,7 @@ type metadataCreateLoadBalancerListenersInput struct {
 
 // String returns the string representation
 func (s CreateLoadBalancerListenersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1496,7 +1496,7 @@ type metadataCreateLoadBalancerListenersOutput struct {
 
 // String returns the string representation
 func (s CreateLoadBalancerListenersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1517,7 +1517,7 @@ type metadataCreateLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s CreateLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1548,7 +1548,7 @@ type metadataCreateLoadBalancerPolicyInput struct {
 
 // String returns the string representation
 func (s CreateLoadBalancerPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1566,7 +1566,7 @@ type metadataCreateLoadBalancerPolicyOutput struct {
 
 // String returns the string representation
 func (s CreateLoadBalancerPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1588,7 +1588,7 @@ type metadataCrossZoneLoadBalancing struct {
 
 // String returns the string representation
 func (s CrossZoneLoadBalancing) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1609,7 +1609,7 @@ type metadataDeleteLoadBalancerInput struct {
 
 // String returns the string representation
 func (s DeleteLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1633,7 +1633,7 @@ type metadataDeleteLoadBalancerListenersInput struct {
 
 // String returns the string representation
 func (s DeleteLoadBalancerListenersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1651,7 +1651,7 @@ type metadataDeleteLoadBalancerListenersOutput struct {
 
 // String returns the string representation
 func (s DeleteLoadBalancerListenersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1669,7 +1669,7 @@ type metadataDeleteLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s DeleteLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1694,7 +1694,7 @@ type metadataDeleteLoadBalancerPolicyInput struct {
 
 // String returns the string representation
 func (s DeleteLoadBalancerPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1712,7 +1712,7 @@ type metadataDeleteLoadBalancerPolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteLoadBalancerPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1736,7 +1736,7 @@ type metadataDeregisterInstancesFromLoadBalancerInput struct {
 
 // String returns the string representation
 func (s DeregisterInstancesFromLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1757,7 +1757,7 @@ type metadataDeregisterInstancesFromLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s DeregisterInstancesFromLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1781,7 +1781,7 @@ type metadataDescribeInstanceHealthInput struct {
 
 // String returns the string representation
 func (s DescribeInstanceHealthInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1802,7 +1802,7 @@ type metadataDescribeInstanceHealthOutput struct {
 
 // String returns the string representation
 func (s DescribeInstanceHealthOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1823,7 +1823,7 @@ type metadataDescribeLoadBalancerAttributesInput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancerAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1844,7 +1844,7 @@ type metadataDescribeLoadBalancerAttributesOutput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancerAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1868,7 +1868,7 @@ type metadataDescribeLoadBalancerPoliciesInput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancerPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1889,7 +1889,7 @@ type metadataDescribeLoadBalancerPoliciesOutput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancerPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1911,7 +1911,7 @@ type metadataDescribeLoadBalancerPolicyTypesInput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancerPolicyTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1932,7 +1932,7 @@ type metadataDescribeLoadBalancerPolicyTypesOutput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancerPolicyTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1961,7 +1961,7 @@ type metadataDescribeLoadBalancersInput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1986,7 +1986,7 @@ type metadataDescribeLoadBalancersOutput struct {
 
 // String returns the string representation
 func (s DescribeLoadBalancersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2007,7 +2007,7 @@ type metadataDescribeTagsInput struct {
 
 // String returns the string representation
 func (s DescribeTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2028,7 +2028,7 @@ type metadataDescribeTagsOutput struct {
 
 // String returns the string representation
 func (s DescribeTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2052,7 +2052,7 @@ type metadataDetachLoadBalancerFromSubnetsInput struct {
 
 // String returns the string representation
 func (s DetachLoadBalancerFromSubnetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2073,7 +2073,7 @@ type metadataDetachLoadBalancerFromSubnetsOutput struct {
 
 // String returns the string representation
 func (s DetachLoadBalancerFromSubnetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2097,7 +2097,7 @@ type metadataDisableAvailabilityZonesForLoadBalancerInput struct {
 
 // String returns the string representation
 func (s DisableAvailabilityZonesForLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2118,7 +2118,7 @@ type metadataDisableAvailabilityZonesForLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s DisableAvailabilityZonesForLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2142,7 +2142,7 @@ type metadataEnableAvailabilityZonesForLoadBalancerInput struct {
 
 // String returns the string representation
 func (s EnableAvailabilityZonesForLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2163,7 +2163,7 @@ type metadataEnableAvailabilityZonesForLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s EnableAvailabilityZonesForLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2220,7 +2220,7 @@ type metadataHealthCheck struct {
 
 // String returns the string representation
 func (s HealthCheck) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2242,7 +2242,7 @@ type metadataInstance struct {
 
 // String returns the string representation
 func (s Instance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2306,7 +2306,7 @@ type metadataInstanceState struct {
 
 // String returns the string representation
 func (s InstanceState) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2334,7 +2334,7 @@ type metadataLBCookieStickinessPolicy struct {
 
 // String returns the string representation
 func (s LBCookieStickinessPolicy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2384,7 +2384,7 @@ type metadataListener struct {
 
 // String returns the string representation
 func (s Listener) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2413,7 +2413,7 @@ type metadataListenerDescription struct {
 
 // String returns the string representation
 func (s ListenerDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2466,7 +2466,7 @@ type metadataLoadBalancerAttributes struct {
 
 // String returns the string representation
 func (s LoadBalancerAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2547,7 +2547,7 @@ type metadataLoadBalancerDescription struct {
 
 // String returns the string representation
 func (s LoadBalancerDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2571,7 +2571,7 @@ type metadataModifyLoadBalancerAttributesInput struct {
 
 // String returns the string representation
 func (s ModifyLoadBalancerAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2595,7 +2595,7 @@ type metadataModifyLoadBalancerAttributesOutput struct {
 
 // String returns the string representation
 func (s ModifyLoadBalancerAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2623,7 +2623,7 @@ type metadataPolicies struct {
 
 // String returns the string representation
 func (s Policies) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2648,7 +2648,7 @@ type metadataPolicyAttribute struct {
 
 // String returns the string representation
 func (s PolicyAttribute) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2673,7 +2673,7 @@ type metadataPolicyAttributeDescription struct {
 
 // String returns the string representation
 func (s PolicyAttributeDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2713,7 +2713,7 @@ type metadataPolicyAttributeTypeDescription struct {
 
 // String returns the string representation
 func (s PolicyAttributeTypeDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2741,7 +2741,7 @@ type metadataPolicyDescription struct {
 
 // String returns the string representation
 func (s PolicyDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2770,7 +2770,7 @@ type metadataPolicyTypeDescription struct {
 
 // String returns the string representation
 func (s PolicyTypeDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2794,7 +2794,7 @@ type metadataRegisterInstancesWithLoadBalancerInput struct {
 
 // String returns the string representation
 func (s RegisterInstancesWithLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2815,7 +2815,7 @@ type metadataRegisterInstancesWithLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s RegisterInstancesWithLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2840,7 +2840,7 @@ type metadataRemoveTagsInput struct {
 
 // String returns the string representation
 func (s RemoveTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2858,7 +2858,7 @@ type metadataRemoveTagsOutput struct {
 
 // String returns the string representation
 func (s RemoveTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2885,7 +2885,7 @@ type metadataSetLoadBalancerListenerSSLCertificateInput struct {
 
 // String returns the string representation
 func (s SetLoadBalancerListenerSSLCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2903,7 +2903,7 @@ type metadataSetLoadBalancerListenerSSLCertificateOutput struct {
 
 // String returns the string representation
 func (s SetLoadBalancerListenerSSLCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2931,7 +2931,7 @@ type metadataSetLoadBalancerPoliciesForBackendServerInput struct {
 
 // String returns the string representation
 func (s SetLoadBalancerPoliciesForBackendServerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2949,7 +2949,7 @@ type metadataSetLoadBalancerPoliciesForBackendServerOutput struct {
 
 // String returns the string representation
 func (s SetLoadBalancerPoliciesForBackendServerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2977,7 +2977,7 @@ type metadataSetLoadBalancerPoliciesOfListenerInput struct {
 
 // String returns the string representation
 func (s SetLoadBalancerPoliciesOfListenerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2995,7 +2995,7 @@ type metadataSetLoadBalancerPoliciesOfListenerOutput struct {
 
 // String returns the string representation
 func (s SetLoadBalancerPoliciesOfListenerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3020,7 +3020,7 @@ type metadataSourceSecurityGroup struct {
 
 // String returns the string representation
 func (s SourceSecurityGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3045,7 +3045,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3070,7 +3070,7 @@ type metadataTagDescription struct {
 
 // String returns the string representation
 func (s TagDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3092,7 +3092,7 @@ type metadataTagKeyOnly struct {
 
 // String returns the string representation
 func (s TagKeyOnly) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/elb/examples_test.go
+++ b/service/elb/examples_test.go
@@ -50,7 +50,7 @@ func ExampleELB_AddTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_ApplySecurityGroupsToLoadBalancer() {
@@ -81,7 +81,7 @@ func ExampleELB_ApplySecurityGroupsToLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_AttachLoadBalancerToSubnets() {
@@ -112,7 +112,7 @@ func ExampleELB_AttachLoadBalancerToSubnets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_ConfigureHealthCheck() {
@@ -120,11 +120,11 @@ func ExampleELB_ConfigureHealthCheck() {
 
 	params := &elb.ConfigureHealthCheckInput{
 		HealthCheck: &elb.HealthCheck{ // Required
-			HealthyThreshold:   aws.Long(1),                     // Required
-			Interval:           aws.Long(1),                     // Required
+			HealthyThreshold:   aws.Int64(1),
+			Interval:           aws.Int64(1),
 			Target:             aws.String("HealthCheckTarget"), // Required
-			Timeout:            aws.Long(1),                     // Required
-			UnhealthyThreshold: aws.Long(1),                     // Required
+			Timeout:            aws.Int64(1),
+			UnhealthyThreshold: aws.Int64(1),
 		},
 		LoadBalancerName: aws.String("AccessPointName"), // Required
 	}
@@ -146,7 +146,7 @@ func ExampleELB_ConfigureHealthCheck() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_CreateAppCookieStickinessPolicy() {
@@ -175,7 +175,7 @@ func ExampleELB_CreateAppCookieStickinessPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_CreateLBCookieStickinessPolicy() {
@@ -184,7 +184,7 @@ func ExampleELB_CreateLBCookieStickinessPolicy() {
 	params := &elb.CreateLBCookieStickinessPolicyInput{
 		LoadBalancerName:       aws.String("AccessPointName"), // Required
 		PolicyName:             aws.String("PolicyName"),      // Required
-		CookieExpirationPeriod: aws.Long(1),
+		CookieExpirationPeriod: aws.Int64(1),
 	}
 	resp, err := svc.CreateLBCookieStickinessPolicy(params)
 
@@ -204,7 +204,7 @@ func ExampleELB_CreateLBCookieStickinessPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_CreateLoadBalancer() {
@@ -213,8 +213,8 @@ func ExampleELB_CreateLoadBalancer() {
 	params := &elb.CreateLoadBalancerInput{
 		Listeners: []*elb.Listener{ // Required
 			{ // Required
-				InstancePort:     aws.Long(1),            // Required
-				LoadBalancerPort: aws.Long(1),            // Required
+				InstancePort:     aws.Int64(1),
+				LoadBalancerPort: aws.Int64(1),
 				Protocol:         aws.String("Protocol"), // Required
 				InstanceProtocol: aws.String("Protocol"),
 				SSLCertificateID: aws.String("SSLCertificateId"),
@@ -261,7 +261,7 @@ func ExampleELB_CreateLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_CreateLoadBalancerListeners() {
@@ -270,8 +270,8 @@ func ExampleELB_CreateLoadBalancerListeners() {
 	params := &elb.CreateLoadBalancerListenersInput{
 		Listeners: []*elb.Listener{ // Required
 			{ // Required
-				InstancePort:     aws.Long(1),            // Required
-				LoadBalancerPort: aws.Long(1),            // Required
+				InstancePort:     aws.Int64(1),
+				LoadBalancerPort: aws.Int64(1),
 				Protocol:         aws.String("Protocol"), // Required
 				InstanceProtocol: aws.String("Protocol"),
 				SSLCertificateID: aws.String("SSLCertificateId"),
@@ -298,7 +298,7 @@ func ExampleELB_CreateLoadBalancerListeners() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_CreateLoadBalancerPolicy() {
@@ -334,7 +334,7 @@ func ExampleELB_CreateLoadBalancerPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DeleteLoadBalancer() {
@@ -361,7 +361,7 @@ func ExampleELB_DeleteLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DeleteLoadBalancerListeners() {
@@ -370,8 +370,7 @@ func ExampleELB_DeleteLoadBalancerListeners() {
 	params := &elb.DeleteLoadBalancerListenersInput{
 		LoadBalancerName: aws.String("AccessPointName"), // Required
 		LoadBalancerPorts: []*int64{ // Required
-			aws.Long(1), // Required
-			// More values...
+			aws.Int64(1),
 		},
 	}
 	resp, err := svc.DeleteLoadBalancerListeners(params)
@@ -392,7 +391,7 @@ func ExampleELB_DeleteLoadBalancerListeners() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DeleteLoadBalancerPolicy() {
@@ -420,7 +419,7 @@ func ExampleELB_DeleteLoadBalancerPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DeregisterInstancesFromLoadBalancer() {
@@ -453,7 +452,7 @@ func ExampleELB_DeregisterInstancesFromLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DescribeInstanceHealth() {
@@ -486,7 +485,7 @@ func ExampleELB_DescribeInstanceHealth() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DescribeLoadBalancerAttributes() {
@@ -513,7 +512,7 @@ func ExampleELB_DescribeLoadBalancerAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DescribeLoadBalancerPolicies() {
@@ -544,7 +543,7 @@ func ExampleELB_DescribeLoadBalancerPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DescribeLoadBalancerPolicyTypes() {
@@ -574,7 +573,7 @@ func ExampleELB_DescribeLoadBalancerPolicyTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DescribeLoadBalancers() {
@@ -586,7 +585,7 @@ func ExampleELB_DescribeLoadBalancers() {
 			// More values...
 		},
 		Marker:   aws.String("Marker"),
-		PageSize: aws.Long(1),
+		PageSize: aws.Int64(1),
 	}
 	resp, err := svc.DescribeLoadBalancers(params)
 
@@ -606,7 +605,7 @@ func ExampleELB_DescribeLoadBalancers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DescribeTags() {
@@ -636,7 +635,7 @@ func ExampleELB_DescribeTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DetachLoadBalancerFromSubnets() {
@@ -667,7 +666,7 @@ func ExampleELB_DetachLoadBalancerFromSubnets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_DisableAvailabilityZonesForLoadBalancer() {
@@ -698,7 +697,7 @@ func ExampleELB_DisableAvailabilityZonesForLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_EnableAvailabilityZonesForLoadBalancer() {
@@ -729,7 +728,7 @@ func ExampleELB_EnableAvailabilityZonesForLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_ModifyLoadBalancerAttributes() {
@@ -738,8 +737,8 @@ func ExampleELB_ModifyLoadBalancerAttributes() {
 	params := &elb.ModifyLoadBalancerAttributesInput{
 		LoadBalancerAttributes: &elb.LoadBalancerAttributes{ // Required
 			AccessLog: &elb.AccessLog{
-				Enabled:        aws.Boolean(true), // Required
-				EmitInterval:   aws.Long(1),
+				Enabled:        aws.Bool(true),
+				EmitInterval:   aws.Int64(1),
 				S3BucketName:   aws.String("S3BucketName"),
 				S3BucketPrefix: aws.String("AccessLogPrefix"),
 			},
@@ -751,14 +750,14 @@ func ExampleELB_ModifyLoadBalancerAttributes() {
 				// More values...
 			},
 			ConnectionDraining: &elb.ConnectionDraining{
-				Enabled: aws.Boolean(true), // Required
-				Timeout: aws.Long(1),
+				Enabled: aws.Bool(true),
+				Timeout: aws.Int64(1),
 			},
 			ConnectionSettings: &elb.ConnectionSettings{
-				IdleTimeout: aws.Long(1), // Required
+				IdleTimeout: aws.Int64(1),
 			},
 			CrossZoneLoadBalancing: &elb.CrossZoneLoadBalancing{
-				Enabled: aws.Boolean(true), // Required
+				Enabled: aws.Bool(true),
 			},
 		},
 		LoadBalancerName: aws.String("AccessPointName"), // Required
@@ -781,7 +780,7 @@ func ExampleELB_ModifyLoadBalancerAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_RegisterInstancesWithLoadBalancer() {
@@ -814,7 +813,7 @@ func ExampleELB_RegisterInstancesWithLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_RemoveTags() {
@@ -850,15 +849,15 @@ func ExampleELB_RemoveTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_SetLoadBalancerListenerSSLCertificate() {
 	svc := elb.New(nil)
 
 	params := &elb.SetLoadBalancerListenerSSLCertificateInput{
-		LoadBalancerName: aws.String("AccessPointName"),  // Required
-		LoadBalancerPort: aws.Long(1),                    // Required
+		LoadBalancerName: aws.String("AccessPointName"), // Required
+		LoadBalancerPort: aws.Int64(1),
 		SSLCertificateID: aws.String("SSLCertificateId"), // Required
 	}
 	resp, err := svc.SetLoadBalancerListenerSSLCertificate(params)
@@ -879,14 +878,14 @@ func ExampleELB_SetLoadBalancerListenerSSLCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_SetLoadBalancerPoliciesForBackendServer() {
 	svc := elb.New(nil)
 
 	params := &elb.SetLoadBalancerPoliciesForBackendServerInput{
-		InstancePort:     aws.Long(1),                   // Required
+		InstancePort:     aws.Int64(1),
 		LoadBalancerName: aws.String("AccessPointName"), // Required
 		PolicyNames: []*string{ // Required
 			aws.String("PolicyName"), // Required
@@ -911,7 +910,7 @@ func ExampleELB_SetLoadBalancerPoliciesForBackendServer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleELB_SetLoadBalancerPoliciesOfListener() {
@@ -919,7 +918,7 @@ func ExampleELB_SetLoadBalancerPoliciesOfListener() {
 
 	params := &elb.SetLoadBalancerPoliciesOfListenerInput{
 		LoadBalancerName: aws.String("AccessPointName"), // Required
-		LoadBalancerPort: aws.Long(1),                   // Required
+		LoadBalancerPort: aws.Int64(1),
 		PolicyNames: []*string{ // Required
 			aws.String("PolicyName"), // Required
 			// More values...
@@ -943,5 +942,5 @@ func ExampleELB_SetLoadBalancerPoliciesOfListener() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -662,7 +662,7 @@ type metadataAddInstanceGroupsInput struct {
 
 // String returns the string representation
 func (s AddInstanceGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -687,7 +687,7 @@ type metadataAddInstanceGroupsOutput struct {
 
 // String returns the string representation
 func (s AddInstanceGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -713,7 +713,7 @@ type metadataAddJobFlowStepsInput struct {
 
 // String returns the string representation
 func (s AddJobFlowStepsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -735,7 +735,7 @@ type metadataAddJobFlowStepsOutput struct {
 
 // String returns the string representation
 func (s AddJobFlowStepsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -764,7 +764,7 @@ type metadataAddTagsInput struct {
 
 // String returns the string representation
 func (s AddTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -783,7 +783,7 @@ type metadataAddTagsOutput struct {
 
 // String returns the string representation
 func (s AddTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -826,7 +826,7 @@ type metadataApplication struct {
 
 // String returns the string representation
 func (s Application) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -851,7 +851,7 @@ type metadataBootstrapActionConfig struct {
 
 // String returns the string representation
 func (s BootstrapActionConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -873,7 +873,7 @@ type metadataBootstrapActionDetail struct {
 
 // String returns the string representation
 func (s BootstrapActionDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -952,7 +952,7 @@ type metadataCluster struct {
 
 // String returns the string representation
 func (s Cluster) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -977,7 +977,7 @@ type metadataClusterStateChangeReason struct {
 
 // String returns the string representation
 func (s ClusterStateChangeReason) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1006,7 +1006,7 @@ type metadataClusterStatus struct {
 
 // String returns the string representation
 func (s ClusterStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1042,7 +1042,7 @@ type metadataClusterSummary struct {
 
 // String returns the string representation
 func (s ClusterSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1070,7 +1070,7 @@ type metadataClusterTimeline struct {
 
 // String returns the string representation
 func (s ClusterTimeline) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1098,7 +1098,7 @@ type metadataCommand struct {
 
 // String returns the string representation
 func (s Command) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1120,7 +1120,7 @@ type metadataDescribeClusterInput struct {
 
 // String returns the string representation
 func (s DescribeClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1142,7 +1142,7 @@ type metadataDescribeClusterOutput struct {
 
 // String returns the string representation
 func (s DescribeClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1173,7 +1173,7 @@ type metadataDescribeJobFlowsInput struct {
 
 // String returns the string representation
 func (s DescribeJobFlowsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1195,7 +1195,7 @@ type metadataDescribeJobFlowsOutput struct {
 
 // String returns the string representation
 func (s DescribeJobFlowsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1220,7 +1220,7 @@ type metadataDescribeStepInput struct {
 
 // String returns the string representation
 func (s DescribeStepInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1242,7 +1242,7 @@ type metadataDescribeStepOutput struct {
 
 // String returns the string representation
 func (s DescribeStepOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1297,7 +1297,7 @@ type metadataEC2InstanceAttributes struct {
 
 // String returns the string representation
 func (s EC2InstanceAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1333,7 +1333,7 @@ type metadataHadoopJARStepConfig struct {
 
 // String returns the string representation
 func (s HadoopJARStepConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1369,7 +1369,7 @@ type metadataHadoopStepConfig struct {
 
 // String returns the string representation
 func (s HadoopStepConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1409,7 +1409,7 @@ type metadataInstance struct {
 
 // String returns the string representation
 func (s Instance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1458,7 +1458,7 @@ type metadataInstanceGroup struct {
 
 // String returns the string representation
 func (s InstanceGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1496,7 +1496,7 @@ type metadataInstanceGroupConfig struct {
 
 // String returns the string representation
 func (s InstanceGroupConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1559,7 +1559,7 @@ type metadataInstanceGroupDetail struct {
 
 // String returns the string representation
 func (s InstanceGroupDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1589,7 +1589,7 @@ type metadataInstanceGroupModifyConfig struct {
 
 // String returns the string representation
 func (s InstanceGroupModifyConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1614,7 +1614,7 @@ type metadataInstanceGroupStateChangeReason struct {
 
 // String returns the string representation
 func (s InstanceGroupStateChangeReason) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1642,7 +1642,7 @@ type metadataInstanceGroupStatus struct {
 
 // String returns the string representation
 func (s InstanceGroupStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1670,7 +1670,7 @@ type metadataInstanceGroupTimeline struct {
 
 // String returns the string representation
 func (s InstanceGroupTimeline) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1695,7 +1695,7 @@ type metadataInstanceStateChangeReason struct {
 
 // String returns the string representation
 func (s InstanceStateChangeReason) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1723,7 +1723,7 @@ type metadataInstanceStatus struct {
 
 // String returns the string representation
 func (s InstanceStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1751,7 +1751,7 @@ type metadataInstanceTimeline struct {
 
 // String returns the string representation
 func (s InstanceTimeline) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1818,7 +1818,7 @@ type metadataJobFlowDetail struct {
 
 // String returns the string representation
 func (s JobFlowDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1856,7 +1856,7 @@ type metadataJobFlowExecutionStatusDetail struct {
 
 // String returns the string representation
 func (s JobFlowExecutionStatusDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1935,7 +1935,7 @@ type metadataJobFlowInstancesConfig struct {
 
 // String returns the string representation
 func (s JobFlowInstancesConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2004,7 +2004,7 @@ type metadataJobFlowInstancesDetail struct {
 
 // String returns the string representation
 func (s JobFlowInstancesDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2029,7 +2029,7 @@ type metadataKeyValue struct {
 
 // String returns the string representation
 func (s KeyValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2054,7 +2054,7 @@ type metadataListBootstrapActionsInput struct {
 
 // String returns the string representation
 func (s ListBootstrapActionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2079,7 +2079,7 @@ type metadataListBootstrapActionsOutput struct {
 
 // String returns the string representation
 func (s ListBootstrapActionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2111,7 +2111,7 @@ type metadataListClustersInput struct {
 
 // String returns the string representation
 func (s ListClustersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2137,7 +2137,7 @@ type metadataListClustersOutput struct {
 
 // String returns the string representation
 func (s ListClustersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2162,7 +2162,7 @@ type metadataListInstanceGroupsInput struct {
 
 // String returns the string representation
 func (s ListInstanceGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2187,7 +2187,7 @@ type metadataListInstanceGroupsOutput struct {
 
 // String returns the string representation
 func (s ListInstanceGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2218,7 +2218,7 @@ type metadataListInstancesInput struct {
 
 // String returns the string representation
 func (s ListInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2243,7 +2243,7 @@ type metadataListInstancesOutput struct {
 
 // String returns the string representation
 func (s ListInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2274,7 +2274,7 @@ type metadataListStepsInput struct {
 
 // String returns the string representation
 func (s ListStepsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2299,7 +2299,7 @@ type metadataListStepsOutput struct {
 
 // String returns the string representation
 func (s ListStepsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2321,7 +2321,7 @@ type metadataModifyInstanceGroupsInput struct {
 
 // String returns the string representation
 func (s ModifyInstanceGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2339,7 +2339,7 @@ type metadataModifyInstanceGroupsOutput struct {
 
 // String returns the string representation
 func (s ModifyInstanceGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2361,7 +2361,7 @@ type metadataPlacementType struct {
 
 // String returns the string representation
 func (s PlacementType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2387,7 +2387,7 @@ type metadataRemoveTagsInput struct {
 
 // String returns the string representation
 func (s RemoveTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2406,7 +2406,7 @@ type metadataRemoveTagsOutput struct {
 
 // String returns the string representation
 func (s RemoveTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2501,7 +2501,7 @@ type metadataRunJobFlowInput struct {
 
 // String returns the string representation
 func (s RunJobFlowInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2523,7 +2523,7 @@ type metadataRunJobFlowOutput struct {
 
 // String returns the string representation
 func (s RunJobFlowOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2549,7 +2549,7 @@ type metadataScriptBootstrapActionConfig struct {
 
 // String returns the string representation
 func (s ScriptBootstrapActionConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2578,7 +2578,7 @@ type metadataSetTerminationProtectionInput struct {
 
 // String returns the string representation
 func (s SetTerminationProtectionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2596,7 +2596,7 @@ type metadataSetTerminationProtectionOutput struct {
 
 // String returns the string representation
 func (s SetTerminationProtectionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2625,7 +2625,7 @@ type metadataSetVisibleToAllUsersInput struct {
 
 // String returns the string representation
 func (s SetVisibleToAllUsersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2643,7 +2643,7 @@ type metadataSetVisibleToAllUsersOutput struct {
 
 // String returns the string representation
 func (s SetVisibleToAllUsersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2678,7 +2678,7 @@ type metadataStep struct {
 
 // String returns the string representation
 func (s Step) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2706,7 +2706,7 @@ type metadataStepConfig struct {
 
 // String returns the string representation
 func (s StepConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2731,7 +2731,7 @@ type metadataStepDetail struct {
 
 // String returns the string representation
 func (s StepDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2765,7 +2765,7 @@ type metadataStepExecutionStatusDetail struct {
 
 // String returns the string representation
 func (s StepExecutionStatusDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2790,7 +2790,7 @@ type metadataStepStateChangeReason struct {
 
 // String returns the string representation
 func (s StepStateChangeReason) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2818,7 +2818,7 @@ type metadataStepStatus struct {
 
 // String returns the string representation
 func (s StepStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2853,7 +2853,7 @@ type metadataStepSummary struct {
 
 // String returns the string representation
 func (s StepSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2881,7 +2881,7 @@ type metadataStepTimeline struct {
 
 // String returns the string representation
 func (s StepTimeline) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2908,7 +2908,7 @@ type metadataSupportedProductConfig struct {
 
 // String returns the string representation
 func (s SupportedProductConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2939,7 +2939,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2961,7 +2961,7 @@ type metadataTerminateJobFlowsInput struct {
 
 // String returns the string representation
 func (s TerminateJobFlowsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2979,7 +2979,7 @@ type metadataTerminateJobFlowsOutput struct {
 
 // String returns the string representation
 func (s TerminateJobFlowsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/emr/examples_test.go
+++ b/service/emr/examples_test.go
@@ -22,7 +22,7 @@ func ExampleEMR_AddInstanceGroups() {
 	params := &emr.AddInstanceGroupsInput{
 		InstanceGroups: []*emr.InstanceGroupConfig{ // Required
 			{ // Required
-				InstanceCount: aws.Long(1),                    // Required
+				InstanceCount: aws.Int64(1),                   // Required
 				InstanceRole:  aws.String("InstanceRoleType"), // Required
 				InstanceType:  aws.String("InstanceType"),     // Required
 				BidPrice:      aws.String("XmlStringMaxLen256"),
@@ -51,7 +51,7 @@ func ExampleEMR_AddInstanceGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_AddJobFlowSteps() {
@@ -100,7 +100,7 @@ func ExampleEMR_AddJobFlowSteps() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_AddTags() {
@@ -134,7 +134,7 @@ func ExampleEMR_AddTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_DescribeCluster() {
@@ -161,7 +161,7 @@ func ExampleEMR_DescribeCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_DescribeJobFlows() {
@@ -197,7 +197,7 @@ func ExampleEMR_DescribeJobFlows() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_DescribeStep() {
@@ -225,7 +225,7 @@ func ExampleEMR_DescribeStep() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_ListBootstrapActions() {
@@ -253,7 +253,7 @@ func ExampleEMR_ListBootstrapActions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_ListClusters() {
@@ -286,7 +286,7 @@ func ExampleEMR_ListClusters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_ListInstanceGroups() {
@@ -314,7 +314,7 @@ func ExampleEMR_ListInstanceGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_ListInstances() {
@@ -347,7 +347,7 @@ func ExampleEMR_ListInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_ListSteps() {
@@ -383,7 +383,7 @@ func ExampleEMR_ListSteps() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_ModifyInstanceGroups() {
@@ -397,7 +397,7 @@ func ExampleEMR_ModifyInstanceGroups() {
 					aws.String("InstanceId"), // Required
 					// More values...
 				},
-				InstanceCount: aws.Long(1),
+				InstanceCount: aws.Int64(1),
 			},
 			// More values...
 		},
@@ -420,7 +420,7 @@ func ExampleEMR_ModifyInstanceGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_RemoveTags() {
@@ -451,7 +451,7 @@ func ExampleEMR_RemoveTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_RunJobFlow() {
@@ -472,10 +472,10 @@ func ExampleEMR_RunJobFlow() {
 			EMRManagedMasterSecurityGroup: aws.String("XmlStringMaxLen256"),
 			EMRManagedSlaveSecurityGroup:  aws.String("XmlStringMaxLen256"),
 			HadoopVersion:                 aws.String("XmlStringMaxLen256"),
-			InstanceCount:                 aws.Long(1),
+			InstanceCount:                 aws.Int64(1),
 			InstanceGroups: []*emr.InstanceGroupConfig{
 				{ // Required
-					InstanceCount: aws.Long(1),                    // Required
+					InstanceCount: aws.Int64(1),                   // Required
 					InstanceRole:  aws.String("InstanceRoleType"), // Required
 					InstanceType:  aws.String("InstanceType"),     // Required
 					BidPrice:      aws.String("XmlStringMaxLen256"),
@@ -484,13 +484,13 @@ func ExampleEMR_RunJobFlow() {
 				},
 				// More values...
 			},
-			KeepJobFlowAliveWhenNoSteps: aws.Boolean(true),
+			KeepJobFlowAliveWhenNoSteps: aws.Bool(true),
 			MasterInstanceType:          aws.String("InstanceType"),
 			Placement: &emr.PlacementType{
 				AvailabilityZone: aws.String("XmlString"), // Required
 			},
 			SlaveInstanceType:    aws.String("InstanceType"),
-			TerminationProtected: aws.Boolean(true),
+			TerminationProtected: aws.Bool(true),
 		},
 		Name:           aws.String("XmlStringMaxLen256"), // Required
 		AMIVersion:     aws.String("XmlStringMaxLen256"),
@@ -554,7 +554,7 @@ func ExampleEMR_RunJobFlow() {
 			},
 			// More values...
 		},
-		VisibleToAllUsers: aws.Boolean(true),
+		VisibleToAllUsers: aws.Bool(true),
 	}
 	resp, err := svc.RunJobFlow(params)
 
@@ -574,7 +574,7 @@ func ExampleEMR_RunJobFlow() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_SetTerminationProtection() {
@@ -585,7 +585,7 @@ func ExampleEMR_SetTerminationProtection() {
 			aws.String("XmlString"), // Required
 			// More values...
 		},
-		TerminationProtected: aws.Boolean(true), // Required
+		TerminationProtected: aws.Bool(true), // Required
 	}
 	resp, err := svc.SetTerminationProtection(params)
 
@@ -605,7 +605,7 @@ func ExampleEMR_SetTerminationProtection() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_SetVisibleToAllUsers() {
@@ -616,7 +616,7 @@ func ExampleEMR_SetVisibleToAllUsers() {
 			aws.String("XmlString"), // Required
 			// More values...
 		},
-		VisibleToAllUsers: aws.Boolean(true), // Required
+		VisibleToAllUsers: aws.Bool(true), // Required
 	}
 	resp, err := svc.SetVisibleToAllUsers(params)
 
@@ -636,7 +636,7 @@ func ExampleEMR_SetVisibleToAllUsers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleEMR_TerminateJobFlows() {
@@ -666,5 +666,5 @@ func ExampleEMR_TerminateJobFlows() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -1467,7 +1467,7 @@ type metadataAbortMultipartUploadInput struct {
 
 // String returns the string representation
 func (s AbortMultipartUploadInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1485,7 +1485,7 @@ type metadataAbortMultipartUploadOutput struct {
 
 // String returns the string representation
 func (s AbortMultipartUploadOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1518,7 +1518,7 @@ type metadataAddTagsToVaultInput struct {
 
 // String returns the string representation
 func (s AddTagsToVaultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1536,7 +1536,7 @@ type metadataAddTagsToVaultOutput struct {
 
 // String returns the string representation
 func (s AddTagsToVaultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1568,7 +1568,7 @@ type metadataArchiveCreationOutput struct {
 
 // String returns the string representation
 func (s ArchiveCreationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1614,7 +1614,7 @@ type metadataCompleteMultipartUploadInput struct {
 
 // String returns the string representation
 func (s CompleteMultipartUploadInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1644,7 +1644,7 @@ type metadataCreateVaultInput struct {
 
 // String returns the string representation
 func (s CreateVaultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1666,7 +1666,7 @@ type metadataCreateVaultOutput struct {
 
 // String returns the string representation
 func (s CreateVaultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1689,7 +1689,7 @@ type metadataDataRetrievalPolicy struct {
 
 // String returns the string representation
 func (s DataRetrievalPolicy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1720,7 +1720,7 @@ type metadataDataRetrievalRule struct {
 
 // String returns the string representation
 func (s DataRetrievalRule) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1752,7 +1752,7 @@ type metadataDeleteArchiveInput struct {
 
 // String returns the string representation
 func (s DeleteArchiveInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1770,7 +1770,7 @@ type metadataDeleteArchiveOutput struct {
 
 // String returns the string representation
 func (s DeleteArchiveOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1799,7 +1799,7 @@ type metadataDeleteVaultAccessPolicyInput struct {
 
 // String returns the string representation
 func (s DeleteVaultAccessPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1817,7 +1817,7 @@ type metadataDeleteVaultAccessPolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteVaultAccessPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1846,7 +1846,7 @@ type metadataDeleteVaultInput struct {
 
 // String returns the string representation
 func (s DeleteVaultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1876,7 +1876,7 @@ type metadataDeleteVaultNotificationsInput struct {
 
 // String returns the string representation
 func (s DeleteVaultNotificationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1894,7 +1894,7 @@ type metadataDeleteVaultNotificationsOutput struct {
 
 // String returns the string representation
 func (s DeleteVaultNotificationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1912,7 +1912,7 @@ type metadataDeleteVaultOutput struct {
 
 // String returns the string representation
 func (s DeleteVaultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1944,7 +1944,7 @@ type metadataDescribeJobInput struct {
 
 // String returns the string representation
 func (s DescribeJobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1973,7 +1973,7 @@ type metadataDescribeVaultInput struct {
 
 // String returns the string representation
 func (s DescribeVaultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2016,7 +2016,7 @@ type metadataDescribeVaultOutput struct {
 
 // String returns the string representation
 func (s DescribeVaultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2043,7 +2043,7 @@ type metadataGetDataRetrievalPolicyInput struct {
 
 // String returns the string representation
 func (s GetDataRetrievalPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2065,7 +2065,7 @@ type metadataGetDataRetrievalPolicyOutput struct {
 
 // String returns the string representation
 func (s GetDataRetrievalPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2102,7 +2102,7 @@ type metadataGetJobOutputInput struct {
 
 // String returns the string representation
 func (s GetJobOutputInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2159,7 +2159,7 @@ type metadataGetJobOutputOutput struct {
 
 // String returns the string representation
 func (s GetJobOutputOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2188,7 +2188,7 @@ type metadataGetVaultAccessPolicyInput struct {
 
 // String returns the string representation
 func (s GetVaultAccessPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2210,7 +2210,7 @@ type metadataGetVaultAccessPolicyOutput struct {
 
 // String returns the string representation
 func (s GetVaultAccessPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2240,7 +2240,7 @@ type metadataGetVaultNotificationsInput struct {
 
 // String returns the string representation
 func (s GetVaultNotificationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2262,7 +2262,7 @@ type metadataGetVaultNotificationsOutput struct {
 
 // String returns the string representation
 func (s GetVaultNotificationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2294,7 +2294,7 @@ type metadataInitiateJobInput struct {
 
 // String returns the string representation
 func (s InitiateJobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2319,7 +2319,7 @@ type metadataInitiateJobOutput struct {
 
 // String returns the string representation
 func (s InitiateJobOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2360,7 +2360,7 @@ type metadataInitiateMultipartUploadInput struct {
 
 // String returns the string representation
 func (s InitiateMultipartUploadInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2386,7 +2386,7 @@ type metadataInitiateMultipartUploadOutput struct {
 
 // String returns the string representation
 func (s InitiateMultipartUploadOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2432,7 +2432,7 @@ type metadataInventoryRetrievalJobDescription struct {
 
 // String returns the string representation
 func (s InventoryRetrievalJobDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2471,7 +2471,7 @@ type metadataInventoryRetrievalJobInput struct {
 
 // String returns the string representation
 func (s InventoryRetrievalJobInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2568,7 +2568,7 @@ type metadataJobDescription struct {
 
 // String returns the string representation
 func (s JobDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2627,7 +2627,7 @@ type metadataJobParameters struct {
 
 // String returns the string representation
 func (s JobParameters) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2673,7 +2673,7 @@ type metadataListJobsInput struct {
 
 // String returns the string representation
 func (s ListJobsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2700,7 +2700,7 @@ type metadataListJobsOutput struct {
 
 // String returns the string representation
 func (s ListJobsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2741,7 +2741,7 @@ type metadataListMultipartUploadsInput struct {
 
 // String returns the string representation
 func (s ListMultipartUploadsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2768,7 +2768,7 @@ type metadataListMultipartUploadsOutput struct {
 
 // String returns the string representation
 func (s ListMultipartUploadsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2812,7 +2812,7 @@ type metadataListPartsInput struct {
 
 // String returns the string representation
 func (s ListPartsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2856,7 +2856,7 @@ type metadataListPartsOutput struct {
 
 // String returns the string representation
 func (s ListPartsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2885,7 +2885,7 @@ type metadataListTagsForVaultInput struct {
 
 // String returns the string representation
 func (s ListTagsForVaultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2907,7 +2907,7 @@ type metadataListTagsForVaultOutput struct {
 
 // String returns the string representation
 func (s ListTagsForVaultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2943,7 +2943,7 @@ type metadataListVaultsInput struct {
 
 // String returns the string representation
 func (s ListVaultsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2969,7 +2969,7 @@ type metadataListVaultsOutput struct {
 
 // String returns the string representation
 func (s ListVaultsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2995,7 +2995,7 @@ type metadataPartListElement struct {
 
 // String returns the string representation
 func (s PartListElement) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3027,7 +3027,7 @@ type metadataRemoveTagsFromVaultInput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromVaultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3045,7 +3045,7 @@ type metadataRemoveTagsFromVaultOutput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromVaultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3075,7 +3075,7 @@ type metadataSetDataRetrievalPolicyInput struct {
 
 // String returns the string representation
 func (s SetDataRetrievalPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3093,7 +3093,7 @@ type metadataSetDataRetrievalPolicyOutput struct {
 
 // String returns the string representation
 func (s SetDataRetrievalPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3125,7 +3125,7 @@ type metadataSetVaultAccessPolicyInput struct {
 
 // String returns the string representation
 func (s SetVaultAccessPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3143,7 +3143,7 @@ type metadataSetVaultAccessPolicyOutput struct {
 
 // String returns the string representation
 func (s SetVaultAccessPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3176,7 +3176,7 @@ type metadataSetVaultNotificationsInput struct {
 
 // String returns the string representation
 func (s SetVaultNotificationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3194,7 +3194,7 @@ type metadataSetVaultNotificationsOutput struct {
 
 // String returns the string representation
 func (s SetVaultNotificationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3232,7 +3232,7 @@ type metadataUploadArchiveInput struct {
 
 // String returns the string representation
 func (s UploadArchiveInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3269,7 +3269,7 @@ type metadataUploadListElement struct {
 
 // String returns the string representation
 func (s UploadListElement) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3313,7 +3313,7 @@ type metadataUploadMultipartPartInput struct {
 
 // String returns the string representation
 func (s UploadMultipartPartInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3335,7 +3335,7 @@ type metadataUploadMultipartPartOutput struct {
 
 // String returns the string representation
 func (s UploadMultipartPartOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3357,7 +3357,7 @@ type metadataVaultAccessPolicy struct {
 
 // String returns the string representation
 func (s VaultAccessPolicy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3384,7 +3384,7 @@ type metadataVaultNotificationConfig struct {
 
 // String returns the string representation
 func (s VaultNotificationConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/glacier/examples_test.go
+++ b/service/glacier/examples_test.go
@@ -42,7 +42,7 @@ func ExampleGlacier_AbortMultipartUpload() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_AddTagsToVault() {
@@ -74,7 +74,7 @@ func ExampleGlacier_AddTagsToVault() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_CompleteMultipartUpload() {
@@ -105,7 +105,7 @@ func ExampleGlacier_CompleteMultipartUpload() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_CreateVault() {
@@ -133,7 +133,7 @@ func ExampleGlacier_CreateVault() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_DeleteArchive() {
@@ -162,7 +162,7 @@ func ExampleGlacier_DeleteArchive() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_DeleteVault() {
@@ -190,7 +190,7 @@ func ExampleGlacier_DeleteVault() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_DeleteVaultAccessPolicy() {
@@ -218,7 +218,7 @@ func ExampleGlacier_DeleteVaultAccessPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_DeleteVaultNotifications() {
@@ -246,7 +246,7 @@ func ExampleGlacier_DeleteVaultNotifications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_DescribeJob() {
@@ -275,7 +275,7 @@ func ExampleGlacier_DescribeJob() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_DescribeVault() {
@@ -303,7 +303,7 @@ func ExampleGlacier_DescribeVault() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_GetDataRetrievalPolicy() {
@@ -330,7 +330,7 @@ func ExampleGlacier_GetDataRetrievalPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_GetJobOutput() {
@@ -360,7 +360,7 @@ func ExampleGlacier_GetJobOutput() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_GetVaultAccessPolicy() {
@@ -388,7 +388,7 @@ func ExampleGlacier_GetVaultAccessPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_GetVaultNotifications() {
@@ -416,7 +416,7 @@ func ExampleGlacier_GetVaultNotifications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_InitiateJob() {
@@ -458,7 +458,7 @@ func ExampleGlacier_InitiateJob() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_InitiateMultipartUpload() {
@@ -488,7 +488,7 @@ func ExampleGlacier_InitiateMultipartUpload() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_ListJobs() {
@@ -520,7 +520,7 @@ func ExampleGlacier_ListJobs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_ListMultipartUploads() {
@@ -550,7 +550,7 @@ func ExampleGlacier_ListMultipartUploads() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_ListParts() {
@@ -581,7 +581,7 @@ func ExampleGlacier_ListParts() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_ListTagsForVault() {
@@ -609,7 +609,7 @@ func ExampleGlacier_ListTagsForVault() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_ListVaults() {
@@ -638,7 +638,7 @@ func ExampleGlacier_ListVaults() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_RemoveTagsFromVault() {
@@ -670,7 +670,7 @@ func ExampleGlacier_RemoveTagsFromVault() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_SetDataRetrievalPolicy() {
@@ -681,7 +681,7 @@ func ExampleGlacier_SetDataRetrievalPolicy() {
 		Policy: &glacier.DataRetrievalPolicy{
 			Rules: []*glacier.DataRetrievalRule{
 				{ // Required
-					BytesPerHour: aws.Long(1),
+					BytesPerHour: aws.Int64(1),
 					Strategy:     aws.String("string"),
 				},
 				// More values...
@@ -706,7 +706,7 @@ func ExampleGlacier_SetDataRetrievalPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_SetVaultAccessPolicy() {
@@ -737,7 +737,7 @@ func ExampleGlacier_SetVaultAccessPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_SetVaultNotifications() {
@@ -772,7 +772,7 @@ func ExampleGlacier_SetVaultNotifications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_UploadArchive() {
@@ -803,7 +803,7 @@ func ExampleGlacier_UploadArchive() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleGlacier_UploadMultipartPart() {
@@ -835,5 +835,5 @@ func ExampleGlacier_UploadMultipartPart() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -4004,7 +4004,7 @@ type metadataAccessKey struct {
 
 // String returns the string representation
 func (s AccessKey) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4062,7 +4062,7 @@ type metadataAccessKeyLastUsed struct {
 
 // String returns the string representation
 func (s AccessKeyLastUsed) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4096,7 +4096,7 @@ type metadataAccessKeyMetadata struct {
 
 // String returns the string representation
 func (s AccessKeyMetadata) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4122,7 +4122,7 @@ type metadataAddClientIDToOpenIDConnectProviderInput struct {
 
 // String returns the string representation
 func (s AddClientIDToOpenIDConnectProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4140,7 +4140,7 @@ type metadataAddClientIDToOpenIDConnectProviderOutput struct {
 
 // String returns the string representation
 func (s AddClientIDToOpenIDConnectProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4164,7 +4164,7 @@ type metadataAddRoleToInstanceProfileInput struct {
 
 // String returns the string representation
 func (s AddRoleToInstanceProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4182,7 +4182,7 @@ type metadataAddRoleToInstanceProfileOutput struct {
 
 // String returns the string representation
 func (s AddRoleToInstanceProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4206,7 +4206,7 @@ type metadataAddUserToGroupInput struct {
 
 // String returns the string representation
 func (s AddUserToGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4224,7 +4224,7 @@ type metadataAddUserToGroupOutput struct {
 
 // String returns the string representation
 func (s AddUserToGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4252,7 +4252,7 @@ type metadataAttachGroupPolicyInput struct {
 
 // String returns the string representation
 func (s AttachGroupPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4270,7 +4270,7 @@ type metadataAttachGroupPolicyOutput struct {
 
 // String returns the string representation
 func (s AttachGroupPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4298,7 +4298,7 @@ type metadataAttachRolePolicyInput struct {
 
 // String returns the string representation
 func (s AttachRolePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4316,7 +4316,7 @@ type metadataAttachRolePolicyOutput struct {
 
 // String returns the string representation
 func (s AttachRolePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4344,7 +4344,7 @@ type metadataAttachUserPolicyInput struct {
 
 // String returns the string representation
 func (s AttachUserPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4362,7 +4362,7 @@ type metadataAttachUserPolicyOutput struct {
 
 // String returns the string representation
 func (s AttachUserPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4400,7 +4400,7 @@ type metadataAttachedPolicy struct {
 
 // String returns the string representation
 func (s AttachedPolicy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4425,7 +4425,7 @@ type metadataChangePasswordInput struct {
 
 // String returns the string representation
 func (s ChangePasswordInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4443,7 +4443,7 @@ type metadataChangePasswordOutput struct {
 
 // String returns the string representation
 func (s ChangePasswordOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4464,7 +4464,7 @@ type metadataCreateAccessKeyInput struct {
 
 // String returns the string representation
 func (s CreateAccessKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4486,7 +4486,7 @@ type metadataCreateAccessKeyOutput struct {
 
 // String returns the string representation
 func (s CreateAccessKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4507,7 +4507,7 @@ type metadataCreateAccountAliasInput struct {
 
 // String returns the string representation
 func (s CreateAccountAliasInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4525,7 +4525,7 @@ type metadataCreateAccountAliasOutput struct {
 
 // String returns the string representation
 func (s CreateAccountAliasOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4554,7 +4554,7 @@ type metadataCreateGroupInput struct {
 
 // String returns the string representation
 func (s CreateGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4576,7 +4576,7 @@ type metadataCreateGroupOutput struct {
 
 // String returns the string representation
 func (s CreateGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4605,7 +4605,7 @@ type metadataCreateInstanceProfileInput struct {
 
 // String returns the string representation
 func (s CreateInstanceProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4627,7 +4627,7 @@ type metadataCreateInstanceProfileOutput struct {
 
 // String returns the string representation
 func (s CreateInstanceProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4654,7 +4654,7 @@ type metadataCreateLoginProfileInput struct {
 
 // String returns the string representation
 func (s CreateLoginProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4676,7 +4676,7 @@ type metadataCreateLoginProfileOutput struct {
 
 // String returns the string representation
 func (s CreateLoginProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4739,7 +4739,7 @@ type metadataCreateOpenIDConnectProviderInput struct {
 
 // String returns the string representation
 func (s CreateOpenIDConnectProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4762,7 +4762,7 @@ type metadataCreateOpenIDConnectProviderOutput struct {
 
 // String returns the string representation
 func (s CreateOpenIDConnectProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4804,7 +4804,7 @@ type metadataCreatePolicyInput struct {
 
 // String returns the string representation
 func (s CreatePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4826,7 +4826,7 @@ type metadataCreatePolicyOutput struct {
 
 // String returns the string representation
 func (s CreatePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4865,7 +4865,7 @@ type metadataCreatePolicyVersionInput struct {
 
 // String returns the string representation
 func (s CreatePolicyVersionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4887,7 +4887,7 @@ type metadataCreatePolicyVersionOutput struct {
 
 // String returns the string representation
 func (s CreatePolicyVersionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4919,7 +4919,7 @@ type metadataCreateRoleInput struct {
 
 // String returns the string representation
 func (s CreateRoleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4941,7 +4941,7 @@ type metadataCreateRoleOutput struct {
 
 // String returns the string representation
 func (s CreateRoleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4973,7 +4973,7 @@ type metadataCreateSAMLProviderInput struct {
 
 // String returns the string representation
 func (s CreateSAMLProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4995,7 +4995,7 @@ type metadataCreateSAMLProviderOutput struct {
 
 // String returns the string representation
 func (s CreateSAMLProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5024,7 +5024,7 @@ type metadataCreateUserInput struct {
 
 // String returns the string representation
 func (s CreateUserInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5046,7 +5046,7 @@ type metadataCreateUserOutput struct {
 
 // String returns the string representation
 func (s CreateUserOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5076,7 +5076,7 @@ type metadataCreateVirtualMFADeviceInput struct {
 
 // String returns the string representation
 func (s CreateVirtualMFADeviceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5098,7 +5098,7 @@ type metadataCreateVirtualMFADeviceOutput struct {
 
 // String returns the string representation
 func (s CreateVirtualMFADeviceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5123,7 +5123,7 @@ type metadataDeactivateMFADeviceInput struct {
 
 // String returns the string representation
 func (s DeactivateMFADeviceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5141,7 +5141,7 @@ type metadataDeactivateMFADeviceOutput struct {
 
 // String returns the string representation
 func (s DeactivateMFADeviceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5166,7 +5166,7 @@ type metadataDeleteAccessKeyInput struct {
 
 // String returns the string representation
 func (s DeleteAccessKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5184,7 +5184,7 @@ type metadataDeleteAccessKeyOutput struct {
 
 // String returns the string representation
 func (s DeleteAccessKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5205,7 +5205,7 @@ type metadataDeleteAccountAliasInput struct {
 
 // String returns the string representation
 func (s DeleteAccountAliasInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5223,7 +5223,7 @@ type metadataDeleteAccountAliasOutput struct {
 
 // String returns the string representation
 func (s DeleteAccountAliasOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5241,7 +5241,7 @@ type metadataDeleteAccountPasswordPolicyInput struct {
 
 // String returns the string representation
 func (s DeleteAccountPasswordPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5259,7 +5259,7 @@ type metadataDeleteAccountPasswordPolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteAccountPasswordPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5280,7 +5280,7 @@ type metadataDeleteGroupInput struct {
 
 // String returns the string representation
 func (s DeleteGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5298,7 +5298,7 @@ type metadataDeleteGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5323,7 +5323,7 @@ type metadataDeleteGroupPolicyInput struct {
 
 // String returns the string representation
 func (s DeleteGroupPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5341,7 +5341,7 @@ type metadataDeleteGroupPolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteGroupPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5362,7 +5362,7 @@ type metadataDeleteInstanceProfileInput struct {
 
 // String returns the string representation
 func (s DeleteInstanceProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5380,7 +5380,7 @@ type metadataDeleteInstanceProfileOutput struct {
 
 // String returns the string representation
 func (s DeleteInstanceProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5401,7 +5401,7 @@ type metadataDeleteLoginProfileInput struct {
 
 // String returns the string representation
 func (s DeleteLoginProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5419,7 +5419,7 @@ type metadataDeleteLoginProfileOutput struct {
 
 // String returns the string representation
 func (s DeleteLoginProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5442,7 +5442,7 @@ type metadataDeleteOpenIDConnectProviderInput struct {
 
 // String returns the string representation
 func (s DeleteOpenIDConnectProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5460,7 +5460,7 @@ type metadataDeleteOpenIDConnectProviderOutput struct {
 
 // String returns the string representation
 func (s DeleteOpenIDConnectProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5485,7 +5485,7 @@ type metadataDeletePolicyInput struct {
 
 // String returns the string representation
 func (s DeletePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5503,7 +5503,7 @@ type metadataDeletePolicyOutput struct {
 
 // String returns the string representation
 func (s DeletePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5535,7 +5535,7 @@ type metadataDeletePolicyVersionInput struct {
 
 // String returns the string representation
 func (s DeletePolicyVersionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5553,7 +5553,7 @@ type metadataDeletePolicyVersionOutput struct {
 
 // String returns the string representation
 func (s DeletePolicyVersionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5574,7 +5574,7 @@ type metadataDeleteRoleInput struct {
 
 // String returns the string representation
 func (s DeleteRoleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5592,7 +5592,7 @@ type metadataDeleteRoleOutput struct {
 
 // String returns the string representation
 func (s DeleteRoleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5617,7 +5617,7 @@ type metadataDeleteRolePolicyInput struct {
 
 // String returns the string representation
 func (s DeleteRolePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5635,7 +5635,7 @@ type metadataDeleteRolePolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteRolePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5656,7 +5656,7 @@ type metadataDeleteSAMLProviderInput struct {
 
 // String returns the string representation
 func (s DeleteSAMLProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5674,7 +5674,7 @@ type metadataDeleteSAMLProviderOutput struct {
 
 // String returns the string representation
 func (s DeleteSAMLProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5698,7 +5698,7 @@ type metadataDeleteSSHPublicKeyInput struct {
 
 // String returns the string representation
 func (s DeleteSSHPublicKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5716,7 +5716,7 @@ type metadataDeleteSSHPublicKeyOutput struct {
 
 // String returns the string representation
 func (s DeleteSSHPublicKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5737,7 +5737,7 @@ type metadataDeleteServerCertificateInput struct {
 
 // String returns the string representation
 func (s DeleteServerCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5755,7 +5755,7 @@ type metadataDeleteServerCertificateOutput struct {
 
 // String returns the string representation
 func (s DeleteServerCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5779,7 +5779,7 @@ type metadataDeleteSigningCertificateInput struct {
 
 // String returns the string representation
 func (s DeleteSigningCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5797,7 +5797,7 @@ type metadataDeleteSigningCertificateOutput struct {
 
 // String returns the string representation
 func (s DeleteSigningCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5818,7 +5818,7 @@ type metadataDeleteUserInput struct {
 
 // String returns the string representation
 func (s DeleteUserInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5836,7 +5836,7 @@ type metadataDeleteUserOutput struct {
 
 // String returns the string representation
 func (s DeleteUserOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5861,7 +5861,7 @@ type metadataDeleteUserPolicyInput struct {
 
 // String returns the string representation
 func (s DeleteUserPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5879,7 +5879,7 @@ type metadataDeleteUserPolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteUserPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5901,7 +5901,7 @@ type metadataDeleteVirtualMFADeviceInput struct {
 
 // String returns the string representation
 func (s DeleteVirtualMFADeviceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5919,7 +5919,7 @@ type metadataDeleteVirtualMFADeviceOutput struct {
 
 // String returns the string representation
 func (s DeleteVirtualMFADeviceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5947,7 +5947,7 @@ type metadataDetachGroupPolicyInput struct {
 
 // String returns the string representation
 func (s DetachGroupPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5965,7 +5965,7 @@ type metadataDetachGroupPolicyOutput struct {
 
 // String returns the string representation
 func (s DetachGroupPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5993,7 +5993,7 @@ type metadataDetachRolePolicyInput struct {
 
 // String returns the string representation
 func (s DetachRolePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6011,7 +6011,7 @@ type metadataDetachRolePolicyOutput struct {
 
 // String returns the string representation
 func (s DetachRolePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6039,7 +6039,7 @@ type metadataDetachUserPolicyInput struct {
 
 // String returns the string representation
 func (s DetachUserPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6057,7 +6057,7 @@ type metadataDetachUserPolicyOutput struct {
 
 // String returns the string representation
 func (s DetachUserPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6088,7 +6088,7 @@ type metadataEnableMFADeviceInput struct {
 
 // String returns the string representation
 func (s EnableMFADeviceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6106,7 +6106,7 @@ type metadataEnableMFADeviceOutput struct {
 
 // String returns the string representation
 func (s EnableMFADeviceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6124,7 +6124,7 @@ type metadataGenerateCredentialReportInput struct {
 
 // String returns the string representation
 func (s GenerateCredentialReportInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6149,7 +6149,7 @@ type metadataGenerateCredentialReportOutput struct {
 
 // String returns the string representation
 func (s GenerateCredentialReportOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6170,7 +6170,7 @@ type metadataGetAccessKeyLastUsedInput struct {
 
 // String returns the string representation
 func (s GetAccessKeyLastUsedInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6197,7 +6197,7 @@ type metadataGetAccessKeyLastUsedOutput struct {
 
 // String returns the string representation
 func (s GetAccessKeyLastUsedOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6231,7 +6231,7 @@ type metadataGetAccountAuthorizationDetailsInput struct {
 
 // String returns the string representation
 func (s GetAccountAuthorizationDetailsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6271,7 +6271,7 @@ type metadataGetAccountAuthorizationDetailsOutput struct {
 
 // String returns the string representation
 func (s GetAccountAuthorizationDetailsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6289,7 +6289,7 @@ type metadataGetAccountPasswordPolicyInput struct {
 
 // String returns the string representation
 func (s GetAccountPasswordPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6314,7 +6314,7 @@ type metadataGetAccountPasswordPolicyOutput struct {
 
 // String returns the string representation
 func (s GetAccountPasswordPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6332,7 +6332,7 @@ type metadataGetAccountSummaryInput struct {
 
 // String returns the string representation
 func (s GetAccountSummaryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6496,7 +6496,7 @@ type metadataGetAccountSummaryOutput struct {
 
 // String returns the string representation
 func (s GetAccountSummaryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6514,7 +6514,7 @@ type metadataGetCredentialReportInput struct {
 
 // String returns the string representation
 func (s GetCredentialReportInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6543,7 +6543,7 @@ type metadataGetCredentialReportOutput struct {
 
 // String returns the string representation
 func (s GetCredentialReportOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6576,7 +6576,7 @@ type metadataGetGroupInput struct {
 
 // String returns the string representation
 func (s GetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6610,7 +6610,7 @@ type metadataGetGroupOutput struct {
 
 // String returns the string representation
 func (s GetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6634,7 +6634,7 @@ type metadataGetGroupPolicyInput struct {
 
 // String returns the string representation
 func (s GetGroupPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6662,7 +6662,7 @@ type metadataGetGroupPolicyOutput struct {
 
 // String returns the string representation
 func (s GetGroupPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6683,7 +6683,7 @@ type metadataGetInstanceProfileInput struct {
 
 // String returns the string representation
 func (s GetInstanceProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6705,7 +6705,7 @@ type metadataGetInstanceProfileOutput struct {
 
 // String returns the string representation
 func (s GetInstanceProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6726,7 +6726,7 @@ type metadataGetLoginProfileInput struct {
 
 // String returns the string representation
 func (s GetLoginProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6748,7 +6748,7 @@ type metadataGetLoginProfileOutput struct {
 
 // String returns the string representation
 func (s GetLoginProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6771,7 +6771,7 @@ type metadataGetOpenIDConnectProviderInput struct {
 
 // String returns the string representation
 func (s GetOpenIDConnectProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6806,7 +6806,7 @@ type metadataGetOpenIDConnectProviderOutput struct {
 
 // String returns the string representation
 func (s GetOpenIDConnectProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6831,7 +6831,7 @@ type metadataGetPolicyInput struct {
 
 // String returns the string representation
 func (s GetPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6853,7 +6853,7 @@ type metadataGetPolicyOutput struct {
 
 // String returns the string representation
 func (s GetPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6881,7 +6881,7 @@ type metadataGetPolicyVersionInput struct {
 
 // String returns the string representation
 func (s GetPolicyVersionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6907,7 +6907,7 @@ type metadataGetPolicyVersionOutput struct {
 
 // String returns the string representation
 func (s GetPolicyVersionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6928,7 +6928,7 @@ type metadataGetRoleInput struct {
 
 // String returns the string representation
 func (s GetRoleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6950,7 +6950,7 @@ type metadataGetRoleOutput struct {
 
 // String returns the string representation
 func (s GetRoleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6974,7 +6974,7 @@ type metadataGetRolePolicyInput struct {
 
 // String returns the string representation
 func (s GetRolePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7002,7 +7002,7 @@ type metadataGetRolePolicyOutput struct {
 
 // String returns the string representation
 func (s GetRolePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7023,7 +7023,7 @@ type metadataGetSAMLProviderInput struct {
 
 // String returns the string representation
 func (s GetSAMLProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7051,7 +7051,7 @@ type metadataGetSAMLProviderOutput struct {
 
 // String returns the string representation
 func (s GetSAMLProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7080,7 +7080,7 @@ type metadataGetSSHPublicKeyInput struct {
 
 // String returns the string representation
 func (s GetSSHPublicKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7102,7 +7102,7 @@ type metadataGetSSHPublicKeyOutput struct {
 
 // String returns the string representation
 func (s GetSSHPublicKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7123,7 +7123,7 @@ type metadataGetServerCertificateInput struct {
 
 // String returns the string representation
 func (s GetServerCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7145,7 +7145,7 @@ type metadataGetServerCertificateOutput struct {
 
 // String returns the string representation
 func (s GetServerCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7169,7 +7169,7 @@ type metadataGetUserInput struct {
 
 // String returns the string representation
 func (s GetUserInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7191,7 +7191,7 @@ type metadataGetUserOutput struct {
 
 // String returns the string representation
 func (s GetUserOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7215,7 +7215,7 @@ type metadataGetUserPolicyInput struct {
 
 // String returns the string representation
 func (s GetUserPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7243,7 +7243,7 @@ type metadataGetUserPolicyOutput struct {
 
 // String returns the string representation
 func (s GetUserPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7288,7 +7288,7 @@ type metadataGroup struct {
 
 // String returns the string representation
 func (s Group) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7340,7 +7340,7 @@ type metadataGroupDetail struct {
 
 // String returns the string representation
 func (s GroupDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7394,7 +7394,7 @@ type metadataInstanceProfile struct {
 
 // String returns the string representation
 func (s InstanceProfile) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7427,7 +7427,7 @@ type metadataListAccessKeysInput struct {
 
 // String returns the string representation
 func (s ListAccessKeysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7458,7 +7458,7 @@ type metadataListAccessKeysOutput struct {
 
 // String returns the string representation
 func (s ListAccessKeysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7488,7 +7488,7 @@ type metadataListAccountAliasesInput struct {
 
 // String returns the string representation
 func (s ListAccountAliasesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7519,7 +7519,7 @@ type metadataListAccountAliasesOutput struct {
 
 // String returns the string representation
 func (s ListAccountAliasesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7557,7 +7557,7 @@ type metadataListAttachedGroupPoliciesInput struct {
 
 // String returns the string representation
 func (s ListAttachedGroupPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7588,7 +7588,7 @@ type metadataListAttachedGroupPoliciesOutput struct {
 
 // String returns the string representation
 func (s ListAttachedGroupPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7625,7 +7625,7 @@ type metadataListAttachedRolePoliciesInput struct {
 
 // String returns the string representation
 func (s ListAttachedRolePoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7656,7 +7656,7 @@ type metadataListAttachedRolePoliciesOutput struct {
 
 // String returns the string representation
 func (s ListAttachedRolePoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7693,7 +7693,7 @@ type metadataListAttachedUserPoliciesInput struct {
 
 // String returns the string representation
 func (s ListAttachedUserPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7724,7 +7724,7 @@ type metadataListAttachedUserPoliciesOutput struct {
 
 // String returns the string representation
 func (s ListAttachedUserPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7772,7 +7772,7 @@ type metadataListEntitiesForPolicyInput struct {
 
 // String returns the string representation
 func (s ListEntitiesForPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7809,7 +7809,7 @@ type metadataListEntitiesForPolicyOutput struct {
 
 // String returns the string representation
 func (s ListEntitiesForPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7842,7 +7842,7 @@ type metadataListGroupPoliciesInput struct {
 
 // String returns the string representation
 func (s ListGroupPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7873,7 +7873,7 @@ type metadataListGroupPoliciesOutput struct {
 
 // String returns the string representation
 func (s ListGroupPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7906,7 +7906,7 @@ type metadataListGroupsForUserInput struct {
 
 // String returns the string representation
 func (s ListGroupsForUserInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7937,7 +7937,7 @@ type metadataListGroupsForUserOutput struct {
 
 // String returns the string representation
 func (s ListGroupsForUserOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7974,7 +7974,7 @@ type metadataListGroupsInput struct {
 
 // String returns the string representation
 func (s ListGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8005,7 +8005,7 @@ type metadataListGroupsOutput struct {
 
 // String returns the string representation
 func (s ListGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8038,7 +8038,7 @@ type metadataListInstanceProfilesForRoleInput struct {
 
 // String returns the string representation
 func (s ListInstanceProfilesForRoleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8069,7 +8069,7 @@ type metadataListInstanceProfilesForRoleOutput struct {
 
 // String returns the string representation
 func (s ListInstanceProfilesForRoleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8106,7 +8106,7 @@ type metadataListInstanceProfilesInput struct {
 
 // String returns the string representation
 func (s ListInstanceProfilesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8137,7 +8137,7 @@ type metadataListInstanceProfilesOutput struct {
 
 // String returns the string representation
 func (s ListInstanceProfilesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8170,7 +8170,7 @@ type metadataListMFADevicesInput struct {
 
 // String returns the string representation
 func (s ListMFADevicesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8201,7 +8201,7 @@ type metadataListMFADevicesOutput struct {
 
 // String returns the string representation
 func (s ListMFADevicesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8219,7 +8219,7 @@ type metadataListOpenIDConnectProvidersInput struct {
 
 // String returns the string representation
 func (s ListOpenIDConnectProvidersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8241,7 +8241,7 @@ type metadataListOpenIDConnectProvidersOutput struct {
 
 // String returns the string representation
 func (s ListOpenIDConnectProvidersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8291,7 +8291,7 @@ type metadataListPoliciesInput struct {
 
 // String returns the string representation
 func (s ListPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8322,7 +8322,7 @@ type metadataListPoliciesOutput struct {
 
 // String returns the string representation
 func (s ListPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8359,7 +8359,7 @@ type metadataListPolicyVersionsInput struct {
 
 // String returns the string representation
 func (s ListPolicyVersionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8394,7 +8394,7 @@ type metadataListPolicyVersionsOutput struct {
 
 // String returns the string representation
 func (s ListPolicyVersionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8427,7 +8427,7 @@ type metadataListRolePoliciesInput struct {
 
 // String returns the string representation
 func (s ListRolePoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8458,7 +8458,7 @@ type metadataListRolePoliciesOutput struct {
 
 // String returns the string representation
 func (s ListRolePoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8495,7 +8495,7 @@ type metadataListRolesInput struct {
 
 // String returns the string representation
 func (s ListRolesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8526,7 +8526,7 @@ type metadataListRolesOutput struct {
 
 // String returns the string representation
 func (s ListRolesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8544,7 +8544,7 @@ type metadataListSAMLProvidersInput struct {
 
 // String returns the string representation
 func (s ListSAMLProvidersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8566,7 +8566,7 @@ type metadataListSAMLProvidersOutput struct {
 
 // String returns the string representation
 func (s ListSAMLProvidersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8601,7 +8601,7 @@ type metadataListSSHPublicKeysInput struct {
 
 // String returns the string representation
 func (s ListSSHPublicKeysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8632,7 +8632,7 @@ type metadataListSSHPublicKeysOutput struct {
 
 // String returns the string representation
 func (s ListSSHPublicKeysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8669,7 +8669,7 @@ type metadataListServerCertificatesInput struct {
 
 // String returns the string representation
 func (s ListServerCertificatesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8700,7 +8700,7 @@ type metadataListServerCertificatesOutput struct {
 
 // String returns the string representation
 func (s ListServerCertificatesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8733,7 +8733,7 @@ type metadataListSigningCertificatesInput struct {
 
 // String returns the string representation
 func (s ListSigningCertificatesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8764,7 +8764,7 @@ type metadataListSigningCertificatesOutput struct {
 
 // String returns the string representation
 func (s ListSigningCertificatesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8797,7 +8797,7 @@ type metadataListUserPoliciesInput struct {
 
 // String returns the string representation
 func (s ListUserPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8828,7 +8828,7 @@ type metadataListUserPoliciesOutput struct {
 
 // String returns the string representation
 func (s ListUserPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8865,7 +8865,7 @@ type metadataListUsersInput struct {
 
 // String returns the string representation
 func (s ListUsersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8896,7 +8896,7 @@ type metadataListUsersOutput struct {
 
 // String returns the string representation
 func (s ListUsersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8931,7 +8931,7 @@ type metadataListVirtualMFADevicesInput struct {
 
 // String returns the string representation
 func (s ListVirtualMFADevicesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8963,7 +8963,7 @@ type metadataListVirtualMFADevicesOutput struct {
 
 // String returns the string representation
 func (s ListVirtualMFADevicesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8995,7 +8995,7 @@ type metadataLoginProfile struct {
 
 // String returns the string representation
 func (s LoginProfile) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9026,7 +9026,7 @@ type metadataMFADevice struct {
 
 // String returns the string representation
 func (s MFADevice) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9110,7 +9110,7 @@ type metadataManagedPolicyDetail struct {
 
 // String returns the string representation
 func (s ManagedPolicyDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9136,7 +9136,7 @@ type metadataOpenIDConnectProviderListEntry struct {
 
 // String returns the string representation
 func (s OpenIDConnectProviderListEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9191,7 +9191,7 @@ type metadataPasswordPolicy struct {
 
 // String returns the string representation
 func (s PasswordPolicy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9268,7 +9268,7 @@ type metadataPolicy struct {
 
 // String returns the string representation
 func (s Policy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9296,7 +9296,7 @@ type metadataPolicyDetail struct {
 
 // String returns the string representation
 func (s PolicyDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9325,7 +9325,7 @@ type metadataPolicyGroup struct {
 
 // String returns the string representation
 func (s PolicyGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9354,7 +9354,7 @@ type metadataPolicyRole struct {
 
 // String returns the string representation
 func (s PolicyRole) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9383,7 +9383,7 @@ type metadataPolicyUser struct {
 
 // String returns the string representation
 func (s PolicyUser) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9430,7 +9430,7 @@ type metadataPolicyVersion struct {
 
 // String returns the string representation
 func (s PolicyVersion) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9457,7 +9457,7 @@ type metadataPutGroupPolicyInput struct {
 
 // String returns the string representation
 func (s PutGroupPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9475,7 +9475,7 @@ type metadataPutGroupPolicyOutput struct {
 
 // String returns the string representation
 func (s PutGroupPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9502,7 +9502,7 @@ type metadataPutRolePolicyInput struct {
 
 // String returns the string representation
 func (s PutRolePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9520,7 +9520,7 @@ type metadataPutRolePolicyOutput struct {
 
 // String returns the string representation
 func (s PutRolePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9547,7 +9547,7 @@ type metadataPutUserPolicyInput struct {
 
 // String returns the string representation
 func (s PutUserPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9565,7 +9565,7 @@ type metadataPutUserPolicyOutput struct {
 
 // String returns the string representation
 func (s PutUserPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9592,7 +9592,7 @@ type metadataRemoveClientIDFromOpenIDConnectProviderInput struct {
 
 // String returns the string representation
 func (s RemoveClientIDFromOpenIDConnectProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9610,7 +9610,7 @@ type metadataRemoveClientIDFromOpenIDConnectProviderOutput struct {
 
 // String returns the string representation
 func (s RemoveClientIDFromOpenIDConnectProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9634,7 +9634,7 @@ type metadataRemoveRoleFromInstanceProfileInput struct {
 
 // String returns the string representation
 func (s RemoveRoleFromInstanceProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9652,7 +9652,7 @@ type metadataRemoveRoleFromInstanceProfileOutput struct {
 
 // String returns the string representation
 func (s RemoveRoleFromInstanceProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9676,7 +9676,7 @@ type metadataRemoveUserFromGroupInput struct {
 
 // String returns the string representation
 func (s RemoveUserFromGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9694,7 +9694,7 @@ type metadataRemoveUserFromGroupOutput struct {
 
 // String returns the string representation
 func (s RemoveUserFromGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9724,7 +9724,7 @@ type metadataResyncMFADeviceInput struct {
 
 // String returns the string representation
 func (s ResyncMFADeviceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9742,7 +9742,7 @@ type metadataResyncMFADeviceOutput struct {
 
 // String returns the string representation
 func (s ResyncMFADeviceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9794,7 +9794,7 @@ type metadataRole struct {
 
 // String returns the string representation
 func (s Role) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9854,7 +9854,7 @@ type metadataRoleDetail struct {
 
 // String returns the string representation
 func (s RoleDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9882,7 +9882,7 @@ type metadataSAMLProviderListEntry struct {
 
 // String returns the string representation
 func (s SAMLProviderListEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9924,7 +9924,7 @@ type metadataSSHPublicKey struct {
 
 // String returns the string representation
 func (s SSHPublicKey) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9959,7 +9959,7 @@ type metadataSSHPublicKeyMetadata struct {
 
 // String returns the string representation
 func (s SSHPublicKeyMetadata) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -9991,7 +9991,7 @@ type metadataServerCertificate struct {
 
 // String returns the string representation
 func (s ServerCertificate) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10039,7 +10039,7 @@ type metadataServerCertificateMetadata struct {
 
 // String returns the string representation
 func (s ServerCertificateMetadata) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10071,7 +10071,7 @@ type metadataSetDefaultPolicyVersionInput struct {
 
 // String returns the string representation
 func (s SetDefaultPolicyVersionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10089,7 +10089,7 @@ type metadataSetDefaultPolicyVersionOutput struct {
 
 // String returns the string representation
 func (s SetDefaultPolicyVersionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10127,7 +10127,7 @@ type metadataSigningCertificate struct {
 
 // String returns the string representation
 func (s SigningCertificate) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10156,7 +10156,7 @@ type metadataUpdateAccessKeyInput struct {
 
 // String returns the string representation
 func (s UpdateAccessKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10174,7 +10174,7 @@ type metadataUpdateAccessKeyOutput struct {
 
 // String returns the string representation
 func (s UpdateAccessKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10249,7 +10249,7 @@ type metadataUpdateAccountPasswordPolicyInput struct {
 
 // String returns the string representation
 func (s UpdateAccountPasswordPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10267,7 +10267,7 @@ type metadataUpdateAccountPasswordPolicyOutput struct {
 
 // String returns the string representation
 func (s UpdateAccountPasswordPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10291,7 +10291,7 @@ type metadataUpdateAssumeRolePolicyInput struct {
 
 // String returns the string representation
 func (s UpdateAssumeRolePolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10309,7 +10309,7 @@ type metadataUpdateAssumeRolePolicyOutput struct {
 
 // String returns the string representation
 func (s UpdateAssumeRolePolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10337,7 +10337,7 @@ type metadataUpdateGroupInput struct {
 
 // String returns the string representation
 func (s UpdateGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10355,7 +10355,7 @@ type metadataUpdateGroupOutput struct {
 
 // String returns the string representation
 func (s UpdateGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10382,7 +10382,7 @@ type metadataUpdateLoginProfileInput struct {
 
 // String returns the string representation
 func (s UpdateLoginProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10400,7 +10400,7 @@ type metadataUpdateLoginProfileOutput struct {
 
 // String returns the string representation
 func (s UpdateLoginProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10427,7 +10427,7 @@ type metadataUpdateOpenIDConnectProviderThumbprintInput struct {
 
 // String returns the string representation
 func (s UpdateOpenIDConnectProviderThumbprintInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10445,7 +10445,7 @@ type metadataUpdateOpenIDConnectProviderThumbprintOutput struct {
 
 // String returns the string representation
 func (s UpdateOpenIDConnectProviderThumbprintOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10473,7 +10473,7 @@ type metadataUpdateSAMLProviderInput struct {
 
 // String returns the string representation
 func (s UpdateSAMLProviderInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10495,7 +10495,7 @@ type metadataUpdateSAMLProviderOutput struct {
 
 // String returns the string representation
 func (s UpdateSAMLProviderOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10524,7 +10524,7 @@ type metadataUpdateSSHPublicKeyInput struct {
 
 // String returns the string representation
 func (s UpdateSSHPublicKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10542,7 +10542,7 @@ type metadataUpdateSSHPublicKeyOutput struct {
 
 // String returns the string representation
 func (s UpdateSSHPublicKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10572,7 +10572,7 @@ type metadataUpdateServerCertificateInput struct {
 
 // String returns the string representation
 func (s UpdateServerCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10590,7 +10590,7 @@ type metadataUpdateServerCertificateOutput struct {
 
 // String returns the string representation
 func (s UpdateServerCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10619,7 +10619,7 @@ type metadataUpdateSigningCertificateInput struct {
 
 // String returns the string representation
 func (s UpdateSigningCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10637,7 +10637,7 @@ type metadataUpdateSigningCertificateOutput struct {
 
 // String returns the string representation
 func (s UpdateSigningCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10667,7 +10667,7 @@ type metadataUpdateUserInput struct {
 
 // String returns the string representation
 func (s UpdateUserInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10685,7 +10685,7 @@ type metadataUpdateUserOutput struct {
 
 // String returns the string representation
 func (s UpdateUserOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10710,7 +10710,7 @@ type metadataUploadSSHPublicKeyInput struct {
 
 // String returns the string representation
 func (s UploadSSHPublicKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10732,7 +10732,7 @@ type metadataUploadSSHPublicKeyOutput struct {
 
 // String returns the string representation
 func (s UploadSSHPublicKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10777,7 +10777,7 @@ type metadataUploadServerCertificateInput struct {
 
 // String returns the string representation
 func (s UploadServerCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10800,7 +10800,7 @@ type metadataUploadServerCertificateOutput struct {
 
 // String returns the string representation
 func (s UploadServerCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10824,7 +10824,7 @@ type metadataUploadSigningCertificateInput struct {
 
 // String returns the string representation
 func (s UploadSigningCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10846,7 +10846,7 @@ type metadataUploadSigningCertificateOutput struct {
 
 // String returns the string representation
 func (s UploadSigningCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10913,7 +10913,7 @@ type metadataUser struct {
 
 // String returns the string representation
 func (s User) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -10969,7 +10969,7 @@ type metadataUserDetail struct {
 
 // String returns the string representation
 func (s UserDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -11015,7 +11015,7 @@ type metadataVirtualMFADevice struct {
 
 // String returns the string representation
 func (s VirtualMFADevice) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/iam/examples_test.go
+++ b/service/iam/examples_test.go
@@ -41,7 +41,7 @@ func ExampleIAM_AddClientIDToOpenIDConnectProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_AddRoleToInstanceProfile() {
@@ -69,7 +69,7 @@ func ExampleIAM_AddRoleToInstanceProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_AddUserToGroup() {
@@ -97,7 +97,7 @@ func ExampleIAM_AddUserToGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_AttachGroupPolicy() {
@@ -125,7 +125,7 @@ func ExampleIAM_AttachGroupPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_AttachRolePolicy() {
@@ -153,7 +153,7 @@ func ExampleIAM_AttachRolePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_AttachUserPolicy() {
@@ -181,7 +181,7 @@ func ExampleIAM_AttachUserPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ChangePassword() {
@@ -209,7 +209,7 @@ func ExampleIAM_ChangePassword() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateAccessKey() {
@@ -236,7 +236,7 @@ func ExampleIAM_CreateAccessKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateAccountAlias() {
@@ -263,7 +263,7 @@ func ExampleIAM_CreateAccountAlias() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateGroup() {
@@ -291,7 +291,7 @@ func ExampleIAM_CreateGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateInstanceProfile() {
@@ -319,7 +319,7 @@ func ExampleIAM_CreateInstanceProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateLoginProfile() {
@@ -328,7 +328,7 @@ func ExampleIAM_CreateLoginProfile() {
 	params := &iam.CreateLoginProfileInput{
 		Password:              aws.String("passwordType"), // Required
 		UserName:              aws.String("userNameType"), // Required
-		PasswordResetRequired: aws.Boolean(true),
+		PasswordResetRequired: aws.Bool(true),
 	}
 	resp, err := svc.CreateLoginProfile(params)
 
@@ -348,7 +348,7 @@ func ExampleIAM_CreateLoginProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateOpenIDConnectProvider() {
@@ -383,7 +383,7 @@ func ExampleIAM_CreateOpenIDConnectProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreatePolicy() {
@@ -413,7 +413,7 @@ func ExampleIAM_CreatePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreatePolicyVersion() {
@@ -422,7 +422,7 @@ func ExampleIAM_CreatePolicyVersion() {
 	params := &iam.CreatePolicyVersionInput{
 		PolicyARN:      aws.String("arnType"),            // Required
 		PolicyDocument: aws.String("policyDocumentType"), // Required
-		SetAsDefault:   aws.Boolean(true),
+		SetAsDefault:   aws.Bool(true),
 	}
 	resp, err := svc.CreatePolicyVersion(params)
 
@@ -442,7 +442,7 @@ func ExampleIAM_CreatePolicyVersion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateRole() {
@@ -471,7 +471,7 @@ func ExampleIAM_CreateRole() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateSAMLProvider() {
@@ -499,7 +499,7 @@ func ExampleIAM_CreateSAMLProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateUser() {
@@ -527,7 +527,7 @@ func ExampleIAM_CreateUser() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_CreateVirtualMFADevice() {
@@ -555,7 +555,7 @@ func ExampleIAM_CreateVirtualMFADevice() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeactivateMFADevice() {
@@ -583,7 +583,7 @@ func ExampleIAM_DeactivateMFADevice() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteAccessKey() {
@@ -611,7 +611,7 @@ func ExampleIAM_DeleteAccessKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteAccountAlias() {
@@ -638,7 +638,7 @@ func ExampleIAM_DeleteAccountAlias() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteAccountPasswordPolicy() {
@@ -663,7 +663,7 @@ func ExampleIAM_DeleteAccountPasswordPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteGroup() {
@@ -690,7 +690,7 @@ func ExampleIAM_DeleteGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteGroupPolicy() {
@@ -718,7 +718,7 @@ func ExampleIAM_DeleteGroupPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteInstanceProfile() {
@@ -745,7 +745,7 @@ func ExampleIAM_DeleteInstanceProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteLoginProfile() {
@@ -772,7 +772,7 @@ func ExampleIAM_DeleteLoginProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteOpenIDConnectProvider() {
@@ -799,7 +799,7 @@ func ExampleIAM_DeleteOpenIDConnectProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeletePolicy() {
@@ -826,7 +826,7 @@ func ExampleIAM_DeletePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeletePolicyVersion() {
@@ -854,7 +854,7 @@ func ExampleIAM_DeletePolicyVersion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteRole() {
@@ -881,7 +881,7 @@ func ExampleIAM_DeleteRole() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteRolePolicy() {
@@ -909,7 +909,7 @@ func ExampleIAM_DeleteRolePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteSAMLProvider() {
@@ -936,7 +936,7 @@ func ExampleIAM_DeleteSAMLProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteSSHPublicKey() {
@@ -964,7 +964,7 @@ func ExampleIAM_DeleteSSHPublicKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteServerCertificate() {
@@ -991,7 +991,7 @@ func ExampleIAM_DeleteServerCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteSigningCertificate() {
@@ -1019,7 +1019,7 @@ func ExampleIAM_DeleteSigningCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteUser() {
@@ -1046,7 +1046,7 @@ func ExampleIAM_DeleteUser() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteUserPolicy() {
@@ -1074,7 +1074,7 @@ func ExampleIAM_DeleteUserPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DeleteVirtualMFADevice() {
@@ -1101,7 +1101,7 @@ func ExampleIAM_DeleteVirtualMFADevice() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DetachGroupPolicy() {
@@ -1129,7 +1129,7 @@ func ExampleIAM_DetachGroupPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DetachRolePolicy() {
@@ -1157,7 +1157,7 @@ func ExampleIAM_DetachRolePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_DetachUserPolicy() {
@@ -1185,7 +1185,7 @@ func ExampleIAM_DetachUserPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_EnableMFADevice() {
@@ -1215,7 +1215,7 @@ func ExampleIAM_EnableMFADevice() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GenerateCredentialReport() {
@@ -1240,7 +1240,7 @@ func ExampleIAM_GenerateCredentialReport() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetAccessKeyLastUsed() {
@@ -1267,7 +1267,7 @@ func ExampleIAM_GetAccessKeyLastUsed() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetAccountAuthorizationDetails() {
@@ -1279,7 +1279,7 @@ func ExampleIAM_GetAccountAuthorizationDetails() {
 			// More values...
 		},
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.GetAccountAuthorizationDetails(params)
 
@@ -1299,7 +1299,7 @@ func ExampleIAM_GetAccountAuthorizationDetails() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetAccountPasswordPolicy() {
@@ -1324,7 +1324,7 @@ func ExampleIAM_GetAccountPasswordPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetAccountSummary() {
@@ -1349,7 +1349,7 @@ func ExampleIAM_GetAccountSummary() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetCredentialReport() {
@@ -1374,7 +1374,7 @@ func ExampleIAM_GetCredentialReport() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetGroup() {
@@ -1383,7 +1383,7 @@ func ExampleIAM_GetGroup() {
 	params := &iam.GetGroupInput{
 		GroupName: aws.String("groupNameType"), // Required
 		Marker:    aws.String("markerType"),
-		MaxItems:  aws.Long(1),
+		MaxItems:  aws.Int64(1),
 	}
 	resp, err := svc.GetGroup(params)
 
@@ -1403,7 +1403,7 @@ func ExampleIAM_GetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetGroupPolicy() {
@@ -1431,7 +1431,7 @@ func ExampleIAM_GetGroupPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetInstanceProfile() {
@@ -1458,7 +1458,7 @@ func ExampleIAM_GetInstanceProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetLoginProfile() {
@@ -1485,7 +1485,7 @@ func ExampleIAM_GetLoginProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetOpenIDConnectProvider() {
@@ -1512,7 +1512,7 @@ func ExampleIAM_GetOpenIDConnectProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetPolicy() {
@@ -1539,7 +1539,7 @@ func ExampleIAM_GetPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetPolicyVersion() {
@@ -1567,7 +1567,7 @@ func ExampleIAM_GetPolicyVersion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetRole() {
@@ -1594,7 +1594,7 @@ func ExampleIAM_GetRole() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetRolePolicy() {
@@ -1622,7 +1622,7 @@ func ExampleIAM_GetRolePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetSAMLProvider() {
@@ -1649,7 +1649,7 @@ func ExampleIAM_GetSAMLProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetSSHPublicKey() {
@@ -1678,7 +1678,7 @@ func ExampleIAM_GetSSHPublicKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetServerCertificate() {
@@ -1705,7 +1705,7 @@ func ExampleIAM_GetServerCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetUser() {
@@ -1732,7 +1732,7 @@ func ExampleIAM_GetUser() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_GetUserPolicy() {
@@ -1760,7 +1760,7 @@ func ExampleIAM_GetUserPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListAccessKeys() {
@@ -1768,7 +1768,7 @@ func ExampleIAM_ListAccessKeys() {
 
 	params := &iam.ListAccessKeysInput{
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 		UserName: aws.String("existingUserNameType"),
 	}
 	resp, err := svc.ListAccessKeys(params)
@@ -1789,7 +1789,7 @@ func ExampleIAM_ListAccessKeys() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListAccountAliases() {
@@ -1797,7 +1797,7 @@ func ExampleIAM_ListAccountAliases() {
 
 	params := &iam.ListAccountAliasesInput{
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListAccountAliases(params)
 
@@ -1817,7 +1817,7 @@ func ExampleIAM_ListAccountAliases() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListAttachedGroupPolicies() {
@@ -1826,7 +1826,7 @@ func ExampleIAM_ListAttachedGroupPolicies() {
 	params := &iam.ListAttachedGroupPoliciesInput{
 		GroupName:  aws.String("groupNameType"), // Required
 		Marker:     aws.String("markerType"),
-		MaxItems:   aws.Long(1),
+		MaxItems:   aws.Int64(1),
 		PathPrefix: aws.String("policyPathType"),
 	}
 	resp, err := svc.ListAttachedGroupPolicies(params)
@@ -1847,7 +1847,7 @@ func ExampleIAM_ListAttachedGroupPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListAttachedRolePolicies() {
@@ -1856,7 +1856,7 @@ func ExampleIAM_ListAttachedRolePolicies() {
 	params := &iam.ListAttachedRolePoliciesInput{
 		RoleName:   aws.String("roleNameType"), // Required
 		Marker:     aws.String("markerType"),
-		MaxItems:   aws.Long(1),
+		MaxItems:   aws.Int64(1),
 		PathPrefix: aws.String("policyPathType"),
 	}
 	resp, err := svc.ListAttachedRolePolicies(params)
@@ -1877,7 +1877,7 @@ func ExampleIAM_ListAttachedRolePolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListAttachedUserPolicies() {
@@ -1886,7 +1886,7 @@ func ExampleIAM_ListAttachedUserPolicies() {
 	params := &iam.ListAttachedUserPoliciesInput{
 		UserName:   aws.String("userNameType"), // Required
 		Marker:     aws.String("markerType"),
-		MaxItems:   aws.Long(1),
+		MaxItems:   aws.Int64(1),
 		PathPrefix: aws.String("policyPathType"),
 	}
 	resp, err := svc.ListAttachedUserPolicies(params)
@@ -1907,7 +1907,7 @@ func ExampleIAM_ListAttachedUserPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListEntitiesForPolicy() {
@@ -1917,7 +1917,7 @@ func ExampleIAM_ListEntitiesForPolicy() {
 		PolicyARN:    aws.String("arnType"), // Required
 		EntityFilter: aws.String("EntityType"),
 		Marker:       aws.String("markerType"),
-		MaxItems:     aws.Long(1),
+		MaxItems:     aws.Int64(1),
 		PathPrefix:   aws.String("pathType"),
 	}
 	resp, err := svc.ListEntitiesForPolicy(params)
@@ -1938,7 +1938,7 @@ func ExampleIAM_ListEntitiesForPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListGroupPolicies() {
@@ -1947,7 +1947,7 @@ func ExampleIAM_ListGroupPolicies() {
 	params := &iam.ListGroupPoliciesInput{
 		GroupName: aws.String("groupNameType"), // Required
 		Marker:    aws.String("markerType"),
-		MaxItems:  aws.Long(1),
+		MaxItems:  aws.Int64(1),
 	}
 	resp, err := svc.ListGroupPolicies(params)
 
@@ -1967,7 +1967,7 @@ func ExampleIAM_ListGroupPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListGroups() {
@@ -1975,7 +1975,7 @@ func ExampleIAM_ListGroups() {
 
 	params := &iam.ListGroupsInput{
 		Marker:     aws.String("markerType"),
-		MaxItems:   aws.Long(1),
+		MaxItems:   aws.Int64(1),
 		PathPrefix: aws.String("pathPrefixType"),
 	}
 	resp, err := svc.ListGroups(params)
@@ -1996,7 +1996,7 @@ func ExampleIAM_ListGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListGroupsForUser() {
@@ -2005,7 +2005,7 @@ func ExampleIAM_ListGroupsForUser() {
 	params := &iam.ListGroupsForUserInput{
 		UserName: aws.String("existingUserNameType"), // Required
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListGroupsForUser(params)
 
@@ -2025,7 +2025,7 @@ func ExampleIAM_ListGroupsForUser() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListInstanceProfiles() {
@@ -2033,7 +2033,7 @@ func ExampleIAM_ListInstanceProfiles() {
 
 	params := &iam.ListInstanceProfilesInput{
 		Marker:     aws.String("markerType"),
-		MaxItems:   aws.Long(1),
+		MaxItems:   aws.Int64(1),
 		PathPrefix: aws.String("pathPrefixType"),
 	}
 	resp, err := svc.ListInstanceProfiles(params)
@@ -2054,7 +2054,7 @@ func ExampleIAM_ListInstanceProfiles() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListInstanceProfilesForRole() {
@@ -2063,7 +2063,7 @@ func ExampleIAM_ListInstanceProfilesForRole() {
 	params := &iam.ListInstanceProfilesForRoleInput{
 		RoleName: aws.String("roleNameType"), // Required
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListInstanceProfilesForRole(params)
 
@@ -2083,7 +2083,7 @@ func ExampleIAM_ListInstanceProfilesForRole() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListMFADevices() {
@@ -2091,7 +2091,7 @@ func ExampleIAM_ListMFADevices() {
 
 	params := &iam.ListMFADevicesInput{
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 		UserName: aws.String("existingUserNameType"),
 	}
 	resp, err := svc.ListMFADevices(params)
@@ -2112,7 +2112,7 @@ func ExampleIAM_ListMFADevices() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListOpenIDConnectProviders() {
@@ -2137,7 +2137,7 @@ func ExampleIAM_ListOpenIDConnectProviders() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListPolicies() {
@@ -2145,8 +2145,8 @@ func ExampleIAM_ListPolicies() {
 
 	params := &iam.ListPoliciesInput{
 		Marker:       aws.String("markerType"),
-		MaxItems:     aws.Long(1),
-		OnlyAttached: aws.Boolean(true),
+		MaxItems:     aws.Int64(1),
+		OnlyAttached: aws.Bool(true),
 		PathPrefix:   aws.String("policyPathType"),
 		Scope:        aws.String("policyScopeType"),
 	}
@@ -2168,7 +2168,7 @@ func ExampleIAM_ListPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListPolicyVersions() {
@@ -2177,7 +2177,7 @@ func ExampleIAM_ListPolicyVersions() {
 	params := &iam.ListPolicyVersionsInput{
 		PolicyARN: aws.String("arnType"), // Required
 		Marker:    aws.String("markerType"),
-		MaxItems:  aws.Long(1),
+		MaxItems:  aws.Int64(1),
 	}
 	resp, err := svc.ListPolicyVersions(params)
 
@@ -2197,7 +2197,7 @@ func ExampleIAM_ListPolicyVersions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListRolePolicies() {
@@ -2206,7 +2206,7 @@ func ExampleIAM_ListRolePolicies() {
 	params := &iam.ListRolePoliciesInput{
 		RoleName: aws.String("roleNameType"), // Required
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListRolePolicies(params)
 
@@ -2226,7 +2226,7 @@ func ExampleIAM_ListRolePolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListRoles() {
@@ -2234,7 +2234,7 @@ func ExampleIAM_ListRoles() {
 
 	params := &iam.ListRolesInput{
 		Marker:     aws.String("markerType"),
-		MaxItems:   aws.Long(1),
+		MaxItems:   aws.Int64(1),
 		PathPrefix: aws.String("pathPrefixType"),
 	}
 	resp, err := svc.ListRoles(params)
@@ -2255,7 +2255,7 @@ func ExampleIAM_ListRoles() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListSAMLProviders() {
@@ -2280,7 +2280,7 @@ func ExampleIAM_ListSAMLProviders() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListSSHPublicKeys() {
@@ -2288,7 +2288,7 @@ func ExampleIAM_ListSSHPublicKeys() {
 
 	params := &iam.ListSSHPublicKeysInput{
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 		UserName: aws.String("userNameType"),
 	}
 	resp, err := svc.ListSSHPublicKeys(params)
@@ -2309,7 +2309,7 @@ func ExampleIAM_ListSSHPublicKeys() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListServerCertificates() {
@@ -2317,7 +2317,7 @@ func ExampleIAM_ListServerCertificates() {
 
 	params := &iam.ListServerCertificatesInput{
 		Marker:     aws.String("markerType"),
-		MaxItems:   aws.Long(1),
+		MaxItems:   aws.Int64(1),
 		PathPrefix: aws.String("pathPrefixType"),
 	}
 	resp, err := svc.ListServerCertificates(params)
@@ -2338,7 +2338,7 @@ func ExampleIAM_ListServerCertificates() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListSigningCertificates() {
@@ -2346,7 +2346,7 @@ func ExampleIAM_ListSigningCertificates() {
 
 	params := &iam.ListSigningCertificatesInput{
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 		UserName: aws.String("existingUserNameType"),
 	}
 	resp, err := svc.ListSigningCertificates(params)
@@ -2367,7 +2367,7 @@ func ExampleIAM_ListSigningCertificates() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListUserPolicies() {
@@ -2376,7 +2376,7 @@ func ExampleIAM_ListUserPolicies() {
 	params := &iam.ListUserPoliciesInput{
 		UserName: aws.String("existingUserNameType"), // Required
 		Marker:   aws.String("markerType"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListUserPolicies(params)
 
@@ -2396,7 +2396,7 @@ func ExampleIAM_ListUserPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListUsers() {
@@ -2404,7 +2404,7 @@ func ExampleIAM_ListUsers() {
 
 	params := &iam.ListUsersInput{
 		Marker:     aws.String("markerType"),
-		MaxItems:   aws.Long(1),
+		MaxItems:   aws.Int64(1),
 		PathPrefix: aws.String("pathPrefixType"),
 	}
 	resp, err := svc.ListUsers(params)
@@ -2425,7 +2425,7 @@ func ExampleIAM_ListUsers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ListVirtualMFADevices() {
@@ -2434,7 +2434,7 @@ func ExampleIAM_ListVirtualMFADevices() {
 	params := &iam.ListVirtualMFADevicesInput{
 		AssignmentStatus: aws.String("assignmentStatusType"),
 		Marker:           aws.String("markerType"),
-		MaxItems:         aws.Long(1),
+		MaxItems:         aws.Int64(1),
 	}
 	resp, err := svc.ListVirtualMFADevices(params)
 
@@ -2454,7 +2454,7 @@ func ExampleIAM_ListVirtualMFADevices() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_PutGroupPolicy() {
@@ -2483,7 +2483,7 @@ func ExampleIAM_PutGroupPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_PutRolePolicy() {
@@ -2512,7 +2512,7 @@ func ExampleIAM_PutRolePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_PutUserPolicy() {
@@ -2541,7 +2541,7 @@ func ExampleIAM_PutUserPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_RemoveClientIDFromOpenIDConnectProvider() {
@@ -2569,7 +2569,7 @@ func ExampleIAM_RemoveClientIDFromOpenIDConnectProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_RemoveRoleFromInstanceProfile() {
@@ -2597,7 +2597,7 @@ func ExampleIAM_RemoveRoleFromInstanceProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_RemoveUserFromGroup() {
@@ -2625,7 +2625,7 @@ func ExampleIAM_RemoveUserFromGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_ResyncMFADevice() {
@@ -2655,7 +2655,7 @@ func ExampleIAM_ResyncMFADevice() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_SetDefaultPolicyVersion() {
@@ -2683,7 +2683,7 @@ func ExampleIAM_SetDefaultPolicyVersion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateAccessKey() {
@@ -2712,22 +2712,22 @@ func ExampleIAM_UpdateAccessKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateAccountPasswordPolicy() {
 	svc := iam.New(nil)
 
 	params := &iam.UpdateAccountPasswordPolicyInput{
-		AllowUsersToChangePassword: aws.Boolean(true),
-		HardExpiry:                 aws.Boolean(true),
-		MaxPasswordAge:             aws.Long(1),
-		MinimumPasswordLength:      aws.Long(1),
-		PasswordReusePrevention:    aws.Long(1),
-		RequireLowercaseCharacters: aws.Boolean(true),
-		RequireNumbers:             aws.Boolean(true),
-		RequireSymbols:             aws.Boolean(true),
-		RequireUppercaseCharacters: aws.Boolean(true),
+		AllowUsersToChangePassword: aws.Bool(true),
+		HardExpiry:                 aws.Bool(true),
+		MaxPasswordAge:             aws.Int64(1),
+		MinimumPasswordLength:      aws.Int64(1),
+		PasswordReusePrevention:    aws.Int64(1),
+		RequireLowercaseCharacters: aws.Bool(true),
+		RequireNumbers:             aws.Bool(true),
+		RequireSymbols:             aws.Bool(true),
+		RequireUppercaseCharacters: aws.Bool(true),
 	}
 	resp, err := svc.UpdateAccountPasswordPolicy(params)
 
@@ -2747,7 +2747,7 @@ func ExampleIAM_UpdateAccountPasswordPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateAssumeRolePolicy() {
@@ -2775,7 +2775,7 @@ func ExampleIAM_UpdateAssumeRolePolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateGroup() {
@@ -2804,7 +2804,7 @@ func ExampleIAM_UpdateGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateLoginProfile() {
@@ -2813,7 +2813,7 @@ func ExampleIAM_UpdateLoginProfile() {
 	params := &iam.UpdateLoginProfileInput{
 		UserName:              aws.String("userNameType"), // Required
 		Password:              aws.String("passwordType"),
-		PasswordResetRequired: aws.Boolean(true),
+		PasswordResetRequired: aws.Bool(true),
 	}
 	resp, err := svc.UpdateLoginProfile(params)
 
@@ -2833,7 +2833,7 @@ func ExampleIAM_UpdateLoginProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateOpenIDConnectProviderThumbprint() {
@@ -2864,7 +2864,7 @@ func ExampleIAM_UpdateOpenIDConnectProviderThumbprint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateSAMLProvider() {
@@ -2892,7 +2892,7 @@ func ExampleIAM_UpdateSAMLProvider() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateSSHPublicKey() {
@@ -2921,7 +2921,7 @@ func ExampleIAM_UpdateSSHPublicKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateServerCertificate() {
@@ -2950,7 +2950,7 @@ func ExampleIAM_UpdateServerCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateSigningCertificate() {
@@ -2979,7 +2979,7 @@ func ExampleIAM_UpdateSigningCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UpdateUser() {
@@ -3008,7 +3008,7 @@ func ExampleIAM_UpdateUser() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UploadSSHPublicKey() {
@@ -3036,7 +3036,7 @@ func ExampleIAM_UploadSSHPublicKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UploadServerCertificate() {
@@ -3067,7 +3067,7 @@ func ExampleIAM_UploadServerCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleIAM_UploadSigningCertificate() {
@@ -3095,5 +3095,5 @@ func ExampleIAM_UploadSigningCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -746,7 +746,7 @@ type metadataAddTagsToStreamInput struct {
 
 // String returns the string representation
 func (s AddTagsToStreamInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -764,7 +764,7 @@ type metadataAddTagsToStreamOutput struct {
 
 // String returns the string representation
 func (s AddTagsToStreamOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -797,7 +797,7 @@ type metadataCreateStreamInput struct {
 
 // String returns the string representation
 func (s CreateStreamInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -815,7 +815,7 @@ type metadataCreateStreamOutput struct {
 
 // String returns the string representation
 func (s CreateStreamOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -837,7 +837,7 @@ type metadataDeleteStreamInput struct {
 
 // String returns the string representation
 func (s DeleteStreamInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -855,7 +855,7 @@ type metadataDeleteStreamOutput struct {
 
 // String returns the string representation
 func (s DeleteStreamOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -883,7 +883,7 @@ type metadataDescribeStreamInput struct {
 
 // String returns the string representation
 func (s DescribeStreamInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -906,7 +906,7 @@ type metadataDescribeStreamOutput struct {
 
 // String returns the string representation
 func (s DescribeStreamOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -934,7 +934,7 @@ type metadataGetRecordsInput struct {
 
 // String returns the string representation
 func (s GetRecordsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -967,7 +967,7 @@ type metadataGetRecordsOutput struct {
 
 // String returns the string representation
 func (s GetRecordsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1010,7 +1010,7 @@ type metadataGetShardIteratorInput struct {
 
 // String returns the string representation
 func (s GetShardIteratorInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1034,7 +1034,7 @@ type metadataGetShardIteratorOutput struct {
 
 // String returns the string representation
 func (s GetShardIteratorOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1060,7 +1060,7 @@ type metadataHashKeyRange struct {
 
 // String returns the string representation
 func (s HashKeyRange) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1085,7 +1085,7 @@ type metadataListStreamsInput struct {
 
 // String returns the string representation
 func (s ListStreamsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1111,7 +1111,7 @@ type metadataListStreamsOutput struct {
 
 // String returns the string representation
 func (s ListStreamsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1142,7 +1142,7 @@ type metadataListTagsForStreamInput struct {
 
 // String returns the string representation
 func (s ListTagsForStreamInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1169,7 +1169,7 @@ type metadataListTagsForStreamOutput struct {
 
 // String returns the string representation
 func (s ListTagsForStreamOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1197,7 +1197,7 @@ type metadataMergeShardsInput struct {
 
 // String returns the string representation
 func (s MergeShardsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1215,7 +1215,7 @@ type metadataMergeShardsOutput struct {
 
 // String returns the string representation
 func (s MergeShardsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1263,7 +1263,7 @@ type metadataPutRecordInput struct {
 
 // String returns the string representation
 func (s PutRecordInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1291,7 +1291,7 @@ type metadataPutRecordOutput struct {
 
 // String returns the string representation
 func (s PutRecordOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1316,7 +1316,7 @@ type metadataPutRecordsInput struct {
 
 // String returns the string representation
 func (s PutRecordsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1345,7 +1345,7 @@ type metadataPutRecordsOutput struct {
 
 // String returns the string representation
 func (s PutRecordsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1383,7 +1383,7 @@ type metadataPutRecordsRequestEntry struct {
 
 // String returns the string representation
 func (s PutRecordsRequestEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1422,7 +1422,7 @@ type metadataPutRecordsResultEntry struct {
 
 // String returns the string representation
 func (s PutRecordsResultEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1454,7 +1454,7 @@ type metadataRecord struct {
 
 // String returns the string representation
 func (s Record) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1479,7 +1479,7 @@ type metadataRemoveTagsFromStreamInput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromStreamInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1497,7 +1497,7 @@ type metadataRemoveTagsFromStreamOutput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromStreamOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1523,7 +1523,7 @@ type metadataSequenceNumberRange struct {
 
 // String returns the string representation
 func (s SequenceNumberRange) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1558,7 +1558,7 @@ type metadataShard struct {
 
 // String returns the string representation
 func (s Shard) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1592,7 +1592,7 @@ type metadataSplitShardInput struct {
 
 // String returns the string representation
 func (s SplitShardInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1610,7 +1610,7 @@ type metadataSplitShardOutput struct {
 
 // String returns the string representation
 func (s SplitShardOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1655,7 +1655,7 @@ type metadataStreamDescription struct {
 
 // String returns the string representation
 func (s StreamDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1683,7 +1683,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/kinesis/examples_test.go
+++ b/service/kinesis/examples_test.go
@@ -44,14 +44,14 @@ func ExampleKinesis_AddTagsToStream() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_CreateStream() {
 	svc := kinesis.New(nil)
 
 	params := &kinesis.CreateStreamInput{
-		ShardCount: aws.Long(1),              // Required
+		ShardCount: aws.Int64(1),             // Required
 		StreamName: aws.String("StreamName"), // Required
 	}
 	resp, err := svc.CreateStream(params)
@@ -72,7 +72,7 @@ func ExampleKinesis_CreateStream() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_DeleteStream() {
@@ -99,7 +99,7 @@ func ExampleKinesis_DeleteStream() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_DescribeStream() {
@@ -108,7 +108,7 @@ func ExampleKinesis_DescribeStream() {
 	params := &kinesis.DescribeStreamInput{
 		StreamName:            aws.String("StreamName"), // Required
 		ExclusiveStartShardID: aws.String("ShardId"),
-		Limit: aws.Long(1),
+		Limit: aws.Int64(1),
 	}
 	resp, err := svc.DescribeStream(params)
 
@@ -128,7 +128,7 @@ func ExampleKinesis_DescribeStream() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_GetRecords() {
@@ -136,7 +136,7 @@ func ExampleKinesis_GetRecords() {
 
 	params := &kinesis.GetRecordsInput{
 		ShardIterator: aws.String("ShardIterator"), // Required
-		Limit:         aws.Long(1),
+		Limit:         aws.Int64(1),
 	}
 	resp, err := svc.GetRecords(params)
 
@@ -156,7 +156,7 @@ func ExampleKinesis_GetRecords() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_GetShardIterator() {
@@ -186,7 +186,7 @@ func ExampleKinesis_GetShardIterator() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_ListStreams() {
@@ -194,7 +194,7 @@ func ExampleKinesis_ListStreams() {
 
 	params := &kinesis.ListStreamsInput{
 		ExclusiveStartStreamName: aws.String("StreamName"),
-		Limit: aws.Long(1),
+		Limit: aws.Int64(1),
 	}
 	resp, err := svc.ListStreams(params)
 
@@ -214,7 +214,7 @@ func ExampleKinesis_ListStreams() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_ListTagsForStream() {
@@ -223,7 +223,7 @@ func ExampleKinesis_ListTagsForStream() {
 	params := &kinesis.ListTagsForStreamInput{
 		StreamName:           aws.String("StreamName"), // Required
 		ExclusiveStartTagKey: aws.String("TagKey"),
-		Limit:                aws.Long(1),
+		Limit:                aws.Int64(1),
 	}
 	resp, err := svc.ListTagsForStream(params)
 
@@ -243,7 +243,7 @@ func ExampleKinesis_ListTagsForStream() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_MergeShards() {
@@ -272,7 +272,7 @@ func ExampleKinesis_MergeShards() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_PutRecord() {
@@ -303,7 +303,7 @@ func ExampleKinesis_PutRecord() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_PutRecords() {
@@ -338,7 +338,7 @@ func ExampleKinesis_PutRecords() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_RemoveTagsFromStream() {
@@ -369,7 +369,7 @@ func ExampleKinesis_RemoveTagsFromStream() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKinesis_SplitShard() {
@@ -398,5 +398,5 @@ func ExampleKinesis_SplitShard() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -897,7 +897,7 @@ type metadataAliasListEntry struct {
 
 // String returns the string representation
 func (s AliasListEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -926,7 +926,7 @@ type metadataCreateAliasInput struct {
 
 // String returns the string representation
 func (s CreateAliasInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -944,7 +944,7 @@ type metadataCreateAliasOutput struct {
 
 // String returns the string representation
 func (s CreateAliasOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -988,7 +988,7 @@ type metadataCreateGrantInput struct {
 
 // String returns the string representation
 func (s CreateGrantInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1012,7 +1012,7 @@ type metadataCreateGrantOutput struct {
 
 // String returns the string representation
 func (s CreateGrantOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1042,7 +1042,7 @@ type metadataCreateKeyInput struct {
 
 // String returns the string representation
 func (s CreateKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1063,7 +1063,7 @@ type metadataCreateKeyOutput struct {
 
 // String returns the string representation
 func (s CreateKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1092,7 +1092,7 @@ type metadataDecryptInput struct {
 
 // String returns the string representation
 func (s DecryptInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1118,7 +1118,7 @@ type metadataDecryptOutput struct {
 
 // String returns the string representation
 func (s DecryptOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1140,7 +1140,7 @@ type metadataDeleteAliasInput struct {
 
 // String returns the string representation
 func (s DeleteAliasInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1158,7 +1158,7 @@ type metadataDeleteAliasOutput struct {
 
 // String returns the string representation
 func (s DeleteAliasOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1184,7 +1184,7 @@ type metadataDescribeKeyInput struct {
 
 // String returns the string representation
 func (s DescribeKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1205,7 +1205,7 @@ type metadataDescribeKeyOutput struct {
 
 // String returns the string representation
 func (s DescribeKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1229,7 +1229,7 @@ type metadataDisableKeyInput struct {
 
 // String returns the string representation
 func (s DisableKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1247,7 +1247,7 @@ type metadataDisableKeyOutput struct {
 
 // String returns the string representation
 func (s DisableKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1271,7 +1271,7 @@ type metadataDisableKeyRotationInput struct {
 
 // String returns the string representation
 func (s DisableKeyRotationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1289,7 +1289,7 @@ type metadataDisableKeyRotationOutput struct {
 
 // String returns the string representation
 func (s DisableKeyRotationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1313,7 +1313,7 @@ type metadataEnableKeyInput struct {
 
 // String returns the string representation
 func (s EnableKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1331,7 +1331,7 @@ type metadataEnableKeyOutput struct {
 
 // String returns the string representation
 func (s EnableKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1355,7 +1355,7 @@ type metadataEnableKeyRotationInput struct {
 
 // String returns the string representation
 func (s EnableKeyRotationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1373,7 +1373,7 @@ type metadataEnableKeyRotationOutput struct {
 
 // String returns the string representation
 func (s EnableKeyRotationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1411,7 +1411,7 @@ type metadataEncryptInput struct {
 
 // String returns the string representation
 func (s EncryptInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1436,7 +1436,7 @@ type metadataEncryptOutput struct {
 
 // String returns the string representation
 func (s EncryptOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1479,7 +1479,7 @@ type metadataGenerateDataKeyInput struct {
 
 // String returns the string representation
 func (s GenerateDataKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1515,7 +1515,7 @@ type metadataGenerateDataKeyOutput struct {
 
 // String returns the string representation
 func (s GenerateDataKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1557,7 +1557,7 @@ type metadataGenerateDataKeyWithoutPlaintextInput struct {
 
 // String returns the string representation
 func (s GenerateDataKeyWithoutPlaintextInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1586,7 +1586,7 @@ type metadataGenerateDataKeyWithoutPlaintextOutput struct {
 
 // String returns the string representation
 func (s GenerateDataKeyWithoutPlaintextOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1608,7 +1608,7 @@ type metadataGenerateRandomInput struct {
 
 // String returns the string representation
 func (s GenerateRandomInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1629,7 +1629,7 @@ type metadataGenerateRandomOutput struct {
 
 // String returns the string representation
 func (s GenerateRandomOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1657,7 +1657,7 @@ type metadataGetKeyPolicyInput struct {
 
 // String returns the string representation
 func (s GetKeyPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1678,7 +1678,7 @@ type metadataGetKeyPolicyOutput struct {
 
 // String returns the string representation
 func (s GetKeyPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1702,7 +1702,7 @@ type metadataGetKeyRotationStatusInput struct {
 
 // String returns the string representation
 func (s GetKeyRotationStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1723,7 +1723,7 @@ type metadataGetKeyRotationStatusOutput struct {
 
 // String returns the string representation
 func (s GetKeyRotationStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1749,7 +1749,7 @@ type metadataGrantConstraints struct {
 
 // String returns the string representation
 func (s GrantConstraints) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1789,7 +1789,7 @@ type metadataGrantListEntry struct {
 
 // String returns the string representation
 func (s GrantListEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1814,7 +1814,7 @@ type metadataKeyListEntry struct {
 
 // String returns the string representation
 func (s KeyListEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1854,7 +1854,7 @@ type metadataKeyMetadata struct {
 
 // String returns the string representation
 func (s KeyMetadata) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1882,7 +1882,7 @@ type metadataListAliasesInput struct {
 
 // String returns the string representation
 func (s ListAliasesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1912,7 +1912,7 @@ type metadataListAliasesOutput struct {
 
 // String returns the string representation
 func (s ListAliasesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1947,7 +1947,7 @@ type metadataListGrantsInput struct {
 
 // String returns the string representation
 func (s ListGrantsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1977,7 +1977,7 @@ type metadataListGrantsOutput struct {
 
 // String returns the string representation
 func (s ListGrantsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2014,7 +2014,7 @@ type metadataListKeyPoliciesInput struct {
 
 // String returns the string representation
 func (s ListKeyPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2045,7 +2045,7 @@ type metadataListKeyPoliciesOutput struct {
 
 // String returns the string representation
 func (s ListKeyPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2074,7 +2074,7 @@ type metadataListKeysInput struct {
 
 // String returns the string representation
 func (s ListKeysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2104,7 +2104,7 @@ type metadataListKeysOutput struct {
 
 // String returns the string representation
 func (s ListKeysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2135,7 +2135,7 @@ type metadataPutKeyPolicyInput struct {
 
 // String returns the string representation
 func (s PutKeyPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2153,7 +2153,7 @@ type metadataPutKeyPolicyOutput struct {
 
 // String returns the string representation
 func (s PutKeyPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2193,7 +2193,7 @@ type metadataReEncryptInput struct {
 
 // String returns the string representation
 func (s ReEncryptInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2221,7 +2221,7 @@ type metadataReEncryptOutput struct {
 
 // String returns the string representation
 func (s ReEncryptOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2252,7 +2252,7 @@ type metadataRetireGrantInput struct {
 
 // String returns the string representation
 func (s RetireGrantInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2270,7 +2270,7 @@ type metadataRetireGrantOutput struct {
 
 // String returns the string representation
 func (s RetireGrantOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2297,7 +2297,7 @@ type metadataRevokeGrantInput struct {
 
 // String returns the string representation
 func (s RevokeGrantInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2315,7 +2315,7 @@ type metadataRevokeGrantOutput struct {
 
 // String returns the string representation
 func (s RevokeGrantOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2344,7 +2344,7 @@ type metadataUpdateAliasInput struct {
 
 // String returns the string representation
 func (s UpdateAliasInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2362,7 +2362,7 @@ type metadataUpdateAliasOutput struct {
 
 // String returns the string representation
 func (s UpdateAliasOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2389,7 +2389,7 @@ type metadataUpdateKeyDescriptionInput struct {
 
 // String returns the string representation
 func (s UpdateKeyDescriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2407,7 +2407,7 @@ type metadataUpdateKeyDescriptionOutput struct {
 
 // String returns the string representation
 func (s UpdateKeyDescriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/kms/examples_test.go
+++ b/service/kms/examples_test.go
@@ -41,7 +41,7 @@ func ExampleKMS_CreateAlias() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_CreateGrant() {
@@ -88,7 +88,7 @@ func ExampleKMS_CreateGrant() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_CreateKey() {
@@ -117,7 +117,7 @@ func ExampleKMS_CreateKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_Decrypt() {
@@ -152,7 +152,7 @@ func ExampleKMS_Decrypt() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_DeleteAlias() {
@@ -179,7 +179,7 @@ func ExampleKMS_DeleteAlias() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_DescribeKey() {
@@ -206,7 +206,7 @@ func ExampleKMS_DescribeKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_DisableKey() {
@@ -233,7 +233,7 @@ func ExampleKMS_DisableKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_DisableKeyRotation() {
@@ -260,7 +260,7 @@ func ExampleKMS_DisableKeyRotation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_EnableKey() {
@@ -287,7 +287,7 @@ func ExampleKMS_EnableKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_EnableKeyRotation() {
@@ -314,7 +314,7 @@ func ExampleKMS_EnableKeyRotation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_Encrypt() {
@@ -350,7 +350,7 @@ func ExampleKMS_Encrypt() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_GenerateDataKey() {
@@ -367,7 +367,7 @@ func ExampleKMS_GenerateDataKey() {
 			// More values...
 		},
 		KeySpec:       aws.String("DataKeySpec"),
-		NumberOfBytes: aws.Long(1),
+		NumberOfBytes: aws.Int64(1),
 	}
 	resp, err := svc.GenerateDataKey(params)
 
@@ -387,7 +387,7 @@ func ExampleKMS_GenerateDataKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_GenerateDataKeyWithoutPlaintext() {
@@ -404,7 +404,7 @@ func ExampleKMS_GenerateDataKeyWithoutPlaintext() {
 			// More values...
 		},
 		KeySpec:       aws.String("DataKeySpec"),
-		NumberOfBytes: aws.Long(1),
+		NumberOfBytes: aws.Int64(1),
 	}
 	resp, err := svc.GenerateDataKeyWithoutPlaintext(params)
 
@@ -424,14 +424,14 @@ func ExampleKMS_GenerateDataKeyWithoutPlaintext() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_GenerateRandom() {
 	svc := kms.New(nil)
 
 	params := &kms.GenerateRandomInput{
-		NumberOfBytes: aws.Long(1),
+		NumberOfBytes: aws.Int64(1),
 	}
 	resp, err := svc.GenerateRandom(params)
 
@@ -451,7 +451,7 @@ func ExampleKMS_GenerateRandom() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_GetKeyPolicy() {
@@ -479,7 +479,7 @@ func ExampleKMS_GetKeyPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_GetKeyRotationStatus() {
@@ -506,14 +506,14 @@ func ExampleKMS_GetKeyRotationStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_ListAliases() {
 	svc := kms.New(nil)
 
 	params := &kms.ListAliasesInput{
-		Limit:  aws.Long(1),
+		Limit:  aws.Int64(1),
 		Marker: aws.String("MarkerType"),
 	}
 	resp, err := svc.ListAliases(params)
@@ -534,7 +534,7 @@ func ExampleKMS_ListAliases() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_ListGrants() {
@@ -542,7 +542,7 @@ func ExampleKMS_ListGrants() {
 
 	params := &kms.ListGrantsInput{
 		KeyID:  aws.String("KeyIdType"), // Required
-		Limit:  aws.Long(1),
+		Limit:  aws.Int64(1),
 		Marker: aws.String("MarkerType"),
 	}
 	resp, err := svc.ListGrants(params)
@@ -563,7 +563,7 @@ func ExampleKMS_ListGrants() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_ListKeyPolicies() {
@@ -571,7 +571,7 @@ func ExampleKMS_ListKeyPolicies() {
 
 	params := &kms.ListKeyPoliciesInput{
 		KeyID:  aws.String("KeyIdType"), // Required
-		Limit:  aws.Long(1),
+		Limit:  aws.Int64(1),
 		Marker: aws.String("MarkerType"),
 	}
 	resp, err := svc.ListKeyPolicies(params)
@@ -592,14 +592,14 @@ func ExampleKMS_ListKeyPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_ListKeys() {
 	svc := kms.New(nil)
 
 	params := &kms.ListKeysInput{
-		Limit:  aws.Long(1),
+		Limit:  aws.Int64(1),
 		Marker: aws.String("MarkerType"),
 	}
 	resp, err := svc.ListKeys(params)
@@ -620,7 +620,7 @@ func ExampleKMS_ListKeys() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_PutKeyPolicy() {
@@ -649,7 +649,7 @@ func ExampleKMS_PutKeyPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_ReEncrypt() {
@@ -689,7 +689,7 @@ func ExampleKMS_ReEncrypt() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_RetireGrant() {
@@ -718,7 +718,7 @@ func ExampleKMS_RetireGrant() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_RevokeGrant() {
@@ -746,7 +746,7 @@ func ExampleKMS_RevokeGrant() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_UpdateAlias() {
@@ -774,7 +774,7 @@ func ExampleKMS_UpdateAlias() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleKMS_UpdateKeyDescription() {
@@ -802,5 +802,5 @@ func ExampleKMS_UpdateKeyDescription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -653,7 +653,7 @@ type metadataAddPermissionInput struct {
 
 // String returns the string representation
 func (s AddPermissionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -675,7 +675,7 @@ type metadataAddPermissionOutput struct {
 
 // String returns the string representation
 func (s AddPermissionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -724,7 +724,7 @@ type metadataCreateEventSourceMappingInput struct {
 
 // String returns the string representation
 func (s CreateEventSourceMappingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -788,7 +788,7 @@ type metadataCreateFunctionInput struct {
 
 // String returns the string representation
 func (s CreateFunctionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -809,7 +809,7 @@ type metadataDeleteEventSourceMappingInput struct {
 
 // String returns the string representation
 func (s DeleteEventSourceMappingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -837,7 +837,7 @@ type metadataDeleteFunctionInput struct {
 
 // String returns the string representation
 func (s DeleteFunctionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -855,7 +855,7 @@ type metadataDeleteFunctionOutput struct {
 
 // String returns the string representation
 func (s DeleteFunctionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -903,7 +903,7 @@ type metadataEventSourceMappingConfiguration struct {
 
 // String returns the string representation
 func (s EventSourceMappingConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -938,7 +938,7 @@ type metadataFunctionCode struct {
 
 // String returns the string representation
 func (s FunctionCode) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -964,7 +964,7 @@ type metadataFunctionCodeLocation struct {
 
 // String returns the string representation
 func (s FunctionCodeLocation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1017,7 +1017,7 @@ type metadataFunctionConfiguration struct {
 
 // String returns the string representation
 func (s FunctionConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1038,7 +1038,7 @@ type metadataGetEventSourceMappingInput struct {
 
 // String returns the string representation
 func (s GetEventSourceMappingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1067,7 +1067,7 @@ type metadataGetFunctionConfigurationInput struct {
 
 // String returns the string representation
 func (s GetFunctionConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1095,7 +1095,7 @@ type metadataGetFunctionInput struct {
 
 // String returns the string representation
 func (s GetFunctionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1120,7 +1120,7 @@ type metadataGetFunctionOutput struct {
 
 // String returns the string representation
 func (s GetFunctionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1148,7 +1148,7 @@ type metadataGetPolicyInput struct {
 
 // String returns the string representation
 func (s GetPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1170,7 +1170,7 @@ type metadataGetPolicyOutput struct {
 
 // String returns the string representation
 func (s GetPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1194,7 +1194,7 @@ type metadataInvokeAsyncInput struct {
 
 // String returns the string representation
 func (s InvokeAsyncInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1216,7 +1216,7 @@ type metadataInvokeAsyncOutput struct {
 
 // String returns the string representation
 func (s InvokeAsyncOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1271,7 +1271,7 @@ type metadataInvokeInput struct {
 
 // String returns the string representation
 func (s InvokeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1317,7 +1317,7 @@ type metadataInvokeOutput struct {
 
 // String returns the string representation
 func (s InvokeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1357,7 +1357,7 @@ type metadataListEventSourceMappingsInput struct {
 
 // String returns the string representation
 func (s ListEventSourceMappingsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1382,7 +1382,7 @@ type metadataListEventSourceMappingsOutput struct {
 
 // String returns the string representation
 func (s ListEventSourceMappingsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1408,7 +1408,7 @@ type metadataListFunctionsInput struct {
 
 // String returns the string representation
 func (s ListFunctionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1433,7 +1433,7 @@ type metadataListFunctionsOutput struct {
 
 // String returns the string representation
 func (s ListFunctionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1464,7 +1464,7 @@ type metadataRemovePermissionInput struct {
 
 // String returns the string representation
 func (s RemovePermissionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1482,7 +1482,7 @@ type metadataRemovePermissionOutput struct {
 
 // String returns the string representation
 func (s RemovePermissionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1521,7 +1521,7 @@ type metadataUpdateEventSourceMappingInput struct {
 
 // String returns the string representation
 func (s UpdateEventSourceMappingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1563,7 +1563,7 @@ type metadataUpdateFunctionCodeInput struct {
 
 // String returns the string representation
 func (s UpdateFunctionCodeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1616,7 +1616,7 @@ type metadataUpdateFunctionConfigurationInput struct {
 
 // String returns the string representation
 func (s UpdateFunctionConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/lambda/examples_test.go
+++ b/service/lambda/examples_test.go
@@ -45,7 +45,7 @@ func ExampleLambda_AddPermission() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_CreateEventSourceMapping() {
@@ -55,8 +55,8 @@ func ExampleLambda_CreateEventSourceMapping() {
 		EventSourceARN:   aws.String("Arn"),                 // Required
 		FunctionName:     aws.String("FunctionName"),        // Required
 		StartingPosition: aws.String("EventSourcePosition"), // Required
-		BatchSize:        aws.Long(1),
-		Enabled:          aws.Boolean(true),
+		BatchSize:        aws.Int64(1),
+		Enabled:          aws.Bool(true),
 	}
 	resp, err := svc.CreateEventSourceMapping(params)
 
@@ -76,7 +76,7 @@ func ExampleLambda_CreateEventSourceMapping() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_CreateFunction() {
@@ -94,8 +94,8 @@ func ExampleLambda_CreateFunction() {
 		Role:         aws.String("RoleArn"),      // Required
 		Runtime:      aws.String("Runtime"),      // Required
 		Description:  aws.String("Description"),
-		MemorySize:   aws.Long(1),
-		Timeout:      aws.Long(1),
+		MemorySize:   aws.Int64(1),
+		Timeout:      aws.Int64(1),
 	}
 	resp, err := svc.CreateFunction(params)
 
@@ -115,7 +115,7 @@ func ExampleLambda_CreateFunction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_DeleteEventSourceMapping() {
@@ -142,7 +142,7 @@ func ExampleLambda_DeleteEventSourceMapping() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_DeleteFunction() {
@@ -169,7 +169,7 @@ func ExampleLambda_DeleteFunction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_GetEventSourceMapping() {
@@ -196,7 +196,7 @@ func ExampleLambda_GetEventSourceMapping() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_GetFunction() {
@@ -223,7 +223,7 @@ func ExampleLambda_GetFunction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_GetFunctionConfiguration() {
@@ -250,7 +250,7 @@ func ExampleLambda_GetFunctionConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_GetPolicy() {
@@ -277,7 +277,7 @@ func ExampleLambda_GetPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_Invoke() {
@@ -308,7 +308,7 @@ func ExampleLambda_Invoke() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_InvokeAsync() {
@@ -336,7 +336,7 @@ func ExampleLambda_InvokeAsync() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_ListEventSourceMappings() {
@@ -346,7 +346,7 @@ func ExampleLambda_ListEventSourceMappings() {
 		EventSourceARN: aws.String("Arn"),
 		FunctionName:   aws.String("FunctionName"),
 		Marker:         aws.String("String"),
-		MaxItems:       aws.Long(1),
+		MaxItems:       aws.Int64(1),
 	}
 	resp, err := svc.ListEventSourceMappings(params)
 
@@ -366,7 +366,7 @@ func ExampleLambda_ListEventSourceMappings() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_ListFunctions() {
@@ -374,7 +374,7 @@ func ExampleLambda_ListFunctions() {
 
 	params := &lambda.ListFunctionsInput{
 		Marker:   aws.String("String"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListFunctions(params)
 
@@ -394,7 +394,7 @@ func ExampleLambda_ListFunctions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_RemovePermission() {
@@ -422,7 +422,7 @@ func ExampleLambda_RemovePermission() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_UpdateEventSourceMapping() {
@@ -430,8 +430,8 @@ func ExampleLambda_UpdateEventSourceMapping() {
 
 	params := &lambda.UpdateEventSourceMappingInput{
 		UUID:         aws.String("String"), // Required
-		BatchSize:    aws.Long(1),
-		Enabled:      aws.Boolean(true),
+		BatchSize:    aws.Int64(1),
+		Enabled:      aws.Bool(true),
 		FunctionName: aws.String("FunctionName"),
 	}
 	resp, err := svc.UpdateEventSourceMapping(params)
@@ -452,7 +452,7 @@ func ExampleLambda_UpdateEventSourceMapping() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_UpdateFunctionCode() {
@@ -483,7 +483,7 @@ func ExampleLambda_UpdateFunctionCode() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleLambda_UpdateFunctionConfiguration() {
@@ -493,9 +493,9 @@ func ExampleLambda_UpdateFunctionConfiguration() {
 		FunctionName: aws.String("FunctionName"), // Required
 		Description:  aws.String("Description"),
 		Handler:      aws.String("Handler"),
-		MemorySize:   aws.Long(1),
+		MemorySize:   aws.Int64(1),
 		Role:         aws.String("RoleArn"),
-		Timeout:      aws.Long(1),
+		Timeout:      aws.Int64(1),
 	}
 	resp, err := svc.UpdateFunctionConfiguration(params)
 
@@ -515,5 +515,5 @@ func ExampleLambda_UpdateFunctionConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -965,7 +965,7 @@ type metadataBatchPrediction struct {
 
 // String returns the string representation
 func (s BatchPrediction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1005,7 +1005,7 @@ type metadataCreateBatchPredictionInput struct {
 
 // String returns the string representation
 func (s CreateBatchPredictionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1033,7 +1033,7 @@ type metadataCreateBatchPredictionOutput struct {
 
 // String returns the string representation
 func (s CreateBatchPredictionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1110,7 +1110,7 @@ type metadataCreateDataSourceFromRDSInput struct {
 
 // String returns the string representation
 func (s CreateDataSourceFromRDSInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1141,7 +1141,7 @@ type metadataCreateDataSourceFromRDSOutput struct {
 
 // String returns the string representation
 func (s CreateDataSourceFromRDSOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1207,7 +1207,7 @@ type metadataCreateDataSourceFromRedshiftInput struct {
 
 // String returns the string representation
 func (s CreateDataSourceFromRedshiftInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1235,7 +1235,7 @@ type metadataCreateDataSourceFromRedshiftOutput struct {
 
 // String returns the string representation
 func (s CreateDataSourceFromRedshiftOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1281,7 +1281,7 @@ type metadataCreateDataSourceFromS3Input struct {
 
 // String returns the string representation
 func (s CreateDataSourceFromS3Input) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1308,7 +1308,7 @@ type metadataCreateDataSourceFromS3Output struct {
 
 // String returns the string representation
 func (s CreateDataSourceFromS3Output) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1342,7 +1342,7 @@ type metadataCreateEvaluationInput struct {
 
 // String returns the string representation
 func (s CreateEvaluationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1369,7 +1369,7 @@ type metadataCreateEvaluationOutput struct {
 
 // String returns the string representation
 func (s CreateEvaluationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1449,7 +1449,7 @@ type metadataCreateMLModelInput struct {
 
 // String returns the string representation
 func (s CreateMLModelInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1476,7 +1476,7 @@ type metadataCreateMLModelOutput struct {
 
 // String returns the string representation
 func (s CreateMLModelOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1497,7 +1497,7 @@ type metadataCreateRealtimeEndpointInput struct {
 
 // String returns the string representation
 func (s CreateRealtimeEndpointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1528,7 +1528,7 @@ type metadataCreateRealtimeEndpointOutput struct {
 
 // String returns the string representation
 func (s CreateRealtimeEndpointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1610,7 +1610,7 @@ type metadataDataSource struct {
 
 // String returns the string representation
 func (s DataSource) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1631,7 +1631,7 @@ type metadataDeleteBatchPredictionInput struct {
 
 // String returns the string representation
 func (s DeleteBatchPredictionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1657,7 +1657,7 @@ type metadataDeleteBatchPredictionOutput struct {
 
 // String returns the string representation
 func (s DeleteBatchPredictionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1678,7 +1678,7 @@ type metadataDeleteDataSourceInput struct {
 
 // String returns the string representation
 func (s DeleteDataSourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1701,7 +1701,7 @@ type metadataDeleteDataSourceOutput struct {
 
 // String returns the string representation
 func (s DeleteDataSourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1722,7 +1722,7 @@ type metadataDeleteEvaluationInput struct {
 
 // String returns the string representation
 func (s DeleteEvaluationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1749,7 +1749,7 @@ type metadataDeleteEvaluationOutput struct {
 
 // String returns the string representation
 func (s DeleteEvaluationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1770,7 +1770,7 @@ type metadataDeleteMLModelInput struct {
 
 // String returns the string representation
 func (s DeleteMLModelInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1796,7 +1796,7 @@ type metadataDeleteMLModelOutput struct {
 
 // String returns the string representation
 func (s DeleteMLModelOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1817,7 +1817,7 @@ type metadataDeleteRealtimeEndpointInput struct {
 
 // String returns the string representation
 func (s DeleteRealtimeEndpointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1845,7 +1845,7 @@ type metadataDeleteRealtimeEndpointOutput struct {
 
 // String returns the string representation
 func (s DeleteRealtimeEndpointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1929,7 +1929,7 @@ type metadataDescribeBatchPredictionsInput struct {
 
 // String returns the string representation
 func (s DescribeBatchPredictionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1956,7 +1956,7 @@ type metadataDescribeBatchPredictionsOutput struct {
 
 // String returns the string representation
 func (s DescribeBatchPredictionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2035,7 +2035,7 @@ type metadataDescribeDataSourcesInput struct {
 
 // String returns the string representation
 func (s DescribeDataSourcesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2062,7 +2062,7 @@ type metadataDescribeDataSourcesOutput struct {
 
 // String returns the string representation
 func (s DescribeDataSourcesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2143,7 +2143,7 @@ type metadataDescribeEvaluationsInput struct {
 
 // String returns the string representation
 func (s DescribeEvaluationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2170,7 +2170,7 @@ type metadataDescribeEvaluationsOutput struct {
 
 // String returns the string representation
 func (s DescribeEvaluationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2254,7 +2254,7 @@ type metadataDescribeMLModelsInput struct {
 
 // String returns the string representation
 func (s DescribeMLModelsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2281,7 +2281,7 @@ type metadataDescribeMLModelsOutput struct {
 
 // String returns the string representation
 func (s DescribeMLModelsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2363,7 +2363,7 @@ type metadataEvaluation struct {
 
 // String returns the string representation
 func (s Evaluation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2384,7 +2384,7 @@ type metadataGetBatchPredictionInput struct {
 
 // String returns the string representation
 func (s GetBatchPredictionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2454,7 +2454,7 @@ type metadataGetBatchPredictionOutput struct {
 
 // String returns the string representation
 func (s GetBatchPredictionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2482,7 +2482,7 @@ type metadataGetDataSourceInput struct {
 
 // String returns the string representation
 func (s GetDataSourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2570,7 +2570,7 @@ type metadataGetDataSourceOutput struct {
 
 // String returns the string representation
 func (s GetDataSourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2592,7 +2592,7 @@ type metadataGetEvaluationInput struct {
 
 // String returns the string representation
 func (s GetEvaluationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2674,7 +2674,7 @@ type metadataGetEvaluationOutput struct {
 
 // String returns the string representation
 func (s GetEvaluationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2702,7 +2702,7 @@ type metadataGetMLModelInput struct {
 
 // String returns the string representation
 func (s GetMLModelInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2834,7 +2834,7 @@ type metadataGetMLModelOutput struct {
 
 // String returns the string representation
 func (s GetMLModelOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2955,7 +2955,7 @@ type metadataMLModel struct {
 
 // String returns the string representation
 func (s MLModel) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2990,7 +2990,7 @@ type metadataPerformanceMetrics struct {
 
 // String returns the string representation
 func (s PerformanceMetrics) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3016,7 +3016,7 @@ type metadataPredictInput struct {
 
 // String returns the string representation
 func (s PredictInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3047,7 +3047,7 @@ type metadataPredictOutput struct {
 
 // String returns the string representation
 func (s PredictOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3088,7 +3088,7 @@ type metadataPrediction struct {
 
 // String returns the string representation
 func (s Prediction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3158,7 +3158,7 @@ type metadataRDSDataSpec struct {
 
 // String returns the string representation
 func (s RDSDataSpec) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3183,7 +3183,7 @@ type metadataRDSDatabase struct {
 
 // String returns the string representation
 func (s RDSDatabase) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3212,7 +3212,7 @@ type metadataRDSDatabaseCredentials struct {
 
 // String returns the string representation
 func (s RDSDatabaseCredentials) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3260,7 +3260,7 @@ type metadataRDSMetadata struct {
 
 // String returns the string representation
 func (s RDSMetadata) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3302,7 +3302,7 @@ type metadataRealtimeEndpointInfo struct {
 
 // String returns the string representation
 func (s RealtimeEndpointInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3345,7 +3345,7 @@ type metadataRedshiftDataSpec struct {
 
 // String returns the string representation
 func (s RedshiftDataSpec) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3371,7 +3371,7 @@ type metadataRedshiftDatabase struct {
 
 // String returns the string representation
 func (s RedshiftDatabase) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3403,7 +3403,7 @@ type metadataRedshiftDatabaseCredentials struct {
 
 // String returns the string representation
 func (s RedshiftDatabaseCredentials) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3436,7 +3436,7 @@ type metadataRedshiftMetadata struct {
 
 // String returns the string representation
 func (s RedshiftMetadata) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3469,7 +3469,7 @@ type metadataS3DataSpec struct {
 
 // String returns the string representation
 func (s S3DataSpec) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3493,7 +3493,7 @@ type metadataUpdateBatchPredictionInput struct {
 
 // String returns the string representation
 func (s UpdateBatchPredictionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3518,7 +3518,7 @@ type metadataUpdateBatchPredictionOutput struct {
 
 // String returns the string representation
 func (s UpdateBatchPredictionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3543,7 +3543,7 @@ type metadataUpdateDataSourceInput struct {
 
 // String returns the string representation
 func (s UpdateDataSourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3568,7 +3568,7 @@ type metadataUpdateDataSourceOutput struct {
 
 // String returns the string representation
 func (s UpdateDataSourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3593,7 +3593,7 @@ type metadataUpdateEvaluationInput struct {
 
 // String returns the string representation
 func (s UpdateEvaluationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3618,7 +3618,7 @@ type metadataUpdateEvaluationOutput struct {
 
 // String returns the string representation
 func (s UpdateEvaluationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3650,7 +3650,7 @@ type metadataUpdateMLModelInput struct {
 
 // String returns the string representation
 func (s UpdateMLModelInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3675,7 +3675,7 @@ type metadataUpdateMLModelOutput struct {
 
 // String returns the string representation
 func (s UpdateMLModelOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/machinelearning/examples_test.go
+++ b/service/machinelearning/examples_test.go
@@ -44,7 +44,7 @@ func ExampleMachineLearning_CreateBatchPrediction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_CreateDataSourceFromRDS() {
@@ -75,7 +75,7 @@ func ExampleMachineLearning_CreateDataSourceFromRDS() {
 			DataSchemaURI:     aws.String("S3Url"),
 		},
 		RoleARN:           aws.String("RoleARN"), // Required
-		ComputeStatistics: aws.Boolean(true),
+		ComputeStatistics: aws.Bool(true),
 		DataSourceName:    aws.String("EntityName"),
 	}
 	resp, err := svc.CreateDataSourceFromRDS(params)
@@ -96,7 +96,7 @@ func ExampleMachineLearning_CreateDataSourceFromRDS() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_CreateDataSourceFromRedshift() {
@@ -120,7 +120,7 @@ func ExampleMachineLearning_CreateDataSourceFromRedshift() {
 			DataSchemaURI:     aws.String("S3Url"),
 		},
 		RoleARN:           aws.String("RoleARN"), // Required
-		ComputeStatistics: aws.Boolean(true),
+		ComputeStatistics: aws.Bool(true),
 		DataSourceName:    aws.String("EntityName"),
 	}
 	resp, err := svc.CreateDataSourceFromRedshift(params)
@@ -141,7 +141,7 @@ func ExampleMachineLearning_CreateDataSourceFromRedshift() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_CreateDataSourceFromS3() {
@@ -155,7 +155,7 @@ func ExampleMachineLearning_CreateDataSourceFromS3() {
 			DataSchema:           aws.String("DataSchema"),
 			DataSchemaLocationS3: aws.String("S3Url"),
 		},
-		ComputeStatistics: aws.Boolean(true),
+		ComputeStatistics: aws.Bool(true),
 		DataSourceName:    aws.String("EntityName"),
 	}
 	resp, err := svc.CreateDataSourceFromS3(params)
@@ -176,7 +176,7 @@ func ExampleMachineLearning_CreateDataSourceFromS3() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_CreateEvaluation() {
@@ -206,7 +206,7 @@ func ExampleMachineLearning_CreateEvaluation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_CreateMLModel() {
@@ -242,7 +242,7 @@ func ExampleMachineLearning_CreateMLModel() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_CreateRealtimeEndpoint() {
@@ -269,7 +269,7 @@ func ExampleMachineLearning_CreateRealtimeEndpoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DeleteBatchPrediction() {
@@ -296,7 +296,7 @@ func ExampleMachineLearning_DeleteBatchPrediction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DeleteDataSource() {
@@ -323,7 +323,7 @@ func ExampleMachineLearning_DeleteDataSource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DeleteEvaluation() {
@@ -350,7 +350,7 @@ func ExampleMachineLearning_DeleteEvaluation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DeleteMLModel() {
@@ -377,7 +377,7 @@ func ExampleMachineLearning_DeleteMLModel() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DeleteRealtimeEndpoint() {
@@ -404,7 +404,7 @@ func ExampleMachineLearning_DeleteRealtimeEndpoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DescribeBatchPredictions() {
@@ -417,7 +417,7 @@ func ExampleMachineLearning_DescribeBatchPredictions() {
 		GT:             aws.String("ComparatorValue"),
 		LE:             aws.String("ComparatorValue"),
 		LT:             aws.String("ComparatorValue"),
-		Limit:          aws.Long(1),
+		Limit:          aws.Int64(1),
 		NE:             aws.String("ComparatorValue"),
 		NextToken:      aws.String("StringType"),
 		Prefix:         aws.String("ComparatorValue"),
@@ -441,7 +441,7 @@ func ExampleMachineLearning_DescribeBatchPredictions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DescribeDataSources() {
@@ -454,7 +454,7 @@ func ExampleMachineLearning_DescribeDataSources() {
 		GT:             aws.String("ComparatorValue"),
 		LE:             aws.String("ComparatorValue"),
 		LT:             aws.String("ComparatorValue"),
-		Limit:          aws.Long(1),
+		Limit:          aws.Int64(1),
 		NE:             aws.String("ComparatorValue"),
 		NextToken:      aws.String("StringType"),
 		Prefix:         aws.String("ComparatorValue"),
@@ -478,7 +478,7 @@ func ExampleMachineLearning_DescribeDataSources() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DescribeEvaluations() {
@@ -491,7 +491,7 @@ func ExampleMachineLearning_DescribeEvaluations() {
 		GT:             aws.String("ComparatorValue"),
 		LE:             aws.String("ComparatorValue"),
 		LT:             aws.String("ComparatorValue"),
-		Limit:          aws.Long(1),
+		Limit:          aws.Int64(1),
 		NE:             aws.String("ComparatorValue"),
 		NextToken:      aws.String("StringType"),
 		Prefix:         aws.String("ComparatorValue"),
@@ -515,7 +515,7 @@ func ExampleMachineLearning_DescribeEvaluations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_DescribeMLModels() {
@@ -528,7 +528,7 @@ func ExampleMachineLearning_DescribeMLModels() {
 		GT:             aws.String("ComparatorValue"),
 		LE:             aws.String("ComparatorValue"),
 		LT:             aws.String("ComparatorValue"),
-		Limit:          aws.Long(1),
+		Limit:          aws.Int64(1),
 		NE:             aws.String("ComparatorValue"),
 		NextToken:      aws.String("StringType"),
 		Prefix:         aws.String("ComparatorValue"),
@@ -552,7 +552,7 @@ func ExampleMachineLearning_DescribeMLModels() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_GetBatchPrediction() {
@@ -579,7 +579,7 @@ func ExampleMachineLearning_GetBatchPrediction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_GetDataSource() {
@@ -587,7 +587,7 @@ func ExampleMachineLearning_GetDataSource() {
 
 	params := &machinelearning.GetDataSourceInput{
 		DataSourceID: aws.String("EntityId"), // Required
-		Verbose:      aws.Boolean(true),
+		Verbose:      aws.Bool(true),
 	}
 	resp, err := svc.GetDataSource(params)
 
@@ -607,7 +607,7 @@ func ExampleMachineLearning_GetDataSource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_GetEvaluation() {
@@ -634,7 +634,7 @@ func ExampleMachineLearning_GetEvaluation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_GetMLModel() {
@@ -642,7 +642,7 @@ func ExampleMachineLearning_GetMLModel() {
 
 	params := &machinelearning.GetMLModelInput{
 		MLModelID: aws.String("EntityId"), // Required
-		Verbose:   aws.Boolean(true),
+		Verbose:   aws.Bool(true),
 	}
 	resp, err := svc.GetMLModel(params)
 
@@ -662,7 +662,7 @@ func ExampleMachineLearning_GetMLModel() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_Predict() {
@@ -694,7 +694,7 @@ func ExampleMachineLearning_Predict() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_UpdateBatchPrediction() {
@@ -722,7 +722,7 @@ func ExampleMachineLearning_UpdateBatchPrediction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_UpdateDataSource() {
@@ -750,7 +750,7 @@ func ExampleMachineLearning_UpdateDataSource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_UpdateEvaluation() {
@@ -778,7 +778,7 @@ func ExampleMachineLearning_UpdateEvaluation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleMachineLearning_UpdateMLModel() {
@@ -787,7 +787,7 @@ func ExampleMachineLearning_UpdateMLModel() {
 	params := &machinelearning.UpdateMLModelInput{
 		MLModelID:      aws.String("EntityId"), // Required
 		MLModelName:    aws.String("EntityName"),
-		ScoreThreshold: aws.Double(1.0),
+		ScoreThreshold: aws.Float64(1.0),
 	}
 	resp, err := svc.UpdateMLModel(params)
 
@@ -807,5 +807,5 @@ func ExampleMachineLearning_UpdateMLModel() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -74,7 +74,7 @@ type metadataEvent struct {
 
 // String returns the string representation
 func (s Event) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -103,7 +103,7 @@ type metadataPutEventsInput struct {
 
 // String returns the string representation
 func (s PutEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -121,7 +121,7 @@ type metadataPutEventsOutput struct {
 
 // String returns the string representation
 func (s PutEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -154,7 +154,7 @@ type metadataSession struct {
 
 // String returns the string representation
 func (s Session) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/mobileanalytics/examples_test.go
+++ b/service/mobileanalytics/examples_test.go
@@ -30,11 +30,10 @@ func ExampleMobileAnalytics_PutEvents() {
 					// More values...
 				},
 				Metrics: map[string]*float64{
-					"Key": aws.Double(1.0), // Required
-					// More values...
+					"Key": aws.Float64(1.0),
 				},
 				Session: &mobileanalytics.Session{
-					Duration:       aws.Long(1),
+					Duration:       aws.Int64(1),
 					ID:             aws.String("String50Chars"),
 					StartTimestamp: aws.String("ISO8601Timestamp"),
 					StopTimestamp:  aws.String("ISO8601Timestamp"),
@@ -63,5 +62,5 @@ func ExampleMobileAnalytics_PutEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -2251,7 +2251,7 @@ type metadataAgentVersion struct {
 
 // String returns the string representation
 func (s AgentVersion) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2323,7 +2323,7 @@ type metadataApp struct {
 
 // String returns the string representation
 func (s App) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2348,7 +2348,7 @@ type metadataAssignInstanceInput struct {
 
 // String returns the string representation
 func (s AssignInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2366,7 +2366,7 @@ type metadataAssignInstanceOutput struct {
 
 // String returns the string representation
 func (s AssignInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2390,7 +2390,7 @@ type metadataAssignVolumeInput struct {
 
 // String returns the string representation
 func (s AssignVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2408,7 +2408,7 @@ type metadataAssignVolumeOutput struct {
 
 // String returns the string representation
 func (s AssignVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2432,7 +2432,7 @@ type metadataAssociateElasticIPInput struct {
 
 // String returns the string representation
 func (s AssociateElasticIPInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2450,7 +2450,7 @@ type metadataAssociateElasticIPOutput struct {
 
 // String returns the string representation
 func (s AssociateElasticIPOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2475,7 +2475,7 @@ type metadataAttachElasticLoadBalancerInput struct {
 
 // String returns the string representation
 func (s AttachElasticLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2493,7 +2493,7 @@ type metadataAttachElasticLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s AttachElasticLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2550,7 +2550,7 @@ type metadataAutoScalingThresholds struct {
 
 // String returns the string representation
 func (s AutoScalingThresholds) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2586,7 +2586,7 @@ type metadataBlockDeviceMapping struct {
 
 // String returns the string representation
 func (s BlockDeviceMapping) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2611,7 +2611,7 @@ type metadataChefConfiguration struct {
 
 // String returns the string representation
 func (s ChefConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2803,7 +2803,7 @@ type metadataCloneStackInput struct {
 
 // String returns the string representation
 func (s CloneStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2825,7 +2825,7 @@ type metadataCloneStackOutput struct {
 
 // String returns the string representation
 func (s CloneStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2879,7 +2879,7 @@ type metadataCommand struct {
 
 // String returns the string representation
 func (s Command) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2951,7 +2951,7 @@ type metadataCreateAppInput struct {
 
 // String returns the string representation
 func (s CreateAppInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2973,7 +2973,7 @@ type metadataCreateAppOutput struct {
 
 // String returns the string representation
 func (s CreateAppOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3018,7 +3018,7 @@ type metadataCreateDeploymentInput struct {
 
 // String returns the string representation
 func (s CreateDeploymentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3041,7 +3041,7 @@ type metadataCreateDeploymentOutput struct {
 
 // String returns the string representation
 func (s CreateDeploymentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3155,7 +3155,7 @@ type metadataCreateInstanceInput struct {
 
 // String returns the string representation
 func (s CreateInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3177,7 +3177,7 @@ type metadataCreateInstanceOutput struct {
 
 // String returns the string representation
 func (s CreateInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3264,7 +3264,7 @@ type metadataCreateLayerInput struct {
 
 // String returns the string representation
 func (s CreateLayerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3286,7 +3286,7 @@ type metadataCreateLayerOutput struct {
 
 // String returns the string representation
 func (s CreateLayerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3463,7 +3463,7 @@ type metadataCreateStackInput struct {
 
 // String returns the string representation
 func (s CreateStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3486,7 +3486,7 @@ type metadataCreateStackOutput struct {
 
 // String returns the string representation
 func (s CreateStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3521,7 +3521,7 @@ type metadataCreateUserProfileInput struct {
 
 // String returns the string representation
 func (s CreateUserProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3543,7 +3543,7 @@ type metadataCreateUserProfileOutput struct {
 
 // String returns the string representation
 func (s CreateUserProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3572,7 +3572,7 @@ type metadataDataSource struct {
 
 // String returns the string representation
 func (s DataSource) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3593,7 +3593,7 @@ type metadataDeleteAppInput struct {
 
 // String returns the string representation
 func (s DeleteAppInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3611,7 +3611,7 @@ type metadataDeleteAppOutput struct {
 
 // String returns the string representation
 func (s DeleteAppOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3638,7 +3638,7 @@ type metadataDeleteInstanceInput struct {
 
 // String returns the string representation
 func (s DeleteInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3656,7 +3656,7 @@ type metadataDeleteInstanceOutput struct {
 
 // String returns the string representation
 func (s DeleteInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3677,7 +3677,7 @@ type metadataDeleteLayerInput struct {
 
 // String returns the string representation
 func (s DeleteLayerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3695,7 +3695,7 @@ type metadataDeleteLayerOutput struct {
 
 // String returns the string representation
 func (s DeleteLayerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3716,7 +3716,7 @@ type metadataDeleteStackInput struct {
 
 // String returns the string representation
 func (s DeleteStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3734,7 +3734,7 @@ type metadataDeleteStackOutput struct {
 
 // String returns the string representation
 func (s DeleteStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3755,7 +3755,7 @@ type metadataDeleteUserProfileInput struct {
 
 // String returns the string representation
 func (s DeleteUserProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3773,7 +3773,7 @@ type metadataDeleteUserProfileOutput struct {
 
 // String returns the string representation
 func (s DeleteUserProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3838,7 +3838,7 @@ type metadataDeployment struct {
 
 // String returns the string representation
 func (s Deployment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3901,7 +3901,7 @@ type metadataDeploymentCommand struct {
 
 // String returns the string representation
 func (s DeploymentCommand) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3922,7 +3922,7 @@ type metadataDeregisterElasticIPInput struct {
 
 // String returns the string representation
 func (s DeregisterElasticIPInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3940,7 +3940,7 @@ type metadataDeregisterElasticIPOutput struct {
 
 // String returns the string representation
 func (s DeregisterElasticIPOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3961,7 +3961,7 @@ type metadataDeregisterInstanceInput struct {
 
 // String returns the string representation
 func (s DeregisterInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3979,7 +3979,7 @@ type metadataDeregisterInstanceOutput struct {
 
 // String returns the string representation
 func (s DeregisterInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4000,7 +4000,7 @@ type metadataDeregisterRDSDBInstanceInput struct {
 
 // String returns the string representation
 func (s DeregisterRDSDBInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4018,7 +4018,7 @@ type metadataDeregisterRDSDBInstanceOutput struct {
 
 // String returns the string representation
 func (s DeregisterRDSDBInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4041,7 +4041,7 @@ type metadataDeregisterVolumeInput struct {
 
 // String returns the string representation
 func (s DeregisterVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4059,7 +4059,7 @@ type metadataDeregisterVolumeOutput struct {
 
 // String returns the string representation
 func (s DeregisterVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4083,7 +4083,7 @@ type metadataDescribeAgentVersionsInput struct {
 
 // String returns the string representation
 func (s DescribeAgentVersionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4107,7 +4107,7 @@ type metadataDescribeAgentVersionsOutput struct {
 
 // String returns the string representation
 func (s DescribeAgentVersionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4134,7 +4134,7 @@ type metadataDescribeAppsInput struct {
 
 // String returns the string representation
 func (s DescribeAppsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4156,7 +4156,7 @@ type metadataDescribeAppsOutput struct {
 
 // String returns the string representation
 func (s DescribeAppsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4187,7 +4187,7 @@ type metadataDescribeCommandsInput struct {
 
 // String returns the string representation
 func (s DescribeCommandsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4209,7 +4209,7 @@ type metadataDescribeCommandsOutput struct {
 
 // String returns the string representation
 func (s DescribeCommandsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4240,7 +4240,7 @@ type metadataDescribeDeploymentsInput struct {
 
 // String returns the string representation
 func (s DescribeDeploymentsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4262,7 +4262,7 @@ type metadataDescribeDeploymentsOutput struct {
 
 // String returns the string representation
 func (s DescribeDeploymentsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4293,7 +4293,7 @@ type metadataDescribeElasticIPsInput struct {
 
 // String returns the string representation
 func (s DescribeElasticIPsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4315,7 +4315,7 @@ type metadataDescribeElasticIPsOutput struct {
 
 // String returns the string representation
 func (s DescribeElasticIPsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4340,7 +4340,7 @@ type metadataDescribeElasticLoadBalancersInput struct {
 
 // String returns the string representation
 func (s DescribeElasticLoadBalancersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4363,7 +4363,7 @@ type metadataDescribeElasticLoadBalancersOutput struct {
 
 // String returns the string representation
 func (s DescribeElasticLoadBalancersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4394,7 +4394,7 @@ type metadataDescribeInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4416,7 +4416,7 @@ type metadataDescribeInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4442,7 +4442,7 @@ type metadataDescribeLayersInput struct {
 
 // String returns the string representation
 func (s DescribeLayersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4464,7 +4464,7 @@ type metadataDescribeLayersOutput struct {
 
 // String returns the string representation
 func (s DescribeLayersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4485,7 +4485,7 @@ type metadataDescribeLoadBasedAutoScalingInput struct {
 
 // String returns the string representation
 func (s DescribeLoadBasedAutoScalingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4508,7 +4508,7 @@ type metadataDescribeLoadBasedAutoScalingOutput struct {
 
 // String returns the string representation
 func (s DescribeLoadBasedAutoScalingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4526,7 +4526,7 @@ type metadataDescribeMyUserProfileInput struct {
 
 // String returns the string representation
 func (s DescribeMyUserProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4548,7 +4548,7 @@ type metadataDescribeMyUserProfileOutput struct {
 
 // String returns the string representation
 func (s DescribeMyUserProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4573,7 +4573,7 @@ type metadataDescribePermissionsInput struct {
 
 // String returns the string representation
 func (s DescribePermissionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4602,7 +4602,7 @@ type metadataDescribePermissionsOutput struct {
 
 // String returns the string representation
 func (s DescribePermissionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4632,7 +4632,7 @@ type metadataDescribeRAIDArraysInput struct {
 
 // String returns the string representation
 func (s DescribeRAIDArraysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4654,7 +4654,7 @@ type metadataDescribeRAIDArraysOutput struct {
 
 // String returns the string representation
 func (s DescribeRAIDArraysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4679,7 +4679,7 @@ type metadataDescribeRDSDBInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeRDSDBInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4701,7 +4701,7 @@ type metadataDescribeRDSDBInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeRDSDBInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4732,7 +4732,7 @@ type metadataDescribeServiceErrorsInput struct {
 
 // String returns the string representation
 func (s DescribeServiceErrorsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4754,7 +4754,7 @@ type metadataDescribeServiceErrorsOutput struct {
 
 // String returns the string representation
 func (s DescribeServiceErrorsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4775,7 +4775,7 @@ type metadataDescribeStackProvisioningParametersInput struct {
 
 // String returns the string representation
 func (s DescribeStackProvisioningParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4800,7 +4800,7 @@ type metadataDescribeStackProvisioningParametersOutput struct {
 
 // String returns the string representation
 func (s DescribeStackProvisioningParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4821,7 +4821,7 @@ type metadataDescribeStackSummaryInput struct {
 
 // String returns the string representation
 func (s DescribeStackSummaryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4843,7 +4843,7 @@ type metadataDescribeStackSummaryOutput struct {
 
 // String returns the string representation
 func (s DescribeStackSummaryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4865,7 +4865,7 @@ type metadataDescribeStacksInput struct {
 
 // String returns the string representation
 func (s DescribeStacksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4887,7 +4887,7 @@ type metadataDescribeStacksOutput struct {
 
 // String returns the string representation
 func (s DescribeStacksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4908,7 +4908,7 @@ type metadataDescribeTimeBasedAutoScalingInput struct {
 
 // String returns the string representation
 func (s DescribeTimeBasedAutoScalingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4931,7 +4931,7 @@ type metadataDescribeTimeBasedAutoScalingOutput struct {
 
 // String returns the string representation
 func (s DescribeTimeBasedAutoScalingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4952,7 +4952,7 @@ type metadataDescribeUserProfilesInput struct {
 
 // String returns the string representation
 func (s DescribeUserProfilesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4974,7 +4974,7 @@ type metadataDescribeUserProfilesOutput struct {
 
 // String returns the string representation
 func (s DescribeUserProfilesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5008,7 +5008,7 @@ type metadataDescribeVolumesInput struct {
 
 // String returns the string representation
 func (s DescribeVolumesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5030,7 +5030,7 @@ type metadataDescribeVolumesOutput struct {
 
 // String returns the string representation
 func (s DescribeVolumesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5055,7 +5055,7 @@ type metadataDetachElasticLoadBalancerInput struct {
 
 // String returns the string representation
 func (s DetachElasticLoadBalancerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5073,7 +5073,7 @@ type metadataDetachElasticLoadBalancerOutput struct {
 
 // String returns the string representation
 func (s DetachElasticLoadBalancerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5094,7 +5094,7 @@ type metadataDisassociateElasticIPInput struct {
 
 // String returns the string representation
 func (s DisassociateElasticIPInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5112,7 +5112,7 @@ type metadataDisassociateElasticIPOutput struct {
 
 // String returns the string representation
 func (s DisassociateElasticIPOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5150,7 +5150,7 @@ type metadataEBSBlockDevice struct {
 
 // String returns the string representation
 func (s EBSBlockDevice) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5184,7 +5184,7 @@ type metadataElasticIP struct {
 
 // String returns the string representation
 func (s ElasticIP) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5231,7 +5231,7 @@ type metadataElasticLoadBalancer struct {
 
 // String returns the string representation
 func (s ElasticLoadBalancer) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5267,7 +5267,7 @@ type metadataEnvironmentVariable struct {
 
 // String returns the string representation
 func (s EnvironmentVariable) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5288,7 +5288,7 @@ type metadataGetHostnameSuggestionInput struct {
 
 // String returns the string representation
 func (s GetHostnameSuggestionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5313,7 +5313,7 @@ type metadataGetHostnameSuggestionOutput struct {
 
 // String returns the string representation
 func (s GetHostnameSuggestionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5340,7 +5340,7 @@ type metadataGrantAccessInput struct {
 
 // String returns the string representation
 func (s GrantAccessInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5363,7 +5363,7 @@ type metadataGrantAccessOutput struct {
 
 // String returns the string representation
 func (s GrantAccessOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5510,7 +5510,7 @@ type metadataInstance struct {
 
 // String returns the string representation
 func (s Instance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5536,7 +5536,7 @@ type metadataInstanceIdentity struct {
 
 // String returns the string representation
 func (s InstanceIdentity) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5612,7 +5612,7 @@ type metadataInstancesCount struct {
 
 // String returns the string representation
 func (s InstancesCount) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5715,7 +5715,7 @@ type metadataLayer struct {
 
 // String returns the string representation
 func (s Layer) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5737,7 +5737,7 @@ type metadataLifecycleEventConfiguration struct {
 
 // String returns the string representation
 func (s LifecycleEventConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5770,7 +5770,7 @@ type metadataLoadBasedAutoScalingConfiguration struct {
 
 // String returns the string representation
 func (s LoadBasedAutoScalingConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5808,7 +5808,7 @@ type metadataPermission struct {
 
 // String returns the string representation
 func (s Permission) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5867,7 +5867,7 @@ type metadataRAIDArray struct {
 
 // String returns the string representation
 func (s RAIDArray) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5915,7 +5915,7 @@ type metadataRDSDBInstance struct {
 
 // String returns the string representation
 func (s RDSDBInstance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5936,7 +5936,7 @@ type metadataRebootInstanceInput struct {
 
 // String returns the string representation
 func (s RebootInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5954,7 +5954,7 @@ type metadataRebootInstanceOutput struct {
 
 // String returns the string representation
 func (s RebootInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5998,7 +5998,7 @@ type metadataRecipes struct {
 
 // String returns the string representation
 func (s Recipes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6022,7 +6022,7 @@ type metadataRegisterElasticIPInput struct {
 
 // String returns the string representation
 func (s RegisterElasticIPInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6044,7 +6044,7 @@ type metadataRegisterElasticIPOutput struct {
 
 // String returns the string representation
 func (s RegisterElasticIPOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6084,7 +6084,7 @@ type metadataRegisterInstanceInput struct {
 
 // String returns the string representation
 func (s RegisterInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6106,7 +6106,7 @@ type metadataRegisterInstanceOutput struct {
 
 // String returns the string representation
 func (s RegisterInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6136,7 +6136,7 @@ type metadataRegisterRDSDBInstanceInput struct {
 
 // String returns the string representation
 func (s RegisterRDSDBInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6154,7 +6154,7 @@ type metadataRegisterRDSDBInstanceOutput struct {
 
 // String returns the string representation
 func (s RegisterRDSDBInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6178,7 +6178,7 @@ type metadataRegisterVolumeInput struct {
 
 // String returns the string representation
 func (s RegisterVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6200,7 +6200,7 @@ type metadataRegisterVolumeOutput struct {
 
 // String returns the string representation
 func (s RegisterVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6228,7 +6228,7 @@ type metadataReportedOs struct {
 
 // String returns the string representation
 func (s ReportedOs) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6257,7 +6257,7 @@ type metadataSSLConfiguration struct {
 
 // String returns the string representation
 func (s SSLConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6288,7 +6288,7 @@ type metadataSelfUserProfile struct {
 
 // String returns the string representation
 func (s SelfUserProfile) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6325,7 +6325,7 @@ type metadataServiceError struct {
 
 // String returns the string representation
 func (s ServiceError) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6359,7 +6359,7 @@ type metadataSetLoadBasedAutoScalingInput struct {
 
 // String returns the string representation
 func (s SetLoadBasedAutoScalingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6377,7 +6377,7 @@ type metadataSetLoadBasedAutoScalingOutput struct {
 
 // String returns the string representation
 func (s SetLoadBasedAutoScalingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6414,7 +6414,7 @@ type metadataSetPermissionInput struct {
 
 // String returns the string representation
 func (s SetPermissionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6432,7 +6432,7 @@ type metadataSetPermissionOutput struct {
 
 // String returns the string representation
 func (s SetPermissionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6456,7 +6456,7 @@ type metadataSetTimeBasedAutoScalingInput struct {
 
 // String returns the string representation
 func (s SetTimeBasedAutoScalingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6474,7 +6474,7 @@ type metadataSetTimeBasedAutoScalingOutput struct {
 
 // String returns the string representation
 func (s SetTimeBasedAutoScalingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6501,7 +6501,7 @@ type metadataShutdownEventConfiguration struct {
 
 // String returns the string representation
 func (s ShutdownEventConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6557,7 +6557,7 @@ type metadataSource struct {
 
 // String returns the string representation
 func (s Source) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6663,7 +6663,7 @@ type metadataStack struct {
 
 // String returns the string representation
 func (s Stack) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6689,7 +6689,7 @@ type metadataStackConfigurationManager struct {
 
 // String returns the string representation
 func (s StackConfigurationManager) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6726,7 +6726,7 @@ type metadataStackSummary struct {
 
 // String returns the string representation
 func (s StackSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6747,7 +6747,7 @@ type metadataStartInstanceInput struct {
 
 // String returns the string representation
 func (s StartInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6765,7 +6765,7 @@ type metadataStartInstanceOutput struct {
 
 // String returns the string representation
 func (s StartInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6786,7 +6786,7 @@ type metadataStartStackInput struct {
 
 // String returns the string representation
 func (s StartStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6804,7 +6804,7 @@ type metadataStartStackOutput struct {
 
 // String returns the string representation
 func (s StartStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6825,7 +6825,7 @@ type metadataStopInstanceInput struct {
 
 // String returns the string representation
 func (s StopInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6843,7 +6843,7 @@ type metadataStopInstanceOutput struct {
 
 // String returns the string representation
 func (s StopInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6864,7 +6864,7 @@ type metadataStopStackInput struct {
 
 // String returns the string representation
 func (s StopStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6882,7 +6882,7 @@ type metadataStopStackOutput struct {
 
 // String returns the string representation
 func (s StopStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6917,7 +6917,7 @@ type metadataTemporaryCredential struct {
 
 // String returns the string representation
 func (s TemporaryCredential) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6942,7 +6942,7 @@ type metadataTimeBasedAutoScalingConfiguration struct {
 
 // String returns the string representation
 func (s TimeBasedAutoScalingConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6963,7 +6963,7 @@ type metadataUnassignInstanceInput struct {
 
 // String returns the string representation
 func (s UnassignInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6981,7 +6981,7 @@ type metadataUnassignInstanceOutput struct {
 
 // String returns the string representation
 func (s UnassignInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7002,7 +7002,7 @@ type metadataUnassignVolumeInput struct {
 
 // String returns the string representation
 func (s UnassignVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7020,7 +7020,7 @@ type metadataUnassignVolumeOutput struct {
 
 // String returns the string representation
 func (s UnassignVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7085,7 +7085,7 @@ type metadataUpdateAppInput struct {
 
 // String returns the string representation
 func (s UpdateAppInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7103,7 +7103,7 @@ type metadataUpdateAppOutput struct {
 
 // String returns the string representation
 func (s UpdateAppOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7127,7 +7127,7 @@ type metadataUpdateElasticIPInput struct {
 
 // String returns the string representation
 func (s UpdateElasticIPInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7145,7 +7145,7 @@ type metadataUpdateElasticIPOutput struct {
 
 // String returns the string representation
 func (s UpdateElasticIPOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7242,7 +7242,7 @@ type metadataUpdateInstanceInput struct {
 
 // String returns the string representation
 func (s UpdateInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7260,7 +7260,7 @@ type metadataUpdateInstanceOutput struct {
 
 // String returns the string representation
 func (s UpdateInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7340,7 +7340,7 @@ type metadataUpdateLayerInput struct {
 
 // String returns the string representation
 func (s UpdateLayerInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7358,7 +7358,7 @@ type metadataUpdateLayerOutput struct {
 
 // String returns the string representation
 func (s UpdateLayerOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7379,7 +7379,7 @@ type metadataUpdateMyUserProfileInput struct {
 
 // String returns the string representation
 func (s UpdateMyUserProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7397,7 +7397,7 @@ type metadataUpdateMyUserProfileOutput struct {
 
 // String returns the string representation
 func (s UpdateMyUserProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7424,7 +7424,7 @@ type metadataUpdateRDSDBInstanceInput struct {
 
 // String returns the string representation
 func (s UpdateRDSDBInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7442,7 +7442,7 @@ type metadataUpdateRDSDBInstanceOutput struct {
 
 // String returns the string representation
 func (s UpdateRDSDBInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7596,7 +7596,7 @@ type metadataUpdateStackInput struct {
 
 // String returns the string representation
 func (s UpdateStackInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7614,7 +7614,7 @@ type metadataUpdateStackOutput struct {
 
 // String returns the string representation
 func (s UpdateStackOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7649,7 +7649,7 @@ type metadataUpdateUserProfileInput struct {
 
 // String returns the string representation
 func (s UpdateUserProfileInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7667,7 +7667,7 @@ type metadataUpdateUserProfileOutput struct {
 
 // String returns the string representation
 func (s UpdateUserProfileOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7694,7 +7694,7 @@ type metadataUpdateVolumeInput struct {
 
 // String returns the string representation
 func (s UpdateVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7712,7 +7712,7 @@ type metadataUpdateVolumeOutput struct {
 
 // String returns the string representation
 func (s UpdateVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7747,7 +7747,7 @@ type metadataUserProfile struct {
 
 // String returns the string representation
 func (s UserProfile) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7807,7 +7807,7 @@ type metadataVolume struct {
 
 // String returns the string representation
 func (s Volume) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7847,7 +7847,7 @@ type metadataVolumeConfiguration struct {
 
 // String returns the string representation
 func (s VolumeConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7900,7 +7900,7 @@ type metadataWeeklyAutoScalingSchedule struct {
 
 // String returns the string representation
 func (s WeeklyAutoScalingSchedule) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/opsworks/examples_test.go
+++ b/service/opsworks/examples_test.go
@@ -44,7 +44,7 @@ func ExampleOpsWorks_AssignInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_AssignVolume() {
@@ -72,7 +72,7 @@ func ExampleOpsWorks_AssignVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_AssociateElasticIP() {
@@ -100,7 +100,7 @@ func ExampleOpsWorks_AssociateElasticIP() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_AttachElasticLoadBalancer() {
@@ -128,7 +128,7 @@ func ExampleOpsWorks_AttachElasticLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_CloneStack() {
@@ -144,13 +144,13 @@ func ExampleOpsWorks_CloneStack() {
 		},
 		ChefConfiguration: &opsworks.ChefConfiguration{
 			BerkshelfVersion: aws.String("String"),
-			ManageBerkshelf:  aws.Boolean(true),
+			ManageBerkshelf:  aws.Bool(true),
 		},
 		CloneAppIDs: []*string{
 			aws.String("String"), // Required
 			// More values...
 		},
-		ClonePermissions: aws.Boolean(true),
+		ClonePermissions: aws.Bool(true),
 		ConfigurationManager: &opsworks.StackConfigurationManager{
 			Name:    aws.String("String"),
 			Version: aws.String("String"),
@@ -173,8 +173,8 @@ func ExampleOpsWorks_CloneStack() {
 		HostnameTheme:             aws.String("String"),
 		Name:                      aws.String("String"),
 		Region:                    aws.String("String"),
-		UseCustomCookbooks:        aws.Boolean(true),
-		UseOpsWorksSecurityGroups: aws.Boolean(true),
+		UseCustomCookbooks:        aws.Bool(true),
+		UseOpsWorksSecurityGroups: aws.Bool(true),
 		VPCID: aws.String("String"),
 	}
 	resp, err := svc.CloneStack(params)
@@ -195,7 +195,7 @@ func ExampleOpsWorks_CloneStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_CreateApp() {
@@ -230,12 +230,12 @@ func ExampleOpsWorks_CreateApp() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		EnableSSL: aws.Boolean(true),
+		EnableSSL: aws.Bool(true),
 		Environment: []*opsworks.EnvironmentVariable{
 			{ // Required
 				Key:    aws.String("String"), // Required
 				Value:  aws.String("String"), // Required
-				Secure: aws.Boolean(true),
+				Secure: aws.Bool(true),
 			},
 			// More values...
 		},
@@ -264,7 +264,7 @@ func ExampleOpsWorks_CreateApp() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_CreateDeployment() {
@@ -308,7 +308,7 @@ func ExampleOpsWorks_CreateDeployment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_CreateInstance() {
@@ -330,10 +330,10 @@ func ExampleOpsWorks_CreateInstance() {
 			{ // Required
 				DeviceName: aws.String("String"),
 				EBS: &opsworks.EBSBlockDevice{
-					DeleteOnTermination: aws.Boolean(true),
-					IOPS:                aws.Long(1),
+					DeleteOnTermination: aws.Bool(true),
+					IOPS:                aws.Int64(1),
 					SnapshotID:          aws.String("String"),
-					VolumeSize:          aws.Long(1),
+					VolumeSize:          aws.Int64(1),
 					VolumeType:          aws.String("VolumeType"),
 				},
 				NoDevice:    aws.String("String"),
@@ -341,9 +341,9 @@ func ExampleOpsWorks_CreateInstance() {
 			},
 			// More values...
 		},
-		EBSOptimized:         aws.Boolean(true),
+		EBSOptimized:         aws.Bool(true),
 		Hostname:             aws.String("String"),
-		InstallUpdatesOnBoot: aws.Boolean(true),
+		InstallUpdatesOnBoot: aws.Bool(true),
 		Os:                   aws.String("String"),
 		RootDeviceType:       aws.String("RootDeviceType"),
 		SSHKeyName:           aws.String("String"),
@@ -368,7 +368,7 @@ func ExampleOpsWorks_CreateInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_CreateLayer() {
@@ -383,8 +383,8 @@ func ExampleOpsWorks_CreateLayer() {
 			"Key": aws.String("String"), // Required
 			// More values...
 		},
-		AutoAssignElasticIPs:     aws.Boolean(true),
-		AutoAssignPublicIPs:      aws.Boolean(true),
+		AutoAssignElasticIPs:     aws.Bool(true),
+		AutoAssignPublicIPs:      aws.Bool(true),
 		CustomInstanceProfileARN: aws.String("String"),
 		CustomRecipes: &opsworks.Recipes{
 			Configure: []*string{
@@ -412,26 +412,26 @@ func ExampleOpsWorks_CreateLayer() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		EnableAutoHealing:    aws.Boolean(true),
-		InstallUpdatesOnBoot: aws.Boolean(true),
+		EnableAutoHealing:    aws.Bool(true),
+		InstallUpdatesOnBoot: aws.Bool(true),
 		LifecycleEventConfiguration: &opsworks.LifecycleEventConfiguration{
 			Shutdown: &opsworks.ShutdownEventConfiguration{
-				DelayUntilELBConnectionsDrained: aws.Boolean(true),
-				ExecutionTimeout:                aws.Long(1),
+				DelayUntilELBConnectionsDrained: aws.Bool(true),
+				ExecutionTimeout:                aws.Int64(1),
 			},
 		},
 		Packages: []*string{
 			aws.String("String"), // Required
 			// More values...
 		},
-		UseEBSOptimizedInstances: aws.Boolean(true),
+		UseEBSOptimizedInstances: aws.Bool(true),
 		VolumeConfigurations: []*opsworks.VolumeConfiguration{
 			{ // Required
 				MountPoint:    aws.String("String"), // Required
-				NumberOfDisks: aws.Long(1),          // Required
-				Size:          aws.Long(1),          // Required
-				IOPS:          aws.Long(1),
-				RAIDLevel:     aws.Long(1),
+				NumberOfDisks: aws.Int64(1),         // Required
+				Size:          aws.Int64(1),         // Required
+				IOPS:          aws.Int64(1),
+				RAIDLevel:     aws.Int64(1),
 				VolumeType:    aws.String("String"),
 			},
 			// More values...
@@ -455,7 +455,7 @@ func ExampleOpsWorks_CreateLayer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_CreateStack() {
@@ -473,7 +473,7 @@ func ExampleOpsWorks_CreateStack() {
 		},
 		ChefConfiguration: &opsworks.ChefConfiguration{
 			BerkshelfVersion: aws.String("String"),
-			ManageBerkshelf:  aws.Boolean(true),
+			ManageBerkshelf:  aws.Bool(true),
 		},
 		ConfigurationManager: &opsworks.StackConfigurationManager{
 			Name:    aws.String("String"),
@@ -494,8 +494,8 @@ func ExampleOpsWorks_CreateStack() {
 		DefaultSSHKeyName:         aws.String("String"),
 		DefaultSubnetID:           aws.String("String"),
 		HostnameTheme:             aws.String("String"),
-		UseCustomCookbooks:        aws.Boolean(true),
-		UseOpsWorksSecurityGroups: aws.Boolean(true),
+		UseCustomCookbooks:        aws.Bool(true),
+		UseOpsWorksSecurityGroups: aws.Bool(true),
 		VPCID: aws.String("String"),
 	}
 	resp, err := svc.CreateStack(params)
@@ -516,7 +516,7 @@ func ExampleOpsWorks_CreateStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_CreateUserProfile() {
@@ -524,7 +524,7 @@ func ExampleOpsWorks_CreateUserProfile() {
 
 	params := &opsworks.CreateUserProfileInput{
 		IAMUserARN:          aws.String("String"), // Required
-		AllowSelfManagement: aws.Boolean(true),
+		AllowSelfManagement: aws.Bool(true),
 		SSHPublicKey:        aws.String("String"),
 		SSHUsername:         aws.String("String"),
 	}
@@ -546,7 +546,7 @@ func ExampleOpsWorks_CreateUserProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeleteApp() {
@@ -573,7 +573,7 @@ func ExampleOpsWorks_DeleteApp() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeleteInstance() {
@@ -581,8 +581,8 @@ func ExampleOpsWorks_DeleteInstance() {
 
 	params := &opsworks.DeleteInstanceInput{
 		InstanceID:      aws.String("String"), // Required
-		DeleteElasticIP: aws.Boolean(true),
-		DeleteVolumes:   aws.Boolean(true),
+		DeleteElasticIP: aws.Bool(true),
+		DeleteVolumes:   aws.Bool(true),
 	}
 	resp, err := svc.DeleteInstance(params)
 
@@ -602,7 +602,7 @@ func ExampleOpsWorks_DeleteInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeleteLayer() {
@@ -629,7 +629,7 @@ func ExampleOpsWorks_DeleteLayer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeleteStack() {
@@ -656,7 +656,7 @@ func ExampleOpsWorks_DeleteStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeleteUserProfile() {
@@ -683,7 +683,7 @@ func ExampleOpsWorks_DeleteUserProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeregisterElasticIP() {
@@ -710,7 +710,7 @@ func ExampleOpsWorks_DeregisterElasticIP() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeregisterInstance() {
@@ -737,7 +737,7 @@ func ExampleOpsWorks_DeregisterInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeregisterRDSDBInstance() {
@@ -764,7 +764,7 @@ func ExampleOpsWorks_DeregisterRDSDBInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DeregisterVolume() {
@@ -791,7 +791,7 @@ func ExampleOpsWorks_DeregisterVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeAgentVersions() {
@@ -822,7 +822,7 @@ func ExampleOpsWorks_DescribeAgentVersions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeApps() {
@@ -853,7 +853,7 @@ func ExampleOpsWorks_DescribeApps() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeCommands() {
@@ -885,7 +885,7 @@ func ExampleOpsWorks_DescribeCommands() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeDeployments() {
@@ -917,7 +917,7 @@ func ExampleOpsWorks_DescribeDeployments() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeElasticIPs() {
@@ -949,7 +949,7 @@ func ExampleOpsWorks_DescribeElasticIPs() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeElasticLoadBalancers() {
@@ -980,7 +980,7 @@ func ExampleOpsWorks_DescribeElasticLoadBalancers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeInstances() {
@@ -1012,7 +1012,7 @@ func ExampleOpsWorks_DescribeInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeLayers() {
@@ -1043,7 +1043,7 @@ func ExampleOpsWorks_DescribeLayers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeLoadBasedAutoScaling() {
@@ -1073,7 +1073,7 @@ func ExampleOpsWorks_DescribeLoadBasedAutoScaling() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeMyUserProfile() {
@@ -1098,7 +1098,7 @@ func ExampleOpsWorks_DescribeMyUserProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribePermissions() {
@@ -1126,7 +1126,7 @@ func ExampleOpsWorks_DescribePermissions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeRAIDArrays() {
@@ -1158,7 +1158,7 @@ func ExampleOpsWorks_DescribeRAIDArrays() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeRDSDBInstances() {
@@ -1189,7 +1189,7 @@ func ExampleOpsWorks_DescribeRDSDBInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeServiceErrors() {
@@ -1221,7 +1221,7 @@ func ExampleOpsWorks_DescribeServiceErrors() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeStackProvisioningParameters() {
@@ -1248,7 +1248,7 @@ func ExampleOpsWorks_DescribeStackProvisioningParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeStackSummary() {
@@ -1275,7 +1275,7 @@ func ExampleOpsWorks_DescribeStackSummary() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeStacks() {
@@ -1305,7 +1305,7 @@ func ExampleOpsWorks_DescribeStacks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeTimeBasedAutoScaling() {
@@ -1335,7 +1335,7 @@ func ExampleOpsWorks_DescribeTimeBasedAutoScaling() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeUserProfiles() {
@@ -1365,7 +1365,7 @@ func ExampleOpsWorks_DescribeUserProfiles() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DescribeVolumes() {
@@ -1398,7 +1398,7 @@ func ExampleOpsWorks_DescribeVolumes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DetachElasticLoadBalancer() {
@@ -1426,7 +1426,7 @@ func ExampleOpsWorks_DetachElasticLoadBalancer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_DisassociateElasticIP() {
@@ -1453,7 +1453,7 @@ func ExampleOpsWorks_DisassociateElasticIP() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_GetHostnameSuggestion() {
@@ -1480,7 +1480,7 @@ func ExampleOpsWorks_GetHostnameSuggestion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_GrantAccess() {
@@ -1488,7 +1488,7 @@ func ExampleOpsWorks_GrantAccess() {
 
 	params := &opsworks.GrantAccessInput{
 		InstanceID:        aws.String("String"), // Required
-		ValidForInMinutes: aws.Long(1),
+		ValidForInMinutes: aws.Int64(1),
 	}
 	resp, err := svc.GrantAccess(params)
 
@@ -1508,7 +1508,7 @@ func ExampleOpsWorks_GrantAccess() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_RebootInstance() {
@@ -1535,7 +1535,7 @@ func ExampleOpsWorks_RebootInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_RegisterElasticIP() {
@@ -1563,7 +1563,7 @@ func ExampleOpsWorks_RegisterElasticIP() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_RegisterInstance() {
@@ -1599,7 +1599,7 @@ func ExampleOpsWorks_RegisterInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_RegisterRDSDBInstance() {
@@ -1629,7 +1629,7 @@ func ExampleOpsWorks_RegisterRDSDBInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_RegisterVolume() {
@@ -1657,7 +1657,7 @@ func ExampleOpsWorks_RegisterVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_SetLoadBasedAutoScaling() {
@@ -1670,25 +1670,25 @@ func ExampleOpsWorks_SetLoadBasedAutoScaling() {
 				aws.String("String"), // Required
 				// More values...
 			},
-			CPUThreshold:       aws.Double(1.0),
-			IgnoreMetricsTime:  aws.Long(1),
-			InstanceCount:      aws.Long(1),
-			LoadThreshold:      aws.Double(1.0),
-			MemoryThreshold:    aws.Double(1.0),
-			ThresholdsWaitTime: aws.Long(1),
+			CPUThreshold:       aws.Float64(1.0),
+			IgnoreMetricsTime:  aws.Int64(1),
+			InstanceCount:      aws.Int64(1),
+			LoadThreshold:      aws.Float64(1.0),
+			MemoryThreshold:    aws.Float64(1.0),
+			ThresholdsWaitTime: aws.Int64(1),
 		},
-		Enable: aws.Boolean(true),
+		Enable: aws.Bool(true),
 		UpScaling: &opsworks.AutoScalingThresholds{
 			Alarms: []*string{
 				aws.String("String"), // Required
 				// More values...
 			},
-			CPUThreshold:       aws.Double(1.0),
-			IgnoreMetricsTime:  aws.Long(1),
-			InstanceCount:      aws.Long(1),
-			LoadThreshold:      aws.Double(1.0),
-			MemoryThreshold:    aws.Double(1.0),
-			ThresholdsWaitTime: aws.Long(1),
+			CPUThreshold:       aws.Float64(1.0),
+			IgnoreMetricsTime:  aws.Int64(1),
+			InstanceCount:      aws.Int64(1),
+			LoadThreshold:      aws.Float64(1.0),
+			MemoryThreshold:    aws.Float64(1.0),
+			ThresholdsWaitTime: aws.Int64(1),
 		},
 	}
 	resp, err := svc.SetLoadBasedAutoScaling(params)
@@ -1709,7 +1709,7 @@ func ExampleOpsWorks_SetLoadBasedAutoScaling() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_SetPermission() {
@@ -1718,8 +1718,8 @@ func ExampleOpsWorks_SetPermission() {
 	params := &opsworks.SetPermissionInput{
 		IAMUserARN: aws.String("String"), // Required
 		StackID:    aws.String("String"), // Required
-		AllowSSH:   aws.Boolean(true),
-		AllowSudo:  aws.Boolean(true),
+		AllowSSH:   aws.Bool(true),
+		AllowSudo:  aws.Bool(true),
 		Level:      aws.String("String"),
 	}
 	resp, err := svc.SetPermission(params)
@@ -1740,7 +1740,7 @@ func ExampleOpsWorks_SetPermission() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_SetTimeBasedAutoScaling() {
@@ -1797,7 +1797,7 @@ func ExampleOpsWorks_SetTimeBasedAutoScaling() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_StartInstance() {
@@ -1824,7 +1824,7 @@ func ExampleOpsWorks_StartInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_StartStack() {
@@ -1851,7 +1851,7 @@ func ExampleOpsWorks_StartStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_StopInstance() {
@@ -1878,7 +1878,7 @@ func ExampleOpsWorks_StopInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_StopStack() {
@@ -1905,7 +1905,7 @@ func ExampleOpsWorks_StopStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UnassignInstance() {
@@ -1932,7 +1932,7 @@ func ExampleOpsWorks_UnassignInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UnassignVolume() {
@@ -1959,7 +1959,7 @@ func ExampleOpsWorks_UnassignVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateApp() {
@@ -1992,12 +1992,12 @@ func ExampleOpsWorks_UpdateApp() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		EnableSSL: aws.Boolean(true),
+		EnableSSL: aws.Bool(true),
 		Environment: []*opsworks.EnvironmentVariable{
 			{ // Required
 				Key:    aws.String("String"), // Required
 				Value:  aws.String("String"), // Required
-				Secure: aws.Boolean(true),
+				Secure: aws.Bool(true),
 			},
 			// More values...
 		},
@@ -2027,7 +2027,7 @@ func ExampleOpsWorks_UpdateApp() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateElasticIP() {
@@ -2055,7 +2055,7 @@ func ExampleOpsWorks_UpdateElasticIP() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateInstance() {
@@ -2067,9 +2067,9 @@ func ExampleOpsWorks_UpdateInstance() {
 		AgentVersion:         aws.String("String"),
 		Architecture:         aws.String("Architecture"),
 		AutoScalingType:      aws.String("AutoScalingType"),
-		EBSOptimized:         aws.Boolean(true),
+		EBSOptimized:         aws.Bool(true),
 		Hostname:             aws.String("String"),
-		InstallUpdatesOnBoot: aws.Boolean(true),
+		InstallUpdatesOnBoot: aws.Bool(true),
 		InstanceType:         aws.String("String"),
 		LayerIDs: []*string{
 			aws.String("String"), // Required
@@ -2096,7 +2096,7 @@ func ExampleOpsWorks_UpdateInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateLayer() {
@@ -2108,8 +2108,8 @@ func ExampleOpsWorks_UpdateLayer() {
 			"Key": aws.String("String"), // Required
 			// More values...
 		},
-		AutoAssignElasticIPs:     aws.Boolean(true),
-		AutoAssignPublicIPs:      aws.Boolean(true),
+		AutoAssignElasticIPs:     aws.Bool(true),
+		AutoAssignPublicIPs:      aws.Bool(true),
 		CustomInstanceProfileARN: aws.String("String"),
 		CustomRecipes: &opsworks.Recipes{
 			Configure: []*string{
@@ -2137,12 +2137,12 @@ func ExampleOpsWorks_UpdateLayer() {
 			aws.String("String"), // Required
 			// More values...
 		},
-		EnableAutoHealing:    aws.Boolean(true),
-		InstallUpdatesOnBoot: aws.Boolean(true),
+		EnableAutoHealing:    aws.Bool(true),
+		InstallUpdatesOnBoot: aws.Bool(true),
 		LifecycleEventConfiguration: &opsworks.LifecycleEventConfiguration{
 			Shutdown: &opsworks.ShutdownEventConfiguration{
-				DelayUntilELBConnectionsDrained: aws.Boolean(true),
-				ExecutionTimeout:                aws.Long(1),
+				DelayUntilELBConnectionsDrained: aws.Bool(true),
+				ExecutionTimeout:                aws.Int64(1),
 			},
 		},
 		Name: aws.String("String"),
@@ -2151,14 +2151,14 @@ func ExampleOpsWorks_UpdateLayer() {
 			// More values...
 		},
 		Shortname:                aws.String("String"),
-		UseEBSOptimizedInstances: aws.Boolean(true),
+		UseEBSOptimizedInstances: aws.Bool(true),
 		VolumeConfigurations: []*opsworks.VolumeConfiguration{
 			{ // Required
 				MountPoint:    aws.String("String"), // Required
-				NumberOfDisks: aws.Long(1),          // Required
-				Size:          aws.Long(1),          // Required
-				IOPS:          aws.Long(1),
-				RAIDLevel:     aws.Long(1),
+				NumberOfDisks: aws.Int64(1),         // Required
+				Size:          aws.Int64(1),         // Required
+				IOPS:          aws.Int64(1),
+				RAIDLevel:     aws.Int64(1),
 				VolumeType:    aws.String("String"),
 			},
 			// More values...
@@ -2182,7 +2182,7 @@ func ExampleOpsWorks_UpdateLayer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateMyUserProfile() {
@@ -2209,7 +2209,7 @@ func ExampleOpsWorks_UpdateMyUserProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateRDSDBInstance() {
@@ -2238,7 +2238,7 @@ func ExampleOpsWorks_UpdateRDSDBInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateStack() {
@@ -2253,7 +2253,7 @@ func ExampleOpsWorks_UpdateStack() {
 		},
 		ChefConfiguration: &opsworks.ChefConfiguration{
 			BerkshelfVersion: aws.String("String"),
-			ManageBerkshelf:  aws.Boolean(true),
+			ManageBerkshelf:  aws.Bool(true),
 		},
 		ConfigurationManager: &opsworks.StackConfigurationManager{
 			Name:    aws.String("String"),
@@ -2277,8 +2277,8 @@ func ExampleOpsWorks_UpdateStack() {
 		HostnameTheme:             aws.String("String"),
 		Name:                      aws.String("String"),
 		ServiceRoleARN:            aws.String("String"),
-		UseCustomCookbooks:        aws.Boolean(true),
-		UseOpsWorksSecurityGroups: aws.Boolean(true),
+		UseCustomCookbooks:        aws.Bool(true),
+		UseOpsWorksSecurityGroups: aws.Bool(true),
 	}
 	resp, err := svc.UpdateStack(params)
 
@@ -2298,7 +2298,7 @@ func ExampleOpsWorks_UpdateStack() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateUserProfile() {
@@ -2306,7 +2306,7 @@ func ExampleOpsWorks_UpdateUserProfile() {
 
 	params := &opsworks.UpdateUserProfileInput{
 		IAMUserARN:          aws.String("String"), // Required
-		AllowSelfManagement: aws.Boolean(true),
+		AllowSelfManagement: aws.Bool(true),
 		SSHPublicKey:        aws.String("String"),
 		SSHUsername:         aws.String("String"),
 	}
@@ -2328,7 +2328,7 @@ func ExampleOpsWorks_UpdateUserProfile() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleOpsWorks_UpdateVolume() {
@@ -2357,5 +2357,5 @@ func ExampleOpsWorks_UpdateVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -2004,7 +2004,7 @@ type metadataAccountQuota struct {
 
 // String returns the string representation
 func (s AccountQuota) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2039,7 +2039,7 @@ type metadataAddSourceIdentifierToSubscriptionInput struct {
 
 // String returns the string representation
 func (s AddSourceIdentifierToSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2061,7 +2061,7 @@ type metadataAddSourceIdentifierToSubscriptionOutput struct {
 
 // String returns the string representation
 func (s AddSourceIdentifierToSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2087,7 +2087,7 @@ type metadataAddTagsToResourceInput struct {
 
 // String returns the string representation
 func (s AddTagsToResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2105,7 +2105,7 @@ type metadataAddTagsToResourceOutput struct {
 
 // String returns the string representation
 func (s AddTagsToResourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2139,7 +2139,7 @@ type metadataApplyPendingMaintenanceActionInput struct {
 
 // String returns the string representation
 func (s ApplyPendingMaintenanceActionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2160,7 +2160,7 @@ type metadataApplyPendingMaintenanceActionOutput struct {
 
 // String returns the string representation
 func (s ApplyPendingMaintenanceActionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2201,7 +2201,7 @@ type metadataAuthorizeDBSecurityGroupIngressInput struct {
 
 // String returns the string representation
 func (s AuthorizeDBSecurityGroupIngressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2226,7 +2226,7 @@ type metadataAuthorizeDBSecurityGroupIngressOutput struct {
 
 // String returns the string representation
 func (s AuthorizeDBSecurityGroupIngressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2250,7 +2250,7 @@ type metadataAvailabilityZone struct {
 
 // String returns the string representation
 func (s AvailabilityZone) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2284,7 +2284,7 @@ type metadataCertificate struct {
 
 // String returns the string representation
 func (s Certificate) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2309,7 +2309,7 @@ type metadataCharacterSet struct {
 
 // String returns the string representation
 func (s CharacterSet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2353,7 +2353,7 @@ type metadataCopyDBParameterGroupInput struct {
 
 // String returns the string representation
 func (s CopyDBParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2378,7 +2378,7 @@ type metadataCopyDBParameterGroupOutput struct {
 
 // String returns the string representation
 func (s CopyDBParameterGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2422,7 +2422,7 @@ type metadataCopyDBSnapshotInput struct {
 
 // String returns the string representation
 func (s CopyDBSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2446,7 +2446,7 @@ type metadataCopyDBSnapshotOutput struct {
 
 // String returns the string representation
 func (s CopyDBSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2489,7 +2489,7 @@ type metadataCopyOptionGroupInput struct {
 
 // String returns the string representation
 func (s CopyOptionGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2509,7 +2509,7 @@ type metadataCopyOptionGroupOutput struct {
 
 // String returns the string representation
 func (s CopyOptionGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2974,7 +2974,7 @@ type metadataCreateDBInstanceInput struct {
 
 // String returns the string representation
 func (s CreateDBInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2998,7 +2998,7 @@ type metadataCreateDBInstanceOutput struct {
 
 // String returns the string representation
 func (s CreateDBInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3116,7 +3116,7 @@ type metadataCreateDBInstanceReadReplicaInput struct {
 
 // String returns the string representation
 func (s CreateDBInstanceReadReplicaInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3140,7 +3140,7 @@ type metadataCreateDBInstanceReadReplicaOutput struct {
 
 // String returns the string representation
 func (s CreateDBInstanceReadReplicaOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3179,7 +3179,7 @@ type metadataCreateDBParameterGroupInput struct {
 
 // String returns the string representation
 func (s CreateDBParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3204,7 +3204,7 @@ type metadataCreateDBParameterGroupOutput struct {
 
 // String returns the string representation
 func (s CreateDBParameterGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3237,7 +3237,7 @@ type metadataCreateDBSecurityGroupInput struct {
 
 // String returns the string representation
 func (s CreateDBSecurityGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3262,7 +3262,7 @@ type metadataCreateDBSecurityGroupOutput struct {
 
 // String returns the string representation
 func (s CreateDBSecurityGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3300,7 +3300,7 @@ type metadataCreateDBSnapshotInput struct {
 
 // String returns the string representation
 func (s CreateDBSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3324,7 +3324,7 @@ type metadataCreateDBSnapshotOutput struct {
 
 // String returns the string representation
 func (s CreateDBSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3359,7 +3359,7 @@ type metadataCreateDBSubnetGroupInput struct {
 
 // String returns the string representation
 func (s CreateDBSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3384,7 +3384,7 @@ type metadataCreateDBSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s CreateDBSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3449,7 +3449,7 @@ type metadataCreateEventSubscriptionInput struct {
 
 // String returns the string representation
 func (s CreateEventSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3471,7 +3471,7 @@ type metadataCreateEventSubscriptionOutput struct {
 
 // String returns the string representation
 func (s CreateEventSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3512,7 +3512,7 @@ type metadataCreateOptionGroupInput struct {
 
 // String returns the string representation
 func (s CreateOptionGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3532,7 +3532,7 @@ type metadataCreateOptionGroupOutput struct {
 
 // String returns the string representation
 func (s CreateOptionGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3574,7 +3574,7 @@ type metadataDBEngineVersion struct {
 
 // String returns the string representation
 func (s DBEngineVersion) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3752,7 +3752,7 @@ type metadataDBInstance struct {
 
 // String returns the string representation
 func (s DBInstance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3786,7 +3786,7 @@ type metadataDBInstanceStatusInfo struct {
 
 // String returns the string representation
 func (s DBInstanceStatusInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3819,7 +3819,7 @@ type metadataDBParameterGroup struct {
 
 // String returns the string representation
 func (s DBParameterGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3842,7 +3842,7 @@ type metadataDBParameterGroupNameMessage struct {
 
 // String returns the string representation
 func (s DBParameterGroupNameMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3872,7 +3872,7 @@ type metadataDBParameterGroupStatus struct {
 
 // String returns the string representation
 func (s DBParameterGroupStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3913,7 +3913,7 @@ type metadataDBSecurityGroup struct {
 
 // String returns the string representation
 func (s DBSecurityGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3941,7 +3941,7 @@ type metadataDBSecurityGroupMembership struct {
 
 // String returns the string representation
 func (s DBSecurityGroupMembership) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4033,7 +4033,7 @@ type metadataDBSnapshot struct {
 
 // String returns the string representation
 func (s DBSnapshot) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4071,7 +4071,7 @@ type metadataDBSubnetGroup struct {
 
 // String returns the string representation
 func (s DBSubnetGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4119,7 +4119,7 @@ type metadataDeleteDBInstanceInput struct {
 
 // String returns the string representation
 func (s DeleteDBInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4143,7 +4143,7 @@ type metadataDeleteDBInstanceOutput struct {
 
 // String returns the string representation
 func (s DeleteDBInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4169,7 +4169,7 @@ type metadataDeleteDBParameterGroupInput struct {
 
 // String returns the string representation
 func (s DeleteDBParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4187,7 +4187,7 @@ type metadataDeleteDBParameterGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteDBParameterGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4214,7 +4214,7 @@ type metadataDeleteDBSecurityGroupInput struct {
 
 // String returns the string representation
 func (s DeleteDBSecurityGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4232,7 +4232,7 @@ type metadataDeleteDBSecurityGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteDBSecurityGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4256,7 +4256,7 @@ type metadataDeleteDBSnapshotInput struct {
 
 // String returns the string representation
 func (s DeleteDBSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4280,7 +4280,7 @@ type metadataDeleteDBSnapshotOutput struct {
 
 // String returns the string representation
 func (s DeleteDBSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4306,7 +4306,7 @@ type metadataDeleteDBSubnetGroupInput struct {
 
 // String returns the string representation
 func (s DeleteDBSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4324,7 +4324,7 @@ type metadataDeleteDBSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteDBSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4345,7 +4345,7 @@ type metadataDeleteEventSubscriptionInput struct {
 
 // String returns the string representation
 func (s DeleteEventSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4367,7 +4367,7 @@ type metadataDeleteEventSubscriptionOutput struct {
 
 // String returns the string representation
 func (s DeleteEventSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4390,7 +4390,7 @@ type metadataDeleteOptionGroupInput struct {
 
 // String returns the string representation
 func (s DeleteOptionGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4408,7 +4408,7 @@ type metadataDeleteOptionGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteOptionGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4426,7 +4426,7 @@ type metadataDescribeAccountAttributesInput struct {
 
 // String returns the string representation
 func (s DescribeAccountAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4449,7 +4449,7 @@ type metadataDescribeAccountAttributesOutput struct {
 
 // String returns the string representation
 func (s DescribeAccountAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4494,7 +4494,7 @@ type metadataDescribeCertificatesInput struct {
 
 // String returns the string representation
 func (s DescribeCertificatesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4521,7 +4521,7 @@ type metadataDescribeCertificatesOutput struct {
 
 // String returns the string representation
 func (s DescribeCertificatesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4581,7 +4581,7 @@ type metadataDescribeDBEngineVersionsInput struct {
 
 // String returns the string representation
 func (s DescribeDBEngineVersionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4609,7 +4609,7 @@ type metadataDescribeDBEngineVersionsOutput struct {
 
 // String returns the string representation
 func (s DescribeDBEngineVersionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4654,7 +4654,7 @@ type metadataDescribeDBInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeDBInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4682,7 +4682,7 @@ type metadataDescribeDBInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeDBInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4710,7 +4710,7 @@ type metadataDescribeDBLogFilesDetails struct {
 
 // String returns the string representation
 func (s DescribeDBLogFilesDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4761,7 +4761,7 @@ type metadataDescribeDBLogFilesInput struct {
 
 // String returns the string representation
 func (s DescribeDBLogFilesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4786,7 +4786,7 @@ type metadataDescribeDBLogFilesOutput struct {
 
 // String returns the string representation
 func (s DescribeDBLogFilesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4829,7 +4829,7 @@ type metadataDescribeDBParameterGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeDBParameterGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4857,7 +4857,7 @@ type metadataDescribeDBParameterGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeDBParameterGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4907,7 +4907,7 @@ type metadataDescribeDBParametersInput struct {
 
 // String returns the string representation
 func (s DescribeDBParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4935,7 +4935,7 @@ type metadataDescribeDBParametersOutput struct {
 
 // String returns the string representation
 func (s DescribeDBParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4973,7 +4973,7 @@ type metadataDescribeDBSecurityGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeDBSecurityGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5001,7 +5001,7 @@ type metadataDescribeDBSecurityGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeDBSecurityGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5062,7 +5062,7 @@ type metadataDescribeDBSnapshotsInput struct {
 
 // String returns the string representation
 func (s DescribeDBSnapshotsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5090,7 +5090,7 @@ type metadataDescribeDBSnapshotsOutput struct {
 
 // String returns the string representation
 func (s DescribeDBSnapshotsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5128,7 +5128,7 @@ type metadataDescribeDBSubnetGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeDBSubnetGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5156,7 +5156,7 @@ type metadataDescribeDBSubnetGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeDBSubnetGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5194,7 +5194,7 @@ type metadataDescribeEngineDefaultParametersInput struct {
 
 // String returns the string representation
 func (s DescribeEngineDefaultParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5216,7 +5216,7 @@ type metadataDescribeEngineDefaultParametersOutput struct {
 
 // String returns the string representation
 func (s DescribeEngineDefaultParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5242,7 +5242,7 @@ type metadataDescribeEventCategoriesInput struct {
 
 // String returns the string representation
 func (s DescribeEventCategoriesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5264,7 +5264,7 @@ type metadataDescribeEventCategoriesOutput struct {
 
 // String returns the string representation
 func (s DescribeEventCategoriesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5302,7 +5302,7 @@ type metadataDescribeEventSubscriptionsInput struct {
 
 // String returns the string representation
 func (s DescribeEventSubscriptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5329,7 +5329,7 @@ type metadataDescribeEventSubscriptionsOutput struct {
 
 // String returns the string representation
 func (s DescribeEventSubscriptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5404,7 +5404,7 @@ type metadataDescribeEventsInput struct {
 
 // String returns the string representation
 func (s DescribeEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5431,7 +5431,7 @@ type metadataDescribeEventsOutput struct {
 
 // String returns the string representation
 func (s DescribeEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5474,7 +5474,7 @@ type metadataDescribeOptionGroupOptionsInput struct {
 
 // String returns the string representation
 func (s DescribeOptionGroupOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5500,7 +5500,7 @@ type metadataDescribeOptionGroupOptionsOutput struct {
 
 // String returns the string representation
 func (s DescribeOptionGroupOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5548,7 +5548,7 @@ type metadataDescribeOptionGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeOptionGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5575,7 +5575,7 @@ type metadataDescribeOptionGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeOptionGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5629,7 +5629,7 @@ type metadataDescribeOrderableDBInstanceOptionsInput struct {
 
 // String returns the string representation
 func (s DescribeOrderableDBInstanceOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5658,7 +5658,7 @@ type metadataDescribeOrderableDBInstanceOptionsOutput struct {
 
 // String returns the string representation
 func (s DescribeOrderableDBInstanceOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5703,7 +5703,7 @@ type metadataDescribePendingMaintenanceActionsInput struct {
 
 // String returns the string representation
 func (s DescribePendingMaintenanceActionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5730,7 +5730,7 @@ type metadataDescribePendingMaintenanceActionsOutput struct {
 
 // String returns the string representation
 func (s DescribePendingMaintenanceActionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5797,7 +5797,7 @@ type metadataDescribeReservedDBInstancesInput struct {
 
 // String returns the string representation
 func (s DescribeReservedDBInstancesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5862,7 +5862,7 @@ type metadataDescribeReservedDBInstancesOfferingsInput struct {
 
 // String returns the string representation
 func (s DescribeReservedDBInstancesOfferingsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5890,7 +5890,7 @@ type metadataDescribeReservedDBInstancesOfferingsOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedDBInstancesOfferingsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5918,7 +5918,7 @@ type metadataDescribeReservedDBInstancesOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedDBInstancesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5973,7 +5973,7 @@ type metadataDownloadDBLogFilePortionInput struct {
 
 // String returns the string representation
 func (s DownloadDBLogFilePortionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6002,7 +6002,7 @@ type metadataDownloadDBLogFilePortionOutput struct {
 
 // String returns the string representation
 func (s DownloadDBLogFilePortionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6037,7 +6037,7 @@ type metadataEC2SecurityGroup struct {
 
 // String returns the string representation
 func (s EC2SecurityGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6064,7 +6064,7 @@ type metadataEndpoint struct {
 
 // String returns the string representation
 func (s Endpoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6096,7 +6096,7 @@ type metadataEngineDefaults struct {
 
 // String returns the string representation
 func (s EngineDefaults) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6130,7 +6130,7 @@ type metadataEvent struct {
 
 // String returns the string representation
 func (s Event) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6156,7 +6156,7 @@ type metadataEventCategoriesMap struct {
 
 // String returns the string representation
 func (s EventCategoriesMap) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6213,7 +6213,7 @@ type metadataEventSubscription struct {
 
 // String returns the string representation
 func (s EventSubscription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6237,7 +6237,7 @@ type metadataFilter struct {
 
 // String returns the string representation
 func (s Filter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6264,7 +6264,7 @@ type metadataIPRange struct {
 
 // String returns the string representation
 func (s IPRange) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6290,7 +6290,7 @@ type metadataListTagsForResourceInput struct {
 
 // String returns the string representation
 func (s ListTagsForResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6311,7 +6311,7 @@ type metadataListTagsForResourceOutput struct {
 
 // String returns the string representation
 func (s ListTagsForResourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6642,7 +6642,7 @@ type metadataModifyDBInstanceInput struct {
 
 // String returns the string representation
 func (s ModifyDBInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6666,7 +6666,7 @@ type metadataModifyDBInstanceOutput struct {
 
 // String returns the string representation
 func (s ModifyDBInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6705,7 +6705,7 @@ type metadataModifyDBParameterGroupInput struct {
 
 // String returns the string representation
 func (s ModifyDBParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6737,7 +6737,7 @@ type metadataModifyDBSubnetGroupInput struct {
 
 // String returns the string representation
 func (s ModifyDBSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6762,7 +6762,7 @@ type metadataModifyDBSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s ModifyDBSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6806,7 +6806,7 @@ type metadataModifyEventSubscriptionInput struct {
 
 // String returns the string representation
 func (s ModifyEventSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6828,7 +6828,7 @@ type metadataModifyEventSubscriptionOutput struct {
 
 // String returns the string representation
 func (s ModifyEventSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6864,7 +6864,7 @@ type metadataModifyOptionGroupInput struct {
 
 // String returns the string representation
 func (s ModifyOptionGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6884,7 +6884,7 @@ type metadataModifyOptionGroupOutput struct {
 
 // String returns the string representation
 func (s ModifyOptionGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6929,7 +6929,7 @@ type metadataOption struct {
 
 // String returns the string representation
 func (s Option) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6963,7 +6963,7 @@ type metadataOptionConfiguration struct {
 
 // String returns the string representation
 func (s OptionConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7008,7 +7008,7 @@ type metadataOptionGroup struct {
 
 // String returns the string representation
 func (s OptionGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7034,7 +7034,7 @@ type metadataOptionGroupMembership struct {
 
 // String returns the string representation
 func (s OptionGroupMembership) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7092,7 +7092,7 @@ type metadataOptionGroupOption struct {
 
 // String returns the string representation
 func (s OptionGroupOption) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7132,7 +7132,7 @@ type metadataOptionGroupOptionSetting struct {
 
 // String returns the string representation
 func (s OptionGroupOptionSetting) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7182,7 +7182,7 @@ type metadataOptionSetting struct {
 
 // String returns the string representation
 func (s OptionSetting) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7237,7 +7237,7 @@ type metadataOrderableDBInstanceOption struct {
 
 // String returns the string representation
 func (s OrderableDBInstanceOption) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7292,7 +7292,7 @@ type metadataParameter struct {
 
 // String returns the string representation
 func (s Parameter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7339,7 +7339,7 @@ type metadataPendingMaintenanceAction struct {
 
 // String returns the string representation
 func (s PendingMaintenanceAction) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7396,7 +7396,7 @@ type metadataPendingModifiedValues struct {
 
 // String returns the string representation
 func (s PendingModifiedValues) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7447,7 +7447,7 @@ type metadataPromoteReadReplicaInput struct {
 
 // String returns the string representation
 func (s PromoteReadReplicaInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7471,7 +7471,7 @@ type metadataPromoteReadReplicaOutput struct {
 
 // String returns the string representation
 func (s PromoteReadReplicaOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7507,7 +7507,7 @@ type metadataPurchaseReservedDBInstancesOfferingInput struct {
 
 // String returns the string representation
 func (s PurchaseReservedDBInstancesOfferingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7529,7 +7529,7 @@ type metadataPurchaseReservedDBInstancesOfferingOutput struct {
 
 // String returns the string representation
 func (s PurchaseReservedDBInstancesOfferingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7561,7 +7561,7 @@ type metadataRebootDBInstanceInput struct {
 
 // String returns the string representation
 func (s RebootDBInstanceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7585,7 +7585,7 @@ type metadataRebootDBInstanceOutput struct {
 
 // String returns the string representation
 func (s RebootDBInstanceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7611,7 +7611,7 @@ type metadataRecurringCharge struct {
 
 // String returns the string representation
 func (s RecurringCharge) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7637,7 +7637,7 @@ type metadataRemoveSourceIdentifierFromSubscriptionInput struct {
 
 // String returns the string representation
 func (s RemoveSourceIdentifierFromSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7659,7 +7659,7 @@ type metadataRemoveSourceIdentifierFromSubscriptionOutput struct {
 
 // String returns the string representation
 func (s RemoveSourceIdentifierFromSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7685,7 +7685,7 @@ type metadataRemoveTagsFromResourceInput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7703,7 +7703,7 @@ type metadataRemoveTagsFromResourceOutput struct {
 
 // String returns the string representation
 func (s RemoveTagsFromResourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7765,7 +7765,7 @@ type metadataReservedDBInstance struct {
 
 // String returns the string representation
 func (s ReservedDBInstance) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7815,7 +7815,7 @@ type metadataReservedDBInstancesOffering struct {
 
 // String returns the string representation
 func (s ReservedDBInstancesOffering) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7865,7 +7865,7 @@ type metadataResetDBParameterGroupInput struct {
 
 // String returns the string representation
 func (s ResetDBParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7891,7 +7891,7 @@ type metadataResourcePendingMaintenanceActions struct {
 
 // String returns the string representation
 func (s ResourcePendingMaintenanceActions) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8042,7 +8042,7 @@ type metadataRestoreDBInstanceFromDBSnapshotInput struct {
 
 // String returns the string representation
 func (s RestoreDBInstanceFromDBSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8066,7 +8066,7 @@ type metadataRestoreDBInstanceFromDBSnapshotOutput struct {
 
 // String returns the string representation
 func (s RestoreDBInstanceFromDBSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8232,7 +8232,7 @@ type metadataRestoreDBInstanceToPointInTimeInput struct {
 
 // String returns the string representation
 func (s RestoreDBInstanceToPointInTimeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8256,7 +8256,7 @@ type metadataRestoreDBInstanceToPointInTimeOutput struct {
 
 // String returns the string representation
 func (s RestoreDBInstanceToPointInTimeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8299,7 +8299,7 @@ type metadataRevokeDBSecurityGroupIngressInput struct {
 
 // String returns the string representation
 func (s RevokeDBSecurityGroupIngressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8324,7 +8324,7 @@ type metadataRevokeDBSecurityGroupIngressOutput struct {
 
 // String returns the string representation
 func (s RevokeDBSecurityGroupIngressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8355,7 +8355,7 @@ type metadataSubnet struct {
 
 // String returns the string representation
 func (s Subnet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8386,7 +8386,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -8412,7 +8412,7 @@ type metadataVPCSecurityGroupMembership struct {
 
 // String returns the string representation
 func (s VPCSecurityGroupMembership) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/rds/examples_test.go
+++ b/service/rds/examples_test.go
@@ -41,7 +41,7 @@ func ExampleRDS_AddSourceIdentifierToSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_AddTagsToResource() {
@@ -75,7 +75,7 @@ func ExampleRDS_AddTagsToResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_ApplyPendingMaintenanceAction() {
@@ -104,7 +104,7 @@ func ExampleRDS_ApplyPendingMaintenanceAction() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_AuthorizeDBSecurityGroupIngress() {
@@ -135,7 +135,7 @@ func ExampleRDS_AuthorizeDBSecurityGroupIngress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CopyDBParameterGroup() {
@@ -171,7 +171,7 @@ func ExampleRDS_CopyDBParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CopyDBSnapshot() {
@@ -206,7 +206,7 @@ func ExampleRDS_CopyDBSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CopyOptionGroup() {
@@ -242,22 +242,22 @@ func ExampleRDS_CopyOptionGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CreateDBInstance() {
 	svc := rds.New(nil)
 
 	params := &rds.CreateDBInstanceInput{
-		AllocatedStorage:        aws.Long(1),          // Required
+		AllocatedStorage:        aws.Int64(1),         // Required
 		DBInstanceClass:         aws.String("String"), // Required
 		DBInstanceIdentifier:    aws.String("String"), // Required
 		Engine:                  aws.String("String"), // Required
 		MasterUserPassword:      aws.String("String"), // Required
 		MasterUsername:          aws.String("String"), // Required
-		AutoMinorVersionUpgrade: aws.Boolean(true),
+		AutoMinorVersionUpgrade: aws.Bool(true),
 		AvailabilityZone:        aws.String("String"),
-		BackupRetentionPeriod:   aws.Long(1),
+		BackupRetentionPeriod:   aws.Int64(1),
 		CharacterSetName:        aws.String("String"),
 		DBName:                  aws.String("String"),
 		DBParameterGroupName:    aws.String("String"),
@@ -267,16 +267,16 @@ func ExampleRDS_CreateDBInstance() {
 		},
 		DBSubnetGroupName: aws.String("String"),
 		EngineVersion:     aws.String("String"),
-		IOPS:              aws.Long(1),
+		IOPS:              aws.Int64(1),
 		KMSKeyID:          aws.String("String"),
 		LicenseModel:      aws.String("String"),
-		MultiAZ:           aws.Boolean(true),
+		MultiAZ:           aws.Bool(true),
 		OptionGroupName:   aws.String("String"),
-		Port:              aws.Long(1),
+		Port:              aws.Int64(1),
 		PreferredBackupWindow:      aws.String("String"),
 		PreferredMaintenanceWindow: aws.String("String"),
-		PubliclyAccessible:         aws.Boolean(true),
-		StorageEncrypted:           aws.Boolean(true),
+		PubliclyAccessible:         aws.Bool(true),
+		StorageEncrypted:           aws.Bool(true),
 		StorageType:                aws.String("String"),
 		TDECredentialARN:           aws.String("String"),
 		TDECredentialPassword:      aws.String("String"),
@@ -310,7 +310,7 @@ func ExampleRDS_CreateDBInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CreateDBInstanceReadReplica() {
@@ -319,14 +319,14 @@ func ExampleRDS_CreateDBInstanceReadReplica() {
 	params := &rds.CreateDBInstanceReadReplicaInput{
 		DBInstanceIdentifier:       aws.String("String"), // Required
 		SourceDBInstanceIdentifier: aws.String("String"), // Required
-		AutoMinorVersionUpgrade:    aws.Boolean(true),
+		AutoMinorVersionUpgrade:    aws.Bool(true),
 		AvailabilityZone:           aws.String("String"),
 		DBInstanceClass:            aws.String("String"),
 		DBSubnetGroupName:          aws.String("String"),
-		IOPS:                       aws.Long(1),
+		IOPS:                       aws.Int64(1),
 		OptionGroupName:            aws.String("String"),
-		Port:                       aws.Long(1),
-		PubliclyAccessible:         aws.Boolean(true),
+		Port:                       aws.Int64(1),
+		PubliclyAccessible:         aws.Bool(true),
 		StorageType:                aws.String("String"),
 		Tags: []*rds.Tag{
 			{ // Required
@@ -354,7 +354,7 @@ func ExampleRDS_CreateDBInstanceReadReplica() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CreateDBParameterGroup() {
@@ -390,7 +390,7 @@ func ExampleRDS_CreateDBParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CreateDBSecurityGroup() {
@@ -425,7 +425,7 @@ func ExampleRDS_CreateDBSecurityGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CreateDBSnapshot() {
@@ -460,7 +460,7 @@ func ExampleRDS_CreateDBSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CreateDBSubnetGroup() {
@@ -499,7 +499,7 @@ func ExampleRDS_CreateDBSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CreateEventSubscription() {
@@ -508,7 +508,7 @@ func ExampleRDS_CreateEventSubscription() {
 	params := &rds.CreateEventSubscriptionInput{
 		SNSTopicARN:      aws.String("String"), // Required
 		SubscriptionName: aws.String("String"), // Required
-		Enabled:          aws.Boolean(true),
+		Enabled:          aws.Bool(true),
 		EventCategories: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -544,7 +544,7 @@ func ExampleRDS_CreateEventSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_CreateOptionGroup() {
@@ -581,7 +581,7 @@ func ExampleRDS_CreateOptionGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DeleteDBInstance() {
@@ -590,7 +590,7 @@ func ExampleRDS_DeleteDBInstance() {
 	params := &rds.DeleteDBInstanceInput{
 		DBInstanceIdentifier:      aws.String("String"), // Required
 		FinalDBSnapshotIdentifier: aws.String("String"),
-		SkipFinalSnapshot:         aws.Boolean(true),
+		SkipFinalSnapshot:         aws.Bool(true),
 	}
 	resp, err := svc.DeleteDBInstance(params)
 
@@ -610,7 +610,7 @@ func ExampleRDS_DeleteDBInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DeleteDBParameterGroup() {
@@ -637,7 +637,7 @@ func ExampleRDS_DeleteDBParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DeleteDBSecurityGroup() {
@@ -664,7 +664,7 @@ func ExampleRDS_DeleteDBSecurityGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DeleteDBSnapshot() {
@@ -691,7 +691,7 @@ func ExampleRDS_DeleteDBSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DeleteDBSubnetGroup() {
@@ -718,7 +718,7 @@ func ExampleRDS_DeleteDBSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DeleteEventSubscription() {
@@ -745,7 +745,7 @@ func ExampleRDS_DeleteEventSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DeleteOptionGroup() {
@@ -772,7 +772,7 @@ func ExampleRDS_DeleteOptionGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeAccountAttributes() {
@@ -797,7 +797,7 @@ func ExampleRDS_DescribeAccountAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeCertificates() {
@@ -816,7 +816,7 @@ func ExampleRDS_DescribeCertificates() {
 			// More values...
 		},
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeCertificates(params)
 
@@ -836,7 +836,7 @@ func ExampleRDS_DescribeCertificates() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeDBEngineVersions() {
@@ -844,7 +844,7 @@ func ExampleRDS_DescribeDBEngineVersions() {
 
 	params := &rds.DescribeDBEngineVersionsInput{
 		DBParameterGroupFamily: aws.String("String"),
-		DefaultOnly:            aws.Boolean(true),
+		DefaultOnly:            aws.Bool(true),
 		Engine:                 aws.String("String"),
 		EngineVersion:          aws.String("String"),
 		Filters: []*rds.Filter{
@@ -857,9 +857,9 @@ func ExampleRDS_DescribeDBEngineVersions() {
 			},
 			// More values...
 		},
-		ListSupportedCharacterSets: aws.Boolean(true),
+		ListSupportedCharacterSets: aws.Bool(true),
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeDBEngineVersions(params)
 
@@ -879,7 +879,7 @@ func ExampleRDS_DescribeDBEngineVersions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeDBInstances() {
@@ -898,7 +898,7 @@ func ExampleRDS_DescribeDBInstances() {
 			// More values...
 		},
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeDBInstances(params)
 
@@ -918,7 +918,7 @@ func ExampleRDS_DescribeDBInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeDBLogFiles() {
@@ -926,8 +926,8 @@ func ExampleRDS_DescribeDBLogFiles() {
 
 	params := &rds.DescribeDBLogFilesInput{
 		DBInstanceIdentifier: aws.String("String"), // Required
-		FileLastWritten:      aws.Long(1),
-		FileSize:             aws.Long(1),
+		FileLastWritten:      aws.Int64(1),
+		FileSize:             aws.Int64(1),
 		FilenameContains:     aws.String("String"),
 		Filters: []*rds.Filter{
 			{ // Required
@@ -940,7 +940,7 @@ func ExampleRDS_DescribeDBLogFiles() {
 			// More values...
 		},
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeDBLogFiles(params)
 
@@ -960,7 +960,7 @@ func ExampleRDS_DescribeDBLogFiles() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeDBParameterGroups() {
@@ -979,7 +979,7 @@ func ExampleRDS_DescribeDBParameterGroups() {
 			// More values...
 		},
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeDBParameterGroups(params)
 
@@ -999,7 +999,7 @@ func ExampleRDS_DescribeDBParameterGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeDBParameters() {
@@ -1018,7 +1018,7 @@ func ExampleRDS_DescribeDBParameters() {
 			// More values...
 		},
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		Source:     aws.String("String"),
 	}
 	resp, err := svc.DescribeDBParameters(params)
@@ -1039,7 +1039,7 @@ func ExampleRDS_DescribeDBParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeDBSecurityGroups() {
@@ -1058,7 +1058,7 @@ func ExampleRDS_DescribeDBSecurityGroups() {
 			// More values...
 		},
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeDBSecurityGroups(params)
 
@@ -1078,7 +1078,7 @@ func ExampleRDS_DescribeDBSecurityGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeDBSnapshots() {
@@ -1098,7 +1098,7 @@ func ExampleRDS_DescribeDBSnapshots() {
 			// More values...
 		},
 		Marker:       aws.String("String"),
-		MaxRecords:   aws.Long(1),
+		MaxRecords:   aws.Int64(1),
 		SnapshotType: aws.String("String"),
 	}
 	resp, err := svc.DescribeDBSnapshots(params)
@@ -1119,7 +1119,7 @@ func ExampleRDS_DescribeDBSnapshots() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeDBSubnetGroups() {
@@ -1138,7 +1138,7 @@ func ExampleRDS_DescribeDBSubnetGroups() {
 			// More values...
 		},
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeDBSubnetGroups(params)
 
@@ -1158,7 +1158,7 @@ func ExampleRDS_DescribeDBSubnetGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeEngineDefaultParameters() {
@@ -1177,7 +1177,7 @@ func ExampleRDS_DescribeEngineDefaultParameters() {
 			// More values...
 		},
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 	}
 	resp, err := svc.DescribeEngineDefaultParameters(params)
 
@@ -1197,7 +1197,7 @@ func ExampleRDS_DescribeEngineDefaultParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeEventCategories() {
@@ -1234,7 +1234,7 @@ func ExampleRDS_DescribeEventCategories() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeEventSubscriptions() {
@@ -1252,7 +1252,7 @@ func ExampleRDS_DescribeEventSubscriptions() {
 			// More values...
 		},
 		Marker:           aws.String("String"),
-		MaxRecords:       aws.Long(1),
+		MaxRecords:       aws.Int64(1),
 		SubscriptionName: aws.String("String"),
 	}
 	resp, err := svc.DescribeEventSubscriptions(params)
@@ -1273,14 +1273,14 @@ func ExampleRDS_DescribeEventSubscriptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeEvents() {
 	svc := rds.New(nil)
 
 	params := &rds.DescribeEventsInput{
-		Duration: aws.Long(1),
+		Duration: aws.Int64(1),
 		EndTime:  aws.Time(time.Now()),
 		EventCategories: []*string{
 			aws.String("String"), // Required
@@ -1297,7 +1297,7 @@ func ExampleRDS_DescribeEvents() {
 			// More values...
 		},
 		Marker:           aws.String("String"),
-		MaxRecords:       aws.Long(1),
+		MaxRecords:       aws.Int64(1),
 		SourceIdentifier: aws.String("String"),
 		SourceType:       aws.String("SourceType"),
 		StartTime:        aws.Time(time.Now()),
@@ -1320,7 +1320,7 @@ func ExampleRDS_DescribeEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeOptionGroupOptions() {
@@ -1340,7 +1340,7 @@ func ExampleRDS_DescribeOptionGroupOptions() {
 		},
 		MajorEngineVersion: aws.String("String"),
 		Marker:             aws.String("String"),
-		MaxRecords:         aws.Long(1),
+		MaxRecords:         aws.Int64(1),
 	}
 	resp, err := svc.DescribeOptionGroupOptions(params)
 
@@ -1360,7 +1360,7 @@ func ExampleRDS_DescribeOptionGroupOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeOptionGroups() {
@@ -1380,7 +1380,7 @@ func ExampleRDS_DescribeOptionGroups() {
 		},
 		MajorEngineVersion: aws.String("String"),
 		Marker:             aws.String("String"),
-		MaxRecords:         aws.Long(1),
+		MaxRecords:         aws.Int64(1),
 		OptionGroupName:    aws.String("String"),
 	}
 	resp, err := svc.DescribeOptionGroups(params)
@@ -1401,7 +1401,7 @@ func ExampleRDS_DescribeOptionGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeOrderableDBInstanceOptions() {
@@ -1423,8 +1423,8 @@ func ExampleRDS_DescribeOrderableDBInstanceOptions() {
 		},
 		LicenseModel: aws.String("String"),
 		Marker:       aws.String("String"),
-		MaxRecords:   aws.Long(1),
-		VPC:          aws.Boolean(true),
+		MaxRecords:   aws.Int64(1),
+		VPC:          aws.Bool(true),
 	}
 	resp, err := svc.DescribeOrderableDBInstanceOptions(params)
 
@@ -1444,7 +1444,7 @@ func ExampleRDS_DescribeOrderableDBInstanceOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribePendingMaintenanceActions() {
@@ -1462,7 +1462,7 @@ func ExampleRDS_DescribePendingMaintenanceActions() {
 			// More values...
 		},
 		Marker:             aws.String("String"),
-		MaxRecords:         aws.Long(1),
+		MaxRecords:         aws.Int64(1),
 		ResourceIdentifier: aws.String("String"),
 	}
 	resp, err := svc.DescribePendingMaintenanceActions(params)
@@ -1483,7 +1483,7 @@ func ExampleRDS_DescribePendingMaintenanceActions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeReservedDBInstances() {
@@ -1503,8 +1503,8 @@ func ExampleRDS_DescribeReservedDBInstances() {
 			// More values...
 		},
 		Marker:                        aws.String("String"),
-		MaxRecords:                    aws.Long(1),
-		MultiAZ:                       aws.Boolean(true),
+		MaxRecords:                    aws.Int64(1),
+		MultiAZ:                       aws.Bool(true),
 		OfferingType:                  aws.String("String"),
 		ProductDescription:            aws.String("String"),
 		ReservedDBInstanceID:          aws.String("String"),
@@ -1528,7 +1528,7 @@ func ExampleRDS_DescribeReservedDBInstances() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DescribeReservedDBInstancesOfferings() {
@@ -1548,8 +1548,8 @@ func ExampleRDS_DescribeReservedDBInstancesOfferings() {
 			// More values...
 		},
 		Marker:                        aws.String("String"),
-		MaxRecords:                    aws.Long(1),
-		MultiAZ:                       aws.Boolean(true),
+		MaxRecords:                    aws.Int64(1),
+		MultiAZ:                       aws.Bool(true),
 		OfferingType:                  aws.String("String"),
 		ProductDescription:            aws.String("String"),
 		ReservedDBInstancesOfferingID: aws.String("String"),
@@ -1572,7 +1572,7 @@ func ExampleRDS_DescribeReservedDBInstancesOfferings() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_DownloadDBLogFilePortion() {
@@ -1582,7 +1582,7 @@ func ExampleRDS_DownloadDBLogFilePortion() {
 		DBInstanceIdentifier: aws.String("String"), // Required
 		LogFileName:          aws.String("String"), // Required
 		Marker:               aws.String("String"),
-		NumberOfLines:        aws.Long(1),
+		NumberOfLines:        aws.Int64(1),
 	}
 	resp, err := svc.DownloadDBLogFilePortion(params)
 
@@ -1602,7 +1602,7 @@ func ExampleRDS_DownloadDBLogFilePortion() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_ListTagsForResource() {
@@ -1639,7 +1639,7 @@ func ExampleRDS_ListTagsForResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_ModifyDBInstance() {
@@ -1647,11 +1647,11 @@ func ExampleRDS_ModifyDBInstance() {
 
 	params := &rds.ModifyDBInstanceInput{
 		DBInstanceIdentifier:     aws.String("String"), // Required
-		AllocatedStorage:         aws.Long(1),
-		AllowMajorVersionUpgrade: aws.Boolean(true),
-		ApplyImmediately:         aws.Boolean(true),
-		AutoMinorVersionUpgrade:  aws.Boolean(true),
-		BackupRetentionPeriod:    aws.Long(1),
+		AllocatedStorage:         aws.Int64(1),
+		AllowMajorVersionUpgrade: aws.Bool(true),
+		ApplyImmediately:         aws.Bool(true),
+		AutoMinorVersionUpgrade:  aws.Bool(true),
+		BackupRetentionPeriod:    aws.Int64(1),
 		CACertificateIdentifier:  aws.String("String"),
 		DBInstanceClass:          aws.String("String"),
 		DBParameterGroupName:     aws.String("String"),
@@ -1660,9 +1660,9 @@ func ExampleRDS_ModifyDBInstance() {
 			// More values...
 		},
 		EngineVersion:              aws.String("String"),
-		IOPS:                       aws.Long(1),
+		IOPS:                       aws.Int64(1),
 		MasterUserPassword:         aws.String("String"),
-		MultiAZ:                    aws.Boolean(true),
+		MultiAZ:                    aws.Bool(true),
 		NewDBInstanceIdentifier:    aws.String("String"),
 		OptionGroupName:            aws.String("String"),
 		PreferredBackupWindow:      aws.String("String"),
@@ -1693,7 +1693,7 @@ func ExampleRDS_ModifyDBInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_ModifyDBParameterGroup() {
@@ -1708,7 +1708,7 @@ func ExampleRDS_ModifyDBParameterGroup() {
 				ApplyType:            aws.String("String"),
 				DataType:             aws.String("String"),
 				Description:          aws.String("String"),
-				IsModifiable:         aws.Boolean(true),
+				IsModifiable:         aws.Bool(true),
 				MinimumEngineVersion: aws.String("String"),
 				ParameterName:        aws.String("String"),
 				ParameterValue:       aws.String("String"),
@@ -1735,7 +1735,7 @@ func ExampleRDS_ModifyDBParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_ModifyDBSubnetGroup() {
@@ -1767,7 +1767,7 @@ func ExampleRDS_ModifyDBSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_ModifyEventSubscription() {
@@ -1775,7 +1775,7 @@ func ExampleRDS_ModifyEventSubscription() {
 
 	params := &rds.ModifyEventSubscriptionInput{
 		SubscriptionName: aws.String("String"), // Required
-		Enabled:          aws.Boolean(true),
+		Enabled:          aws.Bool(true),
 		EventCategories: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -1801,7 +1801,7 @@ func ExampleRDS_ModifyEventSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_ModifyOptionGroup() {
@@ -1809,7 +1809,7 @@ func ExampleRDS_ModifyOptionGroup() {
 
 	params := &rds.ModifyOptionGroupInput{
 		OptionGroupName:  aws.String("String"), // Required
-		ApplyImmediately: aws.Boolean(true),
+		ApplyImmediately: aws.Bool(true),
 		OptionsToInclude: []*rds.OptionConfiguration{
 			{ // Required
 				OptionName: aws.String("String"), // Required
@@ -1824,14 +1824,14 @@ func ExampleRDS_ModifyOptionGroup() {
 						DataType:      aws.String("String"),
 						DefaultValue:  aws.String("String"),
 						Description:   aws.String("String"),
-						IsCollection:  aws.Boolean(true),
-						IsModifiable:  aws.Boolean(true),
+						IsCollection:  aws.Bool(true),
+						IsModifiable:  aws.Bool(true),
 						Name:          aws.String("String"),
 						Value:         aws.String("String"),
 					},
 					// More values...
 				},
-				Port: aws.Long(1),
+				Port: aws.Int64(1),
 				VPCSecurityGroupMemberships: []*string{
 					aws.String("String"), // Required
 					// More values...
@@ -1862,7 +1862,7 @@ func ExampleRDS_ModifyOptionGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_PromoteReadReplica() {
@@ -1870,7 +1870,7 @@ func ExampleRDS_PromoteReadReplica() {
 
 	params := &rds.PromoteReadReplicaInput{
 		DBInstanceIdentifier:  aws.String("String"), // Required
-		BackupRetentionPeriod: aws.Long(1),
+		BackupRetentionPeriod: aws.Int64(1),
 		PreferredBackupWindow: aws.String("String"),
 	}
 	resp, err := svc.PromoteReadReplica(params)
@@ -1891,7 +1891,7 @@ func ExampleRDS_PromoteReadReplica() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_PurchaseReservedDBInstancesOffering() {
@@ -1899,7 +1899,7 @@ func ExampleRDS_PurchaseReservedDBInstancesOffering() {
 
 	params := &rds.PurchaseReservedDBInstancesOfferingInput{
 		ReservedDBInstancesOfferingID: aws.String("String"), // Required
-		DBInstanceCount:               aws.Long(1),
+		DBInstanceCount:               aws.Int64(1),
 		ReservedDBInstanceID:          aws.String("String"),
 		Tags: []*rds.Tag{
 			{ // Required
@@ -1927,7 +1927,7 @@ func ExampleRDS_PurchaseReservedDBInstancesOffering() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_RebootDBInstance() {
@@ -1935,7 +1935,7 @@ func ExampleRDS_RebootDBInstance() {
 
 	params := &rds.RebootDBInstanceInput{
 		DBInstanceIdentifier: aws.String("String"), // Required
-		ForceFailover:        aws.Boolean(true),
+		ForceFailover:        aws.Bool(true),
 	}
 	resp, err := svc.RebootDBInstance(params)
 
@@ -1955,7 +1955,7 @@ func ExampleRDS_RebootDBInstance() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_RemoveSourceIdentifierFromSubscription() {
@@ -1983,7 +1983,7 @@ func ExampleRDS_RemoveSourceIdentifierFromSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_RemoveTagsFromResource() {
@@ -2014,7 +2014,7 @@ func ExampleRDS_RemoveTagsFromResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_ResetDBParameterGroup() {
@@ -2029,7 +2029,7 @@ func ExampleRDS_ResetDBParameterGroup() {
 				ApplyType:            aws.String("String"),
 				DataType:             aws.String("String"),
 				Description:          aws.String("String"),
-				IsModifiable:         aws.Boolean(true),
+				IsModifiable:         aws.Bool(true),
 				MinimumEngineVersion: aws.String("String"),
 				ParameterName:        aws.String("String"),
 				ParameterValue:       aws.String("String"),
@@ -2037,7 +2037,7 @@ func ExampleRDS_ResetDBParameterGroup() {
 			},
 			// More values...
 		},
-		ResetAllParameters: aws.Boolean(true),
+		ResetAllParameters: aws.Bool(true),
 	}
 	resp, err := svc.ResetDBParameterGroup(params)
 
@@ -2057,7 +2057,7 @@ func ExampleRDS_ResetDBParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_RestoreDBInstanceFromDBSnapshot() {
@@ -2066,18 +2066,18 @@ func ExampleRDS_RestoreDBInstanceFromDBSnapshot() {
 	params := &rds.RestoreDBInstanceFromDBSnapshotInput{
 		DBInstanceIdentifier:    aws.String("String"), // Required
 		DBSnapshotIdentifier:    aws.String("String"), // Required
-		AutoMinorVersionUpgrade: aws.Boolean(true),
+		AutoMinorVersionUpgrade: aws.Bool(true),
 		AvailabilityZone:        aws.String("String"),
 		DBInstanceClass:         aws.String("String"),
 		DBName:                  aws.String("String"),
 		DBSubnetGroupName:       aws.String("String"),
 		Engine:                  aws.String("String"),
-		IOPS:                    aws.Long(1),
+		IOPS:                    aws.Int64(1),
 		LicenseModel:            aws.String("String"),
-		MultiAZ:                 aws.Boolean(true),
+		MultiAZ:                 aws.Bool(true),
 		OptionGroupName:         aws.String("String"),
-		Port:                    aws.Long(1),
-		PubliclyAccessible:      aws.Boolean(true),
+		Port:                    aws.Int64(1),
+		PubliclyAccessible:      aws.Bool(true),
 		StorageType:             aws.String("String"),
 		TDECredentialARN:        aws.String("String"),
 		TDECredentialPassword:   aws.String("String"),
@@ -2107,7 +2107,7 @@ func ExampleRDS_RestoreDBInstanceFromDBSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_RestoreDBInstanceToPointInTime() {
@@ -2116,18 +2116,18 @@ func ExampleRDS_RestoreDBInstanceToPointInTime() {
 	params := &rds.RestoreDBInstanceToPointInTimeInput{
 		SourceDBInstanceIdentifier: aws.String("String"), // Required
 		TargetDBInstanceIdentifier: aws.String("String"), // Required
-		AutoMinorVersionUpgrade:    aws.Boolean(true),
+		AutoMinorVersionUpgrade:    aws.Bool(true),
 		AvailabilityZone:           aws.String("String"),
 		DBInstanceClass:            aws.String("String"),
 		DBName:                     aws.String("String"),
 		DBSubnetGroupName:          aws.String("String"),
 		Engine:                     aws.String("String"),
-		IOPS:                       aws.Long(1),
+		IOPS:                       aws.Int64(1),
 		LicenseModel:               aws.String("String"),
-		MultiAZ:                    aws.Boolean(true),
+		MultiAZ:                    aws.Bool(true),
 		OptionGroupName:            aws.String("String"),
-		Port:                       aws.Long(1),
-		PubliclyAccessible:         aws.Boolean(true),
+		Port:                       aws.Int64(1),
+		PubliclyAccessible:         aws.Bool(true),
 		RestoreTime:                aws.Time(time.Now()),
 		StorageType:                aws.String("String"),
 		TDECredentialARN:           aws.String("String"),
@@ -2139,7 +2139,7 @@ func ExampleRDS_RestoreDBInstanceToPointInTime() {
 			},
 			// More values...
 		},
-		UseLatestRestorableTime: aws.Boolean(true),
+		UseLatestRestorableTime: aws.Bool(true),
 	}
 	resp, err := svc.RestoreDBInstanceToPointInTime(params)
 
@@ -2159,7 +2159,7 @@ func ExampleRDS_RestoreDBInstanceToPointInTime() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRDS_RevokeDBSecurityGroupIngress() {
@@ -2190,5 +2190,5 @@ func ExampleRDS_RevokeDBSecurityGroupIngress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -2191,7 +2191,7 @@ type metadataAccountWithRestoreAccess struct {
 
 // String returns the string representation
 func (s AccountWithRestoreAccess) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2226,7 +2226,7 @@ type metadataAuthorizeClusterSecurityGroupIngressInput struct {
 
 // String returns the string representation
 func (s AuthorizeClusterSecurityGroupIngressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2247,7 +2247,7 @@ type metadataAuthorizeClusterSecurityGroupIngressOutput struct {
 
 // String returns the string representation
 func (s AuthorizeClusterSecurityGroupIngressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2277,7 +2277,7 @@ type metadataAuthorizeSnapshotAccessInput struct {
 
 // String returns the string representation
 func (s AuthorizeSnapshotAccessInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2298,7 +2298,7 @@ type metadataAuthorizeSnapshotAccessOutput struct {
 
 // String returns the string representation
 func (s AuthorizeSnapshotAccessOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2320,7 +2320,7 @@ type metadataAvailabilityZone struct {
 
 // String returns the string representation
 func (s AvailabilityZone) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2454,7 +2454,7 @@ type metadataCluster struct {
 
 // String returns the string representation
 func (s Cluster) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2482,7 +2482,7 @@ type metadataClusterNode struct {
 
 // String returns the string representation
 func (s ClusterNode) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2514,7 +2514,7 @@ type metadataClusterParameterGroup struct {
 
 // String returns the string representation
 func (s ClusterParameterGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2543,7 +2543,7 @@ type metadataClusterParameterGroupNameMessage struct {
 
 // String returns the string representation
 func (s ClusterParameterGroupNameMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2575,7 +2575,7 @@ type metadataClusterParameterGroupStatus struct {
 
 // String returns the string representation
 func (s ClusterParameterGroupStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2616,7 +2616,7 @@ type metadataClusterParameterStatus struct {
 
 // String returns the string representation
 func (s ClusterParameterStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2652,7 +2652,7 @@ type metadataClusterSecurityGroup struct {
 
 // String returns the string representation
 func (s ClusterSecurityGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2677,7 +2677,7 @@ type metadataClusterSecurityGroupMembership struct {
 
 // String returns the string representation
 func (s ClusterSecurityGroupMembership) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2708,7 +2708,7 @@ type metadataClusterSnapshotCopyStatus struct {
 
 // String returns the string representation
 func (s ClusterSnapshotCopyStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2746,7 +2746,7 @@ type metadataClusterSubnetGroup struct {
 
 // String returns the string representation
 func (s ClusterSubnetGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2775,7 +2775,7 @@ type metadataClusterVersion struct {
 
 // String returns the string representation
 func (s ClusterVersion) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2819,7 +2819,7 @@ type metadataCopyClusterSnapshotInput struct {
 
 // String returns the string representation
 func (s CopyClusterSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2840,7 +2840,7 @@ type metadataCopyClusterSnapshotOutput struct {
 
 // String returns the string representation
 func (s CopyClusterSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3071,7 +3071,7 @@ type metadataCreateClusterInput struct {
 
 // String returns the string representation
 func (s CreateClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3092,7 +3092,7 @@ type metadataCreateClusterOutput struct {
 
 // String returns the string representation
 func (s CreateClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3137,7 +3137,7 @@ type metadataCreateClusterParameterGroupInput struct {
 
 // String returns the string representation
 func (s CreateClusterParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3158,7 +3158,7 @@ type metadataCreateClusterParameterGroupOutput struct {
 
 // String returns the string representation
 func (s CreateClusterParameterGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3193,7 +3193,7 @@ type metadataCreateClusterSecurityGroupInput struct {
 
 // String returns the string representation
 func (s CreateClusterSecurityGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3214,7 +3214,7 @@ type metadataCreateClusterSecurityGroupOutput struct {
 
 // String returns the string representation
 func (s CreateClusterSecurityGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3248,7 +3248,7 @@ type metadataCreateClusterSnapshotInput struct {
 
 // String returns the string representation
 func (s CreateClusterSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3269,7 +3269,7 @@ type metadataCreateClusterSnapshotOutput struct {
 
 // String returns the string representation
 func (s CreateClusterSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3307,7 +3307,7 @@ type metadataCreateClusterSubnetGroupInput struct {
 
 // String returns the string representation
 func (s CreateClusterSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3328,7 +3328,7 @@ type metadataCreateClusterSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s CreateClusterSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3400,7 +3400,7 @@ type metadataCreateEventSubscriptionInput struct {
 
 // String returns the string representation
 func (s CreateEventSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3420,7 +3420,7 @@ type metadataCreateEventSubscriptionOutput struct {
 
 // String returns the string representation
 func (s CreateEventSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3445,7 +3445,7 @@ type metadataCreateHSMClientCertificateInput struct {
 
 // String returns the string representation
 func (s CreateHSMClientCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3468,7 +3468,7 @@ type metadataCreateHSMClientCertificateOutput struct {
 
 // String returns the string representation
 func (s CreateHSMClientCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3509,7 +3509,7 @@ type metadataCreateHSMConfigurationInput struct {
 
 // String returns the string representation
 func (s CreateHSMConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3532,7 +3532,7 @@ type metadataCreateHSMConfigurationOutput struct {
 
 // String returns the string representation
 func (s CreateHSMConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3569,7 +3569,7 @@ type metadataCreateSnapshotCopyGrantInput struct {
 
 // String returns the string representation
 func (s CreateSnapshotCopyGrantInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3596,7 +3596,7 @@ type metadataCreateSnapshotCopyGrantOutput struct {
 
 // String returns the string representation
 func (s CreateSnapshotCopyGrantOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3626,7 +3626,7 @@ type metadataCreateTagsInput struct {
 
 // String returns the string representation
 func (s CreateTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3644,7 +3644,7 @@ type metadataCreateTagsOutput struct {
 
 // String returns the string representation
 func (s CreateTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3677,7 +3677,7 @@ type metadataDefaultClusterParameters struct {
 
 // String returns the string representation
 func (s DefaultClusterParameters) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3722,7 +3722,7 @@ type metadataDeleteClusterInput struct {
 
 // String returns the string representation
 func (s DeleteClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3743,7 +3743,7 @@ type metadataDeleteClusterOutput struct {
 
 // String returns the string representation
 func (s DeleteClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3769,7 +3769,7 @@ type metadataDeleteClusterParameterGroupInput struct {
 
 // String returns the string representation
 func (s DeleteClusterParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3787,7 +3787,7 @@ type metadataDeleteClusterParameterGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteClusterParameterGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3808,7 +3808,7 @@ type metadataDeleteClusterSecurityGroupInput struct {
 
 // String returns the string representation
 func (s DeleteClusterSecurityGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3826,7 +3826,7 @@ type metadataDeleteClusterSecurityGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteClusterSecurityGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3857,7 +3857,7 @@ type metadataDeleteClusterSnapshotInput struct {
 
 // String returns the string representation
 func (s DeleteClusterSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3878,7 +3878,7 @@ type metadataDeleteClusterSnapshotOutput struct {
 
 // String returns the string representation
 func (s DeleteClusterSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3899,7 +3899,7 @@ type metadataDeleteClusterSubnetGroupInput struct {
 
 // String returns the string representation
 func (s DeleteClusterSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3917,7 +3917,7 @@ type metadataDeleteClusterSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s DeleteClusterSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3938,7 +3938,7 @@ type metadataDeleteEventSubscriptionInput struct {
 
 // String returns the string representation
 func (s DeleteEventSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3956,7 +3956,7 @@ type metadataDeleteEventSubscriptionOutput struct {
 
 // String returns the string representation
 func (s DeleteEventSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3977,7 +3977,7 @@ type metadataDeleteHSMClientCertificateInput struct {
 
 // String returns the string representation
 func (s DeleteHSMClientCertificateInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3995,7 +3995,7 @@ type metadataDeleteHSMClientCertificateOutput struct {
 
 // String returns the string representation
 func (s DeleteHSMClientCertificateOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4016,7 +4016,7 @@ type metadataDeleteHSMConfigurationInput struct {
 
 // String returns the string representation
 func (s DeleteHSMConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4034,7 +4034,7 @@ type metadataDeleteHSMConfigurationOutput struct {
 
 // String returns the string representation
 func (s DeleteHSMConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4056,7 +4056,7 @@ type metadataDeleteSnapshotCopyGrantInput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotCopyGrantInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4074,7 +4074,7 @@ type metadataDeleteSnapshotCopyGrantOutput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotCopyGrantOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4100,7 +4100,7 @@ type metadataDeleteTagsInput struct {
 
 // String returns the string representation
 func (s DeleteTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4118,7 +4118,7 @@ type metadataDeleteTagsOutput struct {
 
 // String returns the string representation
 func (s DeleteTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4174,7 +4174,7 @@ type metadataDescribeClusterParameterGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeClusterParameterGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4204,7 +4204,7 @@ type metadataDescribeClusterParameterGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeClusterParameterGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4252,7 +4252,7 @@ type metadataDescribeClusterParametersInput struct {
 
 // String returns the string representation
 func (s DescribeClusterParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4282,7 +4282,7 @@ type metadataDescribeClusterParametersOutput struct {
 
 // String returns the string representation
 func (s DescribeClusterParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4345,7 +4345,7 @@ type metadataDescribeClusterSecurityGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeClusterSecurityGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4374,7 +4374,7 @@ type metadataDescribeClusterSecurityGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeClusterSecurityGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4458,7 +4458,7 @@ type metadataDescribeClusterSnapshotsInput struct {
 
 // String returns the string representation
 func (s DescribeClusterSnapshotsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4487,7 +4487,7 @@ type metadataDescribeClusterSnapshotsOutput struct {
 
 // String returns the string representation
 func (s DescribeClusterSnapshotsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4542,7 +4542,7 @@ type metadataDescribeClusterSubnetGroupsInput struct {
 
 // String returns the string representation
 func (s DescribeClusterSubnetGroupsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4571,7 +4571,7 @@ type metadataDescribeClusterSubnetGroupsOutput struct {
 
 // String returns the string representation
 func (s DescribeClusterSubnetGroupsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4619,7 +4619,7 @@ type metadataDescribeClusterVersionsInput struct {
 
 // String returns the string representation
 func (s DescribeClusterVersionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4648,7 +4648,7 @@ type metadataDescribeClusterVersionsOutput struct {
 
 // String returns the string representation
 func (s DescribeClusterVersionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4708,7 +4708,7 @@ type metadataDescribeClustersInput struct {
 
 // String returns the string representation
 func (s DescribeClustersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4737,7 +4737,7 @@ type metadataDescribeClustersOutput struct {
 
 // String returns the string representation
 func (s DescribeClustersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4776,7 +4776,7 @@ type metadataDescribeDefaultClusterParametersInput struct {
 
 // String returns the string representation
 func (s DescribeDefaultClusterParametersInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4797,7 +4797,7 @@ type metadataDescribeDefaultClusterParametersOutput struct {
 
 // String returns the string representation
 func (s DescribeDefaultClusterParametersOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4821,7 +4821,7 @@ type metadataDescribeEventCategoriesInput struct {
 
 // String returns the string representation
 func (s DescribeEventCategoriesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4842,7 +4842,7 @@ type metadataDescribeEventCategoriesOutput struct {
 
 // String returns the string representation
 func (s DescribeEventCategoriesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4881,7 +4881,7 @@ type metadataDescribeEventSubscriptionsInput struct {
 
 // String returns the string representation
 func (s DescribeEventSubscriptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4909,7 +4909,7 @@ type metadataDescribeEventSubscriptionsOutput struct {
 
 // String returns the string representation
 func (s DescribeEventSubscriptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4992,7 +4992,7 @@ type metadataDescribeEventsInput struct {
 
 // String returns the string representation
 func (s DescribeEventsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5021,7 +5021,7 @@ type metadataDescribeEventsOutput struct {
 
 // String returns the string representation
 func (s DescribeEventsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5078,7 +5078,7 @@ type metadataDescribeHSMClientCertificatesInput struct {
 
 // String returns the string representation
 func (s DescribeHSMClientCertificatesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5108,7 +5108,7 @@ type metadataDescribeHSMClientCertificatesOutput struct {
 
 // String returns the string representation
 func (s DescribeHSMClientCertificatesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5165,7 +5165,7 @@ type metadataDescribeHSMConfigurationsInput struct {
 
 // String returns the string representation
 func (s DescribeHSMConfigurationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5193,7 +5193,7 @@ type metadataDescribeHSMConfigurationsOutput struct {
 
 // String returns the string representation
 func (s DescribeHSMConfigurationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5216,7 +5216,7 @@ type metadataDescribeLoggingStatusInput struct {
 
 // String returns the string representation
 func (s DescribeLoggingStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5264,7 +5264,7 @@ type metadataDescribeOrderableClusterOptionsInput struct {
 
 // String returns the string representation
 func (s DescribeOrderableClusterOptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5294,7 +5294,7 @@ type metadataDescribeOrderableClusterOptionsOutput struct {
 
 // String returns the string representation
 func (s DescribeOrderableClusterOptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5333,7 +5333,7 @@ type metadataDescribeReservedNodeOfferingsInput struct {
 
 // String returns the string representation
 func (s DescribeReservedNodeOfferingsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5362,7 +5362,7 @@ type metadataDescribeReservedNodeOfferingsOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedNodeOfferingsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5400,7 +5400,7 @@ type metadataDescribeReservedNodesInput struct {
 
 // String returns the string representation
 func (s DescribeReservedNodesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5429,7 +5429,7 @@ type metadataDescribeReservedNodesOutput struct {
 
 // String returns the string representation
 func (s DescribeReservedNodesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5454,7 +5454,7 @@ type metadataDescribeResizeInput struct {
 
 // String returns the string representation
 func (s DescribeResizeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5532,7 +5532,7 @@ type metadataDescribeResizeOutput struct {
 
 // String returns the string representation
 func (s DescribeResizeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5591,7 +5591,7 @@ type metadataDescribeSnapshotCopyGrantsInput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotCopyGrantsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5624,7 +5624,7 @@ type metadataDescribeSnapshotCopyGrantsOutput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotCopyGrantsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5686,7 +5686,7 @@ type metadataDescribeTagsInput struct {
 
 // String returns the string representation
 func (s DescribeTagsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5715,7 +5715,7 @@ type metadataDescribeTagsOutput struct {
 
 // String returns the string representation
 func (s DescribeTagsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5738,7 +5738,7 @@ type metadataDisableLoggingInput struct {
 
 // String returns the string representation
 func (s DisableLoggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5763,7 +5763,7 @@ type metadataDisableSnapshotCopyInput struct {
 
 // String returns the string representation
 func (s DisableSnapshotCopyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5784,7 +5784,7 @@ type metadataDisableSnapshotCopyOutput struct {
 
 // String returns the string representation
 func (s DisableSnapshotCopyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5816,7 +5816,7 @@ type metadataEC2SecurityGroup struct {
 
 // String returns the string representation
 func (s EC2SecurityGroup) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5841,7 +5841,7 @@ type metadataElasticIPStatus struct {
 
 // String returns the string representation
 func (s ElasticIPStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5881,7 +5881,7 @@ type metadataEnableLoggingInput struct {
 
 // String returns the string representation
 func (s EnableLoggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5924,7 +5924,7 @@ type metadataEnableSnapshotCopyInput struct {
 
 // String returns the string representation
 func (s EnableSnapshotCopyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5945,7 +5945,7 @@ type metadataEnableSnapshotCopyOutput struct {
 
 // String returns the string representation
 func (s EnableSnapshotCopyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5970,7 +5970,7 @@ type metadataEndpoint struct {
 
 // String returns the string representation
 func (s Endpoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6014,7 +6014,7 @@ type metadataEvent struct {
 
 // String returns the string representation
 func (s Event) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6039,7 +6039,7 @@ type metadataEventCategoriesMap struct {
 
 // String returns the string representation
 func (s EventCategoriesMap) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6071,7 +6071,7 @@ type metadataEventInfoMap struct {
 
 // String returns the string representation
 func (s EventInfoMap) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6140,7 +6140,7 @@ type metadataEventSubscription struct {
 
 // String returns the string representation
 func (s EventSubscription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6171,7 +6171,7 @@ type metadataHSMClientCertificate struct {
 
 // String returns the string representation
 func (s HSMClientCertificate) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6208,7 +6208,7 @@ type metadataHSMConfiguration struct {
 
 // String returns the string representation
 func (s HSMConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6240,7 +6240,7 @@ type metadataHSMStatus struct {
 
 // String returns the string representation
 func (s HSMStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6268,7 +6268,7 @@ type metadataIPRange struct {
 
 // String returns the string representation
 func (s IPRange) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6305,7 +6305,7 @@ type metadataLoggingStatus struct {
 
 // String returns the string representation
 func (s LoggingStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6478,7 +6478,7 @@ type metadataModifyClusterInput struct {
 
 // String returns the string representation
 func (s ModifyClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6499,7 +6499,7 @@ type metadataModifyClusterOutput struct {
 
 // String returns the string representation
 func (s ModifyClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6530,7 +6530,7 @@ type metadataModifyClusterParameterGroupInput struct {
 
 // String returns the string representation
 func (s ModifyClusterParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6558,7 +6558,7 @@ type metadataModifyClusterSubnetGroupInput struct {
 
 // String returns the string representation
 func (s ModifyClusterSubnetGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6579,7 +6579,7 @@ type metadataModifyClusterSubnetGroupOutput struct {
 
 // String returns the string representation
 func (s ModifyClusterSubnetGroupOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6641,7 +6641,7 @@ type metadataModifyEventSubscriptionInput struct {
 
 // String returns the string representation
 func (s ModifyEventSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6661,7 +6661,7 @@ type metadataModifyEventSubscriptionOutput struct {
 
 // String returns the string representation
 func (s ModifyEventSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6697,7 +6697,7 @@ type metadataModifySnapshotCopyRetentionPeriodInput struct {
 
 // String returns the string representation
 func (s ModifySnapshotCopyRetentionPeriodInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6718,7 +6718,7 @@ type metadataModifySnapshotCopyRetentionPeriodOutput struct {
 
 // String returns the string representation
 func (s ModifySnapshotCopyRetentionPeriodOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6749,7 +6749,7 @@ type metadataOrderableClusterOption struct {
 
 // String returns the string representation
 func (s OrderableClusterOption) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6796,7 +6796,7 @@ type metadataParameter struct {
 
 // String returns the string representation
 func (s Parameter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6837,7 +6837,7 @@ type metadataPendingModifiedValues struct {
 
 // String returns the string representation
 func (s PendingModifiedValues) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6863,7 +6863,7 @@ type metadataPurchaseReservedNodeOfferingInput struct {
 
 // String returns the string representation
 func (s PurchaseReservedNodeOfferingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6885,7 +6885,7 @@ type metadataPurchaseReservedNodeOfferingOutput struct {
 
 // String returns the string representation
 func (s PurchaseReservedNodeOfferingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6906,7 +6906,7 @@ type metadataRebootClusterInput struct {
 
 // String returns the string representation
 func (s RebootClusterInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6927,7 +6927,7 @@ type metadataRebootClusterOutput struct {
 
 // String returns the string representation
 func (s RebootClusterOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6953,7 +6953,7 @@ type metadataRecurringCharge struct {
 
 // String returns the string representation
 func (s RecurringCharge) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7018,7 +7018,7 @@ type metadataReservedNode struct {
 
 // String returns the string representation
 func (s ReservedNode) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7066,7 +7066,7 @@ type metadataReservedNodeOffering struct {
 
 // String returns the string representation
 func (s ReservedNodeOffering) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7099,7 +7099,7 @@ type metadataResetClusterParameterGroupInput struct {
 
 // String returns the string representation
 func (s ResetClusterParameterGroupInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7252,7 +7252,7 @@ type metadataRestoreFromClusterSnapshotInput struct {
 
 // String returns the string representation
 func (s RestoreFromClusterSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7273,7 +7273,7 @@ type metadataRestoreFromClusterSnapshotOutput struct {
 
 // String returns the string representation
 func (s RestoreFromClusterSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7315,7 +7315,7 @@ type metadataRestoreStatus struct {
 
 // String returns the string representation
 func (s RestoreStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7355,7 +7355,7 @@ type metadataRevokeClusterSecurityGroupIngressInput struct {
 
 // String returns the string representation
 func (s RevokeClusterSecurityGroupIngressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7376,7 +7376,7 @@ type metadataRevokeClusterSecurityGroupIngressOutput struct {
 
 // String returns the string representation
 func (s RevokeClusterSecurityGroupIngressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7406,7 +7406,7 @@ type metadataRevokeSnapshotAccessInput struct {
 
 // String returns the string representation
 func (s RevokeSnapshotAccessInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7427,7 +7427,7 @@ type metadataRevokeSnapshotAccessOutput struct {
 
 // String returns the string representation
 func (s RevokeSnapshotAccessOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7451,7 +7451,7 @@ type metadataRotateEncryptionKeyInput struct {
 
 // String returns the string representation
 func (s RotateEncryptionKeyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7472,7 +7472,7 @@ type metadataRotateEncryptionKeyOutput struct {
 
 // String returns the string representation
 func (s RotateEncryptionKeyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7591,7 +7591,7 @@ type metadataSnapshot struct {
 
 // String returns the string representation
 func (s Snapshot) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7626,7 +7626,7 @@ type metadataSnapshotCopyGrant struct {
 
 // String returns the string representation
 func (s SnapshotCopyGrant) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7654,7 +7654,7 @@ type metadataSubnet struct {
 
 // String returns the string representation
 func (s Subnet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7679,7 +7679,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7714,7 +7714,7 @@ type metadataTaggedResource struct {
 
 // String returns the string representation
 func (s TaggedResource) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7737,7 +7737,7 @@ type metadataVPCSecurityGroupMembership struct {
 
 // String returns the string representation
 func (s VPCSecurityGroupMembership) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/redshift/examples_test.go
+++ b/service/redshift/examples_test.go
@@ -43,7 +43,7 @@ func ExampleRedshift_AuthorizeClusterSecurityGroupIngress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_AuthorizeSnapshotAccess() {
@@ -72,7 +72,7 @@ func ExampleRedshift_AuthorizeSnapshotAccess() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CopyClusterSnapshot() {
@@ -101,7 +101,7 @@ func ExampleRedshift_CopyClusterSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateCluster() {
@@ -112,8 +112,8 @@ func ExampleRedshift_CreateCluster() {
 		MasterUserPassword:               aws.String("String"), // Required
 		MasterUsername:                   aws.String("String"), // Required
 		NodeType:                         aws.String("String"), // Required
-		AllowVersionUpgrade:              aws.Boolean(true),
-		AutomatedSnapshotRetentionPeriod: aws.Long(1),
+		AllowVersionUpgrade:              aws.Bool(true),
+		AutomatedSnapshotRetentionPeriod: aws.Int64(1),
 		AvailabilityZone:                 aws.String("String"),
 		ClusterParameterGroupName:        aws.String("String"),
 		ClusterSecurityGroups: []*string{
@@ -125,14 +125,14 @@ func ExampleRedshift_CreateCluster() {
 		ClusterVersion:                 aws.String("String"),
 		DBName:                         aws.String("String"),
 		ElasticIP:                      aws.String("String"),
-		Encrypted:                      aws.Boolean(true),
+		Encrypted:                      aws.Bool(true),
 		HSMClientCertificateIdentifier: aws.String("String"),
 		HSMConfigurationIdentifier:     aws.String("String"),
 		KMSKeyID:                       aws.String("String"),
-		NumberOfNodes:                  aws.Long(1),
-		Port:                           aws.Long(1),
+		NumberOfNodes:                  aws.Int64(1),
+		Port:                           aws.Int64(1),
 		PreferredMaintenanceWindow: aws.String("String"),
-		PubliclyAccessible:         aws.Boolean(true),
+		PubliclyAccessible:         aws.Bool(true),
 		Tags: []*redshift.Tag{
 			{ // Required
 				Key:   aws.String("String"),
@@ -163,7 +163,7 @@ func ExampleRedshift_CreateCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateClusterParameterGroup() {
@@ -199,7 +199,7 @@ func ExampleRedshift_CreateClusterParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateClusterSecurityGroup() {
@@ -234,7 +234,7 @@ func ExampleRedshift_CreateClusterSecurityGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateClusterSnapshot() {
@@ -269,7 +269,7 @@ func ExampleRedshift_CreateClusterSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateClusterSubnetGroup() {
@@ -308,7 +308,7 @@ func ExampleRedshift_CreateClusterSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateEventSubscription() {
@@ -317,7 +317,7 @@ func ExampleRedshift_CreateEventSubscription() {
 	params := &redshift.CreateEventSubscriptionInput{
 		SNSTopicARN:      aws.String("String"), // Required
 		SubscriptionName: aws.String("String"), // Required
-		Enabled:          aws.Boolean(true),
+		Enabled:          aws.Bool(true),
 		EventCategories: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -354,7 +354,7 @@ func ExampleRedshift_CreateEventSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateHSMClientCertificate() {
@@ -388,7 +388,7 @@ func ExampleRedshift_CreateHSMClientCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateHSMConfiguration() {
@@ -427,7 +427,7 @@ func ExampleRedshift_CreateHSMConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateSnapshotCopyGrant() {
@@ -462,7 +462,7 @@ func ExampleRedshift_CreateSnapshotCopyGrant() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_CreateTags() {
@@ -496,7 +496,7 @@ func ExampleRedshift_CreateTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteCluster() {
@@ -505,7 +505,7 @@ func ExampleRedshift_DeleteCluster() {
 	params := &redshift.DeleteClusterInput{
 		ClusterIdentifier:              aws.String("String"), // Required
 		FinalClusterSnapshotIdentifier: aws.String("String"),
-		SkipFinalClusterSnapshot:       aws.Boolean(true),
+		SkipFinalClusterSnapshot:       aws.Bool(true),
 	}
 	resp, err := svc.DeleteCluster(params)
 
@@ -525,7 +525,7 @@ func ExampleRedshift_DeleteCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteClusterParameterGroup() {
@@ -552,7 +552,7 @@ func ExampleRedshift_DeleteClusterParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteClusterSecurityGroup() {
@@ -579,7 +579,7 @@ func ExampleRedshift_DeleteClusterSecurityGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteClusterSnapshot() {
@@ -607,7 +607,7 @@ func ExampleRedshift_DeleteClusterSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteClusterSubnetGroup() {
@@ -634,7 +634,7 @@ func ExampleRedshift_DeleteClusterSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteEventSubscription() {
@@ -661,7 +661,7 @@ func ExampleRedshift_DeleteEventSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteHSMClientCertificate() {
@@ -688,7 +688,7 @@ func ExampleRedshift_DeleteHSMClientCertificate() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteHSMConfiguration() {
@@ -715,7 +715,7 @@ func ExampleRedshift_DeleteHSMConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteSnapshotCopyGrant() {
@@ -742,7 +742,7 @@ func ExampleRedshift_DeleteSnapshotCopyGrant() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DeleteTags() {
@@ -773,7 +773,7 @@ func ExampleRedshift_DeleteTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeClusterParameterGroups() {
@@ -781,7 +781,7 @@ func ExampleRedshift_DescribeClusterParameterGroups() {
 
 	params := &redshift.DescribeClusterParameterGroupsInput{
 		Marker:             aws.String("String"),
-		MaxRecords:         aws.Long(1),
+		MaxRecords:         aws.Int64(1),
 		ParameterGroupName: aws.String("String"),
 		TagKeys: []*string{
 			aws.String("String"), // Required
@@ -810,7 +810,7 @@ func ExampleRedshift_DescribeClusterParameterGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeClusterParameters() {
@@ -819,7 +819,7 @@ func ExampleRedshift_DescribeClusterParameters() {
 	params := &redshift.DescribeClusterParametersInput{
 		ParameterGroupName: aws.String("String"), // Required
 		Marker:             aws.String("String"),
-		MaxRecords:         aws.Long(1),
+		MaxRecords:         aws.Int64(1),
 		Source:             aws.String("String"),
 	}
 	resp, err := svc.DescribeClusterParameters(params)
@@ -840,7 +840,7 @@ func ExampleRedshift_DescribeClusterParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeClusterSecurityGroups() {
@@ -849,7 +849,7 @@ func ExampleRedshift_DescribeClusterSecurityGroups() {
 	params := &redshift.DescribeClusterSecurityGroupsInput{
 		ClusterSecurityGroupName: aws.String("String"),
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		TagKeys: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -877,7 +877,7 @@ func ExampleRedshift_DescribeClusterSecurityGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeClusterSnapshots() {
@@ -887,7 +887,7 @@ func ExampleRedshift_DescribeClusterSnapshots() {
 		ClusterIdentifier:  aws.String("String"),
 		EndTime:            aws.Time(time.Now()),
 		Marker:             aws.String("String"),
-		MaxRecords:         aws.Long(1),
+		MaxRecords:         aws.Int64(1),
 		OwnerAccount:       aws.String("String"),
 		SnapshotIdentifier: aws.String("String"),
 		SnapshotType:       aws.String("String"),
@@ -919,7 +919,7 @@ func ExampleRedshift_DescribeClusterSnapshots() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeClusterSubnetGroups() {
@@ -928,7 +928,7 @@ func ExampleRedshift_DescribeClusterSubnetGroups() {
 	params := &redshift.DescribeClusterSubnetGroupsInput{
 		ClusterSubnetGroupName: aws.String("String"),
 		Marker:                 aws.String("String"),
-		MaxRecords:             aws.Long(1),
+		MaxRecords:             aws.Int64(1),
 		TagKeys: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -956,7 +956,7 @@ func ExampleRedshift_DescribeClusterSubnetGroups() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeClusterVersions() {
@@ -966,7 +966,7 @@ func ExampleRedshift_DescribeClusterVersions() {
 		ClusterParameterGroupFamily: aws.String("String"),
 		ClusterVersion:              aws.String("String"),
 		Marker:                      aws.String("String"),
-		MaxRecords:                  aws.Long(1),
+		MaxRecords:                  aws.Int64(1),
 	}
 	resp, err := svc.DescribeClusterVersions(params)
 
@@ -986,7 +986,7 @@ func ExampleRedshift_DescribeClusterVersions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeClusters() {
@@ -995,7 +995,7 @@ func ExampleRedshift_DescribeClusters() {
 	params := &redshift.DescribeClustersInput{
 		ClusterIdentifier: aws.String("String"),
 		Marker:            aws.String("String"),
-		MaxRecords:        aws.Long(1),
+		MaxRecords:        aws.Int64(1),
 		TagKeys: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -1023,7 +1023,7 @@ func ExampleRedshift_DescribeClusters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeDefaultClusterParameters() {
@@ -1032,7 +1032,7 @@ func ExampleRedshift_DescribeDefaultClusterParameters() {
 	params := &redshift.DescribeDefaultClusterParametersInput{
 		ParameterGroupFamily: aws.String("String"), // Required
 		Marker:               aws.String("String"),
-		MaxRecords:           aws.Long(1),
+		MaxRecords:           aws.Int64(1),
 	}
 	resp, err := svc.DescribeDefaultClusterParameters(params)
 
@@ -1052,7 +1052,7 @@ func ExampleRedshift_DescribeDefaultClusterParameters() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeEventCategories() {
@@ -1079,7 +1079,7 @@ func ExampleRedshift_DescribeEventCategories() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeEventSubscriptions() {
@@ -1087,7 +1087,7 @@ func ExampleRedshift_DescribeEventSubscriptions() {
 
 	params := &redshift.DescribeEventSubscriptionsInput{
 		Marker:           aws.String("String"),
-		MaxRecords:       aws.Long(1),
+		MaxRecords:       aws.Int64(1),
 		SubscriptionName: aws.String("String"),
 	}
 	resp, err := svc.DescribeEventSubscriptions(params)
@@ -1108,17 +1108,17 @@ func ExampleRedshift_DescribeEventSubscriptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeEvents() {
 	svc := redshift.New(nil)
 
 	params := &redshift.DescribeEventsInput{
-		Duration:         aws.Long(1),
+		Duration:         aws.Int64(1),
 		EndTime:          aws.Time(time.Now()),
 		Marker:           aws.String("String"),
-		MaxRecords:       aws.Long(1),
+		MaxRecords:       aws.Int64(1),
 		SourceIdentifier: aws.String("String"),
 		SourceType:       aws.String("SourceType"),
 		StartTime:        aws.Time(time.Now()),
@@ -1141,7 +1141,7 @@ func ExampleRedshift_DescribeEvents() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeHSMClientCertificates() {
@@ -1150,7 +1150,7 @@ func ExampleRedshift_DescribeHSMClientCertificates() {
 	params := &redshift.DescribeHSMClientCertificatesInput{
 		HSMClientCertificateIdentifier: aws.String("String"),
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		TagKeys: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -1178,7 +1178,7 @@ func ExampleRedshift_DescribeHSMClientCertificates() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeHSMConfigurations() {
@@ -1187,7 +1187,7 @@ func ExampleRedshift_DescribeHSMConfigurations() {
 	params := &redshift.DescribeHSMConfigurationsInput{
 		HSMConfigurationIdentifier: aws.String("String"),
 		Marker:     aws.String("String"),
-		MaxRecords: aws.Long(1),
+		MaxRecords: aws.Int64(1),
 		TagKeys: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -1215,7 +1215,7 @@ func ExampleRedshift_DescribeHSMConfigurations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeLoggingStatus() {
@@ -1242,7 +1242,7 @@ func ExampleRedshift_DescribeLoggingStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeOrderableClusterOptions() {
@@ -1251,7 +1251,7 @@ func ExampleRedshift_DescribeOrderableClusterOptions() {
 	params := &redshift.DescribeOrderableClusterOptionsInput{
 		ClusterVersion: aws.String("String"),
 		Marker:         aws.String("String"),
-		MaxRecords:     aws.Long(1),
+		MaxRecords:     aws.Int64(1),
 		NodeType:       aws.String("String"),
 	}
 	resp, err := svc.DescribeOrderableClusterOptions(params)
@@ -1272,7 +1272,7 @@ func ExampleRedshift_DescribeOrderableClusterOptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeReservedNodeOfferings() {
@@ -1280,7 +1280,7 @@ func ExampleRedshift_DescribeReservedNodeOfferings() {
 
 	params := &redshift.DescribeReservedNodeOfferingsInput{
 		Marker:                 aws.String("String"),
-		MaxRecords:             aws.Long(1),
+		MaxRecords:             aws.Int64(1),
 		ReservedNodeOfferingID: aws.String("String"),
 	}
 	resp, err := svc.DescribeReservedNodeOfferings(params)
@@ -1301,7 +1301,7 @@ func ExampleRedshift_DescribeReservedNodeOfferings() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeReservedNodes() {
@@ -1309,7 +1309,7 @@ func ExampleRedshift_DescribeReservedNodes() {
 
 	params := &redshift.DescribeReservedNodesInput{
 		Marker:         aws.String("String"),
-		MaxRecords:     aws.Long(1),
+		MaxRecords:     aws.Int64(1),
 		ReservedNodeID: aws.String("String"),
 	}
 	resp, err := svc.DescribeReservedNodes(params)
@@ -1330,7 +1330,7 @@ func ExampleRedshift_DescribeReservedNodes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeResize() {
@@ -1357,7 +1357,7 @@ func ExampleRedshift_DescribeResize() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeSnapshotCopyGrants() {
@@ -1365,7 +1365,7 @@ func ExampleRedshift_DescribeSnapshotCopyGrants() {
 
 	params := &redshift.DescribeSnapshotCopyGrantsInput{
 		Marker:                aws.String("String"),
-		MaxRecords:            aws.Long(1),
+		MaxRecords:            aws.Int64(1),
 		SnapshotCopyGrantName: aws.String("String"),
 		TagKeys: []*string{
 			aws.String("String"), // Required
@@ -1394,7 +1394,7 @@ func ExampleRedshift_DescribeSnapshotCopyGrants() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DescribeTags() {
@@ -1402,7 +1402,7 @@ func ExampleRedshift_DescribeTags() {
 
 	params := &redshift.DescribeTagsInput{
 		Marker:       aws.String("String"),
-		MaxRecords:   aws.Long(1),
+		MaxRecords:   aws.Int64(1),
 		ResourceName: aws.String("String"),
 		ResourceType: aws.String("String"),
 		TagKeys: []*string{
@@ -1432,7 +1432,7 @@ func ExampleRedshift_DescribeTags() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DisableLogging() {
@@ -1459,7 +1459,7 @@ func ExampleRedshift_DisableLogging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_DisableSnapshotCopy() {
@@ -1486,7 +1486,7 @@ func ExampleRedshift_DisableSnapshotCopy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_EnableLogging() {
@@ -1515,7 +1515,7 @@ func ExampleRedshift_EnableLogging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_EnableSnapshotCopy() {
@@ -1524,7 +1524,7 @@ func ExampleRedshift_EnableSnapshotCopy() {
 	params := &redshift.EnableSnapshotCopyInput{
 		ClusterIdentifier:     aws.String("String"), // Required
 		DestinationRegion:     aws.String("String"), // Required
-		RetentionPeriod:       aws.Long(1),
+		RetentionPeriod:       aws.Int64(1),
 		SnapshotCopyGrantName: aws.String("String"),
 	}
 	resp, err := svc.EnableSnapshotCopy(params)
@@ -1545,7 +1545,7 @@ func ExampleRedshift_EnableSnapshotCopy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_ModifyCluster() {
@@ -1553,8 +1553,8 @@ func ExampleRedshift_ModifyCluster() {
 
 	params := &redshift.ModifyClusterInput{
 		ClusterIdentifier:                aws.String("String"), // Required
-		AllowVersionUpgrade:              aws.Boolean(true),
-		AutomatedSnapshotRetentionPeriod: aws.Long(1),
+		AllowVersionUpgrade:              aws.Bool(true),
+		AutomatedSnapshotRetentionPeriod: aws.Int64(1),
 		ClusterParameterGroupName:        aws.String("String"),
 		ClusterSecurityGroups: []*string{
 			aws.String("String"), // Required
@@ -1567,7 +1567,7 @@ func ExampleRedshift_ModifyCluster() {
 		MasterUserPassword:             aws.String("String"),
 		NewClusterIdentifier:           aws.String("String"),
 		NodeType:                       aws.String("String"),
-		NumberOfNodes:                  aws.Long(1),
+		NumberOfNodes:                  aws.Int64(1),
 		PreferredMaintenanceWindow:     aws.String("String"),
 		VPCSecurityGroupIDs: []*string{
 			aws.String("String"), // Required
@@ -1592,7 +1592,7 @@ func ExampleRedshift_ModifyCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_ModifyClusterParameterGroup() {
@@ -1606,7 +1606,7 @@ func ExampleRedshift_ModifyClusterParameterGroup() {
 				ApplyType:            aws.String("ParameterApplyType"),
 				DataType:             aws.String("String"),
 				Description:          aws.String("String"),
-				IsModifiable:         aws.Boolean(true),
+				IsModifiable:         aws.Bool(true),
 				MinimumEngineVersion: aws.String("String"),
 				ParameterName:        aws.String("String"),
 				ParameterValue:       aws.String("String"),
@@ -1633,7 +1633,7 @@ func ExampleRedshift_ModifyClusterParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_ModifyClusterSubnetGroup() {
@@ -1665,7 +1665,7 @@ func ExampleRedshift_ModifyClusterSubnetGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_ModifyEventSubscription() {
@@ -1673,7 +1673,7 @@ func ExampleRedshift_ModifyEventSubscription() {
 
 	params := &redshift.ModifyEventSubscriptionInput{
 		SubscriptionName: aws.String("String"), // Required
-		Enabled:          aws.Boolean(true),
+		Enabled:          aws.Bool(true),
 		EventCategories: []*string{
 			aws.String("String"), // Required
 			// More values...
@@ -1704,7 +1704,7 @@ func ExampleRedshift_ModifyEventSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_ModifySnapshotCopyRetentionPeriod() {
@@ -1712,7 +1712,7 @@ func ExampleRedshift_ModifySnapshotCopyRetentionPeriod() {
 
 	params := &redshift.ModifySnapshotCopyRetentionPeriodInput{
 		ClusterIdentifier: aws.String("String"), // Required
-		RetentionPeriod:   aws.Long(1),          // Required
+		RetentionPeriod:   aws.Int64(1),         // Required
 	}
 	resp, err := svc.ModifySnapshotCopyRetentionPeriod(params)
 
@@ -1732,7 +1732,7 @@ func ExampleRedshift_ModifySnapshotCopyRetentionPeriod() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_PurchaseReservedNodeOffering() {
@@ -1740,7 +1740,7 @@ func ExampleRedshift_PurchaseReservedNodeOffering() {
 
 	params := &redshift.PurchaseReservedNodeOfferingInput{
 		ReservedNodeOfferingID: aws.String("String"), // Required
-		NodeCount:              aws.Long(1),
+		NodeCount:              aws.Int64(1),
 	}
 	resp, err := svc.PurchaseReservedNodeOffering(params)
 
@@ -1760,7 +1760,7 @@ func ExampleRedshift_PurchaseReservedNodeOffering() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_RebootCluster() {
@@ -1787,7 +1787,7 @@ func ExampleRedshift_RebootCluster() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_ResetClusterParameterGroup() {
@@ -1801,7 +1801,7 @@ func ExampleRedshift_ResetClusterParameterGroup() {
 				ApplyType:            aws.String("ParameterApplyType"),
 				DataType:             aws.String("String"),
 				Description:          aws.String("String"),
-				IsModifiable:         aws.Boolean(true),
+				IsModifiable:         aws.Bool(true),
 				MinimumEngineVersion: aws.String("String"),
 				ParameterName:        aws.String("String"),
 				ParameterValue:       aws.String("String"),
@@ -1809,7 +1809,7 @@ func ExampleRedshift_ResetClusterParameterGroup() {
 			},
 			// More values...
 		},
-		ResetAllParameters: aws.Boolean(true),
+		ResetAllParameters: aws.Bool(true),
 	}
 	resp, err := svc.ResetClusterParameterGroup(params)
 
@@ -1829,7 +1829,7 @@ func ExampleRedshift_ResetClusterParameterGroup() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_RestoreFromClusterSnapshot() {
@@ -1838,8 +1838,8 @@ func ExampleRedshift_RestoreFromClusterSnapshot() {
 	params := &redshift.RestoreFromClusterSnapshotInput{
 		ClusterIdentifier:                aws.String("String"), // Required
 		SnapshotIdentifier:               aws.String("String"), // Required
-		AllowVersionUpgrade:              aws.Boolean(true),
-		AutomatedSnapshotRetentionPeriod: aws.Long(1),
+		AllowVersionUpgrade:              aws.Bool(true),
+		AutomatedSnapshotRetentionPeriod: aws.Int64(1),
 		AvailabilityZone:                 aws.String("String"),
 		ClusterParameterGroupName:        aws.String("String"),
 		ClusterSecurityGroups: []*string{
@@ -1853,9 +1853,9 @@ func ExampleRedshift_RestoreFromClusterSnapshot() {
 		KMSKeyID:                       aws.String("String"),
 		NodeType:                       aws.String("String"),
 		OwnerAccount:                   aws.String("String"),
-		Port:                           aws.Long(1),
+		Port:                           aws.Int64(1),
 		PreferredMaintenanceWindow: aws.String("String"),
-		PubliclyAccessible:         aws.Boolean(true),
+		PubliclyAccessible:         aws.Bool(true),
 		SnapshotClusterIdentifier:  aws.String("String"),
 		VPCSecurityGroupIDs: []*string{
 			aws.String("String"), // Required
@@ -1880,7 +1880,7 @@ func ExampleRedshift_RestoreFromClusterSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_RevokeClusterSecurityGroupIngress() {
@@ -1910,7 +1910,7 @@ func ExampleRedshift_RevokeClusterSecurityGroupIngress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_RevokeSnapshotAccess() {
@@ -1939,7 +1939,7 @@ func ExampleRedshift_RevokeSnapshotAccess() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRedshift_RotateEncryptionKey() {
@@ -1966,5 +1966,5 @@ func ExampleRedshift_RotateEncryptionKey() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -1127,7 +1127,7 @@ type metadataAliasTarget struct {
 
 // String returns the string representation
 func (s AliasTarget) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1159,7 +1159,7 @@ type metadataAssociateVPCWithHostedZoneInput struct {
 
 // String returns the string representation
 func (s AssociateVPCWithHostedZoneInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1182,7 +1182,7 @@ type metadataAssociateVPCWithHostedZoneOutput struct {
 
 // String returns the string representation
 func (s AssociateVPCWithHostedZoneOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1210,7 +1210,7 @@ type metadataChange struct {
 
 // String returns the string representation
 func (s Change) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1237,7 +1237,7 @@ type metadataChangeBatch struct {
 
 // String returns the string representation
 func (s ChangeBatch) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1283,7 +1283,7 @@ type metadataChangeInfo struct {
 
 // String returns the string representation
 func (s ChangeInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1309,7 +1309,7 @@ type metadataChangeResourceRecordSetsInput struct {
 
 // String returns the string representation
 func (s ChangeResourceRecordSetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1335,7 +1335,7 @@ type metadataChangeResourceRecordSetsOutput struct {
 
 // String returns the string representation
 func (s ChangeResourceRecordSetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1372,7 +1372,7 @@ type metadataChangeTagsForResourceInput struct {
 
 // String returns the string representation
 func (s ChangeTagsForResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1391,7 +1391,7 @@ type metadataChangeTagsForResourceOutput struct {
 
 // String returns the string representation
 func (s ChangeTagsForResourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1424,7 +1424,7 @@ type metadataCreateHealthCheckInput struct {
 
 // String returns the string representation
 func (s CreateHealthCheckInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1449,7 +1449,7 @@ type metadataCreateHealthCheckOutput struct {
 
 // String returns the string representation
 func (s CreateHealthCheckOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1501,7 +1501,7 @@ type metadataCreateHostedZoneInput struct {
 
 // String returns the string representation
 func (s CreateHostedZoneInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1536,7 +1536,7 @@ type metadataCreateHostedZoneOutput struct {
 
 // String returns the string representation
 func (s CreateHostedZoneOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1568,7 +1568,7 @@ type metadataCreateReusableDelegationSetInput struct {
 
 // String returns the string representation
 func (s CreateReusableDelegationSetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1592,7 +1592,7 @@ type metadataCreateReusableDelegationSetOutput struct {
 
 // String returns the string representation
 func (s CreateReusableDelegationSetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1620,7 +1620,7 @@ type metadataDelegationSet struct {
 
 // String returns the string representation
 func (s DelegationSet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1642,7 +1642,7 @@ type metadataDeleteHealthCheckInput struct {
 
 // String returns the string representation
 func (s DeleteHealthCheckInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1661,7 +1661,7 @@ type metadataDeleteHealthCheckOutput struct {
 
 // String returns the string representation
 func (s DeleteHealthCheckOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1684,7 +1684,7 @@ type metadataDeleteHostedZoneInput struct {
 
 // String returns the string representation
 func (s DeleteHostedZoneInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1707,7 +1707,7 @@ type metadataDeleteHostedZoneOutput struct {
 
 // String returns the string representation
 func (s DeleteHostedZoneOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1729,7 +1729,7 @@ type metadataDeleteReusableDelegationSetInput struct {
 
 // String returns the string representation
 func (s DeleteReusableDelegationSetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1748,7 +1748,7 @@ type metadataDeleteReusableDelegationSetOutput struct {
 
 // String returns the string representation
 func (s DeleteReusableDelegationSetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1779,7 +1779,7 @@ type metadataDisassociateVPCFromHostedZoneInput struct {
 
 // String returns the string representation
 func (s DisassociateVPCFromHostedZoneInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1802,7 +1802,7 @@ type metadataDisassociateVPCFromHostedZoneOutput struct {
 
 // String returns the string representation
 func (s DisassociateVPCFromHostedZoneOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1844,7 +1844,7 @@ type metadataGeoLocation struct {
 
 // String returns the string representation
 func (s GeoLocation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1890,7 +1890,7 @@ type metadataGeoLocationDetails struct {
 
 // String returns the string representation
 func (s GeoLocationDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1914,7 +1914,7 @@ type metadataGetChangeInput struct {
 
 // String returns the string representation
 func (s GetChangeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1938,7 +1938,7 @@ type metadataGetChangeOutput struct {
 
 // String returns the string representation
 func (s GetChangeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1957,7 +1957,7 @@ type metadataGetCheckerIPRangesInput struct {
 
 // String returns the string representation
 func (s GetCheckerIPRangesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1980,7 +1980,7 @@ type metadataGetCheckerIPRangesOutput struct {
 
 // String returns the string representation
 func (s GetCheckerIPRangesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2022,7 +2022,7 @@ type metadataGetGeoLocationInput struct {
 
 // String returns the string representation
 func (s GetGeoLocationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2044,7 +2044,7 @@ type metadataGetGeoLocationOutput struct {
 
 // String returns the string representation
 func (s GetGeoLocationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2064,7 +2064,7 @@ type metadataGetHealthCheckCountInput struct {
 
 // String returns the string representation
 func (s GetHealthCheckCountInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2087,7 +2087,7 @@ type metadataGetHealthCheckCountOutput struct {
 
 // String returns the string representation
 func (s GetHealthCheckCountOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2110,7 +2110,7 @@ type metadataGetHealthCheckInput struct {
 
 // String returns the string representation
 func (s GetHealthCheckInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2134,7 +2134,7 @@ type metadataGetHealthCheckLastFailureReasonInput struct {
 
 // String returns the string representation
 func (s GetHealthCheckLastFailureReasonInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2158,7 +2158,7 @@ type metadataGetHealthCheckLastFailureReasonOutput struct {
 
 // String returns the string representation
 func (s GetHealthCheckLastFailureReasonOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2180,7 +2180,7 @@ type metadataGetHealthCheckOutput struct {
 
 // String returns the string representation
 func (s GetHealthCheckOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2204,7 +2204,7 @@ type metadataGetHealthCheckStatusInput struct {
 
 // String returns the string representation
 func (s GetHealthCheckStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2228,7 +2228,7 @@ type metadataGetHealthCheckStatusOutput struct {
 
 // String returns the string representation
 func (s GetHealthCheckStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2248,7 +2248,7 @@ type metadataGetHostedZoneCountInput struct {
 
 // String returns the string representation
 func (s GetHostedZoneCountInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2271,7 +2271,7 @@ type metadataGetHostedZoneCountOutput struct {
 
 // String returns the string representation
 func (s GetHostedZoneCountOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2294,7 +2294,7 @@ type metadataGetHostedZoneInput struct {
 
 // String returns the string representation
 func (s GetHostedZoneInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2324,7 +2324,7 @@ type metadataGetHostedZoneOutput struct {
 
 // String returns the string representation
 func (s GetHostedZoneOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2347,7 +2347,7 @@ type metadataGetReusableDelegationSetInput struct {
 
 // String returns the string representation
 func (s GetReusableDelegationSetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2371,7 +2371,7 @@ type metadataGetReusableDelegationSetOutput struct {
 
 // String returns the string representation
 func (s GetReusableDelegationSetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2404,7 +2404,7 @@ type metadataHealthCheck struct {
 
 // String returns the string representation
 func (s HealthCheck) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2463,7 +2463,7 @@ type metadataHealthCheckConfig struct {
 
 // String returns the string representation
 func (s HealthCheckConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2490,7 +2490,7 @@ type metadataHealthCheckObservation struct {
 
 // String returns the string representation
 func (s HealthCheckObservation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2531,7 +2531,7 @@ type metadataHostedZone struct {
 
 // String returns the string representation
 func (s HostedZone) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2561,7 +2561,7 @@ type metadataHostedZoneConfig struct {
 
 // String returns the string representation
 func (s HostedZoneConfig) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2607,7 +2607,7 @@ type metadataListGeoLocationsInput struct {
 
 // String returns the string representation
 func (s ListGeoLocationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2659,7 +2659,7 @@ type metadataListGeoLocationsOutput struct {
 
 // String returns the string representation
 func (s ListGeoLocationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2694,7 +2694,7 @@ type metadataListHealthChecksInput struct {
 
 // String returns the string representation
 func (s ListHealthChecksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2741,7 +2741,7 @@ type metadataListHealthChecksOutput struct {
 
 // String returns the string representation
 func (s ListHealthChecksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2787,7 +2787,7 @@ type metadataListHostedZonesByNameInput struct {
 
 // String returns the string representation
 func (s ListHostedZonesByNameInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2845,7 +2845,7 @@ type metadataListHostedZonesByNameOutput struct {
 
 // String returns the string representation
 func (s ListHostedZonesByNameOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2885,7 +2885,7 @@ type metadataListHostedZonesInput struct {
 
 // String returns the string representation
 func (s ListHostedZonesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2932,7 +2932,7 @@ type metadataListHostedZonesOutput struct {
 
 // String returns the string representation
 func (s ListHostedZonesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2982,7 +2982,7 @@ type metadataListResourceRecordSetsInput struct {
 
 // String returns the string representation
 func (s ListResourceRecordSetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3033,7 +3033,7 @@ type metadataListResourceRecordSetsOutput struct {
 
 // String returns the string representation
 func (s ListResourceRecordSetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3070,7 +3070,7 @@ type metadataListReusableDelegationSetsInput struct {
 
 // String returns the string representation
 func (s ListReusableDelegationSetsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3119,7 +3119,7 @@ type metadataListReusableDelegationSetsOutput struct {
 
 // String returns the string representation
 func (s ListReusableDelegationSetsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3149,7 +3149,7 @@ type metadataListTagsForResourceInput struct {
 
 // String returns the string representation
 func (s ListTagsForResourceInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3171,7 +3171,7 @@ type metadataListTagsForResourceOutput struct {
 
 // String returns the string representation
 func (s ListTagsForResourceOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3202,7 +3202,7 @@ type metadataListTagsForResourcesInput struct {
 
 // String returns the string representation
 func (s ListTagsForResourcesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3224,7 +3224,7 @@ type metadataListTagsForResourcesOutput struct {
 
 // String returns the string representation
 func (s ListTagsForResourcesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3247,7 +3247,7 @@ type metadataResourceRecord struct {
 
 // String returns the string representation
 func (s ResourceRecord) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3328,7 +3328,7 @@ type metadataResourceRecordSet struct {
 
 // String returns the string representation
 func (s ResourceRecordSet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3360,7 +3360,7 @@ type metadataResourceTagSet struct {
 
 // String returns the string representation
 func (s ResourceTagSet) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3389,7 +3389,7 @@ type metadataStatusReport struct {
 
 // String returns the string representation
 func (s StatusReport) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3414,7 +3414,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3486,7 +3486,7 @@ type metadataUpdateHealthCheckInput struct {
 
 // String returns the string representation
 func (s UpdateHealthCheckInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3507,7 +3507,7 @@ type metadataUpdateHealthCheckOutput struct {
 
 // String returns the string representation
 func (s UpdateHealthCheckOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3533,7 +3533,7 @@ type metadataUpdateHostedZoneCommentInput struct {
 
 // String returns the string representation
 func (s UpdateHostedZoneCommentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3556,7 +3556,7 @@ type metadataUpdateHostedZoneCommentOutput struct {
 
 // String returns the string representation
 func (s UpdateHostedZoneCommentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3579,7 +3579,7 @@ type metadataVPC struct {
 
 // String returns the string representation
 func (s VPC) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/route53/examples_test.go
+++ b/service/route53/examples_test.go
@@ -45,7 +45,7 @@ func ExampleRoute53_AssociateVPCWithHostedZone() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ChangeResourceRecordSets() {
@@ -61,7 +61,7 @@ func ExampleRoute53_ChangeResourceRecordSets() {
 						Type: aws.String("RRType"),  // Required
 						AliasTarget: &route53.AliasTarget{
 							DNSName:              aws.String("DNSName"),    // Required
-							EvaluateTargetHealth: aws.Boolean(true),        // Required
+							EvaluateTargetHealth: aws.Bool(true),           // Required
 							HostedZoneID:         aws.String("ResourceId"), // Required
 						},
 						Failover: aws.String("ResourceRecordSetFailover"),
@@ -79,8 +79,8 @@ func ExampleRoute53_ChangeResourceRecordSets() {
 							// More values...
 						},
 						SetIdentifier: aws.String("ResourceRecordSetIdentifier"),
-						TTL:           aws.Long(1),
-						Weight:        aws.Long(1),
+						TTL:           aws.Int64(1),
+						Weight:        aws.Int64(1),
 					},
 				},
 				// More values...
@@ -107,7 +107,7 @@ func ExampleRoute53_ChangeResourceRecordSets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ChangeTagsForResource() {
@@ -146,7 +146,7 @@ func ExampleRoute53_ChangeTagsForResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_CreateHealthCheck() {
@@ -156,11 +156,11 @@ func ExampleRoute53_CreateHealthCheck() {
 		CallerReference: aws.String("HealthCheckNonce"), // Required
 		HealthCheckConfig: &route53.HealthCheckConfig{ // Required
 			Type:                     aws.String("HealthCheckType"), // Required
-			FailureThreshold:         aws.Long(1),
+			FailureThreshold:         aws.Int64(1),
 			FullyQualifiedDomainName: aws.String("FullyQualifiedDomainName"),
 			IPAddress:                aws.String("IPAddress"),
-			Port:                     aws.Long(1),
-			RequestInterval:          aws.Long(1),
+			Port:                     aws.Int64(1),
+			RequestInterval:          aws.Int64(1),
 			ResourcePath:             aws.String("ResourcePath"),
 			SearchString:             aws.String("SearchString"),
 		},
@@ -183,7 +183,7 @@ func ExampleRoute53_CreateHealthCheck() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_CreateHostedZone() {
@@ -195,7 +195,7 @@ func ExampleRoute53_CreateHostedZone() {
 		DelegationSetID: aws.String("ResourceId"),
 		HostedZoneConfig: &route53.HostedZoneConfig{
 			Comment:     aws.String("ResourceDescription"),
-			PrivateZone: aws.Boolean(true),
+			PrivateZone: aws.Bool(true),
 		},
 		VPC: &route53.VPC{
 			VPCID:     aws.String("VPCId"),
@@ -220,7 +220,7 @@ func ExampleRoute53_CreateHostedZone() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_CreateReusableDelegationSet() {
@@ -248,7 +248,7 @@ func ExampleRoute53_CreateReusableDelegationSet() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_DeleteHealthCheck() {
@@ -275,7 +275,7 @@ func ExampleRoute53_DeleteHealthCheck() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_DeleteHostedZone() {
@@ -302,7 +302,7 @@ func ExampleRoute53_DeleteHostedZone() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_DeleteReusableDelegationSet() {
@@ -329,7 +329,7 @@ func ExampleRoute53_DeleteReusableDelegationSet() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_DisassociateVPCFromHostedZone() {
@@ -361,7 +361,7 @@ func ExampleRoute53_DisassociateVPCFromHostedZone() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetChange() {
@@ -388,7 +388,7 @@ func ExampleRoute53_GetChange() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetCheckerIPRanges() {
@@ -413,7 +413,7 @@ func ExampleRoute53_GetCheckerIPRanges() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetGeoLocation() {
@@ -442,7 +442,7 @@ func ExampleRoute53_GetGeoLocation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetHealthCheck() {
@@ -469,7 +469,7 @@ func ExampleRoute53_GetHealthCheck() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetHealthCheckCount() {
@@ -494,7 +494,7 @@ func ExampleRoute53_GetHealthCheckCount() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetHealthCheckLastFailureReason() {
@@ -521,7 +521,7 @@ func ExampleRoute53_GetHealthCheckLastFailureReason() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetHealthCheckStatus() {
@@ -548,7 +548,7 @@ func ExampleRoute53_GetHealthCheckStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetHostedZone() {
@@ -575,7 +575,7 @@ func ExampleRoute53_GetHostedZone() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetHostedZoneCount() {
@@ -600,7 +600,7 @@ func ExampleRoute53_GetHostedZoneCount() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_GetReusableDelegationSet() {
@@ -627,7 +627,7 @@ func ExampleRoute53_GetReusableDelegationSet() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ListGeoLocations() {
@@ -657,7 +657,7 @@ func ExampleRoute53_ListGeoLocations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ListHealthChecks() {
@@ -685,7 +685,7 @@ func ExampleRoute53_ListHealthChecks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ListHostedZones() {
@@ -714,7 +714,7 @@ func ExampleRoute53_ListHostedZones() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ListHostedZonesByName() {
@@ -743,7 +743,7 @@ func ExampleRoute53_ListHostedZonesByName() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ListResourceRecordSets() {
@@ -774,7 +774,7 @@ func ExampleRoute53_ListResourceRecordSets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ListReusableDelegationSets() {
@@ -802,7 +802,7 @@ func ExampleRoute53_ListReusableDelegationSets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ListTagsForResource() {
@@ -830,7 +830,7 @@ func ExampleRoute53_ListTagsForResource() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_ListTagsForResources() {
@@ -861,7 +861,7 @@ func ExampleRoute53_ListTagsForResources() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_UpdateHealthCheck() {
@@ -869,11 +869,11 @@ func ExampleRoute53_UpdateHealthCheck() {
 
 	params := &route53.UpdateHealthCheckInput{
 		HealthCheckID:            aws.String("HealthCheckId"), // Required
-		FailureThreshold:         aws.Long(1),
+		FailureThreshold:         aws.Int64(1),
 		FullyQualifiedDomainName: aws.String("FullyQualifiedDomainName"),
-		HealthCheckVersion:       aws.Long(1),
+		HealthCheckVersion:       aws.Int64(1),
 		IPAddress:                aws.String("IPAddress"),
-		Port:                     aws.Long(1),
+		Port:                     aws.Int64(1),
 		ResourcePath:             aws.String("ResourcePath"),
 		SearchString:             aws.String("SearchString"),
 	}
@@ -895,7 +895,7 @@ func ExampleRoute53_UpdateHealthCheck() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53_UpdateHostedZoneComment() {
@@ -923,5 +923,5 @@ func ExampleRoute53_UpdateHostedZoneComment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -655,7 +655,7 @@ type metadataCheckDomainAvailabilityInput struct {
 
 // String returns the string representation
 func (s CheckDomainAvailabilityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -694,7 +694,7 @@ type metadataCheckDomainAvailabilityOutput struct {
 
 // String returns the string representation
 func (s CheckDomainAvailabilityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -903,7 +903,7 @@ type metadataContactDetail struct {
 
 // String returns the string representation
 func (s ContactDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -950,7 +950,7 @@ type metadataDeleteTagsForDomainInput struct {
 
 // String returns the string representation
 func (s DeleteTagsForDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -968,7 +968,7 @@ type metadataDeleteTagsForDomainOutput struct {
 
 // String returns the string representation
 func (s DeleteTagsForDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -988,7 +988,7 @@ type metadataDisableDomainAutoRenewInput struct {
 
 // String returns the string representation
 func (s DisableDomainAutoRenewInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1006,7 +1006,7 @@ type metadataDisableDomainAutoRenewOutput struct {
 
 // String returns the string representation
 func (s DisableDomainAutoRenewOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1038,7 +1038,7 @@ type metadataDisableDomainTransferLockInput struct {
 
 // String returns the string representation
 func (s DisableDomainTransferLockInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1067,7 +1067,7 @@ type metadataDisableDomainTransferLockOutput struct {
 
 // String returns the string representation
 func (s DisableDomainTransferLockOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1110,7 +1110,7 @@ type metadataDomainSummary struct {
 
 // String returns the string representation
 func (s DomainSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1130,7 +1130,7 @@ type metadataEnableDomainAutoRenewInput struct {
 
 // String returns the string representation
 func (s EnableDomainAutoRenewInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1148,7 +1148,7 @@ type metadataEnableDomainAutoRenewOutput struct {
 
 // String returns the string representation
 func (s EnableDomainAutoRenewOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1180,7 +1180,7 @@ type metadataEnableDomainTransferLockInput struct {
 
 // String returns the string representation
 func (s EnableDomainTransferLockInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1209,7 +1209,7 @@ type metadataEnableDomainTransferLockOutput struct {
 
 // String returns the string representation
 func (s EnableDomainTransferLockOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1259,7 +1259,7 @@ type metadataExtraParam struct {
 
 // String returns the string representation
 func (s ExtraParam) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1291,7 +1291,7 @@ type metadataGetDomainDetailInput struct {
 
 // String returns the string representation
 func (s GetDomainDetailInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1447,7 +1447,7 @@ type metadataGetDomainDetailOutput struct {
 
 // String returns the string representation
 func (s GetDomainDetailOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1476,7 +1476,7 @@ type metadataGetOperationDetailInput struct {
 
 // String returns the string representation
 func (s GetOperationDetailInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1523,7 +1523,7 @@ type metadataGetOperationDetailOutput struct {
 
 // String returns the string representation
 func (s GetOperationDetailOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1569,7 +1569,7 @@ type metadataListDomainsInput struct {
 
 // String returns the string representation
 func (s ListDomainsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1604,7 +1604,7 @@ type metadataListDomainsOutput struct {
 
 // String returns the string representation
 func (s ListDomainsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1648,7 +1648,7 @@ type metadataListOperationsInput struct {
 
 // String returns the string representation
 func (s ListOperationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1683,7 +1683,7 @@ type metadataListOperationsOutput struct {
 
 // String returns the string representation
 func (s ListOperationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1705,7 +1705,7 @@ type metadataListTagsForDomainInput struct {
 
 // String returns the string representation
 func (s ListTagsForDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1743,7 +1743,7 @@ type metadataListTagsForDomainOutput struct {
 
 // String returns the string representation
 func (s ListTagsForDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1783,7 +1783,7 @@ type metadataNameserver struct {
 
 // String returns the string representation
 func (s Nameserver) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1823,7 +1823,7 @@ type metadataOperationSummary struct {
 
 // String returns the string representation
 func (s OperationSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1957,7 +1957,7 @@ type metadataRegisterDomainInput struct {
 
 // String returns the string representation
 func (s RegisterDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1986,7 +1986,7 @@ type metadataRegisterDomainOutput struct {
 
 // String returns the string representation
 func (s RegisterDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2018,7 +2018,7 @@ type metadataRetrieveDomainAuthCodeInput struct {
 
 // String returns the string representation
 func (s RetrieveDomainAuthCodeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2042,7 +2042,7 @@ type metadataRetrieveDomainAuthCodeOutput struct {
 
 // String returns the string representation
 func (s RetrieveDomainAuthCodeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2087,7 +2087,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2238,7 +2238,7 @@ type metadataTransferDomainInput struct {
 
 // String returns the string representation
 func (s TransferDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2267,7 +2267,7 @@ type metadataTransferDomainOutput struct {
 
 // String returns the string representation
 func (s TransferDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2332,7 +2332,7 @@ type metadataUpdateDomainContactInput struct {
 
 // String returns the string representation
 func (s UpdateDomainContactInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2361,7 +2361,7 @@ type metadataUpdateDomainContactOutput struct {
 
 // String returns the string representation
 func (s UpdateDomainContactOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2435,7 +2435,7 @@ type metadataUpdateDomainContactPrivacyInput struct {
 
 // String returns the string representation
 func (s UpdateDomainContactPrivacyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2464,7 +2464,7 @@ type metadataUpdateDomainContactPrivacyOutput struct {
 
 // String returns the string representation
 func (s UpdateDomainContactPrivacyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2508,7 +2508,7 @@ type metadataUpdateDomainNameserversInput struct {
 
 // String returns the string representation
 func (s UpdateDomainNameserversInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2537,7 +2537,7 @@ type metadataUpdateDomainNameserversOutput struct {
 
 // String returns the string representation
 func (s UpdateDomainNameserversOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2613,7 +2613,7 @@ type metadataUpdateTagsForDomainInput struct {
 
 // String returns the string representation
 func (s UpdateTagsForDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2631,7 +2631,7 @@ type metadataUpdateTagsForDomainOutput struct {
 
 // String returns the string representation
 func (s UpdateTagsForDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/route53domains/examples_test.go
+++ b/service/route53domains/examples_test.go
@@ -41,7 +41,7 @@ func ExampleRoute53Domains_CheckDomainAvailability() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_DeleteTagsForDomain() {
@@ -72,7 +72,7 @@ func ExampleRoute53Domains_DeleteTagsForDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_DisableDomainAutoRenew() {
@@ -99,7 +99,7 @@ func ExampleRoute53Domains_DisableDomainAutoRenew() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_DisableDomainTransferLock() {
@@ -126,7 +126,7 @@ func ExampleRoute53Domains_DisableDomainTransferLock() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_EnableDomainAutoRenew() {
@@ -153,7 +153,7 @@ func ExampleRoute53Domains_EnableDomainAutoRenew() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_EnableDomainTransferLock() {
@@ -180,7 +180,7 @@ func ExampleRoute53Domains_EnableDomainTransferLock() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_GetDomainDetail() {
@@ -207,7 +207,7 @@ func ExampleRoute53Domains_GetDomainDetail() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_GetOperationDetail() {
@@ -234,7 +234,7 @@ func ExampleRoute53Domains_GetOperationDetail() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_ListDomains() {
@@ -242,7 +242,7 @@ func ExampleRoute53Domains_ListDomains() {
 
 	params := &route53domains.ListDomainsInput{
 		Marker:   aws.String("PageMarker"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListDomains(params)
 
@@ -262,7 +262,7 @@ func ExampleRoute53Domains_ListDomains() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_ListOperations() {
@@ -270,7 +270,7 @@ func ExampleRoute53Domains_ListOperations() {
 
 	params := &route53domains.ListOperationsInput{
 		Marker:   aws.String("PageMarker"),
-		MaxItems: aws.Long(1),
+		MaxItems: aws.Int64(1),
 	}
 	resp, err := svc.ListOperations(params)
 
@@ -290,7 +290,7 @@ func ExampleRoute53Domains_ListOperations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_ListTagsForDomain() {
@@ -317,7 +317,7 @@ func ExampleRoute53Domains_ListTagsForDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_RegisterDomain() {
@@ -347,7 +347,7 @@ func ExampleRoute53Domains_RegisterDomain() {
 			ZipCode:          aws.String("ZipCode"),
 		},
 		DomainName:      aws.String("DomainName"), // Required
-		DurationInYears: aws.Long(1),              // Required
+		DurationInYears: aws.Int64(1),             // Required
 		RegistrantContact: &route53domains.ContactDetail{ // Required
 			AddressLine1: aws.String("AddressLine"),
 			AddressLine2: aws.String("AddressLine"),
@@ -392,11 +392,11 @@ func ExampleRoute53Domains_RegisterDomain() {
 			State:            aws.String("State"),
 			ZipCode:          aws.String("ZipCode"),
 		},
-		AutoRenew:                       aws.Boolean(true),
+		AutoRenew:                       aws.Bool(true),
 		IDNLangCode:                     aws.String("LangCode"),
-		PrivacyProtectAdminContact:      aws.Boolean(true),
-		PrivacyProtectRegistrantContact: aws.Boolean(true),
-		PrivacyProtectTechContact:       aws.Boolean(true),
+		PrivacyProtectAdminContact:      aws.Bool(true),
+		PrivacyProtectRegistrantContact: aws.Bool(true),
+		PrivacyProtectTechContact:       aws.Bool(true),
 	}
 	resp, err := svc.RegisterDomain(params)
 
@@ -416,7 +416,7 @@ func ExampleRoute53Domains_RegisterDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_RetrieveDomainAuthCode() {
@@ -443,7 +443,7 @@ func ExampleRoute53Domains_RetrieveDomainAuthCode() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_TransferDomain() {
@@ -473,7 +473,7 @@ func ExampleRoute53Domains_TransferDomain() {
 			ZipCode:          aws.String("ZipCode"),
 		},
 		DomainName:      aws.String("DomainName"), // Required
-		DurationInYears: aws.Long(1),              // Required
+		DurationInYears: aws.Int64(1),             // Required
 		RegistrantContact: &route53domains.ContactDetail{ // Required
 			AddressLine1: aws.String("AddressLine"),
 			AddressLine2: aws.String("AddressLine"),
@@ -519,7 +519,7 @@ func ExampleRoute53Domains_TransferDomain() {
 			ZipCode:          aws.String("ZipCode"),
 		},
 		AuthCode:    aws.String("DomainAuthCode"),
-		AutoRenew:   aws.Boolean(true),
+		AutoRenew:   aws.Bool(true),
 		IDNLangCode: aws.String("LangCode"),
 		Nameservers: []*route53domains.Nameserver{
 			{ // Required
@@ -531,9 +531,9 @@ func ExampleRoute53Domains_TransferDomain() {
 			},
 			// More values...
 		},
-		PrivacyProtectAdminContact:      aws.Boolean(true),
-		PrivacyProtectRegistrantContact: aws.Boolean(true),
-		PrivacyProtectTechContact:       aws.Boolean(true),
+		PrivacyProtectAdminContact:      aws.Bool(true),
+		PrivacyProtectRegistrantContact: aws.Bool(true),
+		PrivacyProtectTechContact:       aws.Bool(true),
 	}
 	resp, err := svc.TransferDomain(params)
 
@@ -553,7 +553,7 @@ func ExampleRoute53Domains_TransferDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_UpdateDomainContact() {
@@ -646,7 +646,7 @@ func ExampleRoute53Domains_UpdateDomainContact() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_UpdateDomainContactPrivacy() {
@@ -654,9 +654,9 @@ func ExampleRoute53Domains_UpdateDomainContactPrivacy() {
 
 	params := &route53domains.UpdateDomainContactPrivacyInput{
 		DomainName:        aws.String("DomainName"), // Required
-		AdminPrivacy:      aws.Boolean(true),
-		RegistrantPrivacy: aws.Boolean(true),
-		TechPrivacy:       aws.Boolean(true),
+		AdminPrivacy:      aws.Bool(true),
+		RegistrantPrivacy: aws.Bool(true),
+		TechPrivacy:       aws.Bool(true),
 	}
 	resp, err := svc.UpdateDomainContactPrivacy(params)
 
@@ -676,7 +676,7 @@ func ExampleRoute53Domains_UpdateDomainContactPrivacy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_UpdateDomainNameservers() {
@@ -714,7 +714,7 @@ func ExampleRoute53Domains_UpdateDomainNameservers() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleRoute53Domains_UpdateTagsForDomain() {
@@ -748,5 +748,5 @@ func ExampleRoute53Domains_UpdateTagsForDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -1578,7 +1578,7 @@ type metadataAbortMultipartUploadInput struct {
 
 // String returns the string representation
 func (s AbortMultipartUploadInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1600,7 +1600,7 @@ type metadataAbortMultipartUploadOutput struct {
 
 // String returns the string representation
 func (s AbortMultipartUploadOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1623,7 +1623,7 @@ type metadataAccessControlPolicy struct {
 
 // String returns the string representation
 func (s AccessControlPolicy) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1647,7 +1647,7 @@ type metadataBucket struct {
 
 // String returns the string representation
 func (s Bucket) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1667,7 +1667,7 @@ type metadataBucketLoggingStatus struct {
 
 // String returns the string representation
 func (s BucketLoggingStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1687,7 +1687,7 @@ type metadataCORSConfiguration struct {
 
 // String returns the string representation
 func (s CORSConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1724,7 +1724,7 @@ type metadataCORSRule struct {
 
 // String returns the string representation
 func (s CORSRule) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1755,7 +1755,7 @@ type metadataCloudFunctionConfiguration struct {
 
 // String returns the string representation
 func (s CloudFunctionConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1775,7 +1775,7 @@ type metadataCommonPrefix struct {
 
 // String returns the string representation
 func (s CommonPrefix) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1807,7 +1807,7 @@ type metadataCompleteMultipartUploadInput struct {
 
 // String returns the string representation
 func (s CompleteMultipartUploadInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1853,7 +1853,7 @@ type metadataCompleteMultipartUploadOutput struct {
 
 // String returns the string representation
 func (s CompleteMultipartUploadOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1873,7 +1873,7 @@ type metadataCompletedMultipartUpload struct {
 
 // String returns the string representation
 func (s CompletedMultipartUpload) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1898,7 +1898,7 @@ type metadataCompletedPart struct {
 
 // String returns the string representation
 func (s CompletedPart) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1932,7 +1932,7 @@ type metadataCondition struct {
 
 // String returns the string representation
 func (s Condition) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2065,7 +2065,7 @@ type metadataCopyObjectInput struct {
 
 // String returns the string representation
 func (s CopyObjectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2112,7 +2112,7 @@ type metadataCopyObjectOutput struct {
 
 // String returns the string representation
 func (s CopyObjectOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2134,7 +2134,7 @@ type metadataCopyObjectResult struct {
 
 // String returns the string representation
 func (s CopyObjectResult) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2158,7 +2158,7 @@ type metadataCopyPartResult struct {
 
 // String returns the string representation
 func (s CopyPartResult) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2180,7 +2180,7 @@ type metadataCreateBucketConfiguration struct {
 
 // String returns the string representation
 func (s CreateBucketConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2221,7 +2221,7 @@ type metadataCreateBucketInput struct {
 
 // String returns the string representation
 func (s CreateBucketInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2241,7 +2241,7 @@ type metadataCreateBucketOutput struct {
 
 // String returns the string representation
 func (s CreateBucketOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2340,7 +2340,7 @@ type metadataCreateMultipartUploadInput struct {
 
 // String returns the string representation
 func (s CreateMultipartUploadInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2389,7 +2389,7 @@ type metadataCreateMultipartUploadOutput struct {
 
 // String returns the string representation
 func (s CreateMultipartUploadOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2413,7 +2413,7 @@ type metadataDelete struct {
 
 // String returns the string representation
 func (s Delete) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2433,7 +2433,7 @@ type metadataDeleteBucketCORSInput struct {
 
 // String returns the string representation
 func (s DeleteBucketCORSInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2451,7 +2451,7 @@ type metadataDeleteBucketCORSOutput struct {
 
 // String returns the string representation
 func (s DeleteBucketCORSOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2471,7 +2471,7 @@ type metadataDeleteBucketInput struct {
 
 // String returns the string representation
 func (s DeleteBucketInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2491,7 +2491,7 @@ type metadataDeleteBucketLifecycleInput struct {
 
 // String returns the string representation
 func (s DeleteBucketLifecycleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2509,7 +2509,7 @@ type metadataDeleteBucketLifecycleOutput struct {
 
 // String returns the string representation
 func (s DeleteBucketLifecycleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2527,7 +2527,7 @@ type metadataDeleteBucketOutput struct {
 
 // String returns the string representation
 func (s DeleteBucketOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2547,7 +2547,7 @@ type metadataDeleteBucketPolicyInput struct {
 
 // String returns the string representation
 func (s DeleteBucketPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2565,7 +2565,7 @@ type metadataDeleteBucketPolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteBucketPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2585,7 +2585,7 @@ type metadataDeleteBucketReplicationInput struct {
 
 // String returns the string representation
 func (s DeleteBucketReplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2603,7 +2603,7 @@ type metadataDeleteBucketReplicationOutput struct {
 
 // String returns the string representation
 func (s DeleteBucketReplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2623,7 +2623,7 @@ type metadataDeleteBucketTaggingInput struct {
 
 // String returns the string representation
 func (s DeleteBucketTaggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2641,7 +2641,7 @@ type metadataDeleteBucketTaggingOutput struct {
 
 // String returns the string representation
 func (s DeleteBucketTaggingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2661,7 +2661,7 @@ type metadataDeleteBucketWebsiteInput struct {
 
 // String returns the string representation
 func (s DeleteBucketWebsiteInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2679,7 +2679,7 @@ type metadataDeleteBucketWebsiteOutput struct {
 
 // String returns the string representation
 func (s DeleteBucketWebsiteOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2712,7 +2712,7 @@ type metadataDeleteMarkerEntry struct {
 
 // String returns the string representation
 func (s DeleteMarkerEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2747,7 +2747,7 @@ type metadataDeleteObjectInput struct {
 
 // String returns the string representation
 func (s DeleteObjectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2777,7 +2777,7 @@ type metadataDeleteObjectOutput struct {
 
 // String returns the string representation
 func (s DeleteObjectOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2809,7 +2809,7 @@ type metadataDeleteObjectsInput struct {
 
 // String returns the string representation
 func (s DeleteObjectsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2835,7 +2835,7 @@ type metadataDeleteObjectsOutput struct {
 
 // String returns the string representation
 func (s DeleteObjectsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2861,7 +2861,7 @@ type metadataDeletedObject struct {
 
 // String returns the string representation
 func (s DeletedObject) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2883,7 +2883,7 @@ type metadataDestination struct {
 
 // String returns the string representation
 func (s Destination) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2909,7 +2909,7 @@ type metadataError struct {
 
 // String returns the string representation
 func (s Error) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2930,7 +2930,7 @@ type metadataErrorDocument struct {
 
 // String returns the string representation
 func (s ErrorDocument) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2950,7 +2950,7 @@ type metadataGetBucketACLInput struct {
 
 // String returns the string representation
 func (s GetBucketACLInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2973,7 +2973,7 @@ type metadataGetBucketACLOutput struct {
 
 // String returns the string representation
 func (s GetBucketACLOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2993,7 +2993,7 @@ type metadataGetBucketCORSInput struct {
 
 // String returns the string representation
 func (s GetBucketCORSInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3013,7 +3013,7 @@ type metadataGetBucketCORSOutput struct {
 
 // String returns the string representation
 func (s GetBucketCORSOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3033,7 +3033,7 @@ type metadataGetBucketLifecycleInput struct {
 
 // String returns the string representation
 func (s GetBucketLifecycleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3053,7 +3053,7 @@ type metadataGetBucketLifecycleOutput struct {
 
 // String returns the string representation
 func (s GetBucketLifecycleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3073,7 +3073,7 @@ type metadataGetBucketLocationInput struct {
 
 // String returns the string representation
 func (s GetBucketLocationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3093,7 +3093,7 @@ type metadataGetBucketLocationOutput struct {
 
 // String returns the string representation
 func (s GetBucketLocationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3113,7 +3113,7 @@ type metadataGetBucketLoggingInput struct {
 
 // String returns the string representation
 func (s GetBucketLoggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3133,7 +3133,7 @@ type metadataGetBucketLoggingOutput struct {
 
 // String returns the string representation
 func (s GetBucketLoggingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3154,7 +3154,7 @@ type metadataGetBucketNotificationConfigurationRequest struct {
 
 // String returns the string representation
 func (s GetBucketNotificationConfigurationRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3174,7 +3174,7 @@ type metadataGetBucketPolicyInput struct {
 
 // String returns the string representation
 func (s GetBucketPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3195,7 +3195,7 @@ type metadataGetBucketPolicyOutput struct {
 
 // String returns the string representation
 func (s GetBucketPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3215,7 +3215,7 @@ type metadataGetBucketReplicationInput struct {
 
 // String returns the string representation
 func (s GetBucketReplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3237,7 +3237,7 @@ type metadataGetBucketReplicationOutput struct {
 
 // String returns the string representation
 func (s GetBucketReplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3257,7 +3257,7 @@ type metadataGetBucketRequestPaymentInput struct {
 
 // String returns the string representation
 func (s GetBucketRequestPaymentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3278,7 +3278,7 @@ type metadataGetBucketRequestPaymentOutput struct {
 
 // String returns the string representation
 func (s GetBucketRequestPaymentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3298,7 +3298,7 @@ type metadataGetBucketTaggingInput struct {
 
 // String returns the string representation
 func (s GetBucketTaggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3318,7 +3318,7 @@ type metadataGetBucketTaggingOutput struct {
 
 // String returns the string representation
 func (s GetBucketTaggingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3338,7 +3338,7 @@ type metadataGetBucketVersioningInput struct {
 
 // String returns the string representation
 func (s GetBucketVersioningInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3364,7 +3364,7 @@ type metadataGetBucketVersioningOutput struct {
 
 // String returns the string representation
 func (s GetBucketVersioningOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3384,7 +3384,7 @@ type metadataGetBucketWebsiteInput struct {
 
 // String returns the string representation
 func (s GetBucketWebsiteInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3410,7 +3410,7 @@ type metadataGetBucketWebsiteOutput struct {
 
 // String returns the string representation
 func (s GetBucketWebsiteOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3441,7 +3441,7 @@ type metadataGetObjectACLInput struct {
 
 // String returns the string representation
 func (s GetObjectACLInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3468,7 +3468,7 @@ type metadataGetObjectACLOutput struct {
 
 // String returns the string representation
 func (s GetObjectACLOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3552,7 +3552,7 @@ type metadataGetObjectInput struct {
 
 // String returns the string representation
 func (s GetObjectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3663,7 +3663,7 @@ type metadataGetObjectOutput struct {
 
 // String returns the string representation
 func (s GetObjectOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3691,7 +3691,7 @@ type metadataGetObjectTorrentInput struct {
 
 // String returns the string representation
 func (s GetObjectTorrentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3715,7 +3715,7 @@ type metadataGetObjectTorrentOutput struct {
 
 // String returns the string representation
 func (s GetObjectTorrentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3738,7 +3738,7 @@ type metadataGrant struct {
 
 // String returns the string representation
 func (s Grant) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3771,7 +3771,7 @@ type metadataGrantee struct {
 
 // String returns the string representation
 func (s Grantee) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3791,7 +3791,7 @@ type metadataHeadBucketInput struct {
 
 // String returns the string representation
 func (s HeadBucketInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3809,7 +3809,7 @@ type metadataHeadBucketOutput struct {
 
 // String returns the string representation
 func (s HeadBucketOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3875,7 +3875,7 @@ type metadataHeadObjectInput struct {
 
 // String returns the string representation
 func (s HeadObjectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3980,7 +3980,7 @@ type metadataHeadObjectOutput struct {
 
 // String returns the string representation
 func (s HeadObjectOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4004,7 +4004,7 @@ type metadataIndexDocument struct {
 
 // String returns the string representation
 func (s IndexDocument) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4029,7 +4029,7 @@ type metadataInitiator struct {
 
 // String returns the string representation
 func (s Initiator) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4058,7 +4058,7 @@ type metadataLambdaFunctionConfiguration struct {
 
 // String returns the string representation
 func (s LambdaFunctionConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4078,7 +4078,7 @@ type metadataLifecycleConfiguration struct {
 
 // String returns the string representation
 func (s LifecycleConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4104,7 +4104,7 @@ type metadataLifecycleExpiration struct {
 
 // String returns the string representation
 func (s LifecycleExpiration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4150,7 +4150,7 @@ type metadataLifecycleRule struct {
 
 // String returns the string representation
 func (s LifecycleRule) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4168,7 +4168,7 @@ type metadataListBucketsInput struct {
 
 // String returns the string representation
 func (s ListBucketsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4190,7 +4190,7 @@ type metadataListBucketsOutput struct {
 
 // String returns the string representation
 func (s ListBucketsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4239,7 +4239,7 @@ type metadataListMultipartUploadsInput struct {
 
 // String returns the string representation
 func (s ListMultipartUploadsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4297,7 +4297,7 @@ type metadataListMultipartUploadsOutput struct {
 
 // String returns the string representation
 func (s ListMultipartUploadsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4341,7 +4341,7 @@ type metadataListObjectVersionsInput struct {
 
 // String returns the string representation
 func (s ListObjectVersionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4394,7 +4394,7 @@ type metadataListObjectVersionsOutput struct {
 
 // String returns the string representation
 func (s ListObjectVersionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4435,7 +4435,7 @@ type metadataListObjectsInput struct {
 
 // String returns the string representation
 func (s ListObjectsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4483,7 +4483,7 @@ type metadataListObjectsOutput struct {
 
 // String returns the string representation
 func (s ListObjectsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4521,7 +4521,7 @@ type metadataListPartsInput struct {
 
 // String returns the string representation
 func (s ListPartsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4576,7 +4576,7 @@ type metadataListPartsOutput struct {
 
 // String returns the string representation
 func (s ListPartsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4608,7 +4608,7 @@ type metadataLoggingEnabled struct {
 
 // String returns the string representation
 func (s LoggingEnabled) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4643,7 +4643,7 @@ type metadataMultipartUpload struct {
 
 // String returns the string representation
 func (s MultipartUpload) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4673,7 +4673,7 @@ type metadataNoncurrentVersionExpiration struct {
 
 // String returns the string representation
 func (s NoncurrentVersionExpiration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4706,7 +4706,7 @@ type metadataNoncurrentVersionTransition struct {
 
 // String returns the string representation
 func (s NoncurrentVersionTransition) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4732,7 +4732,7 @@ type metadataNotificationConfiguration struct {
 
 // String returns the string representation
 func (s NotificationConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4756,7 +4756,7 @@ type metadataNotificationConfigurationDeprecated struct {
 
 // String returns the string representation
 func (s NotificationConfigurationDeprecated) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4787,7 +4787,7 @@ type metadataObject struct {
 
 // String returns the string representation
 func (s Object) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4811,7 +4811,7 @@ type metadataObjectIdentifier struct {
 
 // String returns the string representation
 func (s ObjectIdentifier) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4852,7 +4852,7 @@ type metadataObjectVersion struct {
 
 // String returns the string representation
 func (s ObjectVersion) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4874,7 +4874,7 @@ type metadataOwner struct {
 
 // String returns the string representation
 func (s Owner) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4905,7 +4905,7 @@ type metadataPart struct {
 
 // String returns the string representation
 func (s Part) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4946,7 +4946,7 @@ type metadataPutBucketACLInput struct {
 
 // String returns the string representation
 func (s PutBucketACLInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4964,7 +4964,7 @@ type metadataPutBucketACLOutput struct {
 
 // String returns the string representation
 func (s PutBucketACLOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4986,7 +4986,7 @@ type metadataPutBucketCORSInput struct {
 
 // String returns the string representation
 func (s PutBucketCORSInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5004,7 +5004,7 @@ type metadataPutBucketCORSOutput struct {
 
 // String returns the string representation
 func (s PutBucketCORSOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5026,7 +5026,7 @@ type metadataPutBucketLifecycleInput struct {
 
 // String returns the string representation
 func (s PutBucketLifecycleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5044,7 +5044,7 @@ type metadataPutBucketLifecycleOutput struct {
 
 // String returns the string representation
 func (s PutBucketLifecycleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5066,7 +5066,7 @@ type metadataPutBucketLoggingInput struct {
 
 // String returns the string representation
 func (s PutBucketLoggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5084,7 +5084,7 @@ type metadataPutBucketLoggingOutput struct {
 
 // String returns the string representation
 func (s PutBucketLoggingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5108,7 +5108,7 @@ type metadataPutBucketNotificationConfigurationInput struct {
 
 // String returns the string representation
 func (s PutBucketNotificationConfigurationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5126,7 +5126,7 @@ type metadataPutBucketNotificationConfigurationOutput struct {
 
 // String returns the string representation
 func (s PutBucketNotificationConfigurationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5148,7 +5148,7 @@ type metadataPutBucketNotificationInput struct {
 
 // String returns the string representation
 func (s PutBucketNotificationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5166,7 +5166,7 @@ type metadataPutBucketNotificationOutput struct {
 
 // String returns the string representation
 func (s PutBucketNotificationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5189,7 +5189,7 @@ type metadataPutBucketPolicyInput struct {
 
 // String returns the string representation
 func (s PutBucketPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5207,7 +5207,7 @@ type metadataPutBucketPolicyOutput struct {
 
 // String returns the string representation
 func (s PutBucketPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5231,7 +5231,7 @@ type metadataPutBucketReplicationInput struct {
 
 // String returns the string representation
 func (s PutBucketReplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5249,7 +5249,7 @@ type metadataPutBucketReplicationOutput struct {
 
 // String returns the string representation
 func (s PutBucketReplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5271,7 +5271,7 @@ type metadataPutBucketRequestPaymentInput struct {
 
 // String returns the string representation
 func (s PutBucketRequestPaymentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5289,7 +5289,7 @@ type metadataPutBucketRequestPaymentOutput struct {
 
 // String returns the string representation
 func (s PutBucketRequestPaymentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5311,7 +5311,7 @@ type metadataPutBucketTaggingInput struct {
 
 // String returns the string representation
 func (s PutBucketTaggingInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5329,7 +5329,7 @@ type metadataPutBucketTaggingOutput struct {
 
 // String returns the string representation
 func (s PutBucketTaggingOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5355,7 +5355,7 @@ type metadataPutBucketVersioningInput struct {
 
 // String returns the string representation
 func (s PutBucketVersioningInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5373,7 +5373,7 @@ type metadataPutBucketVersioningOutput struct {
 
 // String returns the string representation
 func (s PutBucketVersioningOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5395,7 +5395,7 @@ type metadataPutBucketWebsiteInput struct {
 
 // String returns the string representation
 func (s PutBucketWebsiteInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5413,7 +5413,7 @@ type metadataPutBucketWebsiteOutput struct {
 
 // String returns the string representation
 func (s PutBucketWebsiteOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5462,7 +5462,7 @@ type metadataPutObjectACLInput struct {
 
 // String returns the string representation
 func (s PutObjectACLInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5484,7 +5484,7 @@ type metadataPutObjectACLOutput struct {
 
 // String returns the string representation
 func (s PutObjectACLOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5590,7 +5590,7 @@ type metadataPutObjectInput struct {
 
 // String returns the string representation
 func (s PutObjectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5640,7 +5640,7 @@ type metadataPutObjectOutput struct {
 
 // String returns the string representation
 func (s PutObjectOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5670,7 +5670,7 @@ type metadataQueueConfiguration struct {
 
 // String returns the string representation
 func (s QueueConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5699,7 +5699,7 @@ type metadataQueueConfigurationDeprecated struct {
 
 // String returns the string representation
 func (s QueueConfigurationDeprecated) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5741,7 +5741,7 @@ type metadataRedirect struct {
 
 // String returns the string representation
 func (s Redirect) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5766,7 +5766,7 @@ type metadataRedirectAllRequestsTo struct {
 
 // String returns the string representation
 func (s RedirectAllRequestsTo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5794,7 +5794,7 @@ type metadataReplicationConfiguration struct {
 
 // String returns the string representation
 func (s ReplicationConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5825,7 +5825,7 @@ type metadataReplicationRule struct {
 
 // String returns the string representation
 func (s ReplicationRule) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5846,7 +5846,7 @@ type metadataRequestPaymentConfiguration struct {
 
 // String returns the string representation
 func (s RequestPaymentConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5878,7 +5878,7 @@ type metadataRestoreObjectInput struct {
 
 // String returns the string representation
 func (s RestoreObjectInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5900,7 +5900,7 @@ type metadataRestoreObjectOutput struct {
 
 // String returns the string representation
 func (s RestoreObjectOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5921,7 +5921,7 @@ type metadataRestoreRequest struct {
 
 // String returns the string representation
 func (s RestoreRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5950,7 +5950,7 @@ type metadataRoutingRule struct {
 
 // String returns the string representation
 func (s RoutingRule) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5974,7 +5974,7 @@ type metadataTag struct {
 
 // String returns the string representation
 func (s Tag) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5994,7 +5994,7 @@ type metadataTagging struct {
 
 // String returns the string representation
 func (s Tagging) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6017,7 +6017,7 @@ type metadataTargetGrant struct {
 
 // String returns the string representation
 func (s TargetGrant) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6047,7 +6047,7 @@ type metadataTopicConfiguration struct {
 
 // String returns the string representation
 func (s TopicConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6078,7 +6078,7 @@ type metadataTopicConfigurationDeprecated struct {
 
 // String returns the string representation
 func (s TopicConfigurationDeprecated) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6107,7 +6107,7 @@ type metadataTransition struct {
 
 // String returns the string representation
 func (s Transition) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6195,7 +6195,7 @@ type metadataUploadPartCopyInput struct {
 
 // String returns the string representation
 func (s UploadPartCopyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6241,7 +6241,7 @@ type metadataUploadPartCopyOutput struct {
 
 // String returns the string representation
 func (s UploadPartCopyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6298,7 +6298,7 @@ type metadataUploadPartInput struct {
 
 // String returns the string representation
 func (s UploadPartInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6341,7 +6341,7 @@ type metadataUploadPartOutput struct {
 
 // String returns the string representation
 func (s UploadPartOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6367,7 +6367,7 @@ type metadataVersioningConfiguration struct {
 
 // String returns the string representation
 func (s VersioningConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6393,7 +6393,7 @@ type metadataWebsiteConfiguration struct {
 
 // String returns the string representation
 func (s WebsiteConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/s3/bucket_location.go
+++ b/service/s3/bucket_location.go
@@ -29,13 +29,13 @@ func buildGetBucketLocation(r *aws.Request) {
 }
 
 func populateLocationConstraint(r *aws.Request) {
-	if r.ParamsFilled() && r.Config.Region != "us-east-1" {
+	if r.ParamsFilled() && aws.StringValue(r.Config.Region) != "us-east-1" {
 		in := r.Params.(*CreateBucketInput)
 		if in.CreateBucketConfiguration == nil {
 			r.Params = awsutil.CopyOf(r.Params)
 			in = r.Params.(*CreateBucketInput)
 			in.CreateBucketConfiguration = &CreateBucketConfiguration{
-				LocationConstraint: &r.Config.Region,
+				LocationConstraint: r.Config.Region,
 			}
 		}
 	}

--- a/service/s3/bucket_location_test.go
+++ b/service/s3/bucket_location_test.go
@@ -65,7 +65,7 @@ func TestNoPopulateLocationConstraintIfProvided(t *testing.T) {
 }
 
 func TestNoPopulateLocationConstraintIfClassic(t *testing.T) {
-	s := s3.New(&aws.Config{Region: "us-east-1"})
+	s := s3.New(&aws.Config{Region: aws.String("us-east-1")})
 	req, _ := s.CreateBucketRequest(&s3.CreateBucketInput{
 		Bucket: aws.String("bucket"),
 	})

--- a/service/s3/examples_test.go
+++ b/service/s3/examples_test.go
@@ -43,7 +43,7 @@ func ExampleS3_AbortMultipartUpload() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_CompleteMultipartUpload() {
@@ -57,7 +57,7 @@ func ExampleS3_CompleteMultipartUpload() {
 			Parts: []*s3.CompletedPart{
 				{ // Required
 					ETag:       aws.String("ETag"),
-					PartNumber: aws.Long(1),
+					PartNumber: aws.Int64(1),
 				},
 				// More values...
 			},
@@ -82,7 +82,7 @@ func ExampleS3_CompleteMultipartUpload() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_CopyObject() {
@@ -142,7 +142,7 @@ func ExampleS3_CopyObject() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_CreateBucket() {
@@ -178,7 +178,7 @@ func ExampleS3_CreateBucket() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_CreateMultipartUpload() {
@@ -229,7 +229,7 @@ func ExampleS3_CreateMultipartUpload() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteBucket() {
@@ -256,7 +256,7 @@ func ExampleS3_DeleteBucket() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteBucketCORS() {
@@ -283,7 +283,7 @@ func ExampleS3_DeleteBucketCORS() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteBucketLifecycle() {
@@ -310,7 +310,7 @@ func ExampleS3_DeleteBucketLifecycle() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteBucketPolicy() {
@@ -337,7 +337,7 @@ func ExampleS3_DeleteBucketPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteBucketReplication() {
@@ -364,7 +364,7 @@ func ExampleS3_DeleteBucketReplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteBucketTagging() {
@@ -391,7 +391,7 @@ func ExampleS3_DeleteBucketTagging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteBucketWebsite() {
@@ -418,7 +418,7 @@ func ExampleS3_DeleteBucketWebsite() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteObject() {
@@ -449,7 +449,7 @@ func ExampleS3_DeleteObject() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_DeleteObjects() {
@@ -465,7 +465,7 @@ func ExampleS3_DeleteObjects() {
 				},
 				// More values...
 			},
-			Quiet: aws.Boolean(true),
+			Quiet: aws.Bool(true),
 		},
 		MFA:          aws.String("MFA"),
 		RequestPayer: aws.String("RequestPayer"),
@@ -488,7 +488,7 @@ func ExampleS3_DeleteObjects() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketACL() {
@@ -515,7 +515,7 @@ func ExampleS3_GetBucketACL() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketCORS() {
@@ -542,7 +542,7 @@ func ExampleS3_GetBucketCORS() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketLifecycle() {
@@ -569,7 +569,7 @@ func ExampleS3_GetBucketLifecycle() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketLocation() {
@@ -596,7 +596,7 @@ func ExampleS3_GetBucketLocation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketLogging() {
@@ -623,7 +623,7 @@ func ExampleS3_GetBucketLogging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketNotification() {
@@ -650,7 +650,7 @@ func ExampleS3_GetBucketNotification() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketNotificationConfiguration() {
@@ -677,7 +677,7 @@ func ExampleS3_GetBucketNotificationConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketPolicy() {
@@ -704,7 +704,7 @@ func ExampleS3_GetBucketPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketReplication() {
@@ -731,7 +731,7 @@ func ExampleS3_GetBucketReplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketRequestPayment() {
@@ -758,7 +758,7 @@ func ExampleS3_GetBucketRequestPayment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketTagging() {
@@ -785,7 +785,7 @@ func ExampleS3_GetBucketTagging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketVersioning() {
@@ -812,7 +812,7 @@ func ExampleS3_GetBucketVersioning() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetBucketWebsite() {
@@ -839,7 +839,7 @@ func ExampleS3_GetBucketWebsite() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetObject() {
@@ -883,7 +883,7 @@ func ExampleS3_GetObject() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetObjectACL() {
@@ -913,7 +913,7 @@ func ExampleS3_GetObjectACL() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_GetObjectTorrent() {
@@ -942,7 +942,7 @@ func ExampleS3_GetObjectTorrent() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_HeadBucket() {
@@ -969,7 +969,7 @@ func ExampleS3_HeadBucket() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_HeadObject() {
@@ -1007,7 +1007,7 @@ func ExampleS3_HeadObject() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_ListBuckets() {
@@ -1032,7 +1032,7 @@ func ExampleS3_ListBuckets() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_ListMultipartUploads() {
@@ -1043,7 +1043,7 @@ func ExampleS3_ListMultipartUploads() {
 		Delimiter:      aws.String("Delimiter"),
 		EncodingType:   aws.String("EncodingType"),
 		KeyMarker:      aws.String("KeyMarker"),
-		MaxUploads:     aws.Long(1),
+		MaxUploads:     aws.Int64(1),
 		Prefix:         aws.String("Prefix"),
 		UploadIDMarker: aws.String("UploadIdMarker"),
 	}
@@ -1065,7 +1065,7 @@ func ExampleS3_ListMultipartUploads() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_ListObjectVersions() {
@@ -1076,7 +1076,7 @@ func ExampleS3_ListObjectVersions() {
 		Delimiter:       aws.String("Delimiter"),
 		EncodingType:    aws.String("EncodingType"),
 		KeyMarker:       aws.String("KeyMarker"),
-		MaxKeys:         aws.Long(1),
+		MaxKeys:         aws.Int64(1),
 		Prefix:          aws.String("Prefix"),
 		VersionIDMarker: aws.String("VersionIdMarker"),
 	}
@@ -1098,7 +1098,7 @@ func ExampleS3_ListObjectVersions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_ListObjects() {
@@ -1109,7 +1109,7 @@ func ExampleS3_ListObjects() {
 		Delimiter:    aws.String("Delimiter"),
 		EncodingType: aws.String("EncodingType"),
 		Marker:       aws.String("Marker"),
-		MaxKeys:      aws.Long(1),
+		MaxKeys:      aws.Int64(1),
 		Prefix:       aws.String("Prefix"),
 	}
 	resp, err := svc.ListObjects(params)
@@ -1130,7 +1130,7 @@ func ExampleS3_ListObjects() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_ListParts() {
@@ -1140,8 +1140,8 @@ func ExampleS3_ListParts() {
 		Bucket:           aws.String("BucketName"),        // Required
 		Key:              aws.String("ObjectKey"),         // Required
 		UploadID:         aws.String("MultipartUploadId"), // Required
-		MaxParts:         aws.Long(1),
-		PartNumberMarker: aws.Long(1),
+		MaxParts:         aws.Int64(1),
+		PartNumberMarker: aws.Int64(1),
 		RequestPayer:     aws.String("RequestPayer"),
 	}
 	resp, err := svc.ListParts(params)
@@ -1162,7 +1162,7 @@ func ExampleS3_ListParts() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketACL() {
@@ -1214,7 +1214,7 @@ func ExampleS3_PutBucketACL() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketCORS() {
@@ -1241,7 +1241,7 @@ func ExampleS3_PutBucketCORS() {
 						aws.String("ExposeHeader"), // Required
 						// More values...
 					},
-					MaxAgeSeconds: aws.Long(1),
+					MaxAgeSeconds: aws.Int64(1),
 				},
 				// More values...
 			},
@@ -1265,7 +1265,7 @@ func ExampleS3_PutBucketCORS() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketLifecycle() {
@@ -1280,19 +1280,19 @@ func ExampleS3_PutBucketLifecycle() {
 					Status: aws.String("ExpirationStatus"), // Required
 					Expiration: &s3.LifecycleExpiration{
 						Date: aws.Time(time.Now()),
-						Days: aws.Long(1),
+						Days: aws.Int64(1),
 					},
 					ID: aws.String("ID"),
 					NoncurrentVersionExpiration: &s3.NoncurrentVersionExpiration{
-						NoncurrentDays: aws.Long(1),
+						NoncurrentDays: aws.Int64(1),
 					},
 					NoncurrentVersionTransition: &s3.NoncurrentVersionTransition{
-						NoncurrentDays: aws.Long(1),
+						NoncurrentDays: aws.Int64(1),
 						StorageClass:   aws.String("TransitionStorageClass"),
 					},
 					Transition: &s3.Transition{
 						Date:         aws.Time(time.Now()),
-						Days:         aws.Long(1),
+						Days:         aws.Int64(1),
 						StorageClass: aws.String("TransitionStorageClass"),
 					},
 				},
@@ -1318,7 +1318,7 @@ func ExampleS3_PutBucketLifecycle() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketLogging() {
@@ -1364,7 +1364,7 @@ func ExampleS3_PutBucketLogging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketNotification() {
@@ -1421,7 +1421,7 @@ func ExampleS3_PutBucketNotification() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketNotificationConfiguration() {
@@ -1483,7 +1483,7 @@ func ExampleS3_PutBucketNotificationConfiguration() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketPolicy() {
@@ -1511,7 +1511,7 @@ func ExampleS3_PutBucketPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketReplication() {
@@ -1552,7 +1552,7 @@ func ExampleS3_PutBucketReplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketRequestPayment() {
@@ -1582,7 +1582,7 @@ func ExampleS3_PutBucketRequestPayment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketTagging() {
@@ -1618,7 +1618,7 @@ func ExampleS3_PutBucketTagging() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketVersioning() {
@@ -1650,7 +1650,7 @@ func ExampleS3_PutBucketVersioning() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutBucketWebsite() {
@@ -1705,7 +1705,7 @@ func ExampleS3_PutBucketWebsite() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutObject() {
@@ -1720,7 +1720,7 @@ func ExampleS3_PutObject() {
 		ContentDisposition: aws.String("ContentDisposition"),
 		ContentEncoding:    aws.String("ContentEncoding"),
 		ContentLanguage:    aws.String("ContentLanguage"),
-		ContentLength:      aws.Long(1),
+		ContentLength:      aws.Int64(1),
 		ContentType:        aws.String("ContentType"),
 		Expires:            aws.Time(time.Now()),
 		GrantFullControl:   aws.String("GrantFullControl"),
@@ -1758,7 +1758,7 @@ func ExampleS3_PutObject() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_PutObjectACL() {
@@ -1812,7 +1812,7 @@ func ExampleS3_PutObjectACL() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_RestoreObject() {
@@ -1823,7 +1823,7 @@ func ExampleS3_RestoreObject() {
 		Key:          aws.String("ObjectKey"),  // Required
 		RequestPayer: aws.String("RequestPayer"),
 		RestoreRequest: &s3.RestoreRequest{
-			Days: aws.Long(1), // Required
+			Days: aws.Int64(1), // Required
 		},
 		VersionID: aws.String("ObjectVersionId"),
 	}
@@ -1845,7 +1845,7 @@ func ExampleS3_RestoreObject() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_UploadPart() {
@@ -1854,10 +1854,10 @@ func ExampleS3_UploadPart() {
 	params := &s3.UploadPartInput{
 		Bucket:               aws.String("BucketName"),        // Required
 		Key:                  aws.String("ObjectKey"),         // Required
-		PartNumber:           aws.Long(1),                     // Required
+		PartNumber:           aws.Int64(1),                    // Required
 		UploadID:             aws.String("MultipartUploadId"), // Required
 		Body:                 bytes.NewReader([]byte("PAYLOAD")),
-		ContentLength:        aws.Long(1),
+		ContentLength:        aws.Int64(1),
 		RequestPayer:         aws.String("RequestPayer"),
 		SSECustomerAlgorithm: aws.String("SSECustomerAlgorithm"),
 		SSECustomerKey:       aws.String("SSECustomerKey"),
@@ -1881,7 +1881,7 @@ func ExampleS3_UploadPart() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleS3_UploadPartCopy() {
@@ -1891,7 +1891,7 @@ func ExampleS3_UploadPartCopy() {
 		Bucket:                         aws.String("BucketName"),        // Required
 		CopySource:                     aws.String("CopySource"),        // Required
 		Key:                            aws.String("ObjectKey"),         // Required
-		PartNumber:                     aws.Long(1),                     // Required
+		PartNumber:                     aws.Int64(1),                    // Required
 		UploadID:                       aws.String("MultipartUploadId"), // Required
 		CopySourceIfMatch:              aws.String("CopySourceIfMatch"),
 		CopySourceIfModifiedSince:      aws.Time(time.Now()),
@@ -1924,5 +1924,5 @@ func ExampleS3_UploadPartCopy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/s3/host_style_bucket.go
+++ b/service/s3/host_style_bucket.go
@@ -23,7 +23,7 @@ func dnsCompatibleBucketName(bucket string) bool {
 // the host. This is false if S3ForcePathStyle is explicitly set or if the
 // bucket is not DNS compatible.
 func hostStyleBucketName(r *aws.Request, bucket string) bool {
-	if r.Config.S3ForcePathStyle {
+	if aws.BooleanValue(r.Config.S3ForcePathStyle) {
 		return false
 	}
 

--- a/service/s3/host_style_bucket.go
+++ b/service/s3/host_style_bucket.go
@@ -23,7 +23,7 @@ func dnsCompatibleBucketName(bucket string) bool {
 // the host. This is false if S3ForcePathStyle is explicitly set or if the
 // bucket is not DNS compatible.
 func hostStyleBucketName(r *aws.Request, bucket string) bool {
-	if aws.BooleanValue(r.Config.S3ForcePathStyle) {
+	if aws.BoolValue(r.Config.S3ForcePathStyle) {
 		return false
 	}
 

--- a/service/s3/host_style_bucket_test.go
+++ b/service/s3/host_style_bucket_test.go
@@ -51,11 +51,11 @@ func TestHostStyleBucketBuild(t *testing.T) {
 }
 
 func TestHostStyleBucketBuildNoSSL(t *testing.T) {
-	s := s3.New(&aws.Config{DisableSSL: true})
+	s := s3.New(&aws.Config{DisableSSL: aws.Boolean(true)})
 	runTests(t, s, nosslTests)
 }
 
 func TestPathStyleBucketBuild(t *testing.T) {
-	s := s3.New(&aws.Config{S3ForcePathStyle: true})
+	s := s3.New(&aws.Config{S3ForcePathStyle: aws.Boolean(true)})
 	runTests(t, s, forcepathTests)
 }

--- a/service/s3/host_style_bucket_test.go
+++ b/service/s3/host_style_bucket_test.go
@@ -51,11 +51,11 @@ func TestHostStyleBucketBuild(t *testing.T) {
 }
 
 func TestHostStyleBucketBuildNoSSL(t *testing.T) {
-	s := s3.New(&aws.Config{DisableSSL: aws.Boolean(true)})
+	s := s3.New(&aws.Config{DisableSSL: aws.Bool(true)})
 	runTests(t, s, nosslTests)
 }
 
 func TestPathStyleBucketBuild(t *testing.T) {
-	s := s3.New(&aws.Config{S3ForcePathStyle: aws.Boolean(true)})
+	s := s3.New(&aws.Config{S3ForcePathStyle: aws.Bool(true)})
 	runTests(t, s, forcepathTests)
 }

--- a/service/s3/sse_test.go
+++ b/service/s3/sse_test.go
@@ -13,7 +13,7 @@ import (
 var _ = unit.Imported
 
 func TestSSECustomerKeyOverHTTPError(t *testing.T) {
-	s := s3.New(&aws.Config{DisableSSL: true})
+	s := s3.New(&aws.Config{DisableSSL: aws.Boolean(true)})
 	req, _ := s.CopyObjectRequest(&s3.CopyObjectInput{
 		Bucket:         aws.String("bucket"),
 		CopySource:     aws.String("bucket/source"),
@@ -28,7 +28,7 @@ func TestSSECustomerKeyOverHTTPError(t *testing.T) {
 }
 
 func TestCopySourceSSECustomerKeyOverHTTPError(t *testing.T) {
-	s := s3.New(&aws.Config{DisableSSL: true})
+	s := s3.New(&aws.Config{DisableSSL: aws.Boolean(true)})
 	req, _ := s.CopyObjectRequest(&s3.CopyObjectInput{
 		Bucket:     aws.String("bucket"),
 		CopySource: aws.String("bucket/source"),

--- a/service/s3/sse_test.go
+++ b/service/s3/sse_test.go
@@ -13,7 +13,7 @@ import (
 var _ = unit.Imported
 
 func TestSSECustomerKeyOverHTTPError(t *testing.T) {
-	s := s3.New(&aws.Config{DisableSSL: aws.Boolean(true)})
+	s := s3.New(&aws.Config{DisableSSL: aws.Bool(true)})
 	req, _ := s.CopyObjectRequest(&s3.CopyObjectInput{
 		Bucket:         aws.String("bucket"),
 		CopySource:     aws.String("bucket/source"),
@@ -28,7 +28,7 @@ func TestSSECustomerKeyOverHTTPError(t *testing.T) {
 }
 
 func TestCopySourceSSECustomerKeyOverHTTPError(t *testing.T) {
-	s := s3.New(&aws.Config{DisableSSL: aws.Boolean(true)})
+	s := s3.New(&aws.Config{DisableSSL: aws.Bool(true)})
 	req, _ := s.CopyObjectRequest(&s3.CopyObjectInput{
 		Bucket:     aws.String("bucket"),
 		CopySource: aws.String("bucket/source"),

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -836,7 +836,7 @@ type metadataBody struct {
 
 // String returns the string representation
 func (s Body) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -865,7 +865,7 @@ type metadataContent struct {
 
 // String returns the string representation
 func (s Content) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -888,7 +888,7 @@ type metadataDeleteIdentityInput struct {
 
 // String returns the string representation
 func (s DeleteIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -908,7 +908,7 @@ type metadataDeleteIdentityOutput struct {
 
 // String returns the string representation
 func (s DeleteIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -940,7 +940,7 @@ type metadataDeleteIdentityPolicyInput struct {
 
 // String returns the string representation
 func (s DeleteIdentityPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -960,7 +960,7 @@ type metadataDeleteIdentityPolicyOutput struct {
 
 // String returns the string representation
 func (s DeleteIdentityPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -983,7 +983,7 @@ type metadataDeleteVerifiedEmailAddressInput struct {
 
 // String returns the string representation
 func (s DeleteVerifiedEmailAddressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1001,7 +1001,7 @@ type metadataDeleteVerifiedEmailAddressOutput struct {
 
 // String returns the string representation
 func (s DeleteVerifiedEmailAddressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1035,7 +1035,7 @@ type metadataDestination struct {
 
 // String returns the string representation
 func (s Destination) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1063,7 +1063,7 @@ type metadataGetIdentityDKIMAttributesInput struct {
 
 // String returns the string representation
 func (s GetIdentityDKIMAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1085,7 +1085,7 @@ type metadataGetIdentityDKIMAttributesOutput struct {
 
 // String returns the string representation
 func (s GetIdentityDKIMAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1108,7 +1108,7 @@ type metadataGetIdentityNotificationAttributesInput struct {
 
 // String returns the string representation
 func (s GetIdentityNotificationAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1133,7 +1133,7 @@ type metadataGetIdentityNotificationAttributesOutput struct {
 
 // String returns the string representation
 func (s GetIdentityNotificationAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1165,7 +1165,7 @@ type metadataGetIdentityPoliciesInput struct {
 
 // String returns the string representation
 func (s GetIdentityPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1188,7 +1188,7 @@ type metadataGetIdentityPoliciesOutput struct {
 
 // String returns the string representation
 func (s GetIdentityPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1211,7 +1211,7 @@ type metadataGetIdentityVerificationAttributesInput struct {
 
 // String returns the string representation
 func (s GetIdentityVerificationAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1233,7 +1233,7 @@ type metadataGetIdentityVerificationAttributesOutput struct {
 
 // String returns the string representation
 func (s GetIdentityVerificationAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1251,7 +1251,7 @@ type metadataGetSendQuotaInput struct {
 
 // String returns the string representation
 func (s GetSendQuotaInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1285,7 +1285,7 @@ type metadataGetSendQuotaOutput struct {
 
 // String returns the string representation
 func (s GetSendQuotaOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1303,7 +1303,7 @@ type metadataGetSendStatisticsInput struct {
 
 // String returns the string representation
 func (s GetSendStatisticsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1327,7 +1327,7 @@ type metadataGetSendStatisticsOutput struct {
 
 // String returns the string representation
 func (s GetSendStatisticsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1366,7 +1366,7 @@ type metadataIdentityDKIMAttributes struct {
 
 // String returns the string representation
 func (s IdentityDKIMAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1406,7 +1406,7 @@ type metadataIdentityNotificationAttributes struct {
 
 // String returns the string representation
 func (s IdentityNotificationAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1432,7 +1432,7 @@ type metadataIdentityVerificationAttributes struct {
 
 // String returns the string representation
 func (s IdentityVerificationAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1462,7 +1462,7 @@ type metadataListIdentitiesInput struct {
 
 // String returns the string representation
 func (s ListIdentitiesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1487,7 +1487,7 @@ type metadataListIdentitiesOutput struct {
 
 // String returns the string representation
 func (s ListIdentitiesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1514,7 +1514,7 @@ type metadataListIdentityPoliciesInput struct {
 
 // String returns the string representation
 func (s ListIdentityPoliciesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1537,7 +1537,7 @@ type metadataListIdentityPoliciesOutput struct {
 
 // String returns the string representation
 func (s ListIdentityPoliciesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1555,7 +1555,7 @@ type metadataListVerifiedEmailAddressesInput struct {
 
 // String returns the string representation
 func (s ListVerifiedEmailAddressesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1577,7 +1577,7 @@ type metadataListVerifiedEmailAddressesOutput struct {
 
 // String returns the string representation
 func (s ListVerifiedEmailAddressesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1603,7 +1603,7 @@ type metadataMessage struct {
 
 // String returns the string representation
 func (s Message) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1642,7 +1642,7 @@ type metadataPutIdentityPolicyInput struct {
 
 // String returns the string representation
 func (s PutIdentityPolicyInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1662,7 +1662,7 @@ type metadataPutIdentityPolicyOutput struct {
 
 // String returns the string representation
 func (s PutIdentityPolicyOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1696,7 +1696,7 @@ type metadataRawMessage struct {
 
 // String returns the string representation
 func (s RawMessage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1731,7 +1731,7 @@ type metadataSendDataPoint struct {
 
 // String returns the string representation
 func (s SendDataPoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1816,7 +1816,7 @@ type metadataSendEmailInput struct {
 
 // String returns the string representation
 func (s SendEmailInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1838,7 +1838,7 @@ type metadataSendEmailOutput struct {
 
 // String returns the string representation
 func (s SendEmailOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1938,7 +1938,7 @@ type metadataSendRawEmailInput struct {
 
 // String returns the string representation
 func (s SendRawEmailInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1960,7 +1960,7 @@ type metadataSendRawEmailOutput struct {
 
 // String returns the string representation
 func (s SendRawEmailOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1987,7 +1987,7 @@ type metadataSetIdentityDKIMEnabledInput struct {
 
 // String returns the string representation
 func (s SetIdentityDKIMEnabledInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2007,7 +2007,7 @@ type metadataSetIdentityDKIMEnabledOutput struct {
 
 // String returns the string representation
 func (s SetIdentityDKIMEnabledOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2037,7 +2037,7 @@ type metadataSetIdentityFeedbackForwardingEnabledInput struct {
 
 // String returns the string representation
 func (s SetIdentityFeedbackForwardingEnabledInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2057,7 +2057,7 @@ type metadataSetIdentityFeedbackForwardingEnabledOutput struct {
 
 // String returns the string representation
 func (s SetIdentityFeedbackForwardingEnabledOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2090,7 +2090,7 @@ type metadataSetIdentityNotificationTopicInput struct {
 
 // String returns the string representation
 func (s SetIdentityNotificationTopicInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2110,7 +2110,7 @@ type metadataSetIdentityNotificationTopicOutput struct {
 
 // String returns the string representation
 func (s SetIdentityNotificationTopicOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2133,7 +2133,7 @@ type metadataVerifyDomainDKIMInput struct {
 
 // String returns the string representation
 func (s VerifyDomainDKIMInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2166,7 +2166,7 @@ type metadataVerifyDomainDKIMOutput struct {
 
 // String returns the string representation
 func (s VerifyDomainDKIMOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2188,7 +2188,7 @@ type metadataVerifyDomainIdentityInput struct {
 
 // String returns the string representation
 func (s VerifyDomainIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2211,7 +2211,7 @@ type metadataVerifyDomainIdentityOutput struct {
 
 // String returns the string representation
 func (s VerifyDomainIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2233,7 +2233,7 @@ type metadataVerifyEmailAddressInput struct {
 
 // String returns the string representation
 func (s VerifyEmailAddressInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2251,7 +2251,7 @@ type metadataVerifyEmailAddressOutput struct {
 
 // String returns the string representation
 func (s VerifyEmailAddressOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2273,7 +2273,7 @@ type metadataVerifyEmailIdentityInput struct {
 
 // String returns the string representation
 func (s VerifyEmailIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2293,7 +2293,7 @@ type metadataVerifyEmailIdentityOutput struct {
 
 // String returns the string representation
 func (s VerifyEmailIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/ses/examples_test.go
+++ b/service/ses/examples_test.go
@@ -40,7 +40,7 @@ func ExampleSES_DeleteIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_DeleteIdentityPolicy() {
@@ -68,7 +68,7 @@ func ExampleSES_DeleteIdentityPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_DeleteVerifiedEmailAddress() {
@@ -95,7 +95,7 @@ func ExampleSES_DeleteVerifiedEmailAddress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_GetIdentityDKIMAttributes() {
@@ -125,7 +125,7 @@ func ExampleSES_GetIdentityDKIMAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_GetIdentityNotificationAttributes() {
@@ -155,7 +155,7 @@ func ExampleSES_GetIdentityNotificationAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_GetIdentityPolicies() {
@@ -186,7 +186,7 @@ func ExampleSES_GetIdentityPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_GetIdentityVerificationAttributes() {
@@ -216,7 +216,7 @@ func ExampleSES_GetIdentityVerificationAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_GetSendQuota() {
@@ -241,7 +241,7 @@ func ExampleSES_GetSendQuota() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_GetSendStatistics() {
@@ -266,7 +266,7 @@ func ExampleSES_GetSendStatistics() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_ListIdentities() {
@@ -274,7 +274,7 @@ func ExampleSES_ListIdentities() {
 
 	params := &ses.ListIdentitiesInput{
 		IdentityType: aws.String("IdentityType"),
-		MaxItems:     aws.Long(1),
+		MaxItems:     aws.Int64(1),
 		NextToken:    aws.String("NextToken"),
 	}
 	resp, err := svc.ListIdentities(params)
@@ -295,7 +295,7 @@ func ExampleSES_ListIdentities() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_ListIdentityPolicies() {
@@ -322,7 +322,7 @@ func ExampleSES_ListIdentityPolicies() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_ListVerifiedEmailAddresses() {
@@ -347,7 +347,7 @@ func ExampleSES_ListVerifiedEmailAddresses() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_PutIdentityPolicy() {
@@ -376,7 +376,7 @@ func ExampleSES_PutIdentityPolicy() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_SendEmail() {
@@ -440,7 +440,7 @@ func ExampleSES_SendEmail() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_SendRawEmail() {
@@ -477,14 +477,14 @@ func ExampleSES_SendRawEmail() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_SetIdentityDKIMEnabled() {
 	svc := ses.New(nil)
 
 	params := &ses.SetIdentityDKIMEnabledInput{
-		DKIMEnabled: aws.Boolean(true),      // Required
+		DKIMEnabled: aws.Bool(true),         // Required
 		Identity:    aws.String("Identity"), // Required
 	}
 	resp, err := svc.SetIdentityDKIMEnabled(params)
@@ -505,14 +505,14 @@ func ExampleSES_SetIdentityDKIMEnabled() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_SetIdentityFeedbackForwardingEnabled() {
 	svc := ses.New(nil)
 
 	params := &ses.SetIdentityFeedbackForwardingEnabledInput{
-		ForwardingEnabled: aws.Boolean(true),      // Required
+		ForwardingEnabled: aws.Bool(true),         // Required
 		Identity:          aws.String("Identity"), // Required
 	}
 	resp, err := svc.SetIdentityFeedbackForwardingEnabled(params)
@@ -533,7 +533,7 @@ func ExampleSES_SetIdentityFeedbackForwardingEnabled() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_SetIdentityNotificationTopic() {
@@ -562,7 +562,7 @@ func ExampleSES_SetIdentityNotificationTopic() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_VerifyDomainDKIM() {
@@ -589,7 +589,7 @@ func ExampleSES_VerifyDomainDKIM() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_VerifyDomainIdentity() {
@@ -616,7 +616,7 @@ func ExampleSES_VerifyDomainIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_VerifyEmailAddress() {
@@ -643,7 +643,7 @@ func ExampleSES_VerifyEmailAddress() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSES_VerifyEmailIdentity() {
@@ -670,5 +670,5 @@ func ExampleSES_VerifyEmailIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -862,7 +862,7 @@ type metadataAddPermissionInput struct {
 
 // String returns the string representation
 func (s AddPermissionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -880,7 +880,7 @@ type metadataAddPermissionOutput struct {
 
 // String returns the string representation
 func (s AddPermissionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -911,7 +911,7 @@ type metadataConfirmSubscriptionInput struct {
 
 // String returns the string representation
 func (s ConfirmSubscriptionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -933,7 +933,7 @@ type metadataConfirmSubscriptionOutput struct {
 
 // String returns the string representation
 func (s ConfirmSubscriptionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -964,7 +964,7 @@ type metadataCreatePlatformApplicationInput struct {
 
 // String returns the string representation
 func (s CreatePlatformApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -986,7 +986,7 @@ type metadataCreatePlatformApplicationOutput struct {
 
 // String returns the string representation
 func (s CreatePlatformApplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1023,7 +1023,7 @@ type metadataCreatePlatformEndpointInput struct {
 
 // String returns the string representation
 func (s CreatePlatformEndpointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1045,7 +1045,7 @@ type metadataCreatePlatformEndpointOutput struct {
 
 // String returns the string representation
 func (s CreatePlatformEndpointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1071,7 +1071,7 @@ type metadataCreateTopicInput struct {
 
 // String returns the string representation
 func (s CreateTopicInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1093,7 +1093,7 @@ type metadataCreateTopicOutput struct {
 
 // String returns the string representation
 func (s CreateTopicOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1115,7 +1115,7 @@ type metadataDeleteEndpointInput struct {
 
 // String returns the string representation
 func (s DeleteEndpointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1133,7 +1133,7 @@ type metadataDeleteEndpointOutput struct {
 
 // String returns the string representation
 func (s DeleteEndpointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1155,7 +1155,7 @@ type metadataDeletePlatformApplicationInput struct {
 
 // String returns the string representation
 func (s DeletePlatformApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1173,7 +1173,7 @@ type metadataDeletePlatformApplicationOutput struct {
 
 // String returns the string representation
 func (s DeletePlatformApplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1194,7 +1194,7 @@ type metadataDeleteTopicInput struct {
 
 // String returns the string representation
 func (s DeleteTopicInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1212,7 +1212,7 @@ type metadataDeleteTopicOutput struct {
 
 // String returns the string representation
 func (s DeleteTopicOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1237,7 +1237,7 @@ type metadataEndpoint struct {
 
 // String returns the string representation
 func (s Endpoint) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1259,7 +1259,7 @@ type metadataGetEndpointAttributesInput struct {
 
 // String returns the string representation
 func (s GetEndpointAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1291,7 +1291,7 @@ type metadataGetEndpointAttributesOutput struct {
 
 // String returns the string representation
 func (s GetEndpointAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1313,7 +1313,7 @@ type metadataGetPlatformApplicationAttributesInput struct {
 
 // String returns the string representation
 func (s GetPlatformApplicationAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1343,7 +1343,7 @@ type metadataGetPlatformApplicationAttributesOutput struct {
 
 // String returns the string representation
 func (s GetPlatformApplicationAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1365,7 +1365,7 @@ type metadataGetSubscriptionAttributesInput struct {
 
 // String returns the string representation
 func (s GetSubscriptionAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1396,7 +1396,7 @@ type metadataGetSubscriptionAttributesOutput struct {
 
 // String returns the string representation
 func (s GetSubscriptionAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1418,7 +1418,7 @@ type metadataGetTopicAttributesInput struct {
 
 // String returns the string representation
 func (s GetTopicAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1451,7 +1451,7 @@ type metadataGetTopicAttributesOutput struct {
 
 // String returns the string representation
 func (s GetTopicAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1478,7 +1478,7 @@ type metadataListEndpointsByPlatformApplicationInput struct {
 
 // String returns the string representation
 func (s ListEndpointsByPlatformApplicationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1504,7 +1504,7 @@ type metadataListEndpointsByPlatformApplicationOutput struct {
 
 // String returns the string representation
 func (s ListEndpointsByPlatformApplicationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1527,7 +1527,7 @@ type metadataListPlatformApplicationsInput struct {
 
 // String returns the string representation
 func (s ListPlatformApplicationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1553,7 +1553,7 @@ type metadataListPlatformApplicationsOutput struct {
 
 // String returns the string representation
 func (s ListPlatformApplicationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1578,7 +1578,7 @@ type metadataListSubscriptionsByTopicInput struct {
 
 // String returns the string representation
 func (s ListSubscriptionsByTopicInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1604,7 +1604,7 @@ type metadataListSubscriptionsByTopicOutput struct {
 
 // String returns the string representation
 func (s ListSubscriptionsByTopicOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1626,7 +1626,7 @@ type metadataListSubscriptionsInput struct {
 
 // String returns the string representation
 func (s ListSubscriptionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1652,7 +1652,7 @@ type metadataListSubscriptionsOutput struct {
 
 // String returns the string representation
 func (s ListSubscriptionsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1673,7 +1673,7 @@ type metadataListTopicsInput struct {
 
 // String returns the string representation
 func (s ListTopicsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1699,7 +1699,7 @@ type metadataListTopicsOutput struct {
 
 // String returns the string representation
 func (s ListTopicsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1738,7 +1738,7 @@ type metadataMessageAttributeValue struct {
 
 // String returns the string representation
 func (s MessageAttributeValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1763,7 +1763,7 @@ type metadataPlatformApplication struct {
 
 // String returns the string representation
 func (s PlatformApplication) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1844,7 +1844,7 @@ type metadataPublishInput struct {
 
 // String returns the string representation
 func (s PublishInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1868,7 +1868,7 @@ type metadataPublishOutput struct {
 
 // String returns the string representation
 func (s PublishOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1893,7 +1893,7 @@ type metadataRemovePermissionInput struct {
 
 // String returns the string representation
 func (s RemovePermissionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1911,7 +1911,7 @@ type metadataRemovePermissionOutput struct {
 
 // String returns the string representation
 func (s RemovePermissionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1946,7 +1946,7 @@ type metadataSetEndpointAttributesInput struct {
 
 // String returns the string representation
 func (s SetEndpointAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1964,7 +1964,7 @@ type metadataSetEndpointAttributesOutput struct {
 
 // String returns the string representation
 func (s SetEndpointAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2003,7 +2003,7 @@ type metadataSetPlatformApplicationAttributesInput struct {
 
 // String returns the string representation
 func (s SetPlatformApplicationAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2021,7 +2021,7 @@ type metadataSetPlatformApplicationAttributesOutput struct {
 
 // String returns the string representation
 func (s SetPlatformApplicationAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2052,7 +2052,7 @@ type metadataSetSubscriptionAttributesInput struct {
 
 // String returns the string representation
 func (s SetSubscriptionAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2070,7 +2070,7 @@ type metadataSetSubscriptionAttributesOutput struct {
 
 // String returns the string representation
 func (s SetSubscriptionAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2101,7 +2101,7 @@ type metadataSetTopicAttributesInput struct {
 
 // String returns the string representation
 func (s SetTopicAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2119,7 +2119,7 @@ type metadataSetTopicAttributesOutput struct {
 
 // String returns the string representation
 func (s SetTopicAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2162,7 +2162,7 @@ type metadataSubscribeInput struct {
 
 // String returns the string representation
 func (s SubscribeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2185,7 +2185,7 @@ type metadataSubscribeOutput struct {
 
 // String returns the string representation
 func (s SubscribeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2219,7 +2219,7 @@ type metadataSubscription struct {
 
 // String returns the string representation
 func (s Subscription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2242,7 +2242,7 @@ type metadataTopic struct {
 
 // String returns the string representation
 func (s Topic) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2264,7 +2264,7 @@ type metadataUnsubscribeInput struct {
 
 // String returns the string representation
 func (s UnsubscribeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2282,7 +2282,7 @@ type metadataUnsubscribeOutput struct {
 
 // String returns the string representation
 func (s UnsubscribeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/sns/examples_test.go
+++ b/service/sns/examples_test.go
@@ -49,7 +49,7 @@ func ExampleSNS_AddPermission() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_ConfirmSubscription() {
@@ -78,7 +78,7 @@ func ExampleSNS_ConfirmSubscription() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_CreatePlatformApplication() {
@@ -110,7 +110,7 @@ func ExampleSNS_CreatePlatformApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_CreatePlatformEndpoint() {
@@ -143,7 +143,7 @@ func ExampleSNS_CreatePlatformEndpoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_CreateTopic() {
@@ -170,7 +170,7 @@ func ExampleSNS_CreateTopic() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_DeleteEndpoint() {
@@ -197,7 +197,7 @@ func ExampleSNS_DeleteEndpoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_DeletePlatformApplication() {
@@ -224,7 +224,7 @@ func ExampleSNS_DeletePlatformApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_DeleteTopic() {
@@ -251,7 +251,7 @@ func ExampleSNS_DeleteTopic() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_GetEndpointAttributes() {
@@ -278,7 +278,7 @@ func ExampleSNS_GetEndpointAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_GetPlatformApplicationAttributes() {
@@ -305,7 +305,7 @@ func ExampleSNS_GetPlatformApplicationAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_GetSubscriptionAttributes() {
@@ -332,7 +332,7 @@ func ExampleSNS_GetSubscriptionAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_GetTopicAttributes() {
@@ -359,7 +359,7 @@ func ExampleSNS_GetTopicAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_ListEndpointsByPlatformApplication() {
@@ -387,7 +387,7 @@ func ExampleSNS_ListEndpointsByPlatformApplication() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_ListPlatformApplications() {
@@ -414,7 +414,7 @@ func ExampleSNS_ListPlatformApplications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_ListSubscriptions() {
@@ -441,7 +441,7 @@ func ExampleSNS_ListSubscriptions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_ListSubscriptionsByTopic() {
@@ -469,7 +469,7 @@ func ExampleSNS_ListSubscriptionsByTopic() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_ListTopics() {
@@ -496,7 +496,7 @@ func ExampleSNS_ListTopics() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_Publish() {
@@ -535,7 +535,7 @@ func ExampleSNS_Publish() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_RemovePermission() {
@@ -563,7 +563,7 @@ func ExampleSNS_RemovePermission() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_SetEndpointAttributes() {
@@ -594,7 +594,7 @@ func ExampleSNS_SetEndpointAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_SetPlatformApplicationAttributes() {
@@ -625,7 +625,7 @@ func ExampleSNS_SetPlatformApplicationAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_SetSubscriptionAttributes() {
@@ -654,7 +654,7 @@ func ExampleSNS_SetSubscriptionAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_SetTopicAttributes() {
@@ -683,7 +683,7 @@ func ExampleSNS_SetTopicAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_Subscribe() {
@@ -712,7 +712,7 @@ func ExampleSNS_Subscribe() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSNS_Unsubscribe() {
@@ -739,5 +739,5 @@ func ExampleSNS_Unsubscribe() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -772,7 +772,7 @@ type metadataAddPermissionInput struct {
 
 // String returns the string representation
 func (s AddPermissionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -790,7 +790,7 @@ type metadataAddPermissionOutput struct {
 
 // String returns the string representation
 func (s AddPermissionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -822,7 +822,7 @@ type metadataBatchResultErrorEntry struct {
 
 // String returns the string representation
 func (s BatchResultErrorEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -847,7 +847,7 @@ type metadataChangeMessageVisibilityBatchInput struct {
 
 // String returns the string representation
 func (s ChangeMessageVisibilityBatchInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -874,7 +874,7 @@ type metadataChangeMessageVisibilityBatchOutput struct {
 
 // String returns the string representation
 func (s ChangeMessageVisibilityBatchOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -915,7 +915,7 @@ type metadataChangeMessageVisibilityBatchRequestEntry struct {
 
 // String returns the string representation
 func (s ChangeMessageVisibilityBatchRequestEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -937,7 +937,7 @@ type metadataChangeMessageVisibilityBatchResultEntry struct {
 
 // String returns the string representation
 func (s ChangeMessageVisibilityBatchResultEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -966,7 +966,7 @@ type metadataChangeMessageVisibilityInput struct {
 
 // String returns the string representation
 func (s ChangeMessageVisibilityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -984,7 +984,7 @@ type metadataChangeMessageVisibilityOutput struct {
 
 // String returns the string representation
 func (s ChangeMessageVisibilityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1029,7 +1029,7 @@ type metadataCreateQueueInput struct {
 
 // String returns the string representation
 func (s CreateQueueInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1051,7 +1051,7 @@ type metadataCreateQueueOutput struct {
 
 // String returns the string representation
 func (s CreateQueueOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1075,7 +1075,7 @@ type metadataDeleteMessageBatchInput struct {
 
 // String returns the string representation
 func (s DeleteMessageBatchInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1102,7 +1102,7 @@ type metadataDeleteMessageBatchOutput struct {
 
 // String returns the string representation
 func (s DeleteMessageBatchOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1129,7 +1129,7 @@ type metadataDeleteMessageBatchRequestEntry struct {
 
 // String returns the string representation
 func (s DeleteMessageBatchRequestEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1151,7 +1151,7 @@ type metadataDeleteMessageBatchResultEntry struct {
 
 // String returns the string representation
 func (s DeleteMessageBatchResultEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1175,7 +1175,7 @@ type metadataDeleteMessageInput struct {
 
 // String returns the string representation
 func (s DeleteMessageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1193,7 +1193,7 @@ type metadataDeleteMessageOutput struct {
 
 // String returns the string representation
 func (s DeleteMessageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1214,7 +1214,7 @@ type metadataDeleteQueueInput struct {
 
 // String returns the string representation
 func (s DeleteQueueInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1232,7 +1232,7 @@ type metadataDeleteQueueOutput struct {
 
 // String returns the string representation
 func (s DeleteQueueOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1256,7 +1256,7 @@ type metadataGetQueueAttributesInput struct {
 
 // String returns the string representation
 func (s GetQueueAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1278,7 +1278,7 @@ type metadataGetQueueAttributesOutput struct {
 
 // String returns the string representation
 func (s GetQueueAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1303,7 +1303,7 @@ type metadataGetQueueURLInput struct {
 
 // String returns the string representation
 func (s GetQueueURLInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1326,7 +1326,7 @@ type metadataGetQueueURLOutput struct {
 
 // String returns the string representation
 func (s GetQueueURLOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1347,7 +1347,7 @@ type metadataListDeadLetterSourceQueuesInput struct {
 
 // String returns the string representation
 func (s ListDeadLetterSourceQueuesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1370,7 +1370,7 @@ type metadataListDeadLetterSourceQueuesOutput struct {
 
 // String returns the string representation
 func (s ListDeadLetterSourceQueuesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1392,7 +1392,7 @@ type metadataListQueuesInput struct {
 
 // String returns the string representation
 func (s ListQueuesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1414,7 +1414,7 @@ type metadataListQueuesOutput struct {
 
 // String returns the string representation
 func (s ListQueuesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1464,7 +1464,7 @@ type metadataMessage struct {
 
 // String returns the string representation
 func (s Message) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1509,7 +1509,7 @@ type metadataMessageAttributeValue struct {
 
 // String returns the string representation
 func (s MessageAttributeValue) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1531,7 +1531,7 @@ type metadataPurgeQueueInput struct {
 
 // String returns the string representation
 func (s PurgeQueueInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1549,7 +1549,7 @@ type metadataPurgeQueueOutput struct {
 
 // String returns the string representation
 func (s PurgeQueueOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1615,7 +1615,7 @@ type metadataReceiveMessageInput struct {
 
 // String returns the string representation
 func (s ReceiveMessageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1637,7 +1637,7 @@ type metadataReceiveMessageOutput struct {
 
 // String returns the string representation
 func (s ReceiveMessageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1662,7 +1662,7 @@ type metadataRemovePermissionInput struct {
 
 // String returns the string representation
 func (s RemovePermissionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1680,7 +1680,7 @@ type metadataRemovePermissionOutput struct {
 
 // String returns the string representation
 func (s RemovePermissionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1704,7 +1704,7 @@ type metadataSendMessageBatchInput struct {
 
 // String returns the string representation
 func (s SendMessageBatchInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1732,7 +1732,7 @@ type metadataSendMessageBatchOutput struct {
 
 // String returns the string representation
 func (s SendMessageBatchOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1766,7 +1766,7 @@ type metadataSendMessageBatchRequestEntry struct {
 
 // String returns the string representation
 func (s SendMessageBatchRequestEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1803,7 +1803,7 @@ type metadataSendMessageBatchResultEntry struct {
 
 // String returns the string representation
 func (s SendMessageBatchResultEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1838,7 +1838,7 @@ type metadataSendMessageInput struct {
 
 // String returns the string representation
 func (s SendMessageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1874,7 +1874,7 @@ type metadataSendMessageOutput struct {
 
 // String returns the string representation
 func (s SendMessageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1921,7 +1921,7 @@ type metadataSetQueueAttributesInput struct {
 
 // String returns the string representation
 func (s SetQueueAttributesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1939,7 +1939,7 @@ type metadataSetQueueAttributesOutput struct {
 
 // String returns the string representation
 func (s SetQueueAttributesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/sqs/checksums.go
+++ b/service/sqs/checksums.go
@@ -16,7 +16,7 @@ var (
 )
 
 func setupChecksumValidation(r *aws.Request) {
-	if aws.BooleanValue(r.Config.DisableComputeChecksums) {
+	if aws.BoolValue(r.Config.DisableComputeChecksums) {
 		return
 	}
 
@@ -99,6 +99,6 @@ func checksumsMatch(body, expectedMD5 *string) error {
 }
 
 func setChecksumError(r *aws.Request, format string, args ...interface{}) {
-	r.Retryable.Set(true)
+	r.Retryable = aws.Bool(true)
 	r.Error = awserr.New("InvalidChecksum", fmt.Sprintf(format, args...), nil)
 }

--- a/service/sqs/checksums.go
+++ b/service/sqs/checksums.go
@@ -16,7 +16,7 @@ var (
 )
 
 func setupChecksumValidation(r *aws.Request) {
-	if r.Config.DisableComputeChecksums {
+	if aws.BooleanValue(r.Config.DisableComputeChecksums) {
 		return
 	}
 

--- a/service/sqs/checksums_test.go
+++ b/service/sqs/checksums_test.go
@@ -17,7 +17,7 @@ var _ = unit.Imported
 
 var svc = func() *sqs.SQS {
 	s := sqs.New(&aws.Config{
-		DisableParamValidation: true,
+		DisableParamValidation: aws.Boolean(true),
 	})
 	s.Handlers.Send.Clear()
 	return s
@@ -60,8 +60,8 @@ func TestSendMessageChecksumInvalid(t *testing.T) {
 
 func TestSendMessageChecksumInvalidNoValidation(t *testing.T) {
 	s := sqs.New(&aws.Config{
-		DisableParamValidation:  true,
-		DisableComputeChecksums: true,
+		DisableParamValidation:  aws.Boolean(true),
+		DisableComputeChecksums: aws.Boolean(true),
 	})
 	s.Handlers.Send.Clear()
 

--- a/service/sqs/checksums_test.go
+++ b/service/sqs/checksums_test.go
@@ -17,7 +17,7 @@ var _ = unit.Imported
 
 var svc = func() *sqs.SQS {
 	s := sqs.New(&aws.Config{
-		DisableParamValidation: aws.Boolean(true),
+		DisableParamValidation: aws.Bool(true),
 	})
 	s.Handlers.Send.Clear()
 	return s
@@ -60,8 +60,8 @@ func TestSendMessageChecksumInvalid(t *testing.T) {
 
 func TestSendMessageChecksumInvalidNoValidation(t *testing.T) {
 	s := sqs.New(&aws.Config{
-		DisableParamValidation:  aws.Boolean(true),
-		DisableComputeChecksums: aws.Boolean(true),
+		DisableParamValidation:  aws.Bool(true),
+		DisableComputeChecksums: aws.Bool(true),
 	})
 	s.Handlers.Send.Clear()
 

--- a/service/sqs/examples_test.go
+++ b/service/sqs/examples_test.go
@@ -49,7 +49,7 @@ func ExampleSQS_AddPermission() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_ChangeMessageVisibility() {
@@ -58,7 +58,7 @@ func ExampleSQS_ChangeMessageVisibility() {
 	params := &sqs.ChangeMessageVisibilityInput{
 		QueueURL:          aws.String("String"), // Required
 		ReceiptHandle:     aws.String("String"), // Required
-		VisibilityTimeout: aws.Long(1),          // Required
+		VisibilityTimeout: aws.Int64(1),         // Required
 	}
 	resp, err := svc.ChangeMessageVisibility(params)
 
@@ -78,7 +78,7 @@ func ExampleSQS_ChangeMessageVisibility() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_ChangeMessageVisibilityBatch() {
@@ -89,7 +89,7 @@ func ExampleSQS_ChangeMessageVisibilityBatch() {
 			{ // Required
 				ID:                aws.String("String"), // Required
 				ReceiptHandle:     aws.String("String"), // Required
-				VisibilityTimeout: aws.Long(1),
+				VisibilityTimeout: aws.Int64(1),
 			},
 			// More values...
 		},
@@ -113,7 +113,7 @@ func ExampleSQS_ChangeMessageVisibilityBatch() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_CreateQueue() {
@@ -144,7 +144,7 @@ func ExampleSQS_CreateQueue() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_DeleteMessage() {
@@ -172,7 +172,7 @@ func ExampleSQS_DeleteMessage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_DeleteMessageBatch() {
@@ -206,7 +206,7 @@ func ExampleSQS_DeleteMessageBatch() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_DeleteQueue() {
@@ -233,7 +233,7 @@ func ExampleSQS_DeleteQueue() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_GetQueueAttributes() {
@@ -264,7 +264,7 @@ func ExampleSQS_GetQueueAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_GetQueueURL() {
@@ -292,7 +292,7 @@ func ExampleSQS_GetQueueURL() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_ListDeadLetterSourceQueues() {
@@ -319,7 +319,7 @@ func ExampleSQS_ListDeadLetterSourceQueues() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_ListQueues() {
@@ -346,7 +346,7 @@ func ExampleSQS_ListQueues() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_PurgeQueue() {
@@ -373,7 +373,7 @@ func ExampleSQS_PurgeQueue() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_ReceiveMessage() {
@@ -385,13 +385,13 @@ func ExampleSQS_ReceiveMessage() {
 			aws.String("QueueAttributeName"), // Required
 			// More values...
 		},
-		MaxNumberOfMessages: aws.Long(1),
+		MaxNumberOfMessages: aws.Int64(1),
 		MessageAttributeNames: []*string{
 			aws.String("MessageAttributeName"), // Required
 			// More values...
 		},
-		VisibilityTimeout: aws.Long(1),
-		WaitTimeSeconds:   aws.Long(1),
+		VisibilityTimeout: aws.Int64(1),
+		WaitTimeSeconds:   aws.Int64(1),
 	}
 	resp, err := svc.ReceiveMessage(params)
 
@@ -411,7 +411,7 @@ func ExampleSQS_ReceiveMessage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_RemovePermission() {
@@ -439,7 +439,7 @@ func ExampleSQS_RemovePermission() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_SendMessage() {
@@ -448,7 +448,7 @@ func ExampleSQS_SendMessage() {
 	params := &sqs.SendMessageInput{
 		MessageBody:  aws.String("String"), // Required
 		QueueURL:     aws.String("String"), // Required
-		DelaySeconds: aws.Long(1),
+		DelaySeconds: aws.Int64(1),
 		MessageAttributes: map[string]*sqs.MessageAttributeValue{
 			"Key": { // Required
 				DataType: aws.String("String"), // Required
@@ -484,7 +484,7 @@ func ExampleSQS_SendMessage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_SendMessageBatch() {
@@ -495,7 +495,7 @@ func ExampleSQS_SendMessageBatch() {
 			{ // Required
 				ID:           aws.String("String"), // Required
 				MessageBody:  aws.String("String"), // Required
-				DelaySeconds: aws.Long(1),
+				DelaySeconds: aws.Int64(1),
 				MessageAttributes: map[string]*sqs.MessageAttributeValue{
 					"Key": { // Required
 						DataType: aws.String("String"), // Required
@@ -535,7 +535,7 @@ func ExampleSQS_SendMessageBatch() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSQS_SetQueueAttributes() {
@@ -566,5 +566,5 @@ func ExampleSQS_SetQueueAttributes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -353,7 +353,7 @@ type metadataAssociation struct {
 
 // String returns the string representation
 func (s Association) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -384,7 +384,7 @@ type metadataAssociationDescription struct {
 
 // String returns the string representation
 func (s AssociationDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -409,7 +409,7 @@ type metadataAssociationFilter struct {
 
 // String returns the string representation
 func (s AssociationFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -440,7 +440,7 @@ type metadataAssociationStatus struct {
 
 // String returns the string representation
 func (s AssociationStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -461,7 +461,7 @@ type metadataCreateAssociationBatchInput struct {
 
 // String returns the string representation
 func (s CreateAssociationBatchInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -485,7 +485,7 @@ type metadataCreateAssociationBatchOutput struct {
 
 // String returns the string representation
 func (s CreateAssociationBatchOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -510,7 +510,7 @@ type metadataCreateAssociationBatchRequestEntry struct {
 
 // String returns the string representation
 func (s CreateAssociationBatchRequestEntry) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -534,7 +534,7 @@ type metadataCreateAssociationInput struct {
 
 // String returns the string representation
 func (s CreateAssociationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -555,7 +555,7 @@ type metadataCreateAssociationOutput struct {
 
 // String returns the string representation
 func (s CreateAssociationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -580,7 +580,7 @@ type metadataCreateDocumentInput struct {
 
 // String returns the string representation
 func (s CreateDocumentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -601,7 +601,7 @@ type metadataCreateDocumentOutput struct {
 
 // String returns the string representation
 func (s CreateDocumentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -625,7 +625,7 @@ type metadataDeleteAssociationInput struct {
 
 // String returns the string representation
 func (s DeleteAssociationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -643,7 +643,7 @@ type metadataDeleteAssociationOutput struct {
 
 // String returns the string representation
 func (s DeleteAssociationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -664,7 +664,7 @@ type metadataDeleteDocumentInput struct {
 
 // String returns the string representation
 func (s DeleteDocumentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -682,7 +682,7 @@ type metadataDeleteDocumentOutput struct {
 
 // String returns the string representation
 func (s DeleteDocumentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -706,7 +706,7 @@ type metadataDescribeAssociationInput struct {
 
 // String returns the string representation
 func (s DescribeAssociationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -727,7 +727,7 @@ type metadataDescribeAssociationOutput struct {
 
 // String returns the string representation
 func (s DescribeAssociationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -748,7 +748,7 @@ type metadataDescribeDocumentInput struct {
 
 // String returns the string representation
 func (s DescribeDocumentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -769,7 +769,7 @@ type metadataDescribeDocumentOutput struct {
 
 // String returns the string representation
 func (s DescribeDocumentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -800,7 +800,7 @@ type metadataDocumentDescription struct {
 
 // String returns the string representation
 func (s DocumentDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -825,7 +825,7 @@ type metadataDocumentFilter struct {
 
 // String returns the string representation
 func (s DocumentFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -847,7 +847,7 @@ type metadataDocumentIdentifier struct {
 
 // String returns the string representation
 func (s DocumentIdentifier) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -875,7 +875,7 @@ type metadataFailedCreateAssociation struct {
 
 // String returns the string representation
 func (s FailedCreateAssociation) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -896,7 +896,7 @@ type metadataGetDocumentInput struct {
 
 // String returns the string representation
 func (s GetDocumentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -920,7 +920,7 @@ type metadataGetDocumentOutput struct {
 
 // String returns the string representation
 func (s GetDocumentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -950,7 +950,7 @@ type metadataListAssociationsInput struct {
 
 // String returns the string representation
 func (s ListAssociationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -975,7 +975,7 @@ type metadataListAssociationsOutput struct {
 
 // String returns the string representation
 func (s ListAssociationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1005,7 +1005,7 @@ type metadataListDocumentsInput struct {
 
 // String returns the string representation
 func (s ListDocumentsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1030,7 +1030,7 @@ type metadataListDocumentsOutput struct {
 
 // String returns the string representation
 func (s ListDocumentsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1057,7 +1057,7 @@ type metadataUpdateAssociationStatusInput struct {
 
 // String returns the string representation
 func (s UpdateAssociationStatusInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1078,7 +1078,7 @@ type metadataUpdateAssociationStatusOutput struct {
 
 // String returns the string representation
 func (s UpdateAssociationStatusOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/ssm/examples_test.go
+++ b/service/ssm/examples_test.go
@@ -41,7 +41,7 @@ func ExampleSSM_CreateAssociation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_CreateAssociationBatch() {
@@ -74,7 +74,7 @@ func ExampleSSM_CreateAssociationBatch() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_CreateDocument() {
@@ -102,7 +102,7 @@ func ExampleSSM_CreateDocument() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_DeleteAssociation() {
@@ -130,7 +130,7 @@ func ExampleSSM_DeleteAssociation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_DeleteDocument() {
@@ -157,7 +157,7 @@ func ExampleSSM_DeleteDocument() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_DescribeAssociation() {
@@ -185,7 +185,7 @@ func ExampleSSM_DescribeAssociation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_DescribeDocument() {
@@ -212,7 +212,7 @@ func ExampleSSM_DescribeDocument() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_GetDocument() {
@@ -239,7 +239,7 @@ func ExampleSSM_GetDocument() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_ListAssociations() {
@@ -253,7 +253,7 @@ func ExampleSSM_ListAssociations() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("NextToken"),
 	}
 	resp, err := svc.ListAssociations(params)
@@ -274,7 +274,7 @@ func ExampleSSM_ListAssociations() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_ListDocuments() {
@@ -288,7 +288,7 @@ func ExampleSSM_ListDocuments() {
 			},
 			// More values...
 		},
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("NextToken"),
 	}
 	resp, err := svc.ListDocuments(params)
@@ -309,7 +309,7 @@ func ExampleSSM_ListDocuments() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSSM_UpdateAssociationStatus() {
@@ -343,5 +343,5 @@ func ExampleSSM_UpdateAssociationStatus() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -1828,7 +1828,7 @@ type metadataActivateGatewayInput struct {
 
 // String returns the string representation
 func (s ActivateGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1854,7 +1854,7 @@ type metadataActivateGatewayOutput struct {
 
 // String returns the string representation
 func (s ActivateGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1878,7 +1878,7 @@ type metadataAddCacheInput struct {
 
 // String returns the string representation
 func (s AddCacheInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1900,7 +1900,7 @@ type metadataAddCacheOutput struct {
 
 // String returns the string representation
 func (s AddCacheOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1924,7 +1924,7 @@ type metadataAddUploadBufferInput struct {
 
 // String returns the string representation
 func (s AddUploadBufferInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1946,7 +1946,7 @@ type metadataAddUploadBufferOutput struct {
 
 // String returns the string representation
 func (s AddUploadBufferOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1976,7 +1976,7 @@ type metadataAddWorkingStorageInput struct {
 
 // String returns the string representation
 func (s AddWorkingStorageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2000,7 +2000,7 @@ type metadataAddWorkingStorageOutput struct {
 
 // String returns the string representation
 func (s AddWorkingStorageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2035,7 +2035,7 @@ type metadataCachediSCSIVolume struct {
 
 // String returns the string representation
 func (s CachediSCSIVolume) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2062,7 +2062,7 @@ type metadataCancelArchivalInput struct {
 
 // String returns the string representation
 func (s CancelArchivalInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2085,7 +2085,7 @@ type metadataCancelArchivalOutput struct {
 
 // String returns the string representation
 func (s CancelArchivalOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2112,7 +2112,7 @@ type metadataCancelRetrievalInput struct {
 
 // String returns the string representation
 func (s CancelRetrievalInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2135,7 +2135,7 @@ type metadataCancelRetrievalOutput struct {
 
 // String returns the string representation
 func (s CancelRetrievalOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2172,7 +2172,7 @@ type metadataChapInfo struct {
 
 // String returns the string representation
 func (s ChapInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2204,7 +2204,7 @@ type metadataCreateCachediSCSIVolumeInput struct {
 
 // String returns the string representation
 func (s CreateCachediSCSIVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2226,7 +2226,7 @@ type metadataCreateCachediSCSIVolumeOutput struct {
 
 // String returns the string representation
 func (s CreateCachediSCSIVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2248,7 +2248,7 @@ type metadataCreateSnapshotFromVolumeRecoveryPointInput struct {
 
 // String returns the string representation
 func (s CreateSnapshotFromVolumeRecoveryPointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2272,7 +2272,7 @@ type metadataCreateSnapshotFromVolumeRecoveryPointOutput struct {
 
 // String returns the string representation
 func (s CreateSnapshotFromVolumeRecoveryPointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2302,7 +2302,7 @@ type metadataCreateSnapshotInput struct {
 
 // String returns the string representation
 func (s CreateSnapshotInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2329,7 +2329,7 @@ type metadataCreateSnapshotOutput struct {
 
 // String returns the string representation
 func (s CreateSnapshotOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2387,7 +2387,7 @@ type metadataCreateStorediSCSIVolumeInput struct {
 
 // String returns the string representation
 func (s CreateStorediSCSIVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2416,7 +2416,7 @@ type metadataCreateStorediSCSIVolumeOutput struct {
 
 // String returns the string representation
 func (s CreateStorediSCSIVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2461,7 +2461,7 @@ type metadataCreateTapesInput struct {
 
 // String returns the string representation
 func (s CreateTapesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2484,7 +2484,7 @@ type metadataCreateTapesOutput struct {
 
 // String returns the string representation
 func (s CreateTapesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2508,7 +2508,7 @@ type metadataDeleteBandwidthRateLimitInput struct {
 
 // String returns the string representation
 func (s DeleteBandwidthRateLimitInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2532,7 +2532,7 @@ type metadataDeleteBandwidthRateLimitOutput struct {
 
 // String returns the string representation
 func (s DeleteBandwidthRateLimitOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2560,7 +2560,7 @@ type metadataDeleteChapCredentialsInput struct {
 
 // String returns the string representation
 func (s DeleteChapCredentialsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2585,7 +2585,7 @@ type metadataDeleteChapCredentialsOutput struct {
 
 // String returns the string representation
 func (s DeleteChapCredentialsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2608,7 +2608,7 @@ type metadataDeleteGatewayInput struct {
 
 // String returns the string representation
 func (s DeleteGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2631,7 +2631,7 @@ type metadataDeleteGatewayOutput struct {
 
 // String returns the string representation
 func (s DeleteGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2651,7 +2651,7 @@ type metadataDeleteSnapshotScheduleInput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotScheduleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2671,7 +2671,7 @@ type metadataDeleteSnapshotScheduleOutput struct {
 
 // String returns the string representation
 func (s DeleteSnapshotScheduleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2694,7 +2694,7 @@ type metadataDeleteTapeArchiveInput struct {
 
 // String returns the string representation
 func (s DeleteTapeArchiveInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2717,7 +2717,7 @@ type metadataDeleteTapeArchiveOutput struct {
 
 // String returns the string representation
 func (s DeleteTapeArchiveOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2744,7 +2744,7 @@ type metadataDeleteTapeInput struct {
 
 // String returns the string representation
 func (s DeleteTapeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2766,7 +2766,7 @@ type metadataDeleteTapeOutput struct {
 
 // String returns the string representation
 func (s DeleteTapeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2789,7 +2789,7 @@ type metadataDeleteVolumeInput struct {
 
 // String returns the string representation
 func (s DeleteVolumeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2812,7 +2812,7 @@ type metadataDeleteVolumeOutput struct {
 
 // String returns the string representation
 func (s DeleteVolumeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2835,7 +2835,7 @@ type metadataDescribeBandwidthRateLimitInput struct {
 
 // String returns the string representation
 func (s DescribeBandwidthRateLimitInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2866,7 +2866,7 @@ type metadataDescribeBandwidthRateLimitOutput struct {
 
 // String returns the string representation
 func (s DescribeBandwidthRateLimitOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2888,7 +2888,7 @@ type metadataDescribeCacheInput struct {
 
 // String returns the string representation
 func (s DescribeCacheInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2922,7 +2922,7 @@ type metadataDescribeCacheOutput struct {
 
 // String returns the string representation
 func (s DescribeCacheOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2942,7 +2942,7 @@ type metadataDescribeCachediSCSIVolumesInput struct {
 
 // String returns the string representation
 func (s DescribeCachediSCSIVolumesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2965,7 +2965,7 @@ type metadataDescribeCachediSCSIVolumesOutput struct {
 
 // String returns the string representation
 func (s DescribeCachediSCSIVolumesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2989,7 +2989,7 @@ type metadataDescribeChapCredentialsInput struct {
 
 // String returns the string representation
 func (s DescribeChapCredentialsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3025,7 +3025,7 @@ type metadataDescribeChapCredentialsOutput struct {
 
 // String returns the string representation
 func (s DescribeChapCredentialsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3048,7 +3048,7 @@ type metadataDescribeGatewayInformationInput struct {
 
 // String returns the string representation
 func (s DescribeGatewayInformationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3097,7 +3097,7 @@ type metadataDescribeGatewayInformationOutput struct {
 
 // String returns the string representation
 func (s DescribeGatewayInformationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3120,7 +3120,7 @@ type metadataDescribeMaintenanceStartTimeInput struct {
 
 // String returns the string representation
 func (s DescribeMaintenanceStartTimeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3150,7 +3150,7 @@ type metadataDescribeMaintenanceStartTimeOutput struct {
 
 // String returns the string representation
 func (s DescribeMaintenanceStartTimeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3174,7 +3174,7 @@ type metadataDescribeSnapshotScheduleInput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotScheduleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3202,7 +3202,7 @@ type metadataDescribeSnapshotScheduleOutput struct {
 
 // String returns the string representation
 func (s DescribeSnapshotScheduleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3226,7 +3226,7 @@ type metadataDescribeStorediSCSIVolumesInput struct {
 
 // String returns the string representation
 func (s DescribeStorediSCSIVolumesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3246,7 +3246,7 @@ type metadataDescribeStorediSCSIVolumesOutput struct {
 
 // String returns the string representation
 func (s DescribeStorediSCSIVolumesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3277,7 +3277,7 @@ type metadataDescribeTapeArchivesInput struct {
 
 // String returns the string representation
 func (s DescribeTapeArchivesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3309,7 +3309,7 @@ type metadataDescribeTapeArchivesOutput struct {
 
 // String returns the string representation
 func (s DescribeTapeArchivesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3340,7 +3340,7 @@ type metadataDescribeTapeRecoveryPointsInput struct {
 
 // String returns the string representation
 func (s DescribeTapeRecoveryPointsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3374,7 +3374,7 @@ type metadataDescribeTapeRecoveryPointsOutput struct {
 
 // String returns the string representation
 func (s DescribeTapeRecoveryPointsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3415,7 +3415,7 @@ type metadataDescribeTapesInput struct {
 
 // String returns the string representation
 func (s DescribeTapesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3444,7 +3444,7 @@ type metadataDescribeTapesOutput struct {
 
 // String returns the string representation
 func (s DescribeTapesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3466,7 +3466,7 @@ type metadataDescribeUploadBufferInput struct {
 
 // String returns the string representation
 func (s DescribeUploadBufferInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3494,7 +3494,7 @@ type metadataDescribeUploadBufferOutput struct {
 
 // String returns the string representation
 func (s DescribeUploadBufferOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3533,7 +3533,7 @@ type metadataDescribeVTLDevicesInput struct {
 
 // String returns the string representation
 func (s DescribeVTLDevicesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3566,7 +3566,7 @@ type metadataDescribeVTLDevicesOutput struct {
 
 // String returns the string representation
 func (s DescribeVTLDevicesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3589,7 +3589,7 @@ type metadataDescribeWorkingStorageInput struct {
 
 // String returns the string representation
 func (s DescribeWorkingStorageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3626,7 +3626,7 @@ type metadataDescribeWorkingStorageOutput struct {
 
 // String returns the string representation
 func (s DescribeWorkingStorageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3658,7 +3658,7 @@ type metadataDeviceiSCSIAttributes struct {
 
 // String returns the string representation
 func (s DeviceiSCSIAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3681,7 +3681,7 @@ type metadataDisableGatewayInput struct {
 
 // String returns the string representation
 func (s DisableGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3703,7 +3703,7 @@ type metadataDisableGatewayOutput struct {
 
 // String returns the string representation
 func (s DisableGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3735,7 +3735,7 @@ type metadataDisk struct {
 
 // String returns the string representation
 func (s Disk) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3762,7 +3762,7 @@ type metadataError struct {
 
 // String returns the string representation
 func (s Error) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3788,7 +3788,7 @@ type metadataGatewayInfo struct {
 
 // String returns the string representation
 func (s GatewayInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3817,7 +3817,7 @@ type metadataListGatewaysInput struct {
 
 // String returns the string representation
 func (s ListGatewaysInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3839,7 +3839,7 @@ type metadataListGatewaysOutput struct {
 
 // String returns the string representation
 func (s ListGatewaysOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3862,7 +3862,7 @@ type metadataListLocalDisksInput struct {
 
 // String returns the string representation
 func (s ListLocalDisksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3886,7 +3886,7 @@ type metadataListLocalDisksOutput struct {
 
 // String returns the string representation
 func (s ListLocalDisksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3909,7 +3909,7 @@ type metadataListVolumeInitiatorsInput struct {
 
 // String returns the string representation
 func (s ListVolumeInitiatorsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3932,7 +3932,7 @@ type metadataListVolumeInitiatorsOutput struct {
 
 // String returns the string representation
 func (s ListVolumeInitiatorsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3954,7 +3954,7 @@ type metadataListVolumeRecoveryPointsInput struct {
 
 // String returns the string representation
 func (s ListVolumeRecoveryPointsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3978,7 +3978,7 @@ type metadataListVolumeRecoveryPointsOutput struct {
 
 // String returns the string representation
 func (s ListVolumeRecoveryPointsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4012,7 +4012,7 @@ type metadataListVolumesInput struct {
 
 // String returns the string representation
 func (s ListVolumesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4038,7 +4038,7 @@ type metadataListVolumesOutput struct {
 
 // String returns the string representation
 func (s ListVolumesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4069,7 +4069,7 @@ type metadataNetworkInterface struct {
 
 // String returns the string representation
 func (s NetworkInterface) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4091,7 +4091,7 @@ type metadataResetCacheInput struct {
 
 // String returns the string representation
 func (s ResetCacheInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4113,7 +4113,7 @@ type metadataResetCacheOutput struct {
 
 // String returns the string representation
 func (s ResetCacheOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4144,7 +4144,7 @@ type metadataRetrieveTapeArchiveInput struct {
 
 // String returns the string representation
 func (s RetrieveTapeArchiveInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4166,7 +4166,7 @@ type metadataRetrieveTapeArchiveOutput struct {
 
 // String returns the string representation
 func (s RetrieveTapeArchiveOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4193,7 +4193,7 @@ type metadataRetrieveTapeRecoveryPointInput struct {
 
 // String returns the string representation
 func (s RetrieveTapeRecoveryPointInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4216,7 +4216,7 @@ type metadataRetrieveTapeRecoveryPointOutput struct {
 
 // String returns the string representation
 func (s RetrieveTapeRecoveryPointOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4239,7 +4239,7 @@ type metadataShutdownGatewayInput struct {
 
 // String returns the string representation
 func (s ShutdownGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4262,7 +4262,7 @@ type metadataShutdownGatewayOutput struct {
 
 // String returns the string representation
 func (s ShutdownGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4285,7 +4285,7 @@ type metadataStartGatewayInput struct {
 
 // String returns the string representation
 func (s StartGatewayInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4308,7 +4308,7 @@ type metadataStartGatewayOutput struct {
 
 // String returns the string representation
 func (s StartGatewayOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4347,7 +4347,7 @@ type metadataStorediSCSIVolume struct {
 
 // String returns the string representation
 func (s StorediSCSIVolume) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4388,7 +4388,7 @@ type metadataTape struct {
 
 // String returns the string representation
 func (s Tape) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4431,7 +4431,7 @@ type metadataTapeArchive struct {
 
 // String returns the string representation
 func (s TapeArchive) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4465,7 +4465,7 @@ type metadataTapeRecoveryPointInfo struct {
 
 // String returns the string representation
 func (s TapeRecoveryPointInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4496,7 +4496,7 @@ type metadataUpdateBandwidthRateLimitInput struct {
 
 // String returns the string representation
 func (s UpdateBandwidthRateLimitInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4520,7 +4520,7 @@ type metadataUpdateBandwidthRateLimitOutput struct {
 
 // String returns the string representation
 func (s UpdateBandwidthRateLimitOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4563,7 +4563,7 @@ type metadataUpdateChapCredentialsInput struct {
 
 // String returns the string representation
 func (s UpdateChapCredentialsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4590,7 +4590,7 @@ type metadataUpdateChapCredentialsOutput struct {
 
 // String returns the string representation
 func (s UpdateChapCredentialsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4618,7 +4618,7 @@ type metadataUpdateGatewayInformationInput struct {
 
 // String returns the string representation
 func (s UpdateGatewayInformationInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4641,7 +4641,7 @@ type metadataUpdateGatewayInformationOutput struct {
 
 // String returns the string representation
 func (s UpdateGatewayInformationOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4664,7 +4664,7 @@ type metadataUpdateGatewaySoftwareNowInput struct {
 
 // String returns the string representation
 func (s UpdateGatewaySoftwareNowInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4687,7 +4687,7 @@ type metadataUpdateGatewaySoftwareNowOutput struct {
 
 // String returns the string representation
 func (s UpdateGatewaySoftwareNowOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4726,7 +4726,7 @@ type metadataUpdateMaintenanceStartTimeInput struct {
 
 // String returns the string representation
 func (s UpdateMaintenanceStartTimeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4750,7 +4750,7 @@ type metadataUpdateMaintenanceStartTimeOutput struct {
 
 // String returns the string representation
 func (s UpdateMaintenanceStartTimeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4787,7 +4787,7 @@ type metadataUpdateSnapshotScheduleInput struct {
 
 // String returns the string representation
 func (s UpdateSnapshotScheduleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4808,7 +4808,7 @@ type metadataUpdateSnapshotScheduleOutput struct {
 
 // String returns the string representation
 func (s UpdateSnapshotScheduleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4835,7 +4835,7 @@ type metadataUpdateVTLDeviceTypeInput struct {
 
 // String returns the string representation
 func (s UpdateVTLDeviceTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4857,7 +4857,7 @@ type metadataUpdateVTLDeviceTypeOutput struct {
 
 // String returns the string representation
 func (s UpdateVTLDeviceTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4889,7 +4889,7 @@ type metadataVTLDevice struct {
 
 // String returns the string representation
 func (s VTLDevice) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4911,7 +4911,7 @@ type metadataVolumeInfo struct {
 
 // String returns the string representation
 func (s VolumeInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4937,7 +4937,7 @@ type metadataVolumeRecoveryPointInfo struct {
 
 // String returns the string representation
 func (s VolumeRecoveryPointInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4971,7 +4971,7 @@ type metadataVolumeiSCSIAttributes struct {
 
 // String returns the string representation
 func (s VolumeiSCSIAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/storagegateway/examples_test.go
+++ b/service/storagegateway/examples_test.go
@@ -46,7 +46,7 @@ func ExampleStorageGateway_ActivateGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_AddCache() {
@@ -77,7 +77,7 @@ func ExampleStorageGateway_AddCache() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_AddUploadBuffer() {
@@ -108,7 +108,7 @@ func ExampleStorageGateway_AddUploadBuffer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_AddWorkingStorage() {
@@ -139,7 +139,7 @@ func ExampleStorageGateway_AddWorkingStorage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_CancelArchival() {
@@ -167,7 +167,7 @@ func ExampleStorageGateway_CancelArchival() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_CancelRetrieval() {
@@ -195,7 +195,7 @@ func ExampleStorageGateway_CancelRetrieval() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_CreateCachediSCSIVolume() {
@@ -206,7 +206,7 @@ func ExampleStorageGateway_CreateCachediSCSIVolume() {
 		GatewayARN:         aws.String("GatewayARN"),         // Required
 		NetworkInterfaceID: aws.String("NetworkInterfaceId"), // Required
 		TargetName:         aws.String("TargetName"),         // Required
-		VolumeSizeInBytes:  aws.Long(1),                      // Required
+		VolumeSizeInBytes:  aws.Int64(1),                     // Required
 		SnapshotID:         aws.String("SnapshotId"),
 	}
 	resp, err := svc.CreateCachediSCSIVolume(params)
@@ -227,7 +227,7 @@ func ExampleStorageGateway_CreateCachediSCSIVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_CreateSnapshot() {
@@ -255,7 +255,7 @@ func ExampleStorageGateway_CreateSnapshot() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_CreateSnapshotFromVolumeRecoveryPoint() {
@@ -283,7 +283,7 @@ func ExampleStorageGateway_CreateSnapshotFromVolumeRecoveryPoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_CreateStorediSCSIVolume() {
@@ -293,7 +293,7 @@ func ExampleStorageGateway_CreateStorediSCSIVolume() {
 		DiskID:               aws.String("DiskId"),             // Required
 		GatewayARN:           aws.String("GatewayARN"),         // Required
 		NetworkInterfaceID:   aws.String("NetworkInterfaceId"), // Required
-		PreserveExistingData: aws.Boolean(true),                // Required
+		PreserveExistingData: aws.Bool(true),                   // Required
 		TargetName:           aws.String("TargetName"),         // Required
 		SnapshotID:           aws.String("SnapshotId"),
 	}
@@ -315,7 +315,7 @@ func ExampleStorageGateway_CreateStorediSCSIVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_CreateTapes() {
@@ -324,9 +324,9 @@ func ExampleStorageGateway_CreateTapes() {
 	params := &storagegateway.CreateTapesInput{
 		ClientToken:       aws.String("ClientToken"),       // Required
 		GatewayARN:        aws.String("GatewayARN"),        // Required
-		NumTapesToCreate:  aws.Long(1),                     // Required
+		NumTapesToCreate:  aws.Int64(1),                    // Required
 		TapeBarcodePrefix: aws.String("TapeBarcodePrefix"), // Required
-		TapeSizeInBytes:   aws.Long(1),                     // Required
+		TapeSizeInBytes:   aws.Int64(1),                    // Required
 	}
 	resp, err := svc.CreateTapes(params)
 
@@ -346,7 +346,7 @@ func ExampleStorageGateway_CreateTapes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DeleteBandwidthRateLimit() {
@@ -374,7 +374,7 @@ func ExampleStorageGateway_DeleteBandwidthRateLimit() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DeleteChapCredentials() {
@@ -402,7 +402,7 @@ func ExampleStorageGateway_DeleteChapCredentials() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DeleteGateway() {
@@ -429,7 +429,7 @@ func ExampleStorageGateway_DeleteGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DeleteSnapshotSchedule() {
@@ -456,7 +456,7 @@ func ExampleStorageGateway_DeleteSnapshotSchedule() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DeleteTape() {
@@ -484,7 +484,7 @@ func ExampleStorageGateway_DeleteTape() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DeleteTapeArchive() {
@@ -511,7 +511,7 @@ func ExampleStorageGateway_DeleteTapeArchive() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DeleteVolume() {
@@ -538,7 +538,7 @@ func ExampleStorageGateway_DeleteVolume() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeBandwidthRateLimit() {
@@ -565,7 +565,7 @@ func ExampleStorageGateway_DescribeBandwidthRateLimit() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeCache() {
@@ -592,7 +592,7 @@ func ExampleStorageGateway_DescribeCache() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeCachediSCSIVolumes() {
@@ -622,7 +622,7 @@ func ExampleStorageGateway_DescribeCachediSCSIVolumes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeChapCredentials() {
@@ -649,7 +649,7 @@ func ExampleStorageGateway_DescribeChapCredentials() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeGatewayInformation() {
@@ -676,7 +676,7 @@ func ExampleStorageGateway_DescribeGatewayInformation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeMaintenanceStartTime() {
@@ -703,7 +703,7 @@ func ExampleStorageGateway_DescribeMaintenanceStartTime() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeSnapshotSchedule() {
@@ -730,7 +730,7 @@ func ExampleStorageGateway_DescribeSnapshotSchedule() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeStorediSCSIVolumes() {
@@ -760,14 +760,14 @@ func ExampleStorageGateway_DescribeStorediSCSIVolumes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeTapeArchives() {
 	svc := storagegateway.New(nil)
 
 	params := &storagegateway.DescribeTapeArchivesInput{
-		Limit:  aws.Long(1),
+		Limit:  aws.Int64(1),
 		Marker: aws.String("Marker"),
 		TapeARNs: []*string{
 			aws.String("TapeARN"), // Required
@@ -792,7 +792,7 @@ func ExampleStorageGateway_DescribeTapeArchives() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeTapeRecoveryPoints() {
@@ -800,7 +800,7 @@ func ExampleStorageGateway_DescribeTapeRecoveryPoints() {
 
 	params := &storagegateway.DescribeTapeRecoveryPointsInput{
 		GatewayARN: aws.String("GatewayARN"), // Required
-		Limit:      aws.Long(1),
+		Limit:      aws.Int64(1),
 		Marker:     aws.String("Marker"),
 	}
 	resp, err := svc.DescribeTapeRecoveryPoints(params)
@@ -821,7 +821,7 @@ func ExampleStorageGateway_DescribeTapeRecoveryPoints() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeTapes() {
@@ -829,7 +829,7 @@ func ExampleStorageGateway_DescribeTapes() {
 
 	params := &storagegateway.DescribeTapesInput{
 		GatewayARN: aws.String("GatewayARN"), // Required
-		Limit:      aws.Long(1),
+		Limit:      aws.Int64(1),
 		Marker:     aws.String("Marker"),
 		TapeARNs: []*string{
 			aws.String("TapeARN"), // Required
@@ -854,7 +854,7 @@ func ExampleStorageGateway_DescribeTapes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeUploadBuffer() {
@@ -881,7 +881,7 @@ func ExampleStorageGateway_DescribeUploadBuffer() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeVTLDevices() {
@@ -889,7 +889,7 @@ func ExampleStorageGateway_DescribeVTLDevices() {
 
 	params := &storagegateway.DescribeVTLDevicesInput{
 		GatewayARN: aws.String("GatewayARN"), // Required
-		Limit:      aws.Long(1),
+		Limit:      aws.Int64(1),
 		Marker:     aws.String("Marker"),
 		VTLDeviceARNs: []*string{
 			aws.String("VTLDeviceARN"), // Required
@@ -914,7 +914,7 @@ func ExampleStorageGateway_DescribeVTLDevices() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DescribeWorkingStorage() {
@@ -941,7 +941,7 @@ func ExampleStorageGateway_DescribeWorkingStorage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_DisableGateway() {
@@ -968,14 +968,14 @@ func ExampleStorageGateway_DisableGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_ListGateways() {
 	svc := storagegateway.New(nil)
 
 	params := &storagegateway.ListGatewaysInput{
-		Limit:  aws.Long(1),
+		Limit:  aws.Int64(1),
 		Marker: aws.String("Marker"),
 	}
 	resp, err := svc.ListGateways(params)
@@ -996,7 +996,7 @@ func ExampleStorageGateway_ListGateways() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_ListLocalDisks() {
@@ -1023,7 +1023,7 @@ func ExampleStorageGateway_ListLocalDisks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_ListVolumeInitiators() {
@@ -1050,7 +1050,7 @@ func ExampleStorageGateway_ListVolumeInitiators() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_ListVolumeRecoveryPoints() {
@@ -1077,7 +1077,7 @@ func ExampleStorageGateway_ListVolumeRecoveryPoints() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_ListVolumes() {
@@ -1085,7 +1085,7 @@ func ExampleStorageGateway_ListVolumes() {
 
 	params := &storagegateway.ListVolumesInput{
 		GatewayARN: aws.String("GatewayARN"), // Required
-		Limit:      aws.Long(1),
+		Limit:      aws.Int64(1),
 		Marker:     aws.String("Marker"),
 	}
 	resp, err := svc.ListVolumes(params)
@@ -1106,7 +1106,7 @@ func ExampleStorageGateway_ListVolumes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_ResetCache() {
@@ -1133,7 +1133,7 @@ func ExampleStorageGateway_ResetCache() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_RetrieveTapeArchive() {
@@ -1161,7 +1161,7 @@ func ExampleStorageGateway_RetrieveTapeArchive() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_RetrieveTapeRecoveryPoint() {
@@ -1189,7 +1189,7 @@ func ExampleStorageGateway_RetrieveTapeRecoveryPoint() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_ShutdownGateway() {
@@ -1216,7 +1216,7 @@ func ExampleStorageGateway_ShutdownGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_StartGateway() {
@@ -1243,7 +1243,7 @@ func ExampleStorageGateway_StartGateway() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_UpdateBandwidthRateLimit() {
@@ -1251,8 +1251,8 @@ func ExampleStorageGateway_UpdateBandwidthRateLimit() {
 
 	params := &storagegateway.UpdateBandwidthRateLimitInput{
 		GatewayARN:                           aws.String("GatewayARN"), // Required
-		AverageDownloadRateLimitInBitsPerSec: aws.Long(1),
-		AverageUploadRateLimitInBitsPerSec:   aws.Long(1),
+		AverageDownloadRateLimitInBitsPerSec: aws.Int64(1),
+		AverageUploadRateLimitInBitsPerSec:   aws.Int64(1),
 	}
 	resp, err := svc.UpdateBandwidthRateLimit(params)
 
@@ -1272,7 +1272,7 @@ func ExampleStorageGateway_UpdateBandwidthRateLimit() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_UpdateChapCredentials() {
@@ -1302,7 +1302,7 @@ func ExampleStorageGateway_UpdateChapCredentials() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_UpdateGatewayInformation() {
@@ -1331,7 +1331,7 @@ func ExampleStorageGateway_UpdateGatewayInformation() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_UpdateGatewaySoftwareNow() {
@@ -1358,17 +1358,17 @@ func ExampleStorageGateway_UpdateGatewaySoftwareNow() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_UpdateMaintenanceStartTime() {
 	svc := storagegateway.New(nil)
 
 	params := &storagegateway.UpdateMaintenanceStartTimeInput{
-		DayOfWeek:    aws.Long(1),              // Required
+		DayOfWeek:    aws.Int64(1),             // Required
 		GatewayARN:   aws.String("GatewayARN"), // Required
-		HourOfDay:    aws.Long(1),              // Required
-		MinuteOfHour: aws.Long(1),              // Required
+		HourOfDay:    aws.Int64(1),             // Required
+		MinuteOfHour: aws.Int64(1),             // Required
 	}
 	resp, err := svc.UpdateMaintenanceStartTime(params)
 
@@ -1388,15 +1388,15 @@ func ExampleStorageGateway_UpdateMaintenanceStartTime() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_UpdateSnapshotSchedule() {
 	svc := storagegateway.New(nil)
 
 	params := &storagegateway.UpdateSnapshotScheduleInput{
-		RecurrenceInHours: aws.Long(1),             // Required
-		StartAt:           aws.Long(1),             // Required
+		RecurrenceInHours: aws.Int64(1),            // Required
+		StartAt:           aws.Int64(1),            // Required
 		VolumeARN:         aws.String("VolumeARN"), // Required
 		Description:       aws.String("Description"),
 	}
@@ -1418,7 +1418,7 @@ func ExampleStorageGateway_UpdateSnapshotSchedule() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleStorageGateway_UpdateVTLDeviceType() {
@@ -1446,5 +1446,5 @@ func ExampleStorageGateway_UpdateVTLDeviceType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/sts/api.go
+++ b/service/sts/api.go
@@ -540,7 +540,7 @@ type metadataAssumeRoleInput struct {
 
 // String returns the string representation
 func (s AssumeRoleInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -576,7 +576,7 @@ type metadataAssumeRoleOutput struct {
 
 // String returns the string representation
 func (s AssumeRoleOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -637,7 +637,7 @@ type metadataAssumeRoleWithSAMLInput struct {
 
 // String returns the string representation
 func (s AssumeRoleWithSAMLInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -700,7 +700,7 @@ type metadataAssumeRoleWithSAMLOutput struct {
 
 // String returns the string representation
 func (s AssumeRoleWithSAMLOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -766,7 +766,7 @@ type metadataAssumeRoleWithWebIdentityInput struct {
 
 // String returns the string representation
 func (s AssumeRoleWithWebIdentityInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -821,7 +821,7 @@ type metadataAssumeRoleWithWebIdentityOutput struct {
 
 // String returns the string representation
 func (s AssumeRoleWithWebIdentityOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -852,7 +852,7 @@ type metadataAssumedRoleUser struct {
 
 // String returns the string representation
 func (s AssumedRoleUser) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -883,7 +883,7 @@ type metadataCredentials struct {
 
 // String returns the string representation
 func (s Credentials) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -904,7 +904,7 @@ type metadataDecodeAuthorizationMessageInput struct {
 
 // String returns the string representation
 func (s DecodeAuthorizationMessageInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -929,7 +929,7 @@ type metadataDecodeAuthorizationMessageOutput struct {
 
 // String returns the string representation
 func (s DecodeAuthorizationMessageOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -958,7 +958,7 @@ type metadataFederatedUser struct {
 
 // String returns the string representation
 func (s FederatedUser) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1014,7 +1014,7 @@ type metadataGetFederationTokenInput struct {
 
 // String returns the string representation
 func (s GetFederationTokenInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1048,7 +1048,7 @@ type metadataGetFederationTokenOutput struct {
 
 // String returns the string representation
 func (s GetFederationTokenOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1090,7 +1090,7 @@ type metadataGetSessionTokenInput struct {
 
 // String returns the string representation
 func (s GetSessionTokenInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1113,7 +1113,7 @@ type metadataGetSessionTokenOutput struct {
 
 // String returns the string representation
 func (s GetSessionTokenOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/sts/customizations_test.go
+++ b/service/sts/customizations_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var svc = sts.New(&aws.Config{
-	Region: "mock-region",
+	Region: aws.String("mock-region"),
 })
 
 func TestUnsignedRequest_AssumeRoleWithSAML(t *testing.T) {

--- a/service/sts/examples_test.go
+++ b/service/sts/examples_test.go
@@ -22,7 +22,7 @@ func ExampleSTS_AssumeRole() {
 	params := &sts.AssumeRoleInput{
 		RoleARN:         aws.String("arnType"),      // Required
 		RoleSessionName: aws.String("userNameType"), // Required
-		DurationSeconds: aws.Long(1),
+		DurationSeconds: aws.Int64(1),
 		ExternalID:      aws.String("externalIdType"),
 		Policy:          aws.String("sessionPolicyDocumentType"),
 		SerialNumber:    aws.String("serialNumberType"),
@@ -46,7 +46,7 @@ func ExampleSTS_AssumeRole() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSTS_AssumeRoleWithSAML() {
@@ -56,7 +56,7 @@ func ExampleSTS_AssumeRoleWithSAML() {
 		PrincipalARN:    aws.String("arnType"),           // Required
 		RoleARN:         aws.String("arnType"),           // Required
 		SAMLAssertion:   aws.String("SAMLAssertionType"), // Required
-		DurationSeconds: aws.Long(1),
+		DurationSeconds: aws.Int64(1),
 		Policy:          aws.String("sessionPolicyDocumentType"),
 	}
 	resp, err := svc.AssumeRoleWithSAML(params)
@@ -77,7 +77,7 @@ func ExampleSTS_AssumeRoleWithSAML() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSTS_AssumeRoleWithWebIdentity() {
@@ -87,7 +87,7 @@ func ExampleSTS_AssumeRoleWithWebIdentity() {
 		RoleARN:          aws.String("arnType"),         // Required
 		RoleSessionName:  aws.String("userNameType"),    // Required
 		WebIdentityToken: aws.String("clientTokenType"), // Required
-		DurationSeconds:  aws.Long(1),
+		DurationSeconds:  aws.Int64(1),
 		Policy:           aws.String("sessionPolicyDocumentType"),
 		ProviderID:       aws.String("urlType"),
 	}
@@ -109,7 +109,7 @@ func ExampleSTS_AssumeRoleWithWebIdentity() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSTS_DecodeAuthorizationMessage() {
@@ -136,7 +136,7 @@ func ExampleSTS_DecodeAuthorizationMessage() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSTS_GetFederationToken() {
@@ -144,7 +144,7 @@ func ExampleSTS_GetFederationToken() {
 
 	params := &sts.GetFederationTokenInput{
 		Name:            aws.String("userNameType"), // Required
-		DurationSeconds: aws.Long(1),
+		DurationSeconds: aws.Int64(1),
 		Policy:          aws.String("sessionPolicyDocumentType"),
 	}
 	resp, err := svc.GetFederationToken(params)
@@ -165,14 +165,14 @@ func ExampleSTS_GetFederationToken() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSTS_GetSessionToken() {
 	svc := sts.New(nil)
 
 	params := &sts.GetSessionTokenInput{
-		DurationSeconds: aws.Long(1),
+		DurationSeconds: aws.Int64(1),
 		SerialNumber:    aws.String("serialNumberType"),
 		TokenCode:       aws.String("tokenCodeType"),
 	}
@@ -194,5 +194,5 @@ func ExampleSTS_GetSessionToken() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -542,7 +542,7 @@ type metadataAddAttachmentsToSetInput struct {
 
 // String returns the string representation
 func (s AddAttachmentsToSetInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -571,7 +571,7 @@ type metadataAddAttachmentsToSetOutput struct {
 
 // String returns the string representation
 func (s AddAttachmentsToSetOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -605,7 +605,7 @@ type metadataAddCommunicationToCaseInput struct {
 
 // String returns the string representation
 func (s AddCommunicationToCaseInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -627,7 +627,7 @@ type metadataAddCommunicationToCaseOutput struct {
 
 // String returns the string representation
 func (s AddCommunicationToCaseOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -653,7 +653,7 @@ type metadataAttachment struct {
 
 // String returns the string representation
 func (s Attachment) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -679,7 +679,7 @@ type metadataAttachmentDetails struct {
 
 // String returns the string representation
 func (s AttachmentDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -760,7 +760,7 @@ type metadataCaseDetails struct {
 
 // String returns the string representation
 func (s CaseDetails) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -787,7 +787,7 @@ type metadataCategory struct {
 
 // String returns the string representation
 func (s Category) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -824,7 +824,7 @@ type metadataCommunication struct {
 
 // String returns the string representation
 func (s Communication) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -878,7 +878,7 @@ type metadataCreateCaseInput struct {
 
 // String returns the string representation
 func (s CreateCaseInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -902,7 +902,7 @@ type metadataCreateCaseOutput struct {
 
 // String returns the string representation
 func (s CreateCaseOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -924,7 +924,7 @@ type metadataDescribeAttachmentInput struct {
 
 // String returns the string representation
 func (s DescribeAttachmentInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -947,7 +947,7 @@ type metadataDescribeAttachmentOutput struct {
 
 // String returns the string representation
 func (s DescribeAttachmentOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -999,7 +999,7 @@ type metadataDescribeCasesInput struct {
 
 // String returns the string representation
 func (s DescribeCasesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1025,7 +1025,7 @@ type metadataDescribeCasesOutput struct {
 
 // String returns the string representation
 func (s DescribeCasesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1061,7 +1061,7 @@ type metadataDescribeCommunicationsInput struct {
 
 // String returns the string representation
 func (s DescribeCommunicationsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1086,7 +1086,7 @@ type metadataDescribeCommunicationsOutput struct {
 
 // String returns the string representation
 func (s DescribeCommunicationsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1112,7 +1112,7 @@ type metadataDescribeServicesInput struct {
 
 // String returns the string representation
 func (s DescribeServicesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1134,7 +1134,7 @@ type metadataDescribeServicesOutput struct {
 
 // String returns the string representation
 func (s DescribeServicesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1157,7 +1157,7 @@ type metadataDescribeSeverityLevelsInput struct {
 
 // String returns the string representation
 func (s DescribeSeverityLevelsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1180,7 +1180,7 @@ type metadataDescribeSeverityLevelsOutput struct {
 
 // String returns the string representation
 func (s DescribeSeverityLevelsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1201,7 +1201,7 @@ type metadataDescribeTrustedAdvisorCheckRefreshStatusesInput struct {
 
 // String returns the string representation
 func (s DescribeTrustedAdvisorCheckRefreshStatusesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1224,7 +1224,7 @@ type metadataDescribeTrustedAdvisorCheckRefreshStatusesOutput struct {
 
 // String returns the string representation
 func (s DescribeTrustedAdvisorCheckRefreshStatusesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1250,7 +1250,7 @@ type metadataDescribeTrustedAdvisorCheckResultInput struct {
 
 // String returns the string representation
 func (s DescribeTrustedAdvisorCheckResultInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1273,7 +1273,7 @@ type metadataDescribeTrustedAdvisorCheckResultOutput struct {
 
 // String returns the string representation
 func (s DescribeTrustedAdvisorCheckResultOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1294,7 +1294,7 @@ type metadataDescribeTrustedAdvisorCheckSummariesInput struct {
 
 // String returns the string representation
 func (s DescribeTrustedAdvisorCheckSummariesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1317,7 +1317,7 @@ type metadataDescribeTrustedAdvisorCheckSummariesOutput struct {
 
 // String returns the string representation
 func (s DescribeTrustedAdvisorCheckSummariesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1340,7 +1340,7 @@ type metadataDescribeTrustedAdvisorChecksInput struct {
 
 // String returns the string representation
 func (s DescribeTrustedAdvisorChecksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1363,7 +1363,7 @@ type metadataDescribeTrustedAdvisorChecksOutput struct {
 
 // String returns the string representation
 func (s DescribeTrustedAdvisorChecksOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1388,7 +1388,7 @@ type metadataRecentCaseCommunications struct {
 
 // String returns the string representation
 func (s RecentCaseCommunications) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1409,7 +1409,7 @@ type metadataRefreshTrustedAdvisorCheckInput struct {
 
 // String returns the string representation
 func (s RefreshTrustedAdvisorCheckInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1432,7 +1432,7 @@ type metadataRefreshTrustedAdvisorCheckOutput struct {
 
 // String returns the string representation
 func (s RefreshTrustedAdvisorCheckOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1454,7 +1454,7 @@ type metadataResolveCaseInput struct {
 
 // String returns the string representation
 func (s ResolveCaseInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1479,7 +1479,7 @@ type metadataResolveCaseOutput struct {
 
 // String returns the string representation
 func (s ResolveCaseOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1511,7 +1511,7 @@ type metadataService struct {
 
 // String returns the string representation
 func (s Service) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1538,7 +1538,7 @@ type metadataSeverityLevel struct {
 
 // String returns the string representation
 func (s SeverityLevel) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1562,7 +1562,7 @@ type metadataTrustedAdvisorCategorySpecificSummary struct {
 
 // String returns the string representation
 func (s TrustedAdvisorCategorySpecificSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1601,7 +1601,7 @@ type metadataTrustedAdvisorCheckDescription struct {
 
 // String returns the string representation
 func (s TrustedAdvisorCheckDescription) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1631,7 +1631,7 @@ type metadataTrustedAdvisorCheckRefreshStatus struct {
 
 // String returns the string representation
 func (s TrustedAdvisorCheckRefreshStatus) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1671,7 +1671,7 @@ type metadataTrustedAdvisorCheckResult struct {
 
 // String returns the string representation
 func (s TrustedAdvisorCheckResult) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1712,7 +1712,7 @@ type metadataTrustedAdvisorCheckSummary struct {
 
 // String returns the string representation
 func (s TrustedAdvisorCheckSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1740,7 +1740,7 @@ type metadataTrustedAdvisorCostOptimizingSummary struct {
 
 // String returns the string representation
 func (s TrustedAdvisorCostOptimizingSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1779,7 +1779,7 @@ type metadataTrustedAdvisorResourceDetail struct {
 
 // String returns the string representation
 func (s TrustedAdvisorResourceDetail) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1814,7 +1814,7 @@ type metadataTrustedAdvisorResourcesSummary struct {
 
 // String returns the string representation
 func (s TrustedAdvisorResourcesSummary) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/support/examples_test.go
+++ b/service/support/examples_test.go
@@ -47,7 +47,7 @@ func ExampleSupport_AddAttachmentsToSet() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_AddCommunicationToCase() {
@@ -80,7 +80,7 @@ func ExampleSupport_AddCommunicationToCase() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_CreateCase() {
@@ -118,7 +118,7 @@ func ExampleSupport_CreateCase() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeAttachment() {
@@ -145,7 +145,7 @@ func ExampleSupport_DescribeAttachment() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeCases() {
@@ -159,10 +159,10 @@ func ExampleSupport_DescribeCases() {
 			// More values...
 		},
 		DisplayID:             aws.String("DisplayId"),
-		IncludeCommunications: aws.Boolean(true),
-		IncludeResolvedCases:  aws.Boolean(true),
+		IncludeCommunications: aws.Bool(true),
+		IncludeResolvedCases:  aws.Bool(true),
 		Language:              aws.String("Language"),
-		MaxResults:            aws.Long(1),
+		MaxResults:            aws.Int64(1),
 		NextToken:             aws.String("NextToken"),
 	}
 	resp, err := svc.DescribeCases(params)
@@ -183,7 +183,7 @@ func ExampleSupport_DescribeCases() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeCommunications() {
@@ -193,7 +193,7 @@ func ExampleSupport_DescribeCommunications() {
 		CaseID:     aws.String("CaseId"), // Required
 		AfterTime:  aws.String("AfterTime"),
 		BeforeTime: aws.String("BeforeTime"),
-		MaxResults: aws.Long(1),
+		MaxResults: aws.Int64(1),
 		NextToken:  aws.String("NextToken"),
 	}
 	resp, err := svc.DescribeCommunications(params)
@@ -214,7 +214,7 @@ func ExampleSupport_DescribeCommunications() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeServices() {
@@ -245,7 +245,7 @@ func ExampleSupport_DescribeServices() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeSeverityLevels() {
@@ -272,7 +272,7 @@ func ExampleSupport_DescribeSeverityLevels() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeTrustedAdvisorCheckRefreshStatuses() {
@@ -302,7 +302,7 @@ func ExampleSupport_DescribeTrustedAdvisorCheckRefreshStatuses() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeTrustedAdvisorCheckResult() {
@@ -330,7 +330,7 @@ func ExampleSupport_DescribeTrustedAdvisorCheckResult() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeTrustedAdvisorCheckSummaries() {
@@ -360,7 +360,7 @@ func ExampleSupport_DescribeTrustedAdvisorCheckSummaries() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_DescribeTrustedAdvisorChecks() {
@@ -387,7 +387,7 @@ func ExampleSupport_DescribeTrustedAdvisorChecks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_RefreshTrustedAdvisorCheck() {
@@ -414,7 +414,7 @@ func ExampleSupport_RefreshTrustedAdvisorCheck() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSupport_ResolveCase() {
@@ -441,5 +441,5 @@ func ExampleSupport_ResolveCase() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -1595,7 +1595,7 @@ type metadataActivityTaskCancelRequestedEventAttributes struct {
 
 // String returns the string representation
 func (s ActivityTaskCancelRequestedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1632,7 +1632,7 @@ type metadataActivityTaskCanceledEventAttributes struct {
 
 // String returns the string representation
 func (s ActivityTaskCanceledEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1664,7 +1664,7 @@ type metadataActivityTaskCompletedEventAttributes struct {
 
 // String returns the string representation
 func (s ActivityTaskCompletedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1699,7 +1699,7 @@ type metadataActivityTaskFailedEventAttributes struct {
 
 // String returns the string representation
 func (s ActivityTaskFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1769,7 +1769,7 @@ type metadataActivityTaskScheduledEventAttributes struct {
 
 // String returns the string representation
 func (s ActivityTaskScheduledEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1797,7 +1797,7 @@ type metadataActivityTaskStartedEventAttributes struct {
 
 // String returns the string representation
 func (s ActivityTaskStartedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1833,7 +1833,7 @@ type metadataActivityTaskTimedOutEventAttributes struct {
 
 // String returns the string representation
 func (s ActivityTaskTimedOutEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1864,7 +1864,7 @@ type metadataActivityType struct {
 
 // String returns the string representation
 func (s ActivityType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1940,7 +1940,7 @@ type metadataActivityTypeConfiguration struct {
 
 // String returns the string representation
 func (s ActivityTypeConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1974,7 +1974,7 @@ type metadataActivityTypeInfo struct {
 
 // String returns the string representation
 func (s ActivityTypeInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2010,7 +2010,7 @@ type metadataCancelTimerDecisionAttributes struct {
 
 // String returns the string representation
 func (s CancelTimerDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2046,7 +2046,7 @@ type metadataCancelTimerFailedEventAttributes struct {
 
 // String returns the string representation
 func (s CancelTimerFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2082,7 +2082,7 @@ type metadataCancelWorkflowExecutionDecisionAttributes struct {
 
 // String returns the string representation
 func (s CancelWorkflowExecutionDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2115,7 +2115,7 @@ type metadataCancelWorkflowExecutionFailedEventAttributes struct {
 
 // String returns the string representation
 func (s CancelWorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2154,7 +2154,7 @@ type metadataChildWorkflowExecutionCanceledEventAttributes struct {
 
 // String returns the string representation
 func (s ChildWorkflowExecutionCanceledEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2193,7 +2193,7 @@ type metadataChildWorkflowExecutionCompletedEventAttributes struct {
 
 // String returns the string representation
 func (s ChildWorkflowExecutionCompletedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2235,7 +2235,7 @@ type metadataChildWorkflowExecutionFailedEventAttributes struct {
 
 // String returns the string representation
 func (s ChildWorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2266,7 +2266,7 @@ type metadataChildWorkflowExecutionStartedEventAttributes struct {
 
 // String returns the string representation
 func (s ChildWorkflowExecutionStartedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2302,7 +2302,7 @@ type metadataChildWorkflowExecutionTerminatedEventAttributes struct {
 
 // String returns the string representation
 func (s ChildWorkflowExecutionTerminatedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2342,7 +2342,7 @@ type metadataChildWorkflowExecutionTimedOutEventAttributes struct {
 
 // String returns the string representation
 func (s ChildWorkflowExecutionTimedOutEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2366,7 +2366,7 @@ type metadataCloseStatusFilter struct {
 
 // String returns the string representation
 func (s CloseStatusFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2403,7 +2403,7 @@ type metadataCompleteWorkflowExecutionDecisionAttributes struct {
 
 // String returns the string representation
 func (s CompleteWorkflowExecutionDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2436,7 +2436,7 @@ type metadataCompleteWorkflowExecutionFailedEventAttributes struct {
 
 // String returns the string representation
 func (s CompleteWorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2541,7 +2541,7 @@ type metadataContinueAsNewWorkflowExecutionDecisionAttributes struct {
 
 // String returns the string representation
 func (s ContinueAsNewWorkflowExecutionDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2574,7 +2574,7 @@ type metadataContinueAsNewWorkflowExecutionFailedEventAttributes struct {
 
 // String returns the string representation
 func (s ContinueAsNewWorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2636,7 +2636,7 @@ type metadataCountClosedWorkflowExecutionsInput struct {
 
 // String returns the string representation
 func (s CountClosedWorkflowExecutionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2681,7 +2681,7 @@ type metadataCountOpenWorkflowExecutionsInput struct {
 
 // String returns the string representation
 func (s CountOpenWorkflowExecutionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2705,7 +2705,7 @@ type metadataCountPendingActivityTasksInput struct {
 
 // String returns the string representation
 func (s CountPendingActivityTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2729,7 +2729,7 @@ type metadataCountPendingDecisionTasksInput struct {
 
 // String returns the string representation
 func (s CountPendingDecisionTasksInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2901,7 +2901,7 @@ type metadataDecision struct {
 
 // String returns the string representation
 func (s Decision) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2933,7 +2933,7 @@ type metadataDecisionTaskCompletedEventAttributes struct {
 
 // String returns the string representation
 func (s DecisionTaskCompletedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -2972,7 +2972,7 @@ type metadataDecisionTaskScheduledEventAttributes struct {
 
 // String returns the string representation
 func (s DecisionTaskScheduledEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3000,7 +3000,7 @@ type metadataDecisionTaskStartedEventAttributes struct {
 
 // String returns the string representation
 func (s DecisionTaskStartedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3032,7 +3032,7 @@ type metadataDecisionTaskTimedOutEventAttributes struct {
 
 // String returns the string representation
 func (s DecisionTaskTimedOutEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3056,7 +3056,7 @@ type metadataDeprecateActivityTypeInput struct {
 
 // String returns the string representation
 func (s DeprecateActivityTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3074,7 +3074,7 @@ type metadataDeprecateActivityTypeOutput struct {
 
 // String returns the string representation
 func (s DeprecateActivityTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3095,7 +3095,7 @@ type metadataDeprecateDomainInput struct {
 
 // String returns the string representation
 func (s DeprecateDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3113,7 +3113,7 @@ type metadataDeprecateDomainOutput struct {
 
 // String returns the string representation
 func (s DeprecateDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3137,7 +3137,7 @@ type metadataDeprecateWorkflowTypeInput struct {
 
 // String returns the string representation
 func (s DeprecateWorkflowTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3155,7 +3155,7 @@ type metadataDeprecateWorkflowTypeOutput struct {
 
 // String returns the string representation
 func (s DeprecateWorkflowTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3180,7 +3180,7 @@ type metadataDescribeActivityTypeInput struct {
 
 // String returns the string representation
 func (s DescribeActivityTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3213,7 +3213,7 @@ type metadataDescribeActivityTypeOutput struct {
 
 // String returns the string representation
 func (s DescribeActivityTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3234,7 +3234,7 @@ type metadataDescribeDomainInput struct {
 
 // String returns the string representation
 func (s DescribeDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3259,7 +3259,7 @@ type metadataDescribeDomainOutput struct {
 
 // String returns the string representation
 func (s DescribeDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3283,7 +3283,7 @@ type metadataDescribeWorkflowExecutionInput struct {
 
 // String returns the string representation
 func (s DescribeWorkflowExecutionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3323,7 +3323,7 @@ type metadataDescribeWorkflowExecutionOutput struct {
 
 // String returns the string representation
 func (s DescribeWorkflowExecutionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3347,7 +3347,7 @@ type metadataDescribeWorkflowTypeInput struct {
 
 // String returns the string representation
 func (s DescribeWorkflowTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3380,7 +3380,7 @@ type metadataDescribeWorkflowTypeOutput struct {
 
 // String returns the string representation
 func (s DescribeWorkflowTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3402,7 +3402,7 @@ type metadataDomainConfiguration struct {
 
 // String returns the string representation
 func (s DomainConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3435,7 +3435,7 @@ type metadataDomainInfo struct {
 
 // String returns the string representation
 func (s DomainInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3464,7 +3464,7 @@ type metadataExecutionTimeFilter struct {
 
 // String returns the string representation
 func (s ExecutionTimeFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3492,7 +3492,7 @@ type metadataExternalWorkflowExecutionCancelRequestedEventAttributes struct {
 
 // String returns the string representation
 func (s ExternalWorkflowExecutionCancelRequestedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3520,7 +3520,7 @@ type metadataExternalWorkflowExecutionSignaledEventAttributes struct {
 
 // String returns the string representation
 func (s ExternalWorkflowExecutionSignaledEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3559,7 +3559,7 @@ type metadataFailWorkflowExecutionDecisionAttributes struct {
 
 // String returns the string representation
 func (s FailWorkflowExecutionDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3592,7 +3592,7 @@ type metadataFailWorkflowExecutionFailedEventAttributes struct {
 
 // String returns the string representation
 func (s FailWorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3637,7 +3637,7 @@ type metadataGetWorkflowExecutionHistoryInput struct {
 
 // String returns the string representation
 func (s GetWorkflowExecutionHistoryInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3669,7 +3669,7 @@ type metadataGetWorkflowExecutionHistoryOutput struct {
 
 // String returns the string representation
 func (s GetWorkflowExecutionHistoryOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -3981,7 +3981,7 @@ type metadataHistoryEvent struct {
 
 // String returns the string representation
 func (s HistoryEvent) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4029,7 +4029,7 @@ type metadataListActivityTypesInput struct {
 
 // String returns the string representation
 func (s ListActivityTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4059,7 +4059,7 @@ type metadataListActivityTypesOutput struct {
 
 // String returns the string representation
 func (s ListActivityTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4146,7 +4146,7 @@ type metadataListClosedWorkflowExecutionsInput struct {
 
 // String returns the string representation
 func (s ListClosedWorkflowExecutionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4188,7 +4188,7 @@ type metadataListDomainsInput struct {
 
 // String returns the string representation
 func (s ListDomainsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4218,7 +4218,7 @@ type metadataListDomainsOutput struct {
 
 // String returns the string representation
 func (s ListDomainsOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4283,7 +4283,7 @@ type metadataListOpenWorkflowExecutionsInput struct {
 
 // String returns the string representation
 func (s ListOpenWorkflowExecutionsInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4332,7 +4332,7 @@ type metadataListWorkflowTypesInput struct {
 
 // String returns the string representation
 func (s ListWorkflowTypesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4362,7 +4362,7 @@ type metadataListWorkflowTypesOutput struct {
 
 // String returns the string representation
 func (s ListWorkflowTypesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4393,7 +4393,7 @@ type metadataMarkerRecordedEventAttributes struct {
 
 // String returns the string representation
 func (s MarkerRecordedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4419,7 +4419,7 @@ type metadataPendingTaskCount struct {
 
 // String returns the string representation
 func (s PendingTaskCount) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4453,7 +4453,7 @@ type metadataPollForActivityTaskInput struct {
 
 // String returns the string representation
 func (s PollForActivityTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4493,7 +4493,7 @@ type metadataPollForActivityTaskOutput struct {
 
 // String returns the string representation
 func (s PollForActivityTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4553,7 +4553,7 @@ type metadataPollForDecisionTaskInput struct {
 
 // String returns the string representation
 func (s PollForDecisionTaskInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4605,7 +4605,7 @@ type metadataPollForDecisionTaskOutput struct {
 
 // String returns the string representation
 func (s PollForDecisionTaskOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4633,7 +4633,7 @@ type metadataRecordActivityTaskHeartbeatInput struct {
 
 // String returns the string representation
 func (s RecordActivityTaskHeartbeatInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4655,7 +4655,7 @@ type metadataRecordActivityTaskHeartbeatOutput struct {
 
 // String returns the string representation
 func (s RecordActivityTaskHeartbeatOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4694,7 +4694,7 @@ type metadataRecordMarkerDecisionAttributes struct {
 
 // String returns the string representation
 func (s RecordMarkerDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4730,7 +4730,7 @@ type metadataRecordMarkerFailedEventAttributes struct {
 
 // String returns the string representation
 func (s RecordMarkerFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4823,7 +4823,7 @@ type metadataRegisterActivityTypeInput struct {
 
 // String returns the string representation
 func (s RegisterActivityTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4841,7 +4841,7 @@ type metadataRegisterActivityTypeOutput struct {
 
 // String returns the string representation
 func (s RegisterActivityTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4884,7 +4884,7 @@ type metadataRegisterDomainInput struct {
 
 // String returns the string representation
 func (s RegisterDomainInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4902,7 +4902,7 @@ type metadataRegisterDomainOutput struct {
 
 // String returns the string representation
 func (s RegisterDomainOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -4995,7 +4995,7 @@ type metadataRegisterWorkflowTypeInput struct {
 
 // String returns the string representation
 func (s RegisterWorkflowTypeInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5013,7 +5013,7 @@ type metadataRegisterWorkflowTypeOutput struct {
 
 // String returns the string representation
 func (s RegisterWorkflowTypeOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5049,7 +5049,7 @@ type metadataRequestCancelActivityTaskDecisionAttributes struct {
 
 // String returns the string representation
 func (s RequestCancelActivityTaskDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5085,7 +5085,7 @@ type metadataRequestCancelActivityTaskFailedEventAttributes struct {
 
 // String returns the string representation
 func (s RequestCancelActivityTaskFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5128,7 +5128,7 @@ type metadataRequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 
 // String returns the string representation
 func (s RequestCancelExternalWorkflowExecutionDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5176,7 +5176,7 @@ type metadataRequestCancelExternalWorkflowExecutionFailedEventAttributes struct 
 
 // String returns the string representation
 func (s RequestCancelExternalWorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5211,7 +5211,7 @@ type metadataRequestCancelExternalWorkflowExecutionInitiatedEventAttributes stru
 
 // String returns the string representation
 func (s RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5238,7 +5238,7 @@ type metadataRequestCancelWorkflowExecutionInput struct {
 
 // String returns the string representation
 func (s RequestCancelWorkflowExecutionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5256,7 +5256,7 @@ type metadataRequestCancelWorkflowExecutionOutput struct {
 
 // String returns the string representation
 func (s RequestCancelWorkflowExecutionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5284,7 +5284,7 @@ type metadataRespondActivityTaskCanceledInput struct {
 
 // String returns the string representation
 func (s RespondActivityTaskCanceledInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5302,7 +5302,7 @@ type metadataRespondActivityTaskCanceledOutput struct {
 
 // String returns the string representation
 func (s RespondActivityTaskCanceledOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5331,7 +5331,7 @@ type metadataRespondActivityTaskCompletedInput struct {
 
 // String returns the string representation
 func (s RespondActivityTaskCompletedInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5349,7 +5349,7 @@ type metadataRespondActivityTaskCompletedOutput struct {
 
 // String returns the string representation
 func (s RespondActivityTaskCompletedOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5380,7 +5380,7 @@ type metadataRespondActivityTaskFailedInput struct {
 
 // String returns the string representation
 func (s RespondActivityTaskFailedInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5398,7 +5398,7 @@ type metadataRespondActivityTaskFailedOutput struct {
 
 // String returns the string representation
 func (s RespondActivityTaskFailedOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5430,7 +5430,7 @@ type metadataRespondDecisionTaskCompletedInput struct {
 
 // String returns the string representation
 func (s RespondDecisionTaskCompletedInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5448,7 +5448,7 @@ type metadataRespondDecisionTaskCompletedOutput struct {
 
 // String returns the string representation
 func (s RespondDecisionTaskCompletedOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5574,7 +5574,7 @@ type metadataScheduleActivityTaskDecisionAttributes struct {
 
 // String returns the string representation
 func (s ScheduleActivityTaskDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5613,7 +5613,7 @@ type metadataScheduleActivityTaskFailedEventAttributes struct {
 
 // String returns the string representation
 func (s ScheduleActivityTaskFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5664,7 +5664,7 @@ type metadataSignalExternalWorkflowExecutionDecisionAttributes struct {
 
 // String returns the string representation
 func (s SignalExternalWorkflowExecutionDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5713,7 +5713,7 @@ type metadataSignalExternalWorkflowExecutionFailedEventAttributes struct {
 
 // String returns the string representation
 func (s SignalExternalWorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5754,7 +5754,7 @@ type metadataSignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 
 // String returns the string representation
 func (s SignalExternalWorkflowExecutionInitiatedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5788,7 +5788,7 @@ type metadataSignalWorkflowExecutionInput struct {
 
 // String returns the string representation
 func (s SignalWorkflowExecutionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5806,7 +5806,7 @@ type metadataSignalWorkflowExecutionOutput struct {
 
 // String returns the string representation
 func (s SignalWorkflowExecutionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5933,7 +5933,7 @@ type metadataStartChildWorkflowExecutionDecisionAttributes struct {
 
 // String returns the string representation
 func (s StartChildWorkflowExecutionDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -5981,7 +5981,7 @@ type metadataStartChildWorkflowExecutionFailedEventAttributes struct {
 
 // String returns the string representation
 func (s StartChildWorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6062,7 +6062,7 @@ type metadataStartChildWorkflowExecutionInitiatedEventAttributes struct {
 
 // String returns the string representation
 func (s StartChildWorkflowExecutionInitiatedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6113,7 +6113,7 @@ type metadataStartTimerDecisionAttributes struct {
 
 // String returns the string representation
 func (s StartTimerDecisionAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6149,7 +6149,7 @@ type metadataStartTimerFailedEventAttributes struct {
 
 // String returns the string representation
 func (s StartTimerFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6267,7 +6267,7 @@ type metadataStartWorkflowExecutionInput struct {
 
 // String returns the string representation
 func (s StartWorkflowExecutionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6290,7 +6290,7 @@ type metadataStartWorkflowExecutionOutput struct {
 
 // String returns the string representation
 func (s StartWorkflowExecutionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6313,7 +6313,7 @@ type metadataTagFilter struct {
 
 // String returns the string representation
 func (s TagFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6335,7 +6335,7 @@ type metadataTaskList struct {
 
 // String returns the string representation
 func (s TaskList) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6386,7 +6386,7 @@ type metadataTerminateWorkflowExecutionInput struct {
 
 // String returns the string representation
 func (s TerminateWorkflowExecutionInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6404,7 +6404,7 @@ type metadataTerminateWorkflowExecutionOutput struct {
 
 // String returns the string representation
 func (s TerminateWorkflowExecutionOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6437,7 +6437,7 @@ type metadataTimerCanceledEventAttributes struct {
 
 // String returns the string representation
 func (s TimerCanceledEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6464,7 +6464,7 @@ type metadataTimerFiredEventAttributes struct {
 
 // String returns the string representation
 func (s TimerFiredEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6502,7 +6502,7 @@ type metadataTimerStartedEventAttributes struct {
 
 // String returns the string representation
 func (s TimerStartedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6527,7 +6527,7 @@ type metadataWorkflowExecution struct {
 
 // String returns the string representation
 func (s WorkflowExecution) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6561,7 +6561,7 @@ type metadataWorkflowExecutionCancelRequestedEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionCancelRequestedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6589,7 +6589,7 @@ type metadataWorkflowExecutionCanceledEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionCanceledEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6617,7 +6617,7 @@ type metadataWorkflowExecutionCompletedEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionCompletedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6676,7 +6676,7 @@ type metadataWorkflowExecutionConfiguration struct {
 
 // String returns the string representation
 func (s WorkflowExecutionConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6743,7 +6743,7 @@ type metadataWorkflowExecutionContinuedAsNewEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionContinuedAsNewEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6770,7 +6770,7 @@ type metadataWorkflowExecutionCount struct {
 
 // String returns the string representation
 func (s WorkflowExecutionCount) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6801,7 +6801,7 @@ type metadataWorkflowExecutionFailedEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionFailedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6823,7 +6823,7 @@ type metadataWorkflowExecutionFilter struct {
 
 // String returns the string representation
 func (s WorkflowExecutionFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6882,7 +6882,7 @@ type metadataWorkflowExecutionInfo struct {
 
 // String returns the string representation
 func (s WorkflowExecutionInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6912,7 +6912,7 @@ type metadataWorkflowExecutionInfos struct {
 
 // String returns the string representation
 func (s WorkflowExecutionInfos) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6946,7 +6946,7 @@ type metadataWorkflowExecutionOpenCounts struct {
 
 // String returns the string representation
 func (s WorkflowExecutionOpenCounts) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -6985,7 +6985,7 @@ type metadataWorkflowExecutionSignaledEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionSignaledEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7061,7 +7061,7 @@ type metadataWorkflowExecutionStartedEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionStartedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7102,7 +7102,7 @@ type metadataWorkflowExecutionTerminatedEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionTerminatedEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7135,7 +7135,7 @@ type metadataWorkflowExecutionTimedOutEventAttributes struct {
 
 // String returns the string representation
 func (s WorkflowExecutionTimedOutEventAttributes) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7166,7 +7166,7 @@ type metadataWorkflowType struct {
 
 // String returns the string representation
 func (s WorkflowType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7240,7 +7240,7 @@ type metadataWorkflowTypeConfiguration struct {
 
 // String returns the string representation
 func (s WorkflowTypeConfiguration) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7266,7 +7266,7 @@ type metadataWorkflowTypeFilter struct {
 
 // String returns the string representation
 func (s WorkflowTypeFilter) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -7301,7 +7301,7 @@ type metadataWorkflowTypeInfo struct {
 
 // String returns the string representation
 func (s WorkflowTypeInfo) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/swf/examples_test.go
+++ b/service/swf/examples_test.go
@@ -61,7 +61,7 @@ func ExampleSWF_CountClosedWorkflowExecutions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_CountOpenWorkflowExecutions() {
@@ -102,7 +102,7 @@ func ExampleSWF_CountOpenWorkflowExecutions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_CountPendingActivityTasks() {
@@ -132,7 +132,7 @@ func ExampleSWF_CountPendingActivityTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_CountPendingDecisionTasks() {
@@ -162,7 +162,7 @@ func ExampleSWF_CountPendingDecisionTasks() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_DeprecateActivityType() {
@@ -193,7 +193,7 @@ func ExampleSWF_DeprecateActivityType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_DeprecateDomain() {
@@ -220,7 +220,7 @@ func ExampleSWF_DeprecateDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_DeprecateWorkflowType() {
@@ -251,7 +251,7 @@ func ExampleSWF_DeprecateWorkflowType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_DescribeActivityType() {
@@ -282,7 +282,7 @@ func ExampleSWF_DescribeActivityType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_DescribeDomain() {
@@ -309,7 +309,7 @@ func ExampleSWF_DescribeDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_DescribeWorkflowExecution() {
@@ -340,7 +340,7 @@ func ExampleSWF_DescribeWorkflowExecution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_DescribeWorkflowType() {
@@ -371,7 +371,7 @@ func ExampleSWF_DescribeWorkflowType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_GetWorkflowExecutionHistory() {
@@ -383,9 +383,9 @@ func ExampleSWF_GetWorkflowExecutionHistory() {
 			RunID:      aws.String("RunId"),      // Required
 			WorkflowID: aws.String("WorkflowId"), // Required
 		},
-		MaximumPageSize: aws.Long(1),
+		MaximumPageSize: aws.Int64(1),
 		NextPageToken:   aws.String("PageToken"),
-		ReverseOrder:    aws.Boolean(true),
+		ReverseOrder:    aws.Bool(true),
 	}
 	resp, err := svc.GetWorkflowExecutionHistory(params)
 
@@ -405,7 +405,7 @@ func ExampleSWF_GetWorkflowExecutionHistory() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_ListActivityTypes() {
@@ -414,10 +414,10 @@ func ExampleSWF_ListActivityTypes() {
 	params := &swf.ListActivityTypesInput{
 		Domain:             aws.String("DomainName"),         // Required
 		RegistrationStatus: aws.String("RegistrationStatus"), // Required
-		MaximumPageSize:    aws.Long(1),
+		MaximumPageSize:    aws.Int64(1),
 		Name:               aws.String("Name"),
 		NextPageToken:      aws.String("PageToken"),
-		ReverseOrder:       aws.Boolean(true),
+		ReverseOrder:       aws.Bool(true),
 	}
 	resp, err := svc.ListActivityTypes(params)
 
@@ -437,7 +437,7 @@ func ExampleSWF_ListActivityTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_ListClosedWorkflowExecutions() {
@@ -455,9 +455,9 @@ func ExampleSWF_ListClosedWorkflowExecutions() {
 		ExecutionFilter: &swf.WorkflowExecutionFilter{
 			WorkflowID: aws.String("WorkflowId"), // Required
 		},
-		MaximumPageSize: aws.Long(1),
+		MaximumPageSize: aws.Int64(1),
 		NextPageToken:   aws.String("PageToken"),
-		ReverseOrder:    aws.Boolean(true),
+		ReverseOrder:    aws.Bool(true),
 		StartTimeFilter: &swf.ExecutionTimeFilter{
 			OldestDate: aws.Time(time.Now()), // Required
 			LatestDate: aws.Time(time.Now()),
@@ -488,7 +488,7 @@ func ExampleSWF_ListClosedWorkflowExecutions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_ListDomains() {
@@ -496,9 +496,9 @@ func ExampleSWF_ListDomains() {
 
 	params := &swf.ListDomainsInput{
 		RegistrationStatus: aws.String("RegistrationStatus"), // Required
-		MaximumPageSize:    aws.Long(1),
+		MaximumPageSize:    aws.Int64(1),
 		NextPageToken:      aws.String("PageToken"),
-		ReverseOrder:       aws.Boolean(true),
+		ReverseOrder:       aws.Bool(true),
 	}
 	resp, err := svc.ListDomains(params)
 
@@ -518,7 +518,7 @@ func ExampleSWF_ListDomains() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_ListOpenWorkflowExecutions() {
@@ -533,9 +533,9 @@ func ExampleSWF_ListOpenWorkflowExecutions() {
 		ExecutionFilter: &swf.WorkflowExecutionFilter{
 			WorkflowID: aws.String("WorkflowId"), // Required
 		},
-		MaximumPageSize: aws.Long(1),
+		MaximumPageSize: aws.Int64(1),
 		NextPageToken:   aws.String("PageToken"),
-		ReverseOrder:    aws.Boolean(true),
+		ReverseOrder:    aws.Bool(true),
 		TagFilter: &swf.TagFilter{
 			Tag: aws.String("Tag"), // Required
 		},
@@ -562,7 +562,7 @@ func ExampleSWF_ListOpenWorkflowExecutions() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_ListWorkflowTypes() {
@@ -571,10 +571,10 @@ func ExampleSWF_ListWorkflowTypes() {
 	params := &swf.ListWorkflowTypesInput{
 		Domain:             aws.String("DomainName"),         // Required
 		RegistrationStatus: aws.String("RegistrationStatus"), // Required
-		MaximumPageSize:    aws.Long(1),
+		MaximumPageSize:    aws.Int64(1),
 		Name:               aws.String("Name"),
 		NextPageToken:      aws.String("PageToken"),
-		ReverseOrder:       aws.Boolean(true),
+		ReverseOrder:       aws.Bool(true),
 	}
 	resp, err := svc.ListWorkflowTypes(params)
 
@@ -594,7 +594,7 @@ func ExampleSWF_ListWorkflowTypes() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_PollForActivityTask() {
@@ -625,7 +625,7 @@ func ExampleSWF_PollForActivityTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_PollForDecisionTask() {
@@ -637,9 +637,9 @@ func ExampleSWF_PollForDecisionTask() {
 			Name: aws.String("Name"), // Required
 		},
 		Identity:        aws.String("Identity"),
-		MaximumPageSize: aws.Long(1),
+		MaximumPageSize: aws.Int64(1),
 		NextPageToken:   aws.String("PageToken"),
-		ReverseOrder:    aws.Boolean(true),
+		ReverseOrder:    aws.Bool(true),
 	}
 	resp, err := svc.PollForDecisionTask(params)
 
@@ -659,7 +659,7 @@ func ExampleSWF_PollForDecisionTask() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RecordActivityTaskHeartbeat() {
@@ -687,7 +687,7 @@ func ExampleSWF_RecordActivityTaskHeartbeat() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RegisterActivityType() {
@@ -725,7 +725,7 @@ func ExampleSWF_RegisterActivityType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RegisterDomain() {
@@ -754,7 +754,7 @@ func ExampleSWF_RegisterDomain() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RegisterWorkflowType() {
@@ -791,7 +791,7 @@ func ExampleSWF_RegisterWorkflowType() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RequestCancelWorkflowExecution() {
@@ -820,7 +820,7 @@ func ExampleSWF_RequestCancelWorkflowExecution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RespondActivityTaskCanceled() {
@@ -848,7 +848,7 @@ func ExampleSWF_RespondActivityTaskCanceled() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RespondActivityTaskCompleted() {
@@ -876,7 +876,7 @@ func ExampleSWF_RespondActivityTaskCompleted() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RespondActivityTaskFailed() {
@@ -905,7 +905,7 @@ func ExampleSWF_RespondActivityTaskFailed() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_RespondDecisionTaskCompleted() {
@@ -1028,7 +1028,7 @@ func ExampleSWF_RespondDecisionTaskCompleted() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_SignalWorkflowExecution() {
@@ -1059,7 +1059,7 @@ func ExampleSWF_SignalWorkflowExecution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_StartWorkflowExecution() {
@@ -1103,7 +1103,7 @@ func ExampleSWF_StartWorkflowExecution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleSWF_TerminateWorkflowExecution() {
@@ -1135,5 +1135,5 @@ func ExampleSWF_TerminateWorkflowExecution() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -306,7 +306,7 @@ type metadataComputeType struct {
 
 // String returns the string representation
 func (s ComputeType) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -328,7 +328,7 @@ type metadataCreateWorkspacesInput struct {
 
 // String returns the string representation
 func (s CreateWorkspacesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -357,7 +357,7 @@ type metadataCreateWorkspacesOutput struct {
 
 // String returns the string representation
 func (s CreateWorkspacesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -394,7 +394,7 @@ type metadataDefaultWorkspaceCreationProperties struct {
 
 // String returns the string representation
 func (s DefaultWorkspaceCreationProperties) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -430,7 +430,7 @@ type metadataDescribeWorkspaceBundlesInput struct {
 
 // String returns the string representation
 func (s DescribeWorkspaceBundlesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -457,7 +457,7 @@ type metadataDescribeWorkspaceBundlesOutput struct {
 
 // String returns the string representation
 func (s DescribeWorkspaceBundlesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -484,7 +484,7 @@ type metadataDescribeWorkspaceDirectoriesInput struct {
 
 // String returns the string representation
 func (s DescribeWorkspaceDirectoriesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -511,7 +511,7 @@ type metadataDescribeWorkspaceDirectoriesOutput struct {
 
 // String returns the string representation
 func (s DescribeWorkspaceDirectoriesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -560,7 +560,7 @@ type metadataDescribeWorkspacesInput struct {
 
 // String returns the string representation
 func (s DescribeWorkspacesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -590,7 +590,7 @@ type metadataDescribeWorkspacesOutput struct {
 
 // String returns the string representation
 func (s DescribeWorkspacesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -619,7 +619,7 @@ type metadataFailedCreateWorkspaceRequest struct {
 
 // String returns the string representation
 func (s FailedCreateWorkspaceRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -648,7 +648,7 @@ type metadataFailedWorkspaceChangeRequest struct {
 
 // String returns the string representation
 func (s FailedWorkspaceChangeRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -671,7 +671,7 @@ type metadataRebootRequest struct {
 
 // String returns the string representation
 func (s RebootRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -693,7 +693,7 @@ type metadataRebootWorkspacesInput struct {
 
 // String returns the string representation
 func (s RebootWorkspacesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -715,7 +715,7 @@ type metadataRebootWorkspacesOutput struct {
 
 // String returns the string representation
 func (s RebootWorkspacesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -738,7 +738,7 @@ type metadataRebuildRequest struct {
 
 // String returns the string representation
 func (s RebuildRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -760,7 +760,7 @@ type metadataRebuildWorkspacesInput struct {
 
 // String returns the string representation
 func (s RebuildWorkspacesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -782,7 +782,7 @@ type metadataRebuildWorkspacesOutput struct {
 
 // String returns the string representation
 func (s RebuildWorkspacesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -805,7 +805,7 @@ type metadataTerminateRequest struct {
 
 // String returns the string representation
 func (s TerminateRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -827,7 +827,7 @@ type metadataTerminateWorkspacesInput struct {
 
 // String returns the string representation
 func (s TerminateWorkspacesInput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -849,7 +849,7 @@ type metadataTerminateWorkspacesOutput struct {
 
 // String returns the string representation
 func (s TerminateWorkspacesOutput) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -871,7 +871,7 @@ type metadataUserStorage struct {
 
 // String returns the string representation
 func (s UserStorage) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -919,7 +919,7 @@ type metadataWorkspace struct {
 
 // String returns the string representation
 func (s Workspace) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -958,7 +958,7 @@ type metadataWorkspaceBundle struct {
 
 // String returns the string representation
 func (s WorkspaceBundle) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1019,7 +1019,7 @@ type metadataWorkspaceDirectory struct {
 
 // String returns the string representation
 func (s WorkspaceDirectory) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation
@@ -1052,7 +1052,7 @@ type metadataWorkspaceRequest struct {
 
 // String returns the string representation
 func (s WorkspaceRequest) String() string {
-	return awsutil.StringValue(s)
+	return awsutil.Prettify(s)
 }
 
 // GoString returns the string representation

--- a/service/workspaces/examples_test.go
+++ b/service/workspaces/examples_test.go
@@ -47,7 +47,7 @@ func ExampleWorkSpaces_CreateWorkspaces() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleWorkSpaces_DescribeWorkspaceBundles() {
@@ -79,7 +79,7 @@ func ExampleWorkSpaces_DescribeWorkspaceBundles() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleWorkSpaces_DescribeWorkspaceDirectories() {
@@ -110,7 +110,7 @@ func ExampleWorkSpaces_DescribeWorkspaceDirectories() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleWorkSpaces_DescribeWorkspaces() {
@@ -119,7 +119,7 @@ func ExampleWorkSpaces_DescribeWorkspaces() {
 	params := &workspaces.DescribeWorkspacesInput{
 		BundleID:    aws.String("BundleId"),
 		DirectoryID: aws.String("DirectoryId"),
-		Limit:       aws.Long(1),
+		Limit:       aws.Int64(1),
 		NextToken:   aws.String("PaginationToken"),
 		UserName:    aws.String("UserName"),
 		WorkspaceIDs: []*string{
@@ -145,7 +145,7 @@ func ExampleWorkSpaces_DescribeWorkspaces() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleWorkSpaces_RebootWorkspaces() {
@@ -177,7 +177,7 @@ func ExampleWorkSpaces_RebootWorkspaces() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleWorkSpaces_RebuildWorkspaces() {
@@ -209,7 +209,7 @@ func ExampleWorkSpaces_RebuildWorkspaces() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }
 
 func ExampleWorkSpaces_TerminateWorkspaces() {
@@ -241,5 +241,5 @@ func ExampleWorkSpaces_TerminateWorkspaces() {
 	}
 
 	// Pretty-print the response data.
-	fmt.Println(awsutil.StringValue(resp))
+	fmt.Println(awsutil.Prettify(resp))
 }


### PR DESCRIPTION
This change refactors the SDK so that Config fields are pointers instead of
values. Primarily this change fixes the bug preventing setting Config fields
to the field's zero value when creating new service client instances.

```go
svc := s3.New(&aws.Config{
    Region:     aws.String("us-west-2"),
    MaxRetries: aws.Int(10),
})
```

Additionally builder pattern `WithX` methods were added to Config. These
methods can be chained so inline building of Config objects can be done
without using pointers for the fields.

```go
svc := s3.New(aws.NewConfig().WithRegion("us-west-2").WithMaxRetries(10))
```

Additionally For consistency and discoverability the Boolean,Long, and Double helper
methods were renamed to Bool, Int64, and Float64 respectively. awsutil.StringValue
was also renamed to awsutil.Prettify to prevent confusion with the more common aws.StringValue func.

Fixes #157
Fixes #276
Fixes #124