### PR TITLE
aws/awslog: Add Logger interface and default logger to SDK

### DIFF
--- a/aws/awslog/logger.go
+++ b/aws/awslog/logger.go
@@ -1,0 +1,31 @@
+// Package awslog provides a minimalistic interface for the SDK to log messages to.
+package awslog
+
+import (
+	"log"
+	"os"
+)
+
+// A Logger is a minimalistic interface for the SDK to log messages to. Should
+// be used to provide custom logging writers for the SDK to use.
+type Logger interface {
+	Log(...interface{})
+}
+
+// NewDefaultLogger returns a Logger which will write log messages to stdout, and
+// use same formatting runes as the stdlib log.Logger
+func NewDefaultLogger() Logger {
+	return &defaultLogger{
+		logger: log.New(os.Stdout, "", log.LstdFlags),
+	}
+}
+
+// A defaultLogger provides a minimalistic logger satisfying the Logger interface.
+type defaultLogger struct {
+	logger *log.Logger
+}
+
+// Log logs the parameters to the stdlib logger. See log.Println.
+func (l defaultLogger) Log(args ...interface{}) {
+	l.logger.Println(args...)
+}

--- a/aws/config.go
+++ b/aws/config.go
@@ -1,11 +1,11 @@
 package aws
 
 import (
-	"io"
 	"net/http"
 	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awslog"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
@@ -25,6 +25,45 @@ var DefaultChainCredentials = credentials.NewChainCredentials(
 // the service specific retry default will be used.
 const DefaultRetries = -1
 
+// A LogLevel defines the level logging should be performed at. Used to instruct
+// the SDK which statements should be logged.
+type LogLevel uint
+
+// Matches returns true if the v LogLevel is enabled by this LogLevel. Should be
+// used with logging sub levels.
+func (l LogLevel) Matches(v LogLevel) bool {
+	return l&v == v
+}
+
+// AtLeast returns true if this LogLevel is at least high enough to satisfies v.
+func (l LogLevel) AtLeast(v LogLevel) bool {
+	return l >= v
+}
+
+const (
+	// LogOff states that no logging should be performed by the SDK. This is the
+	// default state of the SDK, and should be use to disable all logging.
+	LogOff LogLevel = iota * 0x1000
+
+	// LogDebug state that debug output should be logged by the SDK. This should
+	// be used to inspect request made and responses received.
+	LogDebug
+)
+
+// Debug Logging Sub Levels
+const (
+	// LogDebugWithSigning states that the SDK should log request signing and
+	// presigning events. This should be used to log the signing details of
+	// requests for debugging. Will also enable LogDebug.
+	LogDebugWithSigning LogLevel = LogDebug | (1 << iota)
+
+	// LogDebugWithHTTPBody states the SDK should log HTTP request and response
+	// HTTP bodys in addition to the headers and path. This should be used to
+	// see the body content of requests and responses made while using the SDK
+	// Will also enable LogDebug.
+	LogDebugWithHTTPBody
+)
+
 // DefaultConfig is the default all service configuration will be based off of.
 // By default, all clients use this structure for initialization options unless
 // a custom configuration object is passed in.
@@ -38,9 +77,8 @@ var DefaultConfig = &Config{
 	Region:                  os.Getenv("AWS_REGION"),
 	DisableSSL:              false,
 	HTTPClient:              http.DefaultClient,
-	LogHTTPBody:             false,
-	LogLevel:                0,
-	Logger:                  os.Stdout,
+	LogLevel:                LogOff,
+	Logger:                  awslog.NewDefaultLogger(),
 	MaxRetries:              DefaultRetries,
 	DisableParamValidation:  false,
 	DisableComputeChecksums: false,
@@ -79,21 +117,14 @@ type Config struct {
 	// `http.DefaultClient`.
 	HTTPClient *http.Client
 
-	// Set this to `true` to also log the body of the HTTP requests made by the
-	// client.
-	//
-	// @note `LogLevel` must be set to a non-zero value in order to activate
-	//   body logging.
-	LogHTTPBody bool
-
 	// An integer value representing the logging level. The default log level
-	// is zero (0), which represents no logging. Set to a non-zero value to
-	// perform logging.
-	LogLevel uint
+	// is zero (LogOff), which represents no logging. To enable logging set
+	// to a LogLevel Value.
+	LogLevel LogLevel
 
 	// The logger writer interface to write logging messages to. Defaults to
 	// standard out.
-	Logger io.Writer
+	Logger awslog.Logger
 
 	// The maximum number of times that a request will be retried for failures.
 	// Defaults to -1, which defers the max retry setting to the service specific
@@ -127,7 +158,6 @@ func (c Config) Copy() Config {
 	dst.Region = c.Region
 	dst.DisableSSL = c.DisableSSL
 	dst.HTTPClient = c.HTTPClient
-	dst.LogHTTPBody = c.LogHTTPBody
 	dst.LogLevel = c.LogLevel
 	dst.Logger = c.Logger
 	dst.MaxRetries = c.MaxRetries
@@ -178,12 +208,6 @@ func (c Config) Merge(newcfg *Config) *Config {
 		cfg.HTTPClient = newcfg.HTTPClient
 	} else {
 		cfg.HTTPClient = c.HTTPClient
-	}
-
-	if newcfg.LogHTTPBody {
-		cfg.LogHTTPBody = newcfg.LogHTTPBody
-	} else {
-		cfg.LogHTTPBody = c.LogHTTPBody
 	}
 
 	if newcfg.LogLevel != 0 {

--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"net/http"
-	"os"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awslog"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
@@ -24,9 +24,8 @@ var copyTestConfig = Config{
 	Region:                  "COPY_TEST_AWS_REGION",
 	DisableSSL:              true,
 	HTTPClient:              http.DefaultClient,
-	LogHTTPBody:             true,
-	LogLevel:                2,
-	Logger:                  os.Stdout,
+	LogLevel:                LogDebug,
+	Logger:                  awslog.NewDefaultLogger(),
 	MaxRetries:              DefaultRetries,
 	DisableParamValidation:  true,
 	DisableComputeChecksums: true,
@@ -58,9 +57,8 @@ var mergeTestConfig = Config{
 	Region:                  "MERGE_TEST_AWS_REGION",
 	DisableSSL:              true,
 	HTTPClient:              http.DefaultClient,
-	LogHTTPBody:             true,
-	LogLevel:                2,
-	Logger:                  os.Stdout,
+	LogLevel:                LogDebug,
+	Logger:                  awslog.NewDefaultLogger(),
 	MaxRetries:              10,
 	DisableParamValidation:  true,
 	DisableComputeChecksums: true,

--- a/aws/service.go
+++ b/aws/service.go
@@ -91,30 +91,41 @@ func (s *Service) buildEndpoint() {
 // AddDebugHandlers injects debug logging handlers into the service to log request
 // debug information.
 func (s *Service) AddDebugHandlers() {
-	out := s.Config.Logger
-	if s.Config.LogLevel == 0 {
+	if !s.Config.LogLevel.AtLeast(LogDebug) {
 		return
 	}
 
-	s.Handlers.Send.PushFront(func(r *Request) {
-		logBody := r.Config.LogHTTPBody
-		dumpedBody, _ := httputil.DumpRequestOut(r.HTTPRequest, logBody)
+	s.Handlers.Send.PushFront(logRequest)
+	s.Handlers.Send.PushBack(logResponse)
+}
 
-		fmt.Fprintf(out, "---[ REQUEST POST-SIGN ]-----------------------------\n")
-		fmt.Fprintf(out, "%s\n", string(dumpedBody))
-		fmt.Fprintf(out, "-----------------------------------------------------\n")
-	})
-	s.Handlers.Send.PushBack(func(r *Request) {
-		fmt.Fprintf(out, "---[ RESPONSE ]--------------------------------------\n")
-		if r.HTTPResponse != nil {
-			logBody := r.Config.LogHTTPBody
-			dumpedBody, _ := httputil.DumpResponse(r.HTTPResponse, logBody)
-			fmt.Fprintf(out, "%s\n", string(dumpedBody))
-		} else if r.Error != nil {
-			fmt.Fprintf(out, "%s\n", r.Error)
-		}
-		fmt.Fprintf(out, "-----------------------------------------------------\n")
-	})
+const logReqMsg = `DEBUG: Request %s/%s Details:
+---[ REQUEST POST-SIGN ]-----------------------------
+%s
+-----------------------------------------------------`
+
+func logRequest(r *Request) {
+	logBody := r.Config.LogLevel.Matches(LogDebugWithHTTPBody)
+	dumpedBody, _ := httputil.DumpRequestOut(r.HTTPRequest, logBody)
+
+	r.Config.Logger.Log(fmt.Sprintf(logReqMsg, r.ServiceName, r.Operation.Name, string(dumpedBody)))
+}
+
+const logRespMsg = `DEBUG: Response %s/%s Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`
+
+func logResponse(r *Request) {
+	var msg = "no reponse data"
+	if r.HTTPResponse != nil {
+		logBody := r.Config.LogLevel.Matches(LogDebugWithHTTPBody)
+		dumpedBody, _ := httputil.DumpResponse(r.HTTPResponse, logBody)
+		msg = string(dumpedBody)
+	} else if r.Error != nil {
+		msg = r.Error.Error()
+	}
+	r.Config.Logger.Log(fmt.Sprintf(logRespMsg, r.ServiceName, r.Operation.Name, msg))
 }
 
 // MaxRetries returns the number of maximum returns the service will use to make

--- a/internal/features/shared/shared.go
+++ b/internal/features/shared/shared.go
@@ -26,11 +26,13 @@ const Imported = true
 
 func init() {
 	if os.Getenv("DEBUG") != "" {
-		aws.DefaultConfig.LogLevel = 1
+		aws.DefaultConfig.LogLevel = aws.LogDebug
+	}
+	if os.Getenv("DEBUG_SIGNING") != "" {
+		aws.DefaultConfig.LogLevel = aws.LogDebugWithSigning
 	}
 	if os.Getenv("DEBUG_BODY") != "" {
-		aws.DefaultConfig.LogLevel = 1
-		aws.DefaultConfig.LogHTTPBody = true
+		aws.DefaultConfig.LogLevel = aws.LogDebugWithSigning | aws.LogDebugWithHTTPBody
 	}
 
 	When(`^I call the "(.+?)" API$`, func(op string) {

--- a/internal/signer/v4/v4.go
+++ b/internal/signer/v4/v4.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/internal/protocol/rest"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awslog"
 )
 
 const (
@@ -43,8 +44,8 @@ type signer struct {
 	Credentials *credentials.Credentials
 	Query       url.Values
 	Body        io.ReadSeeker
-	Debug       uint
-	Logger      io.Writer
+	Debug       aws.LogLevel
+	Logger      awslog.Logger
 
 	isPresign          bool
 	formattedTime      string
@@ -138,28 +139,33 @@ func (v4 *signer) sign() error {
 
 	v4.build()
 
-	if v4.Debug > 0 {
+	if v4.Debug.Matches(aws.LogDebugWithSigning) {
 		v4.logSigningInfo()
 	}
 
 	return nil
 }
 
+const logSignInfoMsg = `DEBUG: Request Signiture:
+---[ CANONICAL STRING  ]-----------------------------
+%s
+---[ STRING TO SIGN ]--------------------------------
+%s%s
+-----------------------------------------------------`
+const logSignedURLMsg = `
+---[ SIGNED URL ]------------------------------------
+%s`
+
 func (v4 *signer) logSigningInfo() {
-	out := v4.Logger
-	fmt.Fprintf(out, "---[ CANONICAL STRING  ]-----------------------------\n")
-	fmt.Fprintln(out, v4.canonicalString)
-	fmt.Fprintf(out, "---[ STRING TO SIGN ]--------------------------------\n")
-	fmt.Fprintln(out, v4.stringToSign)
+	signedURLMsg := ""
 	if v4.isPresign {
-		fmt.Fprintf(out, "---[ SIGNED URL ]--------------------------------\n")
-		fmt.Fprintln(out, v4.Request.URL)
+		signedURLMsg = fmt.Sprintf(logSignedURLMsg, v4.Request.URL.String())
 	}
-	fmt.Fprintf(out, "-----------------------------------------------------\n")
+	msg := fmt.Sprintf(logSignInfoMsg, v4.canonicalString, v4.stringToSign, signedURLMsg)
+	v4.Logger.Log(msg)
 }
 
 func (v4 *signer) build() {
-
 	v4.buildTime()             // no depends
 	v4.buildCredentialString() // no depends
 	if v4.isPresign {

--- a/internal/test/integration/integration.go
+++ b/internal/test/integration/integration.go
@@ -21,11 +21,13 @@ const Imported = true
 
 func init() {
 	if os.Getenv("DEBUG") != "" {
-		aws.DefaultConfig.LogLevel = 1
+		aws.DefaultConfig.LogLevel = aws.LogDebug
+	}
+	if os.Getenv("DEBUG_SIGNING") != "" {
+		aws.DefaultConfig.LogLevel = aws.LogDebugWithSigning
 	}
 	if os.Getenv("DEBUG_BODY") != "" {
-		aws.DefaultConfig.LogLevel = 1
-		aws.DefaultConfig.LogHTTPBody = true
+		aws.DefaultConfig.LogLevel = aws.LogDebugWithSigning | aws.LogDebugWithHTTPBody
 	}
 
 	if aws.DefaultConfig.Region == "" {


### PR DESCRIPTION
A logger interface which wrapps the stdlib log.Logger will now be the new
default logger for the SDK.  An interface awslog.Logger can be used to
create custom logger the SDK should use.

This is a minor breaking change which removes the aws.Config.LogHTTPBody,
replacing it with consts for logging level. By default the logging level
is Off, and only debug level is currently provided. This allows us to
make room for future growth without making future breaking changes.

Examples:
```go
// Enable debug logging of service requests and responses.
svc := s3.New(&aws.Config{LogLevel: aws.LogDebug})

// Enable debug Logging with request signing also
svc := s3.New(&aws.Config{LogLevel: aws.LogDebugWithSigning})

// Enable debug logging with request signing and HTTP body
svc := s3.New(&aws.Config{LogLevel: aws.LogDebugWithSigning | aws.LogDebugWithHTTPBody})

// Disable logging
svc := s3.New(&aws.Config{LoglLevel: aws.LogOff})

// Provide custom logger
type MyLogger struct{}
func (l MyLogger) Log(args ...interface{}) {
	fmt.Println(append([]interface{}{"AWS-SDK:"}, args...)...)
}
svc := s3.New(&aws.Config{Logger: &MyLogger{}}}
```