### PR TITLE
service/s3: Expires change to string in HeadObjectOutput and GetObjectOutput

### DIFF
--- a/internal/model/api/customization_passes.go
+++ b/internal/model/api/customization_passes.go
@@ -20,10 +20,28 @@ func (a *API) customizationPasses() {
 
 // s3Customizations customizes the API generation to replace values specific to S3.
 func s3Customizations(a *API) {
-	// Remove ContentMD5 members
-	for _, s := range a.Shapes {
+	var strExpires *Shape
+
+	for name, s := range a.Shapes {
+		// Remove ContentMD5 members
 		if _, ok := s.MemberRefs["ContentMD5"]; ok {
 			delete(s.MemberRefs, "ContentMD5")
+		}
+
+		// Expires should be a string not time.Time since the format is not
+		// enforced by S3, and any value can be set to this field outside of the SDK.
+		if strings.HasSuffix(name, "Output") {
+			if ref, ok := s.MemberRefs["Expires"]; ok {
+				if strExpires == nil {
+					newShape := *ref.Shape
+					strExpires = &newShape
+					strExpires.Type = "string"
+					strExpires.refs = []*ShapeRef{}
+				}
+				ref.Shape.removeRef(ref)
+				ref.Shape = strExpires
+				ref.Shape.refs = append(ref.Shape.refs, &s.MemberRef)
+			}
 		}
 	}
 

--- a/internal/model/api/shape.go
+++ b/internal/model/api/shape.go
@@ -332,3 +332,20 @@ func (s *Shape) IsRequired(member string) bool {
 func (s *Shape) IsInternal() bool {
 	return s.resolvePkg == ""
 }
+
+// removeRef removes a shape reference from the list of references this
+// shape is used in.
+func (s *Shape) removeRef(ref *ShapeRef) {
+	r := s.refs
+	for i := 0; i < len(r); i++ {
+		if r[i] == ref {
+			j:= i+1
+			copy(r[i:], r[j:])
+			for k, n := len(r)-j+i, len(r); k < n; k ++ {
+				r[k] = nil // free up the end of the list
+			} // for k
+			s.refs = r[:len(r)-j+i]
+			break
+		}
+	}
+}

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -3604,7 +3604,7 @@ type GetObjectOutput struct {
 	Expiration *string `location:"header" locationName:"x-amz-expiration" type:"string"`
 
 	// The date and time at which the object is no longer cacheable.
-	Expires *time.Time `location:"header" locationName:"Expires" type:"timestamp" timestampFormat:"rfc822"`
+	Expires *string `location:"header" locationName:"Expires" type:"string"`
 
 	// Last modified date of the object
 	LastModified *time.Time `location:"header" locationName:"Last-Modified" type:"timestamp" timestampFormat:"rfc822"`
@@ -3921,7 +3921,7 @@ type HeadObjectOutput struct {
 	Expiration *string `location:"header" locationName:"x-amz-expiration" type:"string"`
 
 	// The date and time at which the object is no longer cacheable.
-	Expires *time.Time `location:"header" locationName:"Expires" type:"timestamp" timestampFormat:"rfc822"`
+	Expires *string `location:"header" locationName:"Expires" type:"string"`
 
 	// Last modified date of the object
 	LastModified *time.Time `location:"header" locationName:"Last-Modified" type:"timestamp" timestampFormat:"rfc822"`


### PR DESCRIPTION
Since S3 does not enforce any formatting on the Expires field the SDK would fail
to process request response where the Expires field was not RFC822 (HTTP-Date) format.

To parse the time as RFC822 use the following sip

```go
t, err := time.Parse("Mon, 2 Jan 2006 15:04:05 GMT", expiresHeader)
```