### PR TITLE
Update README.md to reflect new param requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ func main() {
 	// Create an EC2 service object in the "us-west-2" region
 	// Note that you can also configure your region globally by
 	// exporting the AWS_REGION environment variable
-	svc := ec2.New(&aws.Config{Region: "us-west-2"})
+	svc := ec2.New(&aws.Config{Region: aws.String("us-west-2")})
 
 	// Call the DescribeInstances Operation
 	resp, err := svc.DescribeInstances(nil)


### PR DESCRIPTION
The `Region` parameter in `aws.Config` must be a string pointer, not a string. Update the example to show users how to instantiate the `aws.Config` object correctly using `aws.String` call.