### PR TITLE
Build against latest Go too (but allow failures)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: false
 
 go:
   - 1.4
+  - tip
 
 install: "go get -v -t ./... && make deps"
 script: make unit
+
+matrix:
+  allow_failures:
+    - go: tip


### PR DESCRIPTION
The current codebase is not compatible with the upcoming Go 1.5.

I'm not sure what approach do maintainers plan to take about `internal` package, but it should be probably solved, otherwise it will be difficult for any other project using this SDK w/ 1.5+.

Related: https://github.com/hashicorp/terraform/issues/2893