### PR TITLE
Fixed upload for 0 length files

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -331,6 +331,7 @@ func (u *uploader) nextReader() (io.ReadSeeker, error) {
 
 			if bytesLeft == 0 {
 				err = io.EOF
+				n = bytesLeft
 			} else if bytesLeft <= u.opts.PartSize {
 				err = io.ErrUnexpectedEOF
 				n = bytesLeft


### PR DESCRIPTION
When uploading 0 length files I got the error: send request failed, caused by: Put ... ContentLength=5242880 with Body length 0

Sample code to reproduce error:
```
package main

import (
	"bytes"
	"fmt"

	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/service/s3"
	"github.com/aws/aws-sdk-go/service/s3/s3manager"
)

func main() {
	s3client := s3.New(&aws.Config{Region: aws.String("us-east-1")})
	s3uploader := s3manager.NewUploader(&s3manager.UploadOptions{
		S3: s3client,
	})

	var data []byte
	_, err := s3uploader.Upload(&s3manager.UploadInput{
		Bucket: aws.String("test-bucket"),
		Key:    aws.String("test-file"),
		Body:   bytes.NewReader(data),
	})
	if err != nil {
		fmt.Println(err)
	}
}
```