### PR TITLE
Refactor handler architecture

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -164,6 +164,8 @@ func (c *Config) WithS3ForcePathStyle(force bool) *Config {
 	return c
 }
 
+// WithSleepDelay overrides the function used to sleep while waiting for the
+// next retry. Defaults to time.Sleep.
 func (c *Config) WithSleepDelay(fn func(time.Duration)) *Config {
 	c.SleepDelay = fn
 	return c

--- a/aws/config.go
+++ b/aws/config.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 )
@@ -73,6 +74,8 @@ type Config struct {
 	// @see http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
 	//   Amazon S3: Virtual Hosting of Buckets
 	S3ForcePathStyle *bool
+
+	SleepDelay func(time.Duration)
 }
 
 // NewConfig returns a new Config pointer that can be chained with builder methods to
@@ -161,6 +164,11 @@ func (c *Config) WithS3ForcePathStyle(force bool) *Config {
 	return c
 }
 
+func (c *Config) WithSleepDelay(fn func(time.Duration)) *Config {
+	c.SleepDelay = fn
+	return c
+}
+
 // Merge returns a new Config with the other Config's attribute values merged into
 // this Config. If the other Config's attribute is nil it will not be merged into
 // the new Config to be returned.
@@ -213,6 +221,10 @@ func (c Config) Merge(other *Config) *Config {
 
 	if other.S3ForcePathStyle != nil {
 		dst.S3ForcePathStyle = other.S3ForcePathStyle
+	}
+
+	if other.SleepDelay != nil {
+		dst.SleepDelay = other.SleepDelay
 	}
 
 	return &dst

--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -1,4 +1,4 @@
-package service
+package corehandlers
 
 import (
 	"bytes"
@@ -9,15 +9,11 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
-
-var sleepDelay = func(delay time.Duration) {
-	time.Sleep(delay)
-}
 
 // Interface for matching types which also have a Len method.
 type lener interface {
@@ -27,7 +23,7 @@ type lener interface {
 // BuildContentLength builds the content length of a request based on the body,
 // or will use the HTTPRequest.Header's "Content-Length" if defined. If unable
 // to determine request body length and no "Content-Length" was specified it will panic.
-func BuildContentLength(r *Request) {
+func BuildContentLength(r *request.Request) {
 	if slength := r.HTTPRequest.Header.Get("Content-Length"); slength != "" {
 		length, _ := strconv.ParseInt(slength, 10, 64)
 		r.HTTPRequest.ContentLength = length
@@ -41,10 +37,10 @@ func BuildContentLength(r *Request) {
 	case lener:
 		length = int64(body.Len())
 	case io.Seeker:
-		r.bodyStart, _ = body.Seek(0, 1)
+		r.BodyStart, _ = body.Seek(0, 1)
 		end, _ := body.Seek(0, 2)
-		body.Seek(r.bodyStart, 0) // make sure to seek back to original location
-		length = end - r.bodyStart
+		body.Seek(r.BodyStart, 0) // make sure to seek back to original location
+		length = end - r.BodyStart
 	default:
 		panic("Cannot get length of body, must provide `ContentLength`")
 	}
@@ -54,14 +50,14 @@ func BuildContentLength(r *Request) {
 }
 
 // UserAgentHandler is a request handler for injecting User agent into requests.
-func UserAgentHandler(r *Request) {
+func UserAgentHandler(r *request.Request) {
 	r.HTTPRequest.Header.Set("User-Agent", aws.SDKName+"/"+aws.SDKVersion)
 }
 
 var reStatusCode = regexp.MustCompile(`^(\d{3})`)
 
 // SendHandler is a request handler to send service request using HTTP client.
-func SendHandler(r *Request) {
+func SendHandler(r *request.Request) {
 	var err error
 	r.HTTPResponse, err = r.Service.Config.HTTPClient.Do(r.HTTPRequest)
 	if err != nil {
@@ -96,7 +92,7 @@ func SendHandler(r *Request) {
 }
 
 // ValidateResponseHandler is a request handler to validate service response.
-func ValidateResponseHandler(r *Request) {
+func ValidateResponseHandler(r *request.Request) {
 	if r.HTTPResponse.StatusCode == 0 || r.HTTPResponse.StatusCode >= 300 {
 		// this may be replaced by an UnmarshalError handler
 		r.Error = awserr.New("UnknownError", "unknown error", nil)
@@ -105,26 +101,23 @@ func ValidateResponseHandler(r *Request) {
 
 // AfterRetryHandler performs final checks to determine if the request should
 // be retried and how long to delay.
-func AfterRetryHandler(r *Request) {
+func AfterRetryHandler(r *request.Request) {
 	// If one of the other handlers already set the retry state
 	// we don't want to override it based on the service's state
 	if r.Retryable == nil {
-		r.Retryable = aws.Bool(r.Service.ShouldRetry(r))
+		r.Retryable = aws.Bool(r.ShouldRetry(r))
 	}
 
 	if r.WillRetry() {
-		r.RetryDelay = r.Service.RetryRules(r)
-		sleepDelay(r.RetryDelay)
+		r.RetryDelay = r.RetryRules(r)
+		fmt.Println(r.Service.Config.SleepDelay)
+		r.Service.Config.SleepDelay(r.RetryDelay)
 
 		// when the expired token exception occurs the credentials
 		// need to be expired locally so that the next request to
 		// get credentials will trigger a credentials refresh.
-		if r.Error != nil {
-			if err, ok := r.Error.(awserr.Error); ok {
-				if isCodeExpiredCreds(err.Code()) {
-					r.Config.Credentials.Expire()
-				}
-			}
+		if r.IsErrorExpired() {
+			r.Service.Config.Credentials.Expire()
 		}
 
 		r.RetryCount++
@@ -132,27 +125,13 @@ func AfterRetryHandler(r *Request) {
 	}
 }
 
-var (
-	// ErrMissingRegion is an error that is returned if region configuration is
-	// not found.
-	//
-	// @readonly
-	ErrMissingRegion error = awserr.New("MissingRegion", "could not find region configuration", nil)
-
-	// ErrMissingEndpoint is an error that is returned if an endpoint cannot be
-	// resolved for a service.
-	//
-	// @readonly
-	ErrMissingEndpoint error = awserr.New("MissingEndpoint", "'Endpoint' configuration is required for this service", nil)
-)
-
 // ValidateEndpointHandler is a request handler to validate a request had the
 // appropriate Region and Endpoint set. Will set r.Error if the endpoint or
 // region is not valid.
-func ValidateEndpointHandler(r *Request) {
+func ValidateEndpointHandler(r *request.Request) {
 	if r.Service.SigningRegion == "" && aws.StringValue(r.Service.Config.Region) == "" {
-		r.Error = ErrMissingRegion
+		r.Error = aws.ErrMissingRegion
 	} else if r.Service.Endpoint == "" {
-		r.Error = ErrMissingEndpoint
+		r.Error = aws.ErrMissingEndpoint
 	}
 }

--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -1,4 +1,4 @@
-package service
+package corehandlers_test
 
 import (
 	"fmt"
@@ -10,16 +10,19 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/corehandlers"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/service"
 )
 
 func TestValidateEndpointHandler(t *testing.T) {
 	os.Clearenv()
-	svc := NewService(aws.NewConfig().WithRegion("us-west-2"))
+	svc := service.New(aws.NewConfig().WithRegion("us-west-2"))
 	svc.Handlers.Clear()
-	svc.Handlers.Validate.PushBack(ValidateEndpointHandler)
+	svc.Handlers.Validate.PushBack(corehandlers.ValidateEndpointHandler)
 
-	req := NewRequest(svc, &Operation{Name: "Operation"}, nil, nil)
+	req := svc.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := req.Build()
 
 	assert.NoError(t, err)
@@ -27,15 +30,15 @@ func TestValidateEndpointHandler(t *testing.T) {
 
 func TestValidateEndpointHandlerErrorRegion(t *testing.T) {
 	os.Clearenv()
-	svc := NewService(nil)
+	svc := service.New(nil)
 	svc.Handlers.Clear()
-	svc.Handlers.Validate.PushBack(ValidateEndpointHandler)
+	svc.Handlers.Validate.PushBack(corehandlers.ValidateEndpointHandler)
 
-	req := NewRequest(svc, &Operation{Name: "Operation"}, nil, nil)
+	req := svc.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := req.Build()
 
 	assert.Error(t, err)
-	assert.Equal(t, ErrMissingRegion, err)
+	assert.Equal(t, aws.ErrMissingRegion, err)
 }
 
 type mockCredsProvider struct {
@@ -55,24 +58,22 @@ func (m *mockCredsProvider) IsExpired() bool {
 func TestAfterRetryRefreshCreds(t *testing.T) {
 	os.Clearenv()
 	credProvider := &mockCredsProvider{}
-	svc := NewService(&aws.Config{Credentials: credentials.NewCredentials(credProvider), MaxRetries: aws.Int(1)})
+	svc := service.New(&aws.Config{Credentials: credentials.NewCredentials(credProvider), MaxRetries: aws.Int(1)})
 
 	svc.Handlers.Clear()
-	svc.Handlers.ValidateResponse.PushBack(func(r *Request) {
+	svc.Handlers.ValidateResponse.PushBack(func(r *request.Request) {
 		r.Error = awserr.New("UnknownError", "", nil)
 		r.HTTPResponse = &http.Response{StatusCode: 400}
 	})
-	svc.Handlers.UnmarshalError.PushBack(func(r *Request) {
+	svc.Handlers.UnmarshalError.PushBack(func(r *request.Request) {
 		r.Error = awserr.New("ExpiredTokenException", "", nil)
 	})
-	svc.Handlers.AfterRetry.PushBack(func(r *Request) {
-		AfterRetryHandler(r)
-	})
+	svc.Handlers.AfterRetry.PushBack(corehandlers.AfterRetryHandler)
 
 	assert.True(t, svc.Config.Credentials.IsExpired(), "Expect to start out expired")
 	assert.False(t, credProvider.retrieveCalled)
 
-	req := NewRequest(svc, &Operation{Name: "Operation"}, nil, nil)
+	req := svc.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	req.Send()
 
 	assert.True(t, svc.Config.Credentials.IsExpired())
@@ -90,14 +91,14 @@ func (t *testSendHandlerTransport) RoundTrip(r *http.Request) (*http.Response, e
 }
 
 func TestSendHandlerError(t *testing.T) {
-	svc := NewService(&aws.Config{
+	svc := service.New(&aws.Config{
 		HTTPClient: &http.Client{
 			Transport: &testSendHandlerTransport{},
 		},
 	})
 	svc.Handlers.Clear()
-	svc.Handlers.Send.PushBack(SendHandler)
-	r := NewRequest(svc, &Operation{Name: "Operation"}, nil, nil)
+	svc.Handlers.Send.PushBack(corehandlers.SendHandler)
+	r := svc.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 
 	r.Send()
 

--- a/aws/corehandlers/handlers_test.go
+++ b/aws/corehandlers/handlers_test.go
@@ -20,7 +20,7 @@ func TestValidateEndpointHandler(t *testing.T) {
 	os.Clearenv()
 	svc := service.New(aws.NewConfig().WithRegion("us-west-2"))
 	svc.Handlers.Clear()
-	svc.Handlers.Validate.PushBack(corehandlers.ValidateEndpointHandler)
+	svc.Handlers.Validate.PushBackNamed(corehandlers.ValidateEndpointHandler)
 
 	req := svc.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := req.Build()
@@ -32,7 +32,7 @@ func TestValidateEndpointHandlerErrorRegion(t *testing.T) {
 	os.Clearenv()
 	svc := service.New(nil)
 	svc.Handlers.Clear()
-	svc.Handlers.Validate.PushBack(corehandlers.ValidateEndpointHandler)
+	svc.Handlers.Validate.PushBackNamed(corehandlers.ValidateEndpointHandler)
 
 	req := svc.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := req.Build()
@@ -68,7 +68,7 @@ func TestAfterRetryRefreshCreds(t *testing.T) {
 	svc.Handlers.UnmarshalError.PushBack(func(r *request.Request) {
 		r.Error = awserr.New("ExpiredTokenException", "", nil)
 	})
-	svc.Handlers.AfterRetry.PushBack(corehandlers.AfterRetryHandler)
+	svc.Handlers.AfterRetry.PushBackNamed(corehandlers.AfterRetryHandler)
 
 	assert.True(t, svc.Config.Credentials.IsExpired(), "Expect to start out expired")
 	assert.False(t, credProvider.retrieveCalled)
@@ -97,7 +97,7 @@ func TestSendHandlerError(t *testing.T) {
 		},
 	})
 	svc.Handlers.Clear()
-	svc.Handlers.Send.PushBack(corehandlers.SendHandler)
+	svc.Handlers.Send.PushBackNamed(corehandlers.SendHandler)
 	r := svc.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 
 	r.Send()

--- a/aws/corehandlers/param_validator.go
+++ b/aws/corehandlers/param_validator.go
@@ -11,7 +11,7 @@ import (
 
 // ValidateParameters is a request handler to validate the input parameters.
 // Validating parameters only has meaning if done prior to the request being sent.
-func ValidateParameters(r *request.Request) {
+var ValidateParametersHandler = request.NamedHandler{"core.ValidateParametersHandler", func(r *request.Request) {
 	if r.ParamsFilled() {
 		v := validator{errors: []string{}}
 		v.validateAny(reflect.ValueOf(r.Params), "")
@@ -22,7 +22,7 @@ func ValidateParameters(r *request.Request) {
 			r.Error = awserr.New("InvalidParameter", msg, nil)
 		}
 	}
-}
+}}
 
 // A validator validates values. Collects validations errors which occurs.
 type validator struct {

--- a/aws/corehandlers/param_validator.go
+++ b/aws/corehandlers/param_validator.go
@@ -1,4 +1,4 @@
-package service
+package corehandlers
 
 import (
 	"fmt"
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 // ValidateParameters is a request handler to validate the input parameters.
 // Validating parameters only has meaning if done prior to the request being sent.
-func ValidateParameters(r *Request) {
+func ValidateParameters(r *request.Request) {
 	if r.ParamsFilled() {
 		v := validator{errors: []string{}}
 		v.validateAny(reflect.ValueOf(r.Params), "")

--- a/aws/corehandlers/param_validator_test.go
+++ b/aws/corehandlers/param_validator_test.go
@@ -1,4 +1,4 @@
-package service
+package corehandlers_test
 
 import (
 	"testing"
@@ -7,13 +7,19 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/corehandlers"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 )
 
-var testSvc = func() *Service {
-	s := &Service{
-		Config:      &aws.Config{},
-		ServiceName: "mock-service",
-		APIVersion:  "2015-01-01",
+var testSvc = func() *service.Service {
+	s := &service.Service{
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      &aws.Config{},
+			ServiceName: "mock-service",
+			APIVersion:  "2015-01-01",
+		},
 	}
 	return s
 }()
@@ -49,15 +55,15 @@ func TestNoErrors(t *testing.T) {
 		OptionalStruct: &ConditionalStructShape{Name: aws.String("Name")},
 	}
 
-	req := NewRequest(testSvc, &Operation{}, input, nil)
-	ValidateParameters(req)
+	req := testSvc.NewRequest(&request.Operation{}, input, nil)
+	corehandlers.ValidateParameters(req)
 	assert.NoError(t, req.Error)
 }
 
 func TestMissingRequiredParameters(t *testing.T) {
 	input := &StructShape{}
-	req := NewRequest(testSvc, &Operation{}, input, nil)
-	ValidateParameters(req)
+	req := testSvc.NewRequest(&request.Operation{}, input, nil)
+	corehandlers.ValidateParameters(req)
 
 	assert.Error(t, req.Error)
 	assert.Equal(t, "InvalidParameter", req.Error.(awserr.Error).Code())
@@ -75,8 +81,8 @@ func TestNestedMissingRequiredParameters(t *testing.T) {
 		OptionalStruct: &ConditionalStructShape{},
 	}
 
-	req := NewRequest(testSvc, &Operation{}, input, nil)
-	ValidateParameters(req)
+	req := testSvc.NewRequest(&request.Operation{}, input, nil)
+	corehandlers.ValidateParameters(req)
 
 	assert.Error(t, req.Error)
 	assert.Equal(t, "InvalidParameter", req.Error.(awserr.Error).Code())

--- a/aws/corehandlers/param_validator_test.go
+++ b/aws/corehandlers/param_validator_test.go
@@ -56,14 +56,14 @@ func TestNoErrors(t *testing.T) {
 	}
 
 	req := testSvc.NewRequest(&request.Operation{}, input, nil)
-	corehandlers.ValidateParameters(req)
+	corehandlers.ValidateParametersHandler.Fn(req)
 	assert.NoError(t, req.Error)
 }
 
 func TestMissingRequiredParameters(t *testing.T) {
 	input := &StructShape{}
 	req := testSvc.NewRequest(&request.Operation{}, input, nil)
-	corehandlers.ValidateParameters(req)
+	corehandlers.ValidateParametersHandler.Fn(req)
 
 	assert.Error(t, req.Error)
 	assert.Equal(t, "InvalidParameter", req.Error.(awserr.Error).Code())
@@ -82,7 +82,7 @@ func TestNestedMissingRequiredParameters(t *testing.T) {
 	}
 
 	req := testSvc.NewRequest(&request.Operation{}, input, nil)
-	corehandlers.ValidateParameters(req)
+	corehandlers.ValidateParametersHandler.Fn(req)
 
 	assert.Error(t, req.Error)
 	assert.Equal(t, "InvalidParameter", req.Error.(awserr.Error).Code())

--- a/aws/defaults/defaults.go
+++ b/aws/defaults/defaults.go
@@ -35,4 +35,5 @@ var DefaultConfig = aws.NewConfig().
 	WithHTTPClient(http.DefaultClient).
 	WithMaxRetries(aws.DefaultRetries).
 	WithLogger(aws.NewDefaultLogger()).
-	WithLogLevel(aws.LogOff)
+	WithLogLevel(aws.LogOff).
+	WithSleepDelay(time.Sleep)

--- a/aws/ec2metadata/api.go
+++ b/aws/ec2metadata/api.go
@@ -3,19 +3,19 @@ package ec2metadata
 import (
 	"path"
 
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 // GetMetadata uses the path provided to request
 func (c *Client) GetMetadata(p string) (string, error) {
-	op := &service.Operation{
+	op := &request.Operation{
 		Name:       "GetMetadata",
 		HTTPMethod: "GET",
 		HTTPPath:   path.Join("/", "meta-data", p),
 	}
 
 	output := &metadataOutput{}
-	req := service.NewRequest(c.Service, op, nil, output)
+	req := request.New(c.Service.ServiceInfo, c.Service.Handlers, c.Service.Retryer, op, nil, output)
 
 	return output.Content, req.Send()
 }

--- a/aws/ec2metadata/api_test.go
+++ b/aws/ec2metadata/api_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 func initTestServer(path string, resp string) *httptest.Server {
@@ -29,14 +29,14 @@ func initTestServer(path string, resp string) *httptest.Server {
 
 func TestEndpoint(t *testing.T) {
 	c := ec2metadata.New(&ec2metadata.Config{})
-	op := &service.Operation{
+	op := &request.Operation{
 		Name:       "GetMetadata",
 		HTTPMethod: "GET",
 		HTTPPath:   path.Join("/", "meta-data", "testpath"),
 	}
 
-	req := service.NewRequest(c.Service, op, nil, nil)
-	assert.Equal(t, "http://169.254.169.254/latest", req.Endpoint)
+	req := c.Service.NewRequest(op, nil, nil)
+	assert.Equal(t, "http://169.254.169.254/latest", req.Service.Endpoint)
 	assert.Equal(t, "http://169.254.169.254/latest/meta-data/testpath", req.HTTPRequest.URL.String())
 }
 
@@ -84,7 +84,7 @@ func TestMetadataAvailable(t *testing.T) {
 func TestMetadataNotAvailable(t *testing.T) {
 	c := ec2metadata.New(nil)
 	c.Handlers.Send.Clear()
-	c.Handlers.Send.PushBack(func(r *service.Request) {
+	c.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: int(0),
 			Status:     http.StatusText(int(0)),

--- a/aws/errors.go
+++ b/aws/errors.go
@@ -1,0 +1,17 @@
+package aws
+
+import "github.com/aws/aws-sdk-go/aws/awserr"
+
+var (
+	// ErrMissingRegion is an error that is returned if region configuration is
+	// not found.
+	//
+	// @readonly
+	ErrMissingRegion error = awserr.New("MissingRegion", "could not find region configuration", nil)
+
+	// ErrMissingEndpoint is an error that is returned if an endpoint cannot be
+	// resolved for a service.
+	//
+	// @readonly
+	ErrMissingEndpoint error = awserr.New("MissingEndpoint", "'Endpoint' configuration is required for this service", nil)
+)

--- a/aws/request/handlers.go
+++ b/aws/request/handlers.go
@@ -1,4 +1,4 @@
-package service
+package request
 
 // A Handlers provides a collection of request handlers for various
 // stages of handling requests.
@@ -15,8 +15,8 @@ type Handlers struct {
 	AfterRetry       HandlerList
 }
 
-// copy returns of this handler's lists.
-func (h *Handlers) copy() Handlers {
+// Copy returns of this handler's lists.
+func (h *Handlers) Copy() Handlers {
 	return Handlers{
 		Validate:         h.Validate.copy(),
 		Build:            h.Build.copy(),

--- a/aws/request/handlers.go
+++ b/aws/request/handlers.go
@@ -47,19 +47,25 @@ func (h *Handlers) Clear() {
 
 // A HandlerList manages zero or more handlers in a list.
 type HandlerList struct {
-	list []func(*Request)
+	list []NamedHandler
+}
+
+// A NamedHandler is a struct that contains a name and function callback.
+type NamedHandler struct {
+	Name string
+	Fn   func(*Request)
 }
 
 // copy creates a copy of the handler list.
 func (l *HandlerList) copy() HandlerList {
 	var n HandlerList
-	n.list = append([]func(*Request){}, l.list...)
+	n.list = append([]NamedHandler{}, l.list...)
 	return n
 }
 
 // Clear clears the handler list.
 func (l *HandlerList) Clear() {
-	l.list = []func(*Request){}
+	l.list = []NamedHandler{}
 }
 
 // Len returns the number of handlers in the list.
@@ -67,19 +73,40 @@ func (l *HandlerList) Len() int {
 	return len(l.list)
 }
 
-// PushBack pushes handlers f to the back of the handler list.
-func (l *HandlerList) PushBack(f ...func(*Request)) {
-	l.list = append(l.list, f...)
+// PushBack pushes handler f to the back of the handler list.
+func (l *HandlerList) PushBack(f func(*Request)) {
+	l.list = append(l.list, NamedHandler{"__anonymous", f})
 }
 
-// PushFront pushes handlers f to the front of the handler list.
-func (l *HandlerList) PushFront(f ...func(*Request)) {
-	l.list = append(f, l.list...)
+// PushFront pushes handler f to the front of the handler list.
+func (l *HandlerList) PushFront(f func(*Request)) {
+	l.list = append([]NamedHandler{{"__anonymous", f}}, l.list...)
+}
+
+// PushBackNamed pushes named handler f to the back of the handler list.
+func (l *HandlerList) PushBackNamed(n NamedHandler) {
+	l.list = append(l.list, n)
+}
+
+// PushFrontNamed pushes named handler f to the front of the handler list.
+func (l *HandlerList) PushFrontNamed(n NamedHandler) {
+	l.list = append([]NamedHandler{n}, l.list...)
+}
+
+// Remove removes a NamedHandler n
+func (l *HandlerList) Remove(n NamedHandler) {
+	newlist := []NamedHandler{}
+	for _, m := range l.list {
+		if m.Name != n.Name {
+			newlist = append(newlist, m)
+		}
+	}
+	l.list = newlist
 }
 
 // Run executes all handlers in the list with a given request object.
 func (l *HandlerList) Run(r *Request) {
 	for _, f := range l.list {
-		f(r)
+		f.Fn(r)
 	}
 }

--- a/aws/request/handlers_test.go
+++ b/aws/request/handlers_test.go
@@ -1,4 +1,4 @@
-package service
+package request_test
 
 import (
 	"testing"
@@ -6,13 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 func TestHandlerList(t *testing.T) {
 	s := ""
-	r := &Request{}
-	l := HandlerList{}
-	l.PushBack(func(r *Request) {
+	r := &request.Request{}
+	l := request.HandlerList{}
+	l.PushBack(func(r *request.Request) {
 		s += "a"
 		r.Data = s
 	})
@@ -22,10 +23,10 @@ func TestHandlerList(t *testing.T) {
 }
 
 func TestMultipleHandlers(t *testing.T) {
-	r := &Request{}
-	l := HandlerList{}
-	l.PushBack(func(r *Request) { r.Data = nil })
-	l.PushFront(func(r *Request) { r.Data = aws.Bool(true) })
+	r := &request.Request{}
+	l := request.HandlerList{}
+	l.PushBack(func(r *request.Request) { r.Data = nil })
+	l.PushFront(func(r *request.Request) { r.Data = aws.Bool(true) })
 	l.Run(r)
 	if r.Data != nil {
 		t.Error("Expected handler to execute")

--- a/aws/request/handlers_test.go
+++ b/aws/request/handlers_test.go
@@ -32,3 +32,16 @@ func TestMultipleHandlers(t *testing.T) {
 		t.Error("Expected handler to execute")
 	}
 }
+
+func TestNamedHandlers(t *testing.T) {
+	l := request.HandlerList{}
+	named := request.NamedHandler{"Name", func(r *request.Request) {}}
+	named2 := request.NamedHandler{"NotName", func(r *request.Request) {}}
+	l.PushBackNamed(named)
+	l.PushBackNamed(named)
+	l.PushBackNamed(named2)
+	l.PushBack(func(r *request.Request) {})
+	assert.Equal(t, 4, l.Len())
+	l.Remove(named)
+	assert.Equal(t, 2, l.Len())
+}

--- a/aws/request/request_pagination_test.go
+++ b/aws/request/request_pagination_test.go
@@ -1,4 +1,4 @@
-package service_test
+package request_test
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -30,7 +30,7 @@ func TestPagination(t *testing.T) {
 	db.Handlers.Unmarshal.Clear()
 	db.Handlers.UnmarshalMeta.Clear()
 	db.Handlers.ValidateResponse.Clear()
-	db.Handlers.Build.PushBack(func(r *service.Request) {
+	db.Handlers.Build.PushBack(func(r *request.Request) {
 		in := r.Params.(*dynamodb.ListTablesInput)
 		if in == nil {
 			tokens = append(tokens, "")
@@ -38,7 +38,7 @@ func TestPagination(t *testing.T) {
 			tokens = append(tokens, *in.ExclusiveStartTableName)
 		}
 	})
-	db.Handlers.Unmarshal.PushBack(func(r *service.Request) {
+	db.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		r.Data = resps[reqNum]
 		reqNum++
 	})
@@ -82,7 +82,7 @@ func TestPaginationEachPage(t *testing.T) {
 	db.Handlers.Unmarshal.Clear()
 	db.Handlers.UnmarshalMeta.Clear()
 	db.Handlers.ValidateResponse.Clear()
-	db.Handlers.Build.PushBack(func(r *service.Request) {
+	db.Handlers.Build.PushBack(func(r *request.Request) {
 		in := r.Params.(*dynamodb.ListTablesInput)
 		if in == nil {
 			tokens = append(tokens, "")
@@ -90,7 +90,7 @@ func TestPaginationEachPage(t *testing.T) {
 			tokens = append(tokens, *in.ExclusiveStartTableName)
 		}
 	})
-	db.Handlers.Unmarshal.PushBack(func(r *service.Request) {
+	db.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		r.Data = resps[reqNum]
 		reqNum++
 	})
@@ -135,7 +135,7 @@ func TestPaginationEarlyExit(t *testing.T) {
 	db.Handlers.Unmarshal.Clear()
 	db.Handlers.UnmarshalMeta.Clear()
 	db.Handlers.ValidateResponse.Clear()
-	db.Handlers.Unmarshal.PushBack(func(r *service.Request) {
+	db.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		r.Data = resps[reqNum]
 		reqNum++
 	})
@@ -166,7 +166,7 @@ func TestSkipPagination(t *testing.T) {
 	client.Handlers.Unmarshal.Clear()
 	client.Handlers.UnmarshalMeta.Clear()
 	client.Handlers.ValidateResponse.Clear()
-	client.Handlers.Unmarshal.PushBack(func(r *service.Request) {
+	client.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		r.Data = &s3.HeadBucketOutput{}
 	})
 
@@ -201,7 +201,7 @@ func TestPaginationTruncation(t *testing.T) {
 	client.Handlers.Unmarshal.Clear()
 	client.Handlers.UnmarshalMeta.Clear()
 	client.Handlers.ValidateResponse.Clear()
-	client.Handlers.Unmarshal.PushBack(func(r *service.Request) {
+	client.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		r.Data = resps[*reqNum]
 		*reqNum++
 	})
@@ -262,7 +262,7 @@ var benchDb = func() *dynamodb.DynamoDB {
 func BenchmarkCodegenIterator(b *testing.B) {
 	reqNum := 0
 	db := benchDb()
-	db.Handlers.Unmarshal.PushBack(func(r *service.Request) {
+	db.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		r.Data = benchResps[reqNum]
 		reqNum++
 	})
@@ -291,7 +291,7 @@ func BenchmarkCodegenIterator(b *testing.B) {
 func BenchmarkEachPageIterator(b *testing.B) {
 	reqNum := 0
 	db := benchDb()
-	db.Handlers.Unmarshal.PushBack(func(r *service.Request) {
+	db.Handlers.Unmarshal.PushBack(func(r *request.Request) {
 		r.Data = benchResps[reqNum]
 		reqNum++
 	})

--- a/aws/request/request_test.go
+++ b/aws/request/request_test.go
@@ -1,4 +1,4 @@
-package service
+package request_test
 
 import (
 	"bytes"
@@ -13,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/service"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +26,7 @@ func body(str string) io.ReadCloser {
 	return ioutil.NopCloser(bytes.NewReader([]byte(str)))
 }
 
-func unmarshal(req *Request) {
+func unmarshal(req *request.Request) {
 	defer req.HTTPResponse.Body.Close()
 	if req.Data != nil {
 		json.NewDecoder(req.HTTPResponse.Body).Decode(req.Data)
@@ -32,7 +34,7 @@ func unmarshal(req *Request) {
 	return
 }
 
-func unmarshalError(req *Request) {
+func unmarshalError(req *request.Request) {
 	bodyBytes, err := ioutil.ReadAll(req.HTTPResponse.Body)
 	if err != nil {
 		req.Error = awserr.New("UnmarshaleError", req.HTTPResponse.Status, err)
@@ -72,17 +74,17 @@ func TestRequestRecoverRetry5xx(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := NewService(aws.NewConfig().WithMaxRetries(10))
+	s := service.New(aws.NewConfig().WithMaxRetries(10))
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
 	s.Handlers.Send.Clear() // mock sending
-	s.Handlers.Send.PushBack(func(r *Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &reqs[reqNum]
 		reqNum++
 	})
 	out := &testData{}
-	r := NewRequest(s, &Operation{Name: "Operation"}, nil, out)
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, int(r.RetryCount))
@@ -98,17 +100,17 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := NewService(aws.NewConfig().WithMaxRetries(10))
+	s := service.New(aws.NewConfig().WithMaxRetries(10))
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
 	s.Handlers.Send.Clear() // mock sending
-	s.Handlers.Send.PushBack(func(r *Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &reqs[reqNum]
 		reqNum++
 	})
 	out := &testData{}
-	r := NewRequest(s, &Operation{Name: "Operation"}, nil, out)
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, int(r.RetryCount))
@@ -117,16 +119,16 @@ func TestRequestRecoverRetry4xxRetryable(t *testing.T) {
 
 // test that retries don't occur for 4xx status codes with a response type that can't be retried
 func TestRequest4xxUnretryable(t *testing.T) {
-	s := NewService(aws.NewConfig().WithMaxRetries(10))
+	s := service.New(aws.NewConfig().WithMaxRetries(10))
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
 	s.Handlers.Send.Clear() // mock sending
-	s.Handlers.Send.PushBack(func(r *Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &http.Response{StatusCode: 401, Body: body(`{"__type":"SignatureDoesNotMatch","message":"Signature does not match."}`)}
 	})
 	out := &testData{}
-	r := NewRequest(s, &Operation{Name: "Operation"}, nil, out)
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
 	assert.NotNil(t, err)
 	if e, ok := err.(awserr.RequestFailure); ok {
@@ -141,7 +143,7 @@ func TestRequest4xxUnretryable(t *testing.T) {
 
 func TestRequestExhaustRetries(t *testing.T) {
 	delays := []time.Duration{}
-	sleepDelay = func(delay time.Duration) {
+	sleepDelay := func(delay time.Duration) {
 		delays = append(delays, delay)
 	}
 
@@ -153,16 +155,16 @@ func TestRequestExhaustRetries(t *testing.T) {
 		{StatusCode: 500, Body: body(`{"__type":"UnknownError","message":"An error occurred."}`)},
 	}
 
-	s := NewService(aws.NewConfig().WithMaxRetries(aws.DefaultRetries))
+	s := service.New(aws.NewConfig().WithMaxRetries(aws.DefaultRetries).WithSleepDelay(sleepDelay))
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
 	s.Handlers.Send.Clear() // mock sending
-	s.Handlers.Send.PushBack(func(r *Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &reqs[reqNum]
 		reqNum++
 	})
-	r := NewRequest(s, &Operation{Name: "Operation"}, nil, nil)
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, nil)
 	err := r.Send()
 	assert.NotNil(t, err)
 	if e, ok := err.(awserr.RequestFailure); ok {
@@ -191,7 +193,7 @@ func TestRequestRecoverExpiredCreds(t *testing.T) {
 		{StatusCode: 200, Body: body(`{"data":"valid"}`)},
 	}
 
-	s := NewService(&aws.Config{MaxRetries: aws.Int(10), Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "")})
+	s := service.New(&aws.Config{MaxRetries: aws.Int(10), Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "")})
 	s.Handlers.Validate.Clear()
 	s.Handlers.Unmarshal.PushBack(unmarshal)
 	s.Handlers.UnmarshalError.PushBack(unmarshalError)
@@ -199,21 +201,21 @@ func TestRequestRecoverExpiredCreds(t *testing.T) {
 	credExpiredBeforeRetry := false
 	credExpiredAfterRetry := false
 
-	s.Handlers.AfterRetry.PushBack(func(r *Request) {
-		credExpiredAfterRetry = r.Config.Credentials.IsExpired()
+	s.Handlers.AfterRetry.PushBack(func(r *request.Request) {
+		credExpiredAfterRetry = r.Service.Config.Credentials.IsExpired()
 	})
 
 	s.Handlers.Sign.Clear()
-	s.Handlers.Sign.PushBack(func(r *Request) {
-		r.Config.Credentials.Get()
+	s.Handlers.Sign.PushBack(func(r *request.Request) {
+		r.Service.Config.Credentials.Get()
 	})
 	s.Handlers.Send.Clear() // mock sending
-	s.Handlers.Send.PushBack(func(r *Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &reqs[reqNum]
 		reqNum++
 	})
 	out := &testData{}
-	r := NewRequest(s, &Operation{Name: "Operation"}, nil, out)
+	r := s.NewRequest(&request.Operation{Name: "Operation"}, nil, out)
 	err := r.Send()
 	assert.Nil(t, err)
 

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -6,6 +6,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+// Retryer is an interface to control retry logic for a given service.
+// The default implementation used by most services is the service.DefaultRetryer
+// structure, which contains basic retry logic using exponential backoff.
 type Retryer interface {
 	RetryRules(*Request) time.Duration
 	ShouldRetry(*Request) bool
@@ -45,6 +48,8 @@ func isCodeExpiredCreds(code string) bool {
 	return ok
 }
 
+// IsErrorRetryable returns whether the error is retryable, based on its Code.
+// Returns false if the request has no Error set.
 func (r *Request) IsErrorRetryable() bool {
 	if r.Error != nil {
 		if err, ok := r.Error.(awserr.Error); ok {
@@ -54,6 +59,8 @@ func (r *Request) IsErrorRetryable() bool {
 	return false
 }
 
+// IsErrorExpired returns whether the error code is a credential expiry error.
+// Returns false if the request has no Error set.
 func (r *Request) IsErrorExpired() bool {
 	if r.Error != nil {
 		if err, ok := r.Error.(awserr.Error); ok {

--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -1,0 +1,64 @@
+package request
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+type Retryer interface {
+	RetryRules(*Request) time.Duration
+	ShouldRetry(*Request) bool
+	MaxRetries() uint
+}
+
+// retryableCodes is a collection of service response codes which are retry-able
+// without any further action.
+var retryableCodes = map[string]struct{}{
+	"RequestError":                           {},
+	"ProvisionedThroughputExceededException": {},
+	"Throttling":                             {},
+	"ThrottlingException":                    {},
+	"RequestLimitExceeded":                   {},
+	"RequestThrottled":                       {},
+}
+
+// credsExpiredCodes is a collection of error codes which signify the credentials
+// need to be refreshed. Expired tokens require refreshing of credentials, and
+// resigning before the request can be retried.
+var credsExpiredCodes = map[string]struct{}{
+	"ExpiredToken":          {},
+	"ExpiredTokenException": {},
+	"RequestExpired":        {}, // EC2 Only
+}
+
+func isCodeRetryable(code string) bool {
+	if _, ok := retryableCodes[code]; ok {
+		return true
+	}
+
+	return isCodeExpiredCreds(code)
+}
+
+func isCodeExpiredCreds(code string) bool {
+	_, ok := credsExpiredCodes[code]
+	return ok
+}
+
+func (r *Request) IsErrorRetryable() bool {
+	if r.Error != nil {
+		if err, ok := r.Error.(awserr.Error); ok {
+			return isCodeRetryable(err.Code())
+		}
+	}
+	return false
+}
+
+func (r *Request) IsErrorExpired() bool {
+	if r.Error != nil {
+		if err, ok := r.Error.(awserr.Error); ok {
+			return isCodeExpiredCreds(err.Code())
+		}
+	}
+	return false
+}

--- a/aws/service/default_retryer.go
+++ b/aws/service/default_retryer.go
@@ -9,6 +9,18 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 )
 
+// DefaultRetryer implements basic retry logic using exponential backoff for
+// most services. If you want to implement custom retry logic, implement the
+// request.Retryer interface or create a structure type that composes this
+// struct and override the specific methods. For example, to override only
+// the MaxRetries method:
+//
+//		type retryer struct {
+//      service.DefaultRetryer
+//    }
+//
+//    // This implementation always has 100 max retries
+//    func (d retryer) MaxRetries() uint { return 100 }
 type DefaultRetryer struct {
 	*Service
 }

--- a/aws/service/default_retryer.go
+++ b/aws/service/default_retryer.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+type DefaultRetryer struct {
+	*Service
+}
+
+// MaxRetries returns the number of maximum returns the service will use to make
+// an individual API request.
+func (d DefaultRetryer) MaxRetries() uint {
+	if aws.IntValue(d.Service.Config.MaxRetries) < 0 {
+		return d.DefaultMaxRetries
+	}
+	return uint(aws.IntValue(d.Service.Config.MaxRetries))
+}
+
+var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// RetryRules returns the delay duration before retrying this request again
+func (d DefaultRetryer) RetryRules(r *request.Request) time.Duration {
+	delay := int(math.Pow(2, float64(r.RetryCount))) * (seededRand.Intn(30) + 30)
+	return time.Duration(delay) * time.Millisecond
+}
+
+// ShouldRetry returns if the request should be retried.
+func (d DefaultRetryer) ShouldRetry(r *request.Request) bool {
+	if r.HTTPResponse.StatusCode >= 500 {
+		return true
+	}
+	return r.IsErrorRetryable()
+}

--- a/aws/service/service.go
+++ b/aws/service/service.go
@@ -47,14 +47,14 @@ func (s *Service) Initialize() {
 
 	s.Retryer = DefaultRetryer{s}
 	s.DefaultMaxRetries = 3
-	s.Handlers.Validate.PushBack(corehandlers.ValidateEndpointHandler)
-	s.Handlers.Build.PushBack(corehandlers.UserAgentHandler)
-	s.Handlers.Sign.PushBack(corehandlers.BuildContentLength)
-	s.Handlers.Send.PushBack(corehandlers.SendHandler)
-	s.Handlers.AfterRetry.PushBack(corehandlers.AfterRetryHandler)
-	s.Handlers.ValidateResponse.PushBack(corehandlers.ValidateResponseHandler)
+	s.Handlers.Validate.PushBackNamed(corehandlers.ValidateEndpointHandler)
+	s.Handlers.Build.PushBackNamed(corehandlers.UserAgentHandler)
+	s.Handlers.Sign.PushBackNamed(corehandlers.BuildContentLengthHandler)
+	s.Handlers.Send.PushBackNamed(corehandlers.SendHandler)
+	s.Handlers.AfterRetry.PushBackNamed(corehandlers.AfterRetryHandler)
+	s.Handlers.ValidateResponse.PushBackNamed(corehandlers.ValidateResponseHandler)
 	if !aws.BoolValue(s.Config.DisableParamValidation) {
-		s.Handlers.Validate.PushBack(corehandlers.ValidateParameters)
+		s.Handlers.Validate.PushBackNamed(corehandlers.ValidateParametersHandler)
 	}
 	s.AddDebugHandlers()
 	s.buildEndpoint()

--- a/aws/service/service.go
+++ b/aws/service/service.go
@@ -3,40 +3,32 @@ package service
 import (
 	"fmt"
 	"io/ioutil"
-	"math"
-	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/corehandlers"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/endpoints"
 )
 
 // A Service implements the base service request and response handling
 // used by all services.
 type Service struct {
-	Config            *aws.Config
-	Handlers          Handlers
-	ServiceName       string
-	APIVersion        string
-	Endpoint          string
-	SigningName       string
-	SigningRegion     string
-	JSONVersion       string
-	TargetPrefix      string
-	RetryRules        func(*Request) time.Duration
-	ShouldRetry       func(*Request) bool
+	serviceinfo.ServiceInfo
+	request.Retryer
 	DefaultMaxRetries uint
+	Handlers          request.Handlers
 }
 
 var schemeRE = regexp.MustCompile("^([^:]+)://")
 
-// NewService will return a pointer to a new Server object initialized.
-func NewService(config *aws.Config) *Service {
-	svc := &Service{Config: config}
+// New will return a pointer to a new Server object initialized.
+func New(config *aws.Config) *Service {
+	svc := &Service{ServiceInfo: serviceinfo.ServiceInfo{Config: config}}
 	svc.Initialize()
 	return svc
 }
@@ -49,28 +41,29 @@ func (s *Service) Initialize() {
 	if s.Config.HTTPClient == nil {
 		s.Config.HTTPClient = http.DefaultClient
 	}
-
-	if s.RetryRules == nil {
-		s.RetryRules = retryRules
+	if s.Config.SleepDelay == nil {
+		s.Config.SleepDelay = time.Sleep
 	}
 
-	if s.ShouldRetry == nil {
-		s.ShouldRetry = shouldRetry
-	}
-
+	s.Retryer = DefaultRetryer{s}
 	s.DefaultMaxRetries = 3
-	s.Handlers.Validate.PushBack(ValidateEndpointHandler)
-	s.Handlers.Build.PushBack(UserAgentHandler)
-	s.Handlers.Sign.PushBack(BuildContentLength)
-	s.Handlers.Send.PushBack(SendHandler)
-	s.Handlers.AfterRetry.PushBack(AfterRetryHandler)
-	s.Handlers.ValidateResponse.PushBack(ValidateResponseHandler)
+	s.Handlers.Validate.PushBack(corehandlers.ValidateEndpointHandler)
+	s.Handlers.Build.PushBack(corehandlers.UserAgentHandler)
+	s.Handlers.Sign.PushBack(corehandlers.BuildContentLength)
+	s.Handlers.Send.PushBack(corehandlers.SendHandler)
+	s.Handlers.AfterRetry.PushBack(corehandlers.AfterRetryHandler)
+	s.Handlers.ValidateResponse.PushBack(corehandlers.ValidateResponseHandler)
+	if !aws.BoolValue(s.Config.DisableParamValidation) {
+		s.Handlers.Validate.PushBack(corehandlers.ValidateParameters)
+	}
 	s.AddDebugHandlers()
 	s.buildEndpoint()
+}
 
-	if !aws.BoolValue(s.Config.DisableParamValidation) {
-		s.Handlers.Validate.PushBack(ValidateParameters)
-	}
+// NewRequest returns a new Request pointer for the service API
+// operation and parameters.
+func (s *Service) NewRequest(operation *request.Operation, params interface{}, data interface{}) *request.Request {
+	return request.New(s.ServiceInfo, s.Handlers, s.Retryer, operation, params, data)
 }
 
 // buildEndpoint builds the endpoint values the service will use to make requests with.
@@ -107,19 +100,19 @@ const logReqMsg = `DEBUG: Request %s/%s Details:
 %s
 -----------------------------------------------------`
 
-func logRequest(r *Request) {
-	logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
+func logRequest(r *request.Request) {
+	logBody := r.Service.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
 	dumpedBody, _ := httputil.DumpRequestOut(r.HTTPRequest, logBody)
 
 	if logBody {
 		// Reset the request body because dumpRequest will re-wrap the r.HTTPRequest's
 		// Body as a NoOpCloser and will not be reset after read by the HTTP
 		// client reader.
-		r.Body.Seek(r.bodyStart, 0)
+		r.Body.Seek(r.BodyStart, 0)
 		r.HTTPRequest.Body = ioutil.NopCloser(r.Body)
 	}
 
-	r.Config.Logger.Log(fmt.Sprintf(logReqMsg, r.ServiceName, r.Operation.Name, string(dumpedBody)))
+	r.Service.Config.Logger.Log(fmt.Sprintf(logReqMsg, r.Service.ServiceName, r.Operation.Name, string(dumpedBody)))
 }
 
 const logRespMsg = `DEBUG: Response %s/%s Details:
@@ -127,78 +120,14 @@ const logRespMsg = `DEBUG: Response %s/%s Details:
 %s
 -----------------------------------------------------`
 
-func logResponse(r *Request) {
+func logResponse(r *request.Request) {
 	var msg = "no reponse data"
 	if r.HTTPResponse != nil {
-		logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
+		logBody := r.Service.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
 		dumpedBody, _ := httputil.DumpResponse(r.HTTPResponse, logBody)
 		msg = string(dumpedBody)
 	} else if r.Error != nil {
 		msg = r.Error.Error()
 	}
-	r.Config.Logger.Log(fmt.Sprintf(logRespMsg, r.ServiceName, r.Operation.Name, msg))
-}
-
-// MaxRetries returns the number of maximum returns the service will use to make
-// an individual API request.
-func (s *Service) MaxRetries() uint {
-	if aws.IntValue(s.Config.MaxRetries) < 0 {
-		return s.DefaultMaxRetries
-	}
-	return uint(aws.IntValue(s.Config.MaxRetries))
-}
-
-var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-// retryRules returns the delay duration before retrying this request again
-func retryRules(r *Request) time.Duration {
-
-	delay := int(math.Pow(2, float64(r.RetryCount))) * (seededRand.Intn(30) + 30)
-	return time.Duration(delay) * time.Millisecond
-}
-
-// retryableCodes is a collection of service response codes which are retry-able
-// without any further action.
-var retryableCodes = map[string]struct{}{
-	"RequestError":                           {},
-	"ProvisionedThroughputExceededException": {},
-	"Throttling":                             {},
-	"ThrottlingException":                    {},
-	"RequestLimitExceeded":                   {},
-	"RequestThrottled":                       {},
-}
-
-// credsExpiredCodes is a collection of error codes which signify the credentials
-// need to be refreshed. Expired tokens require refreshing of credentials, and
-// resigning before the request can be retried.
-var credsExpiredCodes = map[string]struct{}{
-	"ExpiredToken":          {},
-	"ExpiredTokenException": {},
-	"RequestExpired":        {}, // EC2 Only
-}
-
-func isCodeRetryable(code string) bool {
-	if _, ok := retryableCodes[code]; ok {
-		return true
-	}
-
-	return isCodeExpiredCreds(code)
-}
-
-func isCodeExpiredCreds(code string) bool {
-	_, ok := credsExpiredCodes[code]
-	return ok
-}
-
-// shouldRetry returns if the request should be retried.
-func shouldRetry(r *Request) bool {
-	if r.HTTPResponse.StatusCode >= 500 {
-		return true
-	}
-	if r.Error != nil {
-		if err, ok := r.Error.(awserr.Error); ok {
-			return isCodeRetryable(err.Code())
-		}
-	}
-	return false
+	r.Service.Config.Logger.Log(fmt.Sprintf(logRespMsg, r.Service.ServiceName, r.Operation.Name, msg))
 }

--- a/aws/service/serviceinfo/service_info.go
+++ b/aws/service/serviceinfo/service_info.go
@@ -1,0 +1,15 @@
+package serviceinfo
+
+import "github.com/aws/aws-sdk-go/aws"
+
+// ServiceInfo wraps immutable data from the service.Service structure.
+type ServiceInfo struct {
+	Config        *aws.Config
+	ServiceName   string
+	APIVersion    string
+	Endpoint      string
+	SigningName   string
+	SigningRegion string
+	JSONVersion   string
+	TargetPrefix  string
+}

--- a/doc-src/plugin/plugin.rb
+++ b/doc-src/plugin/plugin.rb
@@ -60,9 +60,9 @@ eof
         obj.parameters = []
         opname = obj.name.to_s.sub(/Request$/, '')
         obj.docstring = <<-eof
-#{obj.name} generates a {service.Request} object representing the client request for
+#{obj.name} generates a {request.Request} object representing the client request for
 the {#{opname} #{opname}()} operation. The `output` return value can be used to capture
-response data after {service.Request.Send Request.Send()} is called.
+response data after {request.Request.Send Request.Send()} is called.
 
 Creating a request object using this method should be used when you want to inject
 custom logic into the request lifecycle using a custom handler, or if you want to
@@ -70,7 +70,7 @@ access properties on the request object before or after sending the request. If
 you just want the service response, call the {#{opname} service operation method}
 directly instead.
 
-@note You must call the {service.Request.Send Send()} method on the returned
+@note You must call the {request.Request.Send Send()} method on the returned
   request object in order to execute the request.
 @example Sending a request using the #{obj.name}() method
   req, resp := client.#{obj.name}(params)

--- a/internal/model/api/operation.go
+++ b/internal/model/api/operation.go
@@ -44,12 +44,12 @@ const op{{ .ExportedName }} = "{{ .Name }}"
 
 // {{ .ExportedName }}Request generates a request for the {{ .ExportedName }} operation.
 func (c *{{ .API.StructName }}) {{ .ExportedName }}Request(` +
-	`input {{ .InputRef.GoType }}) (req *service.Request, output {{ .OutputRef.GoType }}) {
-	op := &service.Operation{
+	`input {{ .InputRef.GoType }}) (req *request.Request, output {{ .OutputRef.GoType }}) {
+	op := &request.Operation{
 		Name:       op{{ .ExportedName }},
 		{{ if ne .HTTP.Method "" }}HTTPMethod: "{{ .HTTP.Method }}",
 		{{ end }}{{ if ne .HTTP.RequestURI "" }}HTTPPath:   "{{ .HTTP.RequestURI }}",
-		{{ end }}{{ if .Paginator }}Paginator: &service.Paginator{
+		{{ end }}{{ if .Paginator }}Paginator: &request.Paginator{
 				InputTokens: {{ .Paginator.InputTokensString }},
 				OutputTokens: {{ .Paginator.OutputTokensString }},
 				LimitToken: "{{ .Paginator.LimitKey }}",
@@ -99,7 +99,7 @@ func (o *Operation) GoCode() string {
 
 // tplInfSig defines the template for rendering an Operation's signature within an Interface definition.
 var tplInfSig = template.Must(template.New("opsig").Parse(`
-{{ .ExportedName }}Request({{ .InputRef.GoTypeWithPkgName }}) (*service.Request, {{ .OutputRef.GoTypeWithPkgName }})
+{{ .ExportedName }}Request({{ .InputRef.GoTypeWithPkgName }}) (*request.Request, {{ .OutputRef.GoTypeWithPkgName }})
 
 {{ .ExportedName }}({{ .InputRef.GoTypeWithPkgName }}) ({{ .OutputRef.GoTypeWithPkgName }}, error)
 {{ if .Paginator }}

--- a/internal/protocol/ec2query/build.go
+++ b/internal/protocol/ec2query/build.go
@@ -7,12 +7,12 @@ import (
 	"net/url"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/protocol/query/queryutil"
 )
 
 // Build builds a request for the EC2 protocol.
-func Build(r *service.Request) {
+func Build(r *request.Request) {
 	body := url.Values{
 		"Action":  {r.Operation.Name},
 		"Version": {r.Service.APIVersion},

--- a/internal/protocol/ec2query/build_test.go
+++ b/internal/protocol/ec2query/build_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/ec2query"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,9 +41,11 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice1protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice1protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -66,8 +70,8 @@ func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService1TestCaseOperation1 = "OperationName"
 
 // InputService1TestCaseOperation1Request generates a request for the InputService1TestCaseOperation1 operation.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation1Input) (req *service.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation1Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService1TestCaseOperation1,
 	}
 
@@ -114,9 +118,11 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice2protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice2protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -132,8 +138,8 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -141,8 +147,8 @@ func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService2TestCaseOperation1 = "OperationName"
 
 // InputService2TestCaseOperation1Request generates a request for the InputService2TestCaseOperation1 operation.
-func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *service.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *request.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService2TestCaseOperation1,
 	}
 
@@ -191,9 +197,11 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice3protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice3protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -209,8 +217,8 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -218,8 +226,8 @@ func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService3TestCaseOperation1 = "OperationName"
 
 // InputService3TestCaseOperation1Request generates a request for the InputService3TestCaseOperation1 operation.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation1Input) (req *service.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation1Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService3TestCaseOperation1,
 	}
 
@@ -274,9 +282,11 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice4protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice4protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -292,8 +302,8 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -301,8 +311,8 @@ func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService4TestCaseOperation1 = "OperationName"
 
 // InputService4TestCaseOperation1Request generates a request for the InputService4TestCaseOperation1 operation.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *service.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService4TestCaseOperation1,
 	}
 
@@ -347,9 +357,11 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice5protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice5protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -365,8 +377,8 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -374,8 +386,8 @@ func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService5TestCaseOperation1 = "OperationName"
 
 // InputService5TestCaseOperation1Request generates a request for the InputService5TestCaseOperation1 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation1,
 	}
 
@@ -420,9 +432,11 @@ type InputService6ProtocolTest struct {
 // New returns a new InputService6ProtocolTest client.
 func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice6protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice6protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -438,8 +452,8 @@ func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest
 
 // newRequest creates a new request for a InputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -447,8 +461,8 @@ func (c *InputService6ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService6TestCaseOperation1 = "OperationName"
 
 // InputService6TestCaseOperation1Request generates a request for the InputService6TestCaseOperation1 operation.
-func (c *InputService6ProtocolTest) InputService6TestCaseOperation1Request(input *InputService6TestShapeInputService6TestCaseOperation1Input) (req *service.Request, output *InputService6TestShapeInputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService6ProtocolTest) InputService6TestCaseOperation1Request(input *InputService6TestShapeInputService6TestCaseOperation1Input) (req *request.Request, output *InputService6TestShapeInputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService6TestCaseOperation1,
 	}
 
@@ -493,9 +507,11 @@ type InputService7ProtocolTest struct {
 // New returns a new InputService7ProtocolTest client.
 func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice7protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice7protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -511,8 +527,8 @@ func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest
 
 // newRequest creates a new request for a InputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -520,8 +536,8 @@ func (c *InputService7ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService7TestCaseOperation1 = "OperationName"
 
 // InputService7TestCaseOperation1Request generates a request for the InputService7TestCaseOperation1 operation.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputService7TestCaseOperation1Input) (req *service.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputService7TestCaseOperation1Input) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService7TestCaseOperation1,
 	}
 
@@ -566,9 +582,11 @@ type InputService8ProtocolTest struct {
 // New returns a new InputService8ProtocolTest client.
 func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice8protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice8protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -584,8 +602,8 @@ func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest
 
 // newRequest creates a new request for a InputService8ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService8ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -593,8 +611,8 @@ func (c *InputService8ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService8TestCaseOperation1 = "OperationName"
 
 // InputService8TestCaseOperation1Request generates a request for the InputService8TestCaseOperation1 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputService8TestCaseOperation1Input) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputService8TestCaseOperation1Input) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService8TestCaseOperation1,
 	}
 

--- a/internal/protocol/ec2query/build_test.go
+++ b/internal/protocol/ec2query/build_test.go
@@ -41,7 +41,7 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice1protocoltest",
 			APIVersion:  "2014-01-01",
@@ -62,7 +62,7 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -118,7 +118,7 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice2protocoltest",
 			APIVersion:  "2014-01-01",
@@ -139,7 +139,7 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -197,7 +197,7 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice3protocoltest",
 			APIVersion:  "2014-01-01",
@@ -218,7 +218,7 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -282,7 +282,7 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice4protocoltest",
 			APIVersion:  "2014-01-01",
@@ -303,7 +303,7 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -357,7 +357,7 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice5protocoltest",
 			APIVersion:  "2014-01-01",
@@ -378,7 +378,7 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -432,7 +432,7 @@ type InputService6ProtocolTest struct {
 // New returns a new InputService6ProtocolTest client.
 func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice6protocoltest",
 			APIVersion:  "2014-01-01",
@@ -453,7 +453,7 @@ func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest
 // newRequest creates a new request for a InputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -507,7 +507,7 @@ type InputService7ProtocolTest struct {
 // New returns a new InputService7ProtocolTest client.
 func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice7protocoltest",
 			APIVersion:  "2014-01-01",
@@ -528,7 +528,7 @@ func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest
 // newRequest creates a new request for a InputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -582,7 +582,7 @@ type InputService8ProtocolTest struct {
 // New returns a new InputService8ProtocolTest client.
 func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice8protocoltest",
 			APIVersion:  "2014-01-01",
@@ -603,7 +603,7 @@ func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest
 // newRequest creates a new request for a InputService8ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/ec2query/unmarshal.go
+++ b/internal/protocol/ec2query/unmarshal.go
@@ -7,12 +7,12 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 )
 
 // Unmarshal unmarshals a response body for the EC2 protocol.
-func Unmarshal(r *service.Request) {
+func Unmarshal(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 	if r.DataFilled() {
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
@@ -25,7 +25,7 @@ func Unmarshal(r *service.Request) {
 }
 
 // UnmarshalMeta unmarshals response headers for the EC2 protocol.
-func UnmarshalMeta(r *service.Request) {
+func UnmarshalMeta(r *request.Request) {
 	// TODO implement unmarshaling of request IDs
 }
 
@@ -37,7 +37,7 @@ type xmlErrorResponse struct {
 }
 
 // UnmarshalError unmarshals a response error for the EC2 protocol.
-func UnmarshalError(r *service.Request) {
+func UnmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
 	resp := &xmlErrorResponse{}

--- a/internal/protocol/ec2query/unmarshal_test.go
+++ b/internal/protocol/ec2query/unmarshal_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/ec2query"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,9 +41,11 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice1protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice1protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -66,8 +70,8 @@ func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService1TestCaseOperation1 = "OperationName"
 
 // OutputService1TestCaseOperation1Request generates a request for the OutputService1TestCaseOperation1 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *service.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService1TestCaseOperation1,
 	}
 
@@ -126,9 +130,11 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice2protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice2protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -144,8 +150,8 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -153,8 +159,8 @@ func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService2TestCaseOperation1 = "OperationName"
 
 // OutputService2TestCaseOperation1Request generates a request for the OutputService2TestCaseOperation1 operation.
-func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *service.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *request.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService2TestCaseOperation1,
 	}
 
@@ -199,9 +205,11 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice3protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice3protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -217,8 +225,8 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -226,8 +234,8 @@ func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService3TestCaseOperation1 = "OperationName"
 
 // OutputService3TestCaseOperation1Request generates a request for the OutputService3TestCaseOperation1 operation.
-func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *service.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *request.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService3TestCaseOperation1,
 	}
 
@@ -272,9 +280,11 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice4protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice4protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -290,8 +300,8 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -299,8 +309,8 @@ func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService4TestCaseOperation1 = "OperationName"
 
 // OutputService4TestCaseOperation1Request generates a request for the OutputService4TestCaseOperation1 operation.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *service.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService4TestCaseOperation1,
 	}
 
@@ -345,9 +355,11 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice5protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice5protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -363,8 +375,8 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -372,8 +384,8 @@ func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService5TestCaseOperation1 = "OperationName"
 
 // OutputService5TestCaseOperation1Request generates a request for the OutputService5TestCaseOperation1 operation.
-func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *service.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *request.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService5TestCaseOperation1,
 	}
 
@@ -418,9 +430,11 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice6protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice6protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -436,8 +450,8 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -445,8 +459,8 @@ func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService6TestCaseOperation1 = "OperationName"
 
 // OutputService6TestCaseOperation1Request generates a request for the OutputService6TestCaseOperation1 operation.
-func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *service.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *request.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService6TestCaseOperation1,
 	}
 
@@ -501,9 +515,11 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice7protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice7protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -519,8 +535,8 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -528,8 +544,8 @@ func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService7TestCaseOperation1 = "OperationName"
 
 // OutputService7TestCaseOperation1Request generates a request for the OutputService7TestCaseOperation1 operation.
-func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *service.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *request.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService7TestCaseOperation1,
 	}
 
@@ -574,9 +590,11 @@ type OutputService8ProtocolTest struct {
 // New returns a new OutputService8ProtocolTest client.
 func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice8protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice8protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -592,8 +610,8 @@ func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTe
 
 // newRequest creates a new request for a OutputService8ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService8ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -601,8 +619,8 @@ func (c *OutputService8ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService8TestCaseOperation1 = "OperationName"
 
 // OutputService8TestCaseOperation1Request generates a request for the OutputService8TestCaseOperation1 operation.
-func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1Request(input *OutputService8TestShapeOutputService8TestCaseOperation1Input) (req *service.Request, output *OutputService8TestShapeOutputService8TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1Request(input *OutputService8TestShapeOutputService8TestCaseOperation1Input) (req *request.Request, output *OutputService8TestShapeOutputService8TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService8TestCaseOperation1,
 	}
 

--- a/internal/protocol/ec2query/unmarshal_test.go
+++ b/internal/protocol/ec2query/unmarshal_test.go
@@ -41,7 +41,7 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice1protocoltest",
 			APIVersion:  "",
@@ -62,7 +62,7 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -130,7 +130,7 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice2protocoltest",
 			APIVersion:  "",
@@ -151,7 +151,7 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -205,7 +205,7 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice3protocoltest",
 			APIVersion:  "",
@@ -226,7 +226,7 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -280,7 +280,7 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice4protocoltest",
 			APIVersion:  "",
@@ -301,7 +301,7 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -355,7 +355,7 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice5protocoltest",
 			APIVersion:  "",
@@ -376,7 +376,7 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -430,7 +430,7 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice6protocoltest",
 			APIVersion:  "",
@@ -451,7 +451,7 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -515,7 +515,7 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice7protocoltest",
 			APIVersion:  "",
@@ -536,7 +536,7 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -590,7 +590,7 @@ type OutputService8ProtocolTest struct {
 // New returns a new OutputService8ProtocolTest client.
 func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice8protocoltest",
 			APIVersion:  "",
@@ -611,7 +611,7 @@ func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTe
 // newRequest creates a new request for a OutputService8ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/jsonrpc/build_test.go
+++ b/internal/protocol/jsonrpc/build_test.go
@@ -41,7 +41,7 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "inputservice1protocoltest",
 			APIVersion:   "",
@@ -64,7 +64,7 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -119,7 +119,7 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "inputservice2protocoltest",
 			APIVersion:   "",
@@ -142,7 +142,7 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -196,7 +196,7 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "inputservice3protocoltest",
 			APIVersion:   "",
@@ -219,7 +219,7 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -307,7 +307,7 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "inputservice4protocoltest",
 			APIVersion:   "",
@@ -330,7 +330,7 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -385,7 +385,7 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "inputservice5protocoltest",
 			APIVersion:   "",
@@ -408,7 +408,7 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/jsonrpc/build_test.go
+++ b/internal/protocol/jsonrpc/build_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,11 +41,13 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "inputservice1protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "1.1",
-		TargetPrefix: "com.amazonaws.foo",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "inputservice1protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "1.1",
+			TargetPrefix: "com.amazonaws.foo",
+		},
 	}
 	service.Initialize()
 
@@ -59,8 +63,8 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -68,8 +72,8 @@ func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService1TestCaseOperation1 = "OperationName"
 
 // InputService1TestCaseOperation1Request generates a request for the InputService1TestCaseOperation1 operation.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation1Input) (req *service.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation1Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService1TestCaseOperation1,
 		HTTPMethod: "POST",
 	}
@@ -115,11 +119,13 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "inputservice2protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "1.1",
-		TargetPrefix: "com.amazonaws.foo",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "inputservice2protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "1.1",
+			TargetPrefix: "com.amazonaws.foo",
+		},
 	}
 	service.Initialize()
 
@@ -135,8 +141,8 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -144,8 +150,8 @@ func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService2TestCaseOperation1 = "OperationName"
 
 // InputService2TestCaseOperation1Request generates a request for the InputService2TestCaseOperation1 operation.
-func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *service.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *request.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService2TestCaseOperation1,
 	}
 
@@ -190,11 +196,13 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "inputservice3protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "1.1",
-		TargetPrefix: "com.amazonaws.foo",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "inputservice3protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "1.1",
+			TargetPrefix: "com.amazonaws.foo",
+		},
 	}
 	service.Initialize()
 
@@ -210,8 +218,8 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -219,8 +227,8 @@ func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService3TestCaseOperation1 = "OperationName"
 
 // InputService3TestCaseOperation1Request generates a request for the InputService3TestCaseOperation1 operation.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputShape) (req *service.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService3TestCaseOperation1,
 	}
 
@@ -243,8 +251,8 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 const opInputService3TestCaseOperation2 = "OperationName"
 
 // InputService3TestCaseOperation2Request generates a request for the InputService3TestCaseOperation2 operation.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputShape) (req *service.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name: opInputService3TestCaseOperation2,
 	}
 
@@ -299,11 +307,13 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "inputservice4protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "1.1",
-		TargetPrefix: "com.amazonaws.foo",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "inputservice4protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "1.1",
+			TargetPrefix: "com.amazonaws.foo",
+		},
 	}
 	service.Initialize()
 
@@ -319,8 +329,8 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -328,8 +338,8 @@ func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService4TestCaseOperation1 = "OperationName"
 
 // InputService4TestCaseOperation1Request generates a request for the InputService4TestCaseOperation1 operation.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *service.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService4TestCaseOperation1,
 		HTTPMethod: "POST",
 	}
@@ -375,11 +385,13 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "inputservice5protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "1.1",
-		TargetPrefix: "com.amazonaws.foo",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "inputservice5protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "1.1",
+			TargetPrefix: "com.amazonaws.foo",
+		},
 	}
 	service.Initialize()
 
@@ -395,8 +407,8 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -404,8 +416,8 @@ func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService5TestCaseOperation1 = "OperationName"
 
 // InputService5TestCaseOperation1Request generates a request for the InputService5TestCaseOperation1 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputShape) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation1,
 	}
 
@@ -428,8 +440,8 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 const opInputService5TestCaseOperation2 = "OperationName"
 
 // InputService5TestCaseOperation2Request generates a request for the InputService5TestCaseOperation2 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation2,
 	}
 
@@ -452,8 +464,8 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation2(input *Input
 const opInputService5TestCaseOperation3 = "OperationName"
 
 // InputService5TestCaseOperation3Request generates a request for the InputService5TestCaseOperation3 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation3Request(input *InputService5TestShapeInputShape) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation3Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation3Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation3Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation3,
 	}
 
@@ -476,8 +488,8 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation3(input *Input
 const opInputService5TestCaseOperation4 = "OperationName"
 
 // InputService5TestCaseOperation4Request generates a request for the InputService5TestCaseOperation4 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation4Request(input *InputService5TestShapeInputShape) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation4Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation4Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation4Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation4,
 	}
 
@@ -500,8 +512,8 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation4(input *Input
 const opInputService5TestCaseOperation5 = "OperationName"
 
 // InputService5TestCaseOperation5Request generates a request for the InputService5TestCaseOperation5 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation5Request(input *InputService5TestShapeInputShape) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation5Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation5Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation5Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation5,
 	}
 
@@ -524,8 +536,8 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation5(input *Input
 const opInputService5TestCaseOperation6 = "OperationName"
 
 // InputService5TestCaseOperation6Request generates a request for the InputService5TestCaseOperation6 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputShape) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation6Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation6Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation6Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation6,
 	}
 

--- a/internal/protocol/jsonrpc/jsonrpc.go
+++ b/internal/protocol/jsonrpc/jsonrpc.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/protocol/json/jsonutil"
 )
 
 var emptyJSON = []byte("{}")
 
 // Build builds a JSON payload for a JSON RPC request.
-func Build(req *service.Request) {
+func Build(req *request.Request) {
 	var buf []byte
 	var err error
 	if req.ParamsFilled() {
@@ -46,7 +46,7 @@ func Build(req *service.Request) {
 }
 
 // Unmarshal unmarshals a response for a JSON RPC service.
-func Unmarshal(req *service.Request) {
+func Unmarshal(req *request.Request) {
 	defer req.HTTPResponse.Body.Close()
 	if req.DataFilled() {
 		err := jsonutil.UnmarshalJSON(req.Data, req.HTTPResponse.Body)
@@ -58,12 +58,12 @@ func Unmarshal(req *service.Request) {
 }
 
 // UnmarshalMeta unmarshals headers from a response for a JSON RPC service.
-func UnmarshalMeta(req *service.Request) {
+func UnmarshalMeta(req *request.Request) {
 	req.RequestID = req.HTTPResponse.Header.Get("x-amzn-requestid")
 }
 
 // UnmarshalError unmarshals an error response for a JSON RPC service.
-func UnmarshalError(req *service.Request) {
+func UnmarshalError(req *request.Request) {
 	defer req.HTTPResponse.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(req.HTTPResponse.Body)
 	if err != nil {

--- a/internal/protocol/jsonrpc/unmarshal_test.go
+++ b/internal/protocol/jsonrpc/unmarshal_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,11 +41,13 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "outputservice1protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "",
-		TargetPrefix: "",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "outputservice1protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "",
+			TargetPrefix: "",
+		},
 	}
 	service.Initialize()
 
@@ -59,8 +63,8 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -68,8 +72,8 @@ func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService1TestCaseOperation1 = "OperationName"
 
 // OutputService1TestCaseOperation1Request generates a request for the OutputService1TestCaseOperation1 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *service.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService1TestCaseOperation1,
 	}
 
@@ -112,11 +116,13 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "outputservice2protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "",
-		TargetPrefix: "",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "outputservice2protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "",
+			TargetPrefix: "",
+		},
 	}
 	service.Initialize()
 
@@ -132,8 +138,8 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -141,8 +147,8 @@ func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService2TestCaseOperation1 = "OperationName"
 
 // OutputService2TestCaseOperation1Request generates a request for the OutputService2TestCaseOperation1 operation.
-func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *service.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *request.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService2TestCaseOperation1,
 	}
 
@@ -201,11 +207,13 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "outputservice3protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "",
-		TargetPrefix: "",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "outputservice3protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "",
+			TargetPrefix: "",
+		},
 	}
 	service.Initialize()
 
@@ -221,8 +229,8 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -230,8 +238,8 @@ func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService3TestCaseOperation1 = "OperationName"
 
 // OutputService3TestCaseOperation1Request generates a request for the OutputService3TestCaseOperation1 operation.
-func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *service.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *request.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService3TestCaseOperation1,
 	}
 
@@ -288,11 +296,13 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "outputservice4protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "",
-		TargetPrefix: "",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "outputservice4protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "",
+			TargetPrefix: "",
+		},
 	}
 	service.Initialize()
 
@@ -308,8 +318,8 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -317,8 +327,8 @@ func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService4TestCaseOperation1 = "OperationName"
 
 // OutputService4TestCaseOperation1Request generates a request for the OutputService4TestCaseOperation1 operation.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *service.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService4TestCaseOperation1,
 	}
 
@@ -375,11 +385,13 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "outputservice5protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "",
-		TargetPrefix: "",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "outputservice5protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "",
+			TargetPrefix: "",
+		},
 	}
 	service.Initialize()
 
@@ -395,8 +407,8 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -404,8 +416,8 @@ func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService5TestCaseOperation1 = "OperationName"
 
 // OutputService5TestCaseOperation1Request generates a request for the OutputService5TestCaseOperation1 operation.
-func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *service.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *request.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService5TestCaseOperation1,
 	}
 
@@ -450,11 +462,13 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "outputservice6protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "",
-		TargetPrefix: "",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "outputservice6protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "",
+			TargetPrefix: "",
+		},
 	}
 	service.Initialize()
 
@@ -470,8 +484,8 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -479,8 +493,8 @@ func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService6TestCaseOperation1 = "OperationName"
 
 // OutputService6TestCaseOperation1Request generates a request for the OutputService6TestCaseOperation1 operation.
-func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *service.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *request.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService6TestCaseOperation1,
 	}
 
@@ -525,11 +539,13 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "outputservice7protocoltest",
-		APIVersion:   "",
-		JSONVersion:  "",
-		TargetPrefix: "",
+		Service: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "outputservice7protocoltest",
+			APIVersion:   "",
+			JSONVersion:  "",
+			TargetPrefix: "",
+		},
 	}
 	service.Initialize()
 
@@ -545,8 +561,8 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -554,8 +570,8 @@ func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService7TestCaseOperation1 = "OperationName"
 
 // OutputService7TestCaseOperation1Request generates a request for the OutputService7TestCaseOperation1 operation.
-func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *service.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *request.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService7TestCaseOperation1,
 	}
 

--- a/internal/protocol/jsonrpc/unmarshal_test.go
+++ b/internal/protocol/jsonrpc/unmarshal_test.go
@@ -41,7 +41,7 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "outputservice1protocoltest",
 			APIVersion:   "",
@@ -64,7 +64,7 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -116,7 +116,7 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "outputservice2protocoltest",
 			APIVersion:   "",
@@ -139,7 +139,7 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -207,7 +207,7 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "outputservice3protocoltest",
 			APIVersion:   "",
@@ -230,7 +230,7 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -296,7 +296,7 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "outputservice4protocoltest",
 			APIVersion:   "",
@@ -319,7 +319,7 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -385,7 +385,7 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "outputservice5protocoltest",
 			APIVersion:   "",
@@ -408,7 +408,7 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -462,7 +462,7 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "outputservice6protocoltest",
 			APIVersion:   "",
@@ -485,7 +485,7 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -539,7 +539,7 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:       defaults.DefaultConfig.Merge(config),
 			ServiceName:  "outputservice7protocoltest",
 			APIVersion:   "",
@@ -562,7 +562,7 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/query/build.go
+++ b/internal/protocol/query/build.go
@@ -7,12 +7,12 @@ import (
 	"net/url"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/protocol/query/queryutil"
 )
 
 // Build builds a request for an AWS Query service.
-func Build(r *service.Request) {
+func Build(r *request.Request) {
 	body := url.Values{
 		"Action":  {r.Operation.Name},
 		"Version": {r.Service.APIVersion},

--- a/internal/protocol/query/build_test.go
+++ b/internal/protocol/query/build_test.go
@@ -41,7 +41,7 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice1protocoltest",
 			APIVersion:  "2014-01-01",
@@ -62,7 +62,7 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -118,7 +118,7 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice2protocoltest",
 			APIVersion:  "2014-01-01",
@@ -139,7 +139,7 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -203,7 +203,7 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice3protocoltest",
 			APIVersion:  "2014-01-01",
@@ -224,7 +224,7 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -310,7 +310,7 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice4protocoltest",
 			APIVersion:  "2014-01-01",
@@ -331,7 +331,7 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -419,7 +419,7 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice5protocoltest",
 			APIVersion:  "2014-01-01",
@@ -440,7 +440,7 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -526,7 +526,7 @@ type InputService6ProtocolTest struct {
 // New returns a new InputService6ProtocolTest client.
 func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice6protocoltest",
 			APIVersion:  "2014-01-01",
@@ -547,7 +547,7 @@ func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest
 // newRequest creates a new request for a InputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -601,7 +601,7 @@ type InputService7ProtocolTest struct {
 // New returns a new InputService7ProtocolTest client.
 func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice7protocoltest",
 			APIVersion:  "2014-01-01",
@@ -622,7 +622,7 @@ func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest
 // newRequest creates a new request for a InputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -676,7 +676,7 @@ type InputService8ProtocolTest struct {
 // New returns a new InputService8ProtocolTest client.
 func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice8protocoltest",
 			APIVersion:  "2014-01-01",
@@ -697,7 +697,7 @@ func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest
 // newRequest creates a new request for a InputService8ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -751,7 +751,7 @@ type InputService9ProtocolTest struct {
 // New returns a new InputService9ProtocolTest client.
 func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice9protocoltest",
 			APIVersion:  "2014-01-01",
@@ -772,7 +772,7 @@ func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest
 // newRequest creates a new request for a InputService9ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/query/build_test.go
+++ b/internal/protocol/query/build_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,9 +41,11 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice1protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice1protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -66,8 +70,8 @@ func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService1TestCaseOperation1 = "OperationName"
 
 // InputService1TestCaseOperation1Request generates a request for the InputService1TestCaseOperation1 operation.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation1Input) (req *service.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation1Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService1TestCaseOperation1,
 	}
 
@@ -114,9 +118,11 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice2protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice2protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -132,8 +138,8 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -141,8 +147,8 @@ func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService2TestCaseOperation1 = "OperationName"
 
 // InputService2TestCaseOperation1Request generates a request for the InputService2TestCaseOperation1 operation.
-func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *service.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *request.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService2TestCaseOperation1,
 	}
 
@@ -197,9 +203,11 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice3protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice3protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -215,8 +223,8 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -224,8 +232,8 @@ func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService3TestCaseOperation1 = "OperationName"
 
 // InputService3TestCaseOperation1Request generates a request for the InputService3TestCaseOperation1 operation.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputShape) (req *service.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService3TestCaseOperation1,
 	}
 
@@ -248,8 +256,8 @@ func (c *InputService3ProtocolTest) InputService3TestCaseOperation1(input *Input
 const opInputService3TestCaseOperation2 = "OperationName"
 
 // InputService3TestCaseOperation2Request generates a request for the InputService3TestCaseOperation2 operation.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputShape) (req *service.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation2Request(input *InputService3TestShapeInputShape) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name: opInputService3TestCaseOperation2,
 	}
 
@@ -302,9 +310,11 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice4protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice4protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -320,8 +330,8 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -329,8 +339,8 @@ func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService4TestCaseOperation1 = "OperationName"
 
 // InputService4TestCaseOperation1Request generates a request for the InputService4TestCaseOperation1 operation.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputShape) (req *service.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputShape) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService4TestCaseOperation1,
 	}
 
@@ -353,8 +363,8 @@ func (c *InputService4ProtocolTest) InputService4TestCaseOperation1(input *Input
 const opInputService4TestCaseOperation2 = "OperationName"
 
 // InputService4TestCaseOperation2Request generates a request for the InputService4TestCaseOperation2 operation.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation2Request(input *InputService4TestShapeInputShape) (req *service.Request, output *InputService4TestShapeInputService4TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation2Request(input *InputService4TestShapeInputShape) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name: opInputService4TestCaseOperation2,
 	}
 
@@ -409,9 +419,11 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice5protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice5protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -427,8 +439,8 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -436,8 +448,8 @@ func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService5TestCaseOperation1 = "OperationName"
 
 // InputService5TestCaseOperation1Request generates a request for the InputService5TestCaseOperation1 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputShape) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation1,
 	}
 
@@ -460,8 +472,8 @@ func (c *InputService5ProtocolTest) InputService5TestCaseOperation1(input *Input
 const opInputService5TestCaseOperation2 = "OperationName"
 
 // InputService5TestCaseOperation2Request generates a request for the InputService5TestCaseOperation2 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation2Request(input *InputService5TestShapeInputShape) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name: opInputService5TestCaseOperation2,
 	}
 
@@ -514,9 +526,11 @@ type InputService6ProtocolTest struct {
 // New returns a new InputService6ProtocolTest client.
 func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice6protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice6protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -532,8 +546,8 @@ func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest
 
 // newRequest creates a new request for a InputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -541,8 +555,8 @@ func (c *InputService6ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService6TestCaseOperation1 = "OperationName"
 
 // InputService6TestCaseOperation1Request generates a request for the InputService6TestCaseOperation1 operation.
-func (c *InputService6ProtocolTest) InputService6TestCaseOperation1Request(input *InputService6TestShapeInputService6TestCaseOperation1Input) (req *service.Request, output *InputService6TestShapeInputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService6ProtocolTest) InputService6TestCaseOperation1Request(input *InputService6TestShapeInputService6TestCaseOperation1Input) (req *request.Request, output *InputService6TestShapeInputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService6TestCaseOperation1,
 	}
 
@@ -587,9 +601,11 @@ type InputService7ProtocolTest struct {
 // New returns a new InputService7ProtocolTest client.
 func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice7protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice7protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -605,8 +621,8 @@ func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest
 
 // newRequest creates a new request for a InputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -614,8 +630,8 @@ func (c *InputService7ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService7TestCaseOperation1 = "OperationName"
 
 // InputService7TestCaseOperation1Request generates a request for the InputService7TestCaseOperation1 operation.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputService7TestCaseOperation1Input) (req *service.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputService7TestCaseOperation1Input) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService7TestCaseOperation1,
 	}
 
@@ -660,9 +676,11 @@ type InputService8ProtocolTest struct {
 // New returns a new InputService8ProtocolTest client.
 func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice8protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice8protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -678,8 +696,8 @@ func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest
 
 // newRequest creates a new request for a InputService8ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService8ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -687,8 +705,8 @@ func (c *InputService8ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService8TestCaseOperation1 = "OperationName"
 
 // InputService8TestCaseOperation1Request generates a request for the InputService8TestCaseOperation1 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputService8TestCaseOperation1Input) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputService8TestCaseOperation1Input) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService8TestCaseOperation1,
 	}
 
@@ -733,9 +751,11 @@ type InputService9ProtocolTest struct {
 // New returns a new InputService9ProtocolTest client.
 func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice9protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice9protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -751,8 +771,8 @@ func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest
 
 // newRequest creates a new request for a InputService9ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService9ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -760,8 +780,8 @@ func (c *InputService9ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService9TestCaseOperation1 = "OperationName"
 
 // InputService9TestCaseOperation1Request generates a request for the InputService9TestCaseOperation1 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputShape) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opInputService9TestCaseOperation1,
 	}
 
@@ -784,8 +804,8 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 const opInputService9TestCaseOperation2 = "OperationName"
 
 // InputService9TestCaseOperation2Request generates a request for the InputService9TestCaseOperation2 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation2Request(input *InputService9TestShapeInputShape) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation2Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name: opInputService9TestCaseOperation2,
 	}
 
@@ -808,8 +828,8 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation2(input *Input
 const opInputService9TestCaseOperation3 = "OperationName"
 
 // InputService9TestCaseOperation3Request generates a request for the InputService9TestCaseOperation3 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation3Request(input *InputService9TestShapeInputShape) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation3Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation3Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation3Output) {
+	op := &request.Operation{
 		Name: opInputService9TestCaseOperation3,
 	}
 
@@ -832,8 +852,8 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation3(input *Input
 const opInputService9TestCaseOperation4 = "OperationName"
 
 // InputService9TestCaseOperation4Request generates a request for the InputService9TestCaseOperation4 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation4Request(input *InputService9TestShapeInputShape) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation4Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation4Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation4Output) {
+	op := &request.Operation{
 		Name: opInputService9TestCaseOperation4,
 	}
 
@@ -856,8 +876,8 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation4(input *Input
 const opInputService9TestCaseOperation5 = "OperationName"
 
 // InputService9TestCaseOperation5Request generates a request for the InputService9TestCaseOperation5 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation5Request(input *InputService9TestShapeInputShape) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation5Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation5Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation5Output) {
+	op := &request.Operation{
 		Name: opInputService9TestCaseOperation5,
 	}
 
@@ -880,8 +900,8 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation5(input *Input
 const opInputService9TestCaseOperation6 = "OperationName"
 
 // InputService9TestCaseOperation6Request generates a request for the InputService9TestCaseOperation6 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation6Request(input *InputService9TestShapeInputShape) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation6Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation6Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation6Output) {
+	op := &request.Operation{
 		Name: opInputService9TestCaseOperation6,
 	}
 

--- a/internal/protocol/query/unmarshal.go
+++ b/internal/protocol/query/unmarshal.go
@@ -6,12 +6,12 @@ import (
 	"encoding/xml"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 )
 
 // Unmarshal unmarshals a response for an AWS Query service.
-func Unmarshal(r *service.Request) {
+func Unmarshal(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 	if r.DataFilled() {
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
@@ -24,6 +24,6 @@ func Unmarshal(r *service.Request) {
 }
 
 // UnmarshalMeta unmarshals header response values for an AWS Query service.
-func UnmarshalMeta(r *service.Request) {
+func UnmarshalMeta(r *request.Request) {
 	// TODO implement unmarshaling of request IDs
 }

--- a/internal/protocol/query/unmarshal_error.go
+++ b/internal/protocol/query/unmarshal_error.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 type xmlErrorResponse struct {
@@ -16,7 +16,7 @@ type xmlErrorResponse struct {
 }
 
 // UnmarshalError unmarshals an error response for an AWS Query service.
-func UnmarshalError(r *service.Request) {
+func UnmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
 	resp := &xmlErrorResponse{}

--- a/internal/protocol/query/unmarshal_test.go
+++ b/internal/protocol/query/unmarshal_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,9 +41,11 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice1protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice1protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -66,8 +70,8 @@ func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService1TestCaseOperation1 = "OperationName"
 
 // OutputService1TestCaseOperation1Request generates a request for the OutputService1TestCaseOperation1 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *service.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService1TestCaseOperation1,
 	}
 
@@ -128,9 +132,11 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice2protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice2protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -146,8 +152,8 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -155,8 +161,8 @@ func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService2TestCaseOperation1 = "OperationName"
 
 // OutputService2TestCaseOperation1Request generates a request for the OutputService2TestCaseOperation1 operation.
-func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *service.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *request.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService2TestCaseOperation1,
 	}
 
@@ -203,9 +209,11 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice3protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice3protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -221,8 +229,8 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -230,8 +238,8 @@ func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService3TestCaseOperation1 = "OperationName"
 
 // OutputService3TestCaseOperation1Request generates a request for the OutputService3TestCaseOperation1 operation.
-func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *service.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *request.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService3TestCaseOperation1,
 	}
 
@@ -276,9 +284,11 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice4protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice4protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -294,8 +304,8 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -303,8 +313,8 @@ func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService4TestCaseOperation1 = "OperationName"
 
 // OutputService4TestCaseOperation1Request generates a request for the OutputService4TestCaseOperation1 operation.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *service.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService4TestCaseOperation1,
 	}
 
@@ -349,9 +359,11 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice5protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice5protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -367,8 +379,8 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -376,8 +388,8 @@ func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService5TestCaseOperation1 = "OperationName"
 
 // OutputService5TestCaseOperation1Request generates a request for the OutputService5TestCaseOperation1 operation.
-func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *service.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *request.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService5TestCaseOperation1,
 	}
 
@@ -422,9 +434,11 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice6protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice6protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -440,8 +454,8 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -449,8 +463,8 @@ func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService6TestCaseOperation1 = "OperationName"
 
 // OutputService6TestCaseOperation1Request generates a request for the OutputService6TestCaseOperation1 operation.
-func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *service.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *request.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService6TestCaseOperation1,
 	}
 
@@ -495,9 +509,11 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice7protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice7protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -513,8 +529,8 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -522,8 +538,8 @@ func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService7TestCaseOperation1 = "OperationName"
 
 // OutputService7TestCaseOperation1Request generates a request for the OutputService7TestCaseOperation1 operation.
-func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *service.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *request.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService7TestCaseOperation1,
 	}
 
@@ -568,9 +584,11 @@ type OutputService8ProtocolTest struct {
 // New returns a new OutputService8ProtocolTest client.
 func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice8protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice8protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -586,8 +604,8 @@ func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTe
 
 // newRequest creates a new request for a OutputService8ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService8ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -595,8 +613,8 @@ func (c *OutputService8ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService8TestCaseOperation1 = "OperationName"
 
 // OutputService8TestCaseOperation1Request generates a request for the OutputService8TestCaseOperation1 operation.
-func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1Request(input *OutputService8TestShapeOutputService8TestCaseOperation1Input) (req *service.Request, output *OutputService8TestShapeOutputService8TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1Request(input *OutputService8TestShapeOutputService8TestCaseOperation1Input) (req *request.Request, output *OutputService8TestShapeOutputService8TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService8TestCaseOperation1,
 	}
 
@@ -655,9 +673,11 @@ type OutputService9ProtocolTest struct {
 // New returns a new OutputService9ProtocolTest client.
 func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice9protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice9protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -673,8 +693,8 @@ func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTe
 
 // newRequest creates a new request for a OutputService9ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService9ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -682,8 +702,8 @@ func (c *OutputService9ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService9TestCaseOperation1 = "OperationName"
 
 // OutputService9TestCaseOperation1Request generates a request for the OutputService9TestCaseOperation1 operation.
-func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1Request(input *OutputService9TestShapeOutputService9TestCaseOperation1Input) (req *service.Request, output *OutputService9TestShapeOutputService9TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1Request(input *OutputService9TestShapeOutputService9TestCaseOperation1Input) (req *request.Request, output *OutputService9TestShapeOutputService9TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService9TestCaseOperation1,
 	}
 
@@ -742,9 +762,11 @@ type OutputService10ProtocolTest struct {
 // New returns a new OutputService10ProtocolTest client.
 func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice10protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice10protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -760,8 +782,8 @@ func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10Protocol
 
 // newRequest creates a new request for a OutputService10ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService10ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService10ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -769,8 +791,8 @@ func (c *OutputService10ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService10TestCaseOperation1 = "OperationName"
 
 // OutputService10TestCaseOperation1Request generates a request for the OutputService10TestCaseOperation1 operation.
-func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1Request(input *OutputService10TestShapeOutputService10TestCaseOperation1Input) (req *service.Request, output *OutputService10TestShapeOutputService10TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1Request(input *OutputService10TestShapeOutputService10TestCaseOperation1Input) (req *request.Request, output *OutputService10TestShapeOutputService10TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService10TestCaseOperation1,
 	}
 
@@ -815,9 +837,11 @@ type OutputService11ProtocolTest struct {
 // New returns a new OutputService11ProtocolTest client.
 func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice11protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice11protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -833,8 +857,8 @@ func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11Protocol
 
 // newRequest creates a new request for a OutputService11ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService11ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -842,8 +866,8 @@ func (c *OutputService11ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService11TestCaseOperation1 = "OperationName"
 
 // OutputService11TestCaseOperation1Request generates a request for the OutputService11TestCaseOperation1 operation.
-func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *service.Request, output *OutputService11TestShapeOutputService11TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *request.Request, output *OutputService11TestShapeOutputService11TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService11TestCaseOperation1,
 	}
 
@@ -898,9 +922,11 @@ type OutputService12ProtocolTest struct {
 // New returns a new OutputService12ProtocolTest client.
 func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice12protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice12protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -916,8 +942,8 @@ func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12Protocol
 
 // newRequest creates a new request for a OutputService12ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService12ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -925,8 +951,8 @@ func (c *OutputService12ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService12TestCaseOperation1 = "OperationName"
 
 // OutputService12TestCaseOperation1Request generates a request for the OutputService12TestCaseOperation1 operation.
-func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1Request(input *OutputService12TestShapeOutputService12TestCaseOperation1Input) (req *service.Request, output *OutputService12TestShapeOutputService12TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1Request(input *OutputService12TestShapeOutputService12TestCaseOperation1Input) (req *request.Request, output *OutputService12TestShapeOutputService12TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService12TestCaseOperation1,
 	}
 
@@ -971,9 +997,11 @@ type OutputService13ProtocolTest struct {
 // New returns a new OutputService13ProtocolTest client.
 func NewOutputService13ProtocolTest(config *aws.Config) *OutputService13ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice13protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice13protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -989,8 +1017,8 @@ func NewOutputService13ProtocolTest(config *aws.Config) *OutputService13Protocol
 
 // newRequest creates a new request for a OutputService13ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService13ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService13ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -998,8 +1026,8 @@ func (c *OutputService13ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService13TestCaseOperation1 = "OperationName"
 
 // OutputService13TestCaseOperation1Request generates a request for the OutputService13TestCaseOperation1 operation.
-func (c *OutputService13ProtocolTest) OutputService13TestCaseOperation1Request(input *OutputService13TestShapeOutputService13TestCaseOperation1Input) (req *service.Request, output *OutputService13TestShapeOutputService13TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService13ProtocolTest) OutputService13TestCaseOperation1Request(input *OutputService13TestShapeOutputService13TestCaseOperation1Input) (req *request.Request, output *OutputService13TestShapeOutputService13TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService13TestCaseOperation1,
 	}
 
@@ -1044,9 +1072,11 @@ type OutputService14ProtocolTest struct {
 // New returns a new OutputService14ProtocolTest client.
 func NewOutputService14ProtocolTest(config *aws.Config) *OutputService14ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice14protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice14protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -1062,8 +1092,8 @@ func NewOutputService14ProtocolTest(config *aws.Config) *OutputService14Protocol
 
 // newRequest creates a new request for a OutputService14ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService14ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService14ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -1071,8 +1101,8 @@ func (c *OutputService14ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService14TestCaseOperation1 = "OperationName"
 
 // OutputService14TestCaseOperation1Request generates a request for the OutputService14TestCaseOperation1 operation.
-func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1Request(input *OutputService14TestShapeOutputService14TestCaseOperation1Input) (req *service.Request, output *OutputService14TestShapeOutputService14TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService14ProtocolTest) OutputService14TestCaseOperation1Request(input *OutputService14TestShapeOutputService14TestCaseOperation1Input) (req *request.Request, output *OutputService14TestShapeOutputService14TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService14TestCaseOperation1,
 	}
 

--- a/internal/protocol/query/unmarshal_test.go
+++ b/internal/protocol/query/unmarshal_test.go
@@ -41,7 +41,7 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice1protocoltest",
 			APIVersion:  "",
@@ -62,7 +62,7 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -132,7 +132,7 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice2protocoltest",
 			APIVersion:  "",
@@ -153,7 +153,7 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -209,7 +209,7 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice3protocoltest",
 			APIVersion:  "",
@@ -230,7 +230,7 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -284,7 +284,7 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice4protocoltest",
 			APIVersion:  "",
@@ -305,7 +305,7 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -359,7 +359,7 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice5protocoltest",
 			APIVersion:  "",
@@ -380,7 +380,7 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -434,7 +434,7 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice6protocoltest",
 			APIVersion:  "",
@@ -455,7 +455,7 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -509,7 +509,7 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice7protocoltest",
 			APIVersion:  "",
@@ -530,7 +530,7 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -584,7 +584,7 @@ type OutputService8ProtocolTest struct {
 // New returns a new OutputService8ProtocolTest client.
 func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice8protocoltest",
 			APIVersion:  "",
@@ -605,7 +605,7 @@ func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTe
 // newRequest creates a new request for a OutputService8ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -673,7 +673,7 @@ type OutputService9ProtocolTest struct {
 // New returns a new OutputService9ProtocolTest client.
 func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice9protocoltest",
 			APIVersion:  "",
@@ -694,7 +694,7 @@ func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTe
 // newRequest creates a new request for a OutputService9ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -762,7 +762,7 @@ type OutputService10ProtocolTest struct {
 // New returns a new OutputService10ProtocolTest client.
 func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice10protocoltest",
 			APIVersion:  "",
@@ -783,7 +783,7 @@ func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10Protocol
 // newRequest creates a new request for a OutputService10ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService10ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -837,7 +837,7 @@ type OutputService11ProtocolTest struct {
 // New returns a new OutputService11ProtocolTest client.
 func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice11protocoltest",
 			APIVersion:  "",
@@ -858,7 +858,7 @@ func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11Protocol
 // newRequest creates a new request for a OutputService11ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -922,7 +922,7 @@ type OutputService12ProtocolTest struct {
 // New returns a new OutputService12ProtocolTest client.
 func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice12protocoltest",
 			APIVersion:  "",
@@ -943,7 +943,7 @@ func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12Protocol
 // newRequest creates a new request for a OutputService12ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -997,7 +997,7 @@ type OutputService13ProtocolTest struct {
 // New returns a new OutputService13ProtocolTest client.
 func NewOutputService13ProtocolTest(config *aws.Config) *OutputService13ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice13protocoltest",
 			APIVersion:  "",
@@ -1018,7 +1018,7 @@ func NewOutputService13ProtocolTest(config *aws.Config) *OutputService13Protocol
 // newRequest creates a new request for a OutputService13ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService13ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -1072,7 +1072,7 @@ type OutputService14ProtocolTest struct {
 // New returns a new OutputService14ProtocolTest client.
 func NewOutputService14ProtocolTest(config *aws.Config) *OutputService14ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice14protocoltest",
 			APIVersion:  "",
@@ -1093,7 +1093,7 @@ func NewOutputService14ProtocolTest(config *aws.Config) *OutputService14Protocol
 // newRequest creates a new request for a OutputService14ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService14ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/rest/build.go
+++ b/internal/protocol/rest/build.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 // RFC822 returns an RFC822 formatted timestamp for AWS protocols
@@ -37,7 +37,7 @@ func init() {
 }
 
 // Build builds the REST component of a service request.
-func Build(r *service.Request) {
+func Build(r *request.Request) {
 	if r.ParamsFilled() {
 		v := reflect.ValueOf(r.Params).Elem()
 		buildLocationElements(r, v)
@@ -45,7 +45,7 @@ func Build(r *service.Request) {
 	}
 }
 
-func buildLocationElements(r *service.Request, v reflect.Value) {
+func buildLocationElements(r *request.Request, v reflect.Value) {
 	query := r.HTTPRequest.URL.Query()
 
 	for i := 0; i < v.NumField(); i++ {
@@ -87,7 +87,7 @@ func buildLocationElements(r *service.Request, v reflect.Value) {
 	updatePath(r.HTTPRequest.URL, r.HTTPRequest.URL.Path)
 }
 
-func buildBody(r *service.Request, v reflect.Value) {
+func buildBody(r *request.Request, v reflect.Value) {
 	if field, ok := v.Type().FieldByName("SDKShapeTraits"); ok {
 		if payloadName := field.Tag.Get("payload"); payloadName != "" {
 			pfield, _ := v.Type().FieldByName(payloadName)
@@ -112,7 +112,7 @@ func buildBody(r *service.Request, v reflect.Value) {
 	}
 }
 
-func buildHeader(r *service.Request, v reflect.Value, name string) {
+func buildHeader(r *request.Request, v reflect.Value, name string) {
 	str, err := convertType(v)
 	if err != nil {
 		r.Error = awserr.New("SerializationError", "failed to encode REST request", err)
@@ -121,7 +121,7 @@ func buildHeader(r *service.Request, v reflect.Value, name string) {
 	}
 }
 
-func buildHeaderMap(r *service.Request, v reflect.Value, prefix string) {
+func buildHeaderMap(r *request.Request, v reflect.Value, prefix string) {
 	for _, key := range v.MapKeys() {
 		str, err := convertType(v.MapIndex(key))
 		if err != nil {
@@ -132,7 +132,7 @@ func buildHeaderMap(r *service.Request, v reflect.Value, prefix string) {
 	}
 }
 
-func buildURI(r *service.Request, v reflect.Value, name string) {
+func buildURI(r *request.Request, v reflect.Value, name string) {
 	value, err := convertType(v)
 	if err != nil {
 		r.Error = awserr.New("SerializationError", "failed to encode REST request", err)
@@ -144,7 +144,7 @@ func buildURI(r *service.Request, v reflect.Value, name string) {
 	}
 }
 
-func buildQueryString(r *service.Request, v reflect.Value, name string, query url.Values) {
+func buildQueryString(r *request.Request, v reflect.Value, name string, query url.Values) {
 	str, err := convertType(v)
 	if err != nil {
 		r.Error = awserr.New("SerializationError", "failed to encode REST request", err)

--- a/internal/protocol/rest/unmarshal.go
+++ b/internal/protocol/rest/unmarshal.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 // Unmarshal unmarshals the REST component of a response in a REST service.
-func Unmarshal(r *service.Request) {
+func Unmarshal(r *request.Request) {
 	if r.DataFilled() {
 		v := reflect.Indirect(reflect.ValueOf(r.Data))
 		unmarshalBody(r, v)
@@ -24,7 +24,7 @@ func Unmarshal(r *service.Request) {
 	}
 }
 
-func unmarshalBody(r *service.Request, v reflect.Value) {
+func unmarshalBody(r *request.Request, v reflect.Value) {
 	if field, ok := v.Type().FieldByName("SDKShapeTraits"); ok {
 		if payloadName := field.Tag.Get("payload"); payloadName != "" {
 			pfield, _ := v.Type().FieldByName(payloadName)
@@ -65,7 +65,7 @@ func unmarshalBody(r *service.Request, v reflect.Value) {
 	}
 }
 
-func unmarshalLocationElements(r *service.Request, v reflect.Value) {
+func unmarshalLocationElements(r *request.Request, v reflect.Value) {
 	for i := 0; i < v.NumField(); i++ {
 		m, field := v.Field(i), v.Type().Field(i)
 		if n := field.Name; n[0:1] == strings.ToLower(n[0:1]) {

--- a/internal/protocol/restjson/build_test.go
+++ b/internal/protocol/restjson/build_test.go
@@ -41,7 +41,7 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice1protocoltest",
 			APIVersion:  "2014-01-01",
@@ -62,7 +62,7 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -118,7 +118,7 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice2protocoltest",
 			APIVersion:  "2014-01-01",
@@ -139,7 +139,7 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -195,7 +195,7 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice3protocoltest",
 			APIVersion:  "2014-01-01",
@@ -216,7 +216,7 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -276,7 +276,7 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice4protocoltest",
 			APIVersion:  "2014-01-01",
@@ -297,7 +297,7 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -371,7 +371,7 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice5protocoltest",
 			APIVersion:  "2014-01-01",
@@ -392,7 +392,7 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -468,7 +468,7 @@ type InputService6ProtocolTest struct {
 // New returns a new InputService6ProtocolTest client.
 func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice6protocoltest",
 			APIVersion:  "2014-01-01",
@@ -489,7 +489,7 @@ func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest
 // newRequest creates a new request for a InputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -549,7 +549,7 @@ type InputService7ProtocolTest struct {
 // New returns a new InputService7ProtocolTest client.
 func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice7protocoltest",
 			APIVersion:  "2014-01-01",
@@ -570,7 +570,7 @@ func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest
 // newRequest creates a new request for a InputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -660,7 +660,7 @@ type InputService8ProtocolTest struct {
 // New returns a new InputService8ProtocolTest client.
 func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice8protocoltest",
 			APIVersion:  "2014-01-01",
@@ -681,7 +681,7 @@ func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest
 // newRequest creates a new request for a InputService8ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -923,7 +923,7 @@ type InputService9ProtocolTest struct {
 // New returns a new InputService9ProtocolTest client.
 func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice9protocoltest",
 			APIVersion:  "2014-01-01",
@@ -944,7 +944,7 @@ func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest
 // newRequest creates a new request for a InputService9ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/restjson/build_test.go
+++ b/internal/protocol/restjson/build_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,9 +41,11 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice1protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice1protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -66,8 +70,8 @@ func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService1TestCaseOperation1 = "OperationName"
 
 // InputService1TestCaseOperation1Request generates a request for the InputService1TestCaseOperation1 operation.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation1Input) (req *service.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputService1TestCaseOperation1Input) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService1TestCaseOperation1,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2014-01-01/jobsByPipeline/{PipelineId}",
@@ -114,9 +118,11 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice2protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice2protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -132,8 +138,8 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -141,8 +147,8 @@ func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService2TestCaseOperation1 = "OperationName"
 
 // InputService2TestCaseOperation1Request generates a request for the InputService2TestCaseOperation1 operation.
-func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *service.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *request.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService2TestCaseOperation1,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2014-01-01/jobsByPipeline/{PipelineId}",
@@ -189,9 +195,11 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice3protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice3protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -207,8 +215,8 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -216,8 +224,8 @@ func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService3TestCaseOperation1 = "OperationName"
 
 // InputService3TestCaseOperation1Request generates a request for the InputService3TestCaseOperation1 operation.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation1Input) (req *service.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation1Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService3TestCaseOperation1,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2014-01-01/jobsByPipeline/{PipelineId}",
@@ -268,9 +276,11 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice4protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice4protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -286,8 +296,8 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -295,8 +305,8 @@ func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService4TestCaseOperation1 = "OperationName"
 
 // InputService4TestCaseOperation1Request generates a request for the InputService4TestCaseOperation1 operation.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *service.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService4TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/jobsByPipeline/{PipelineId}",
@@ -361,9 +371,11 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice5protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice5protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -379,8 +391,8 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -388,8 +400,8 @@ func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService5TestCaseOperation1 = "OperationName"
 
 // InputService5TestCaseOperation1Request generates a request for the InputService5TestCaseOperation1 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService5TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/jobsByPipeline/{PipelineId}",
@@ -456,9 +468,11 @@ type InputService6ProtocolTest struct {
 // New returns a new InputService6ProtocolTest client.
 func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice6protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice6protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -474,8 +488,8 @@ func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest
 
 // newRequest creates a new request for a InputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -483,8 +497,8 @@ func (c *InputService6ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService6TestCaseOperation1 = "OperationName"
 
 // InputService6TestCaseOperation1Request generates a request for the InputService6TestCaseOperation1 operation.
-func (c *InputService6ProtocolTest) InputService6TestCaseOperation1Request(input *InputService6TestShapeInputService6TestCaseOperation1Input) (req *service.Request, output *InputService6TestShapeInputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService6ProtocolTest) InputService6TestCaseOperation1Request(input *InputService6TestShapeInputService6TestCaseOperation1Input) (req *request.Request, output *InputService6TestShapeInputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService6TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/vaults/{vaultName}/archives",
@@ -535,9 +549,11 @@ type InputService7ProtocolTest struct {
 // New returns a new InputService7ProtocolTest client.
 func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice7protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice7protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -553,8 +569,8 @@ func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest
 
 // newRequest creates a new request for a InputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -562,8 +578,8 @@ func (c *InputService7ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService7TestCaseOperation1 = "OperationName"
 
 // InputService7TestCaseOperation1Request generates a request for the InputService7TestCaseOperation1 operation.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputShape) (req *service.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputShape) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService7TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -588,8 +604,8 @@ func (c *InputService7ProtocolTest) InputService7TestCaseOperation1(input *Input
 const opInputService7TestCaseOperation2 = "OperationName"
 
 // InputService7TestCaseOperation2Request generates a request for the InputService7TestCaseOperation2 operation.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation2Request(input *InputService7TestShapeInputShape) (req *service.Request, output *InputService7TestShapeInputService7TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation2Request(input *InputService7TestShapeInputShape) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name:       opInputService7TestCaseOperation2,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path?abc=mno",
@@ -644,9 +660,11 @@ type InputService8ProtocolTest struct {
 // New returns a new InputService8ProtocolTest client.
 func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice8protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice8protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -662,8 +680,8 @@ func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest
 
 // newRequest creates a new request for a InputService8ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService8ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -671,8 +689,8 @@ func (c *InputService8ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService8TestCaseOperation1 = "OperationName"
 
 // InputService8TestCaseOperation1Request generates a request for the InputService8TestCaseOperation1 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputShape) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputShape) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService8TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -697,8 +715,8 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation1(input *Input
 const opInputService8TestCaseOperation2 = "OperationName"
 
 // InputService8TestCaseOperation2Request generates a request for the InputService8TestCaseOperation2 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation2Request(input *InputService8TestShapeInputShape) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation2Request(input *InputService8TestShapeInputShape) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name:       opInputService8TestCaseOperation2,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -723,8 +741,8 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation2(input *Input
 const opInputService8TestCaseOperation3 = "OperationName"
 
 // InputService8TestCaseOperation3Request generates a request for the InputService8TestCaseOperation3 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation3Request(input *InputService8TestShapeInputShape) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation3Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation3Request(input *InputService8TestShapeInputShape) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation3Output) {
+	op := &request.Operation{
 		Name:       opInputService8TestCaseOperation3,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -749,8 +767,8 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation3(input *Input
 const opInputService8TestCaseOperation4 = "OperationName"
 
 // InputService8TestCaseOperation4Request generates a request for the InputService8TestCaseOperation4 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation4Request(input *InputService8TestShapeInputShape) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation4Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation4Request(input *InputService8TestShapeInputShape) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation4Output) {
+	op := &request.Operation{
 		Name:       opInputService8TestCaseOperation4,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -775,8 +793,8 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation4(input *Input
 const opInputService8TestCaseOperation5 = "OperationName"
 
 // InputService8TestCaseOperation5Request generates a request for the InputService8TestCaseOperation5 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation5Request(input *InputService8TestShapeInputShape) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation5Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation5Request(input *InputService8TestShapeInputShape) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation5Output) {
+	op := &request.Operation{
 		Name:       opInputService8TestCaseOperation5,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -801,8 +819,8 @@ func (c *InputService8ProtocolTest) InputService8TestCaseOperation5(input *Input
 const opInputService8TestCaseOperation6 = "OperationName"
 
 // InputService8TestCaseOperation6Request generates a request for the InputService8TestCaseOperation6 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation6Request(input *InputService8TestShapeInputShape) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation6Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation6Request(input *InputService8TestShapeInputShape) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation6Output) {
+	op := &request.Operation{
 		Name:       opInputService8TestCaseOperation6,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -905,9 +923,11 @@ type InputService9ProtocolTest struct {
 // New returns a new InputService9ProtocolTest client.
 func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice9protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice9protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -923,8 +943,8 @@ func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest
 
 // newRequest creates a new request for a InputService9ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService9ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -932,8 +952,8 @@ func (c *InputService9ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService9TestCaseOperation1 = "OperationName"
 
 // InputService9TestCaseOperation1Request generates a request for the InputService9TestCaseOperation1 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputShape) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService9TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -958,8 +978,8 @@ func (c *InputService9ProtocolTest) InputService9TestCaseOperation1(input *Input
 const opInputService9TestCaseOperation2 = "OperationName"
 
 // InputService9TestCaseOperation2Request generates a request for the InputService9TestCaseOperation2 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation2Request(input *InputService9TestShapeInputShape) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation2Request(input *InputService9TestShapeInputShape) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name:       opInputService9TestCaseOperation2,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",

--- a/internal/protocol/restjson/restjson.go
+++ b/internal/protocol/restjson/restjson.go
@@ -11,13 +11,13 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/protocol/rest"
 )
 
 // Build builds a request for the REST JSON protocol.
-func Build(r *service.Request) {
+func Build(r *request.Request) {
 	rest.Build(r)
 
 	if t := rest.PayloadType(r.Params); t == "structure" || t == "" {
@@ -26,19 +26,19 @@ func Build(r *service.Request) {
 }
 
 // Unmarshal unmarshals a response body for the REST JSON protocol.
-func Unmarshal(r *service.Request) {
+func Unmarshal(r *request.Request) {
 	if t := rest.PayloadType(r.Data); t == "structure" || t == "" {
 		jsonrpc.Unmarshal(r)
 	}
 }
 
 // UnmarshalMeta unmarshals response headers for the REST JSON protocol.
-func UnmarshalMeta(r *service.Request) {
+func UnmarshalMeta(r *request.Request) {
 	rest.Unmarshal(r)
 }
 
 // UnmarshalError unmarshals a response error for the REST JSON protocol.
-func UnmarshalError(r *service.Request) {
+func UnmarshalError(r *request.Request) {
 	code := r.HTTPResponse.Header.Get("X-Amzn-Errortype")
 	bodyBytes, err := ioutil.ReadAll(r.HTTPResponse.Body)
 	if err != nil {

--- a/internal/protocol/restjson/unmarshal_test.go
+++ b/internal/protocol/restjson/unmarshal_test.go
@@ -41,7 +41,7 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice1protocoltest",
 			APIVersion:  "",
@@ -62,7 +62,7 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -136,7 +136,7 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice2protocoltest",
 			APIVersion:  "",
@@ -157,7 +157,7 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -223,7 +223,7 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice3protocoltest",
 			APIVersion:  "",
@@ -244,7 +244,7 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -310,7 +310,7 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice4protocoltest",
 			APIVersion:  "",
@@ -331,7 +331,7 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -385,7 +385,7 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice5protocoltest",
 			APIVersion:  "",
@@ -406,7 +406,7 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -470,7 +470,7 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice6protocoltest",
 			APIVersion:  "",
@@ -491,7 +491,7 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -545,7 +545,7 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice7protocoltest",
 			APIVersion:  "",
@@ -566,7 +566,7 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -620,7 +620,7 @@ type OutputService8ProtocolTest struct {
 // New returns a new OutputService8ProtocolTest client.
 func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice8protocoltest",
 			APIVersion:  "",
@@ -641,7 +641,7 @@ func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTe
 // newRequest creates a new request for a OutputService8ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -695,7 +695,7 @@ type OutputService9ProtocolTest struct {
 // New returns a new OutputService9ProtocolTest client.
 func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice9protocoltest",
 			APIVersion:  "",
@@ -716,7 +716,7 @@ func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTe
 // newRequest creates a new request for a OutputService9ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -772,7 +772,7 @@ type OutputService10ProtocolTest struct {
 // New returns a new OutputService10ProtocolTest client.
 func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice10protocoltest",
 			APIVersion:  "",
@@ -793,7 +793,7 @@ func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10Protocol
 // newRequest creates a new request for a OutputService10ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService10ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -859,7 +859,7 @@ type OutputService11ProtocolTest struct {
 // New returns a new OutputService11ProtocolTest client.
 func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice11protocoltest",
 			APIVersion:  "",
@@ -880,7 +880,7 @@ func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11Protocol
 // newRequest creates a new request for a OutputService11ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -934,7 +934,7 @@ type OutputService12ProtocolTest struct {
 // New returns a new OutputService12ProtocolTest client.
 func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice12protocoltest",
 			APIVersion:  "",
@@ -955,7 +955,7 @@ func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12Protocol
 // newRequest creates a new request for a OutputService12ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/restjson/unmarshal_test.go
+++ b/internal/protocol/restjson/unmarshal_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,9 +41,11 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice1protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice1protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -66,8 +70,8 @@ func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService1TestCaseOperation1 = "OperationName"
 
 // OutputService1TestCaseOperation1Request generates a request for the OutputService1TestCaseOperation1 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *service.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService1TestCaseOperation1,
 	}
 
@@ -132,9 +136,11 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice2protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice2protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -150,8 +156,8 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -159,8 +165,8 @@ func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService2TestCaseOperation1 = "OperationName"
 
 // OutputService2TestCaseOperation1Request generates a request for the OutputService2TestCaseOperation1 operation.
-func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *service.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *request.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService2TestCaseOperation1,
 	}
 
@@ -217,9 +223,11 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice3protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice3protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -235,8 +243,8 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -244,8 +252,8 @@ func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService3TestCaseOperation1 = "OperationName"
 
 // OutputService3TestCaseOperation1Request generates a request for the OutputService3TestCaseOperation1 operation.
-func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *service.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *request.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService3TestCaseOperation1,
 	}
 
@@ -302,9 +310,11 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice4protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice4protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -320,8 +330,8 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -329,8 +339,8 @@ func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService4TestCaseOperation1 = "OperationName"
 
 // OutputService4TestCaseOperation1Request generates a request for the OutputService4TestCaseOperation1 operation.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *service.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService4TestCaseOperation1,
 	}
 
@@ -375,9 +385,11 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice5protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice5protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -393,8 +405,8 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -402,8 +414,8 @@ func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService5TestCaseOperation1 = "OperationName"
 
 // OutputService5TestCaseOperation1Request generates a request for the OutputService5TestCaseOperation1 operation.
-func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *service.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *request.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService5TestCaseOperation1,
 	}
 
@@ -458,9 +470,11 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice6protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice6protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -476,8 +490,8 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -485,8 +499,8 @@ func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService6TestCaseOperation1 = "OperationName"
 
 // OutputService6TestCaseOperation1Request generates a request for the OutputService6TestCaseOperation1 operation.
-func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *service.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *request.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService6TestCaseOperation1,
 	}
 
@@ -531,9 +545,11 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice7protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice7protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -549,8 +565,8 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -558,8 +574,8 @@ func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService7TestCaseOperation1 = "OperationName"
 
 // OutputService7TestCaseOperation1Request generates a request for the OutputService7TestCaseOperation1 operation.
-func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *service.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *request.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService7TestCaseOperation1,
 	}
 
@@ -604,9 +620,11 @@ type OutputService8ProtocolTest struct {
 // New returns a new OutputService8ProtocolTest client.
 func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice8protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice8protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -622,8 +640,8 @@ func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTe
 
 // newRequest creates a new request for a OutputService8ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService8ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -631,8 +649,8 @@ func (c *OutputService8ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService8TestCaseOperation1 = "OperationName"
 
 // OutputService8TestCaseOperation1Request generates a request for the OutputService8TestCaseOperation1 operation.
-func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1Request(input *OutputService8TestShapeOutputService8TestCaseOperation1Input) (req *service.Request, output *OutputService8TestShapeOutputService8TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1Request(input *OutputService8TestShapeOutputService8TestCaseOperation1Input) (req *request.Request, output *OutputService8TestShapeOutputService8TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService8TestCaseOperation1,
 	}
 
@@ -677,9 +695,11 @@ type OutputService9ProtocolTest struct {
 // New returns a new OutputService9ProtocolTest client.
 func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice9protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice9protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -695,8 +715,8 @@ func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTe
 
 // newRequest creates a new request for a OutputService9ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService9ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -704,8 +724,8 @@ func (c *OutputService9ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService9TestCaseOperation1 = "OperationName"
 
 // OutputService9TestCaseOperation1Request generates a request for the OutputService9TestCaseOperation1 operation.
-func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1Request(input *OutputService9TestShapeOutputService9TestCaseOperation1Input) (req *service.Request, output *OutputService9TestShapeOutputService9TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1Request(input *OutputService9TestShapeOutputService9TestCaseOperation1Input) (req *request.Request, output *OutputService9TestShapeOutputService9TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService9TestCaseOperation1,
 	}
 
@@ -752,9 +772,11 @@ type OutputService10ProtocolTest struct {
 // New returns a new OutputService10ProtocolTest client.
 func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice10protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice10protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -770,8 +792,8 @@ func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10Protocol
 
 // newRequest creates a new request for a OutputService10ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService10ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService10ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -779,8 +801,8 @@ func (c *OutputService10ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService10TestCaseOperation1 = "OperationName"
 
 // OutputService10TestCaseOperation1Request generates a request for the OutputService10TestCaseOperation1 operation.
-func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1Request(input *OutputService10TestShapeOutputService10TestCaseOperation1Input) (req *service.Request, output *OutputService10TestShapeOutputService10TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1Request(input *OutputService10TestShapeOutputService10TestCaseOperation1Input) (req *request.Request, output *OutputService10TestShapeOutputService10TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService10TestCaseOperation1,
 	}
 
@@ -837,9 +859,11 @@ type OutputService11ProtocolTest struct {
 // New returns a new OutputService11ProtocolTest client.
 func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice11protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice11protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -855,8 +879,8 @@ func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11Protocol
 
 // newRequest creates a new request for a OutputService11ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService11ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -864,8 +888,8 @@ func (c *OutputService11ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService11TestCaseOperation1 = "OperationName"
 
 // OutputService11TestCaseOperation1Request generates a request for the OutputService11TestCaseOperation1 operation.
-func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *service.Request, output *OutputService11TestShapeOutputService11TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *request.Request, output *OutputService11TestShapeOutputService11TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService11TestCaseOperation1,
 	}
 
@@ -910,9 +934,11 @@ type OutputService12ProtocolTest struct {
 // New returns a new OutputService12ProtocolTest client.
 func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice12protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice12protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -928,8 +954,8 @@ func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12Protocol
 
 // newRequest creates a new request for a OutputService12ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService12ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -937,8 +963,8 @@ func (c *OutputService12ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService12TestCaseOperation1 = "OperationName"
 
 // OutputService12TestCaseOperation1Request generates a request for the OutputService12TestCaseOperation1 operation.
-func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1Request(input *OutputService12TestShapeOutputService12TestCaseOperation1Input) (req *service.Request, output *OutputService12TestShapeOutputService12TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1Request(input *OutputService12TestShapeOutputService12TestCaseOperation1Input) (req *request.Request, output *OutputService12TestShapeOutputService12TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService12TestCaseOperation1,
 	}
 

--- a/internal/protocol/restxml/build_test.go
+++ b/internal/protocol/restxml/build_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restxml"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,9 +41,11 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice1protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice1protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -66,8 +70,8 @@ func (c *InputService1ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService1TestCaseOperation1 = "OperationName"
 
 // InputService1TestCaseOperation1Request generates a request for the InputService1TestCaseOperation1 operation.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputShape) (req *service.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation1Request(input *InputService1TestShapeInputShape) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService1TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -92,8 +96,8 @@ func (c *InputService1ProtocolTest) InputService1TestCaseOperation1(input *Input
 const opInputService1TestCaseOperation2 = "OperationName"
 
 // InputService1TestCaseOperation2Request generates a request for the InputService1TestCaseOperation2 operation.
-func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input *InputService1TestShapeInputShape) (req *service.Request, output *InputService1TestShapeInputService1TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService1ProtocolTest) InputService1TestCaseOperation2Request(input *InputService1TestShapeInputShape) (req *request.Request, output *InputService1TestShapeInputService1TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name:       opInputService1TestCaseOperation2,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -150,9 +154,11 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice2protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice2protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -168,8 +174,8 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -177,8 +183,8 @@ func (c *InputService2ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService2TestCaseOperation1 = "OperationName"
 
 // InputService2TestCaseOperation1Request generates a request for the InputService2TestCaseOperation1 operation.
-func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *service.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService2ProtocolTest) InputService2TestCaseOperation1Request(input *InputService2TestShapeInputService2TestCaseOperation1Input) (req *request.Request, output *InputService2TestShapeInputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService2TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -231,9 +237,11 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice3protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice3protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -249,8 +257,8 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -258,8 +266,8 @@ func (c *InputService3ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService3TestCaseOperation1 = "OperationName"
 
 // InputService3TestCaseOperation1Request generates a request for the InputService3TestCaseOperation1 operation.
-func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation1Input) (req *service.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService3ProtocolTest) InputService3TestCaseOperation1Request(input *InputService3TestShapeInputService3TestCaseOperation1Input) (req *request.Request, output *InputService3TestShapeInputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService3TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -320,9 +328,11 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice4protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice4protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -338,8 +348,8 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -347,8 +357,8 @@ func (c *InputService4ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService4TestCaseOperation1 = "OperationName"
 
 // InputService4TestCaseOperation1Request generates a request for the InputService4TestCaseOperation1 operation.
-func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *service.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService4ProtocolTest) InputService4TestCaseOperation1Request(input *InputService4TestShapeInputService4TestCaseOperation1Input) (req *request.Request, output *InputService4TestShapeInputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService4TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -409,9 +419,11 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice5protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice5protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -427,8 +439,8 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -436,8 +448,8 @@ func (c *InputService5ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService5TestCaseOperation1 = "OperationName"
 
 // InputService5TestCaseOperation1Request generates a request for the InputService5TestCaseOperation1 operation.
-func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *service.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService5ProtocolTest) InputService5TestCaseOperation1Request(input *InputService5TestShapeInputService5TestCaseOperation1Input) (req *request.Request, output *InputService5TestShapeInputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService5TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -484,9 +496,11 @@ type InputService6ProtocolTest struct {
 // New returns a new InputService6ProtocolTest client.
 func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice6protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice6protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -502,8 +516,8 @@ func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest
 
 // newRequest creates a new request for a InputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -511,8 +525,8 @@ func (c *InputService6ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService6TestCaseOperation1 = "OperationName"
 
 // InputService6TestCaseOperation1Request generates a request for the InputService6TestCaseOperation1 operation.
-func (c *InputService6ProtocolTest) InputService6TestCaseOperation1Request(input *InputService6TestShapeInputService6TestCaseOperation1Input) (req *service.Request, output *InputService6TestShapeInputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService6ProtocolTest) InputService6TestCaseOperation1Request(input *InputService6TestShapeInputService6TestCaseOperation1Input) (req *request.Request, output *InputService6TestShapeInputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService6TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -559,9 +573,11 @@ type InputService7ProtocolTest struct {
 // New returns a new InputService7ProtocolTest client.
 func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice7protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice7protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -577,8 +593,8 @@ func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest
 
 // newRequest creates a new request for a InputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -586,8 +602,8 @@ func (c *InputService7ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService7TestCaseOperation1 = "OperationName"
 
 // InputService7TestCaseOperation1Request generates a request for the InputService7TestCaseOperation1 operation.
-func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputService7TestCaseOperation1Input) (req *service.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService7ProtocolTest) InputService7TestCaseOperation1Request(input *InputService7TestShapeInputService7TestCaseOperation1Input) (req *request.Request, output *InputService7TestShapeInputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService7TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -634,9 +650,11 @@ type InputService8ProtocolTest struct {
 // New returns a new InputService8ProtocolTest client.
 func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice8protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice8protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -652,8 +670,8 @@ func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest
 
 // newRequest creates a new request for a InputService8ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService8ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -661,8 +679,8 @@ func (c *InputService8ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService8TestCaseOperation1 = "OperationName"
 
 // InputService8TestCaseOperation1Request generates a request for the InputService8TestCaseOperation1 operation.
-func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputService8TestCaseOperation1Input) (req *service.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService8ProtocolTest) InputService8TestCaseOperation1Request(input *InputService8TestShapeInputService8TestCaseOperation1Input) (req *request.Request, output *InputService8TestShapeInputService8TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService8TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -709,9 +727,11 @@ type InputService9ProtocolTest struct {
 // New returns a new InputService9ProtocolTest client.
 func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice9protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice9protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -727,8 +747,8 @@ func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest
 
 // newRequest creates a new request for a InputService9ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService9ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -736,8 +756,8 @@ func (c *InputService9ProtocolTest) newRequest(op *service.Operation, params, da
 const opInputService9TestCaseOperation1 = "OperationName"
 
 // InputService9TestCaseOperation1Request generates a request for the InputService9TestCaseOperation1 operation.
-func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputService9TestCaseOperation1Input) (req *service.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService9ProtocolTest) InputService9TestCaseOperation1Request(input *InputService9TestShapeInputService9TestCaseOperation1Input) (req *request.Request, output *InputService9TestShapeInputService9TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService9TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -794,9 +814,11 @@ type InputService10ProtocolTest struct {
 // New returns a new InputService10ProtocolTest client.
 func NewInputService10ProtocolTest(config *aws.Config) *InputService10ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice10protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice10protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -812,8 +834,8 @@ func NewInputService10ProtocolTest(config *aws.Config) *InputService10ProtocolTe
 
 // newRequest creates a new request for a InputService10ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService10ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService10ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -821,8 +843,8 @@ func (c *InputService10ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService10TestCaseOperation1 = "OperationName"
 
 // InputService10TestCaseOperation1Request generates a request for the InputService10TestCaseOperation1 operation.
-func (c *InputService10ProtocolTest) InputService10TestCaseOperation1Request(input *InputService10TestShapeInputService10TestCaseOperation1Input) (req *service.Request, output *InputService10TestShapeInputService10TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService10ProtocolTest) InputService10TestCaseOperation1Request(input *InputService10TestShapeInputService10TestCaseOperation1Input) (req *request.Request, output *InputService10TestShapeInputService10TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService10TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-01-01/hostedzone",
@@ -881,9 +903,11 @@ type InputService11ProtocolTest struct {
 // New returns a new InputService11ProtocolTest client.
 func NewInputService11ProtocolTest(config *aws.Config) *InputService11ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice11protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice11protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -899,8 +923,8 @@ func NewInputService11ProtocolTest(config *aws.Config) *InputService11ProtocolTe
 
 // newRequest creates a new request for a InputService11ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService11ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -908,8 +932,8 @@ func (c *InputService11ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService11TestCaseOperation1 = "OperationName"
 
 // InputService11TestCaseOperation1Request generates a request for the InputService11TestCaseOperation1 operation.
-func (c *InputService11ProtocolTest) InputService11TestCaseOperation1Request(input *InputService11TestShapeInputService11TestCaseOperation1Input) (req *service.Request, output *InputService11TestShapeInputService11TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService11ProtocolTest) InputService11TestCaseOperation1Request(input *InputService11TestShapeInputService11TestCaseOperation1Input) (req *request.Request, output *InputService11TestShapeInputService11TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService11TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -956,9 +980,11 @@ type InputService12ProtocolTest struct {
 // New returns a new InputService12ProtocolTest client.
 func NewInputService12ProtocolTest(config *aws.Config) *InputService12ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice12protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice12protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -974,8 +1000,8 @@ func NewInputService12ProtocolTest(config *aws.Config) *InputService12ProtocolTe
 
 // newRequest creates a new request for a InputService12ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService12ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -983,8 +1009,8 @@ func (c *InputService12ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService12TestCaseOperation1 = "OperationName"
 
 // InputService12TestCaseOperation1Request generates a request for the InputService12TestCaseOperation1 operation.
-func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *service.Request, output *InputService12TestShapeInputService12TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService12ProtocolTest) InputService12TestCaseOperation1Request(input *InputService12TestShapeInputService12TestCaseOperation1Input) (req *request.Request, output *InputService12TestShapeInputService12TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService12TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1031,9 +1057,11 @@ type InputService13ProtocolTest struct {
 // New returns a new InputService13ProtocolTest client.
 func NewInputService13ProtocolTest(config *aws.Config) *InputService13ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice13protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice13protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -1049,8 +1077,8 @@ func NewInputService13ProtocolTest(config *aws.Config) *InputService13ProtocolTe
 
 // newRequest creates a new request for a InputService13ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService13ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService13ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -1058,8 +1086,8 @@ func (c *InputService13ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService13TestCaseOperation1 = "OperationName"
 
 // InputService13TestCaseOperation1Request generates a request for the InputService13TestCaseOperation1 operation.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(input *InputService13TestShapeInputShape) (req *service.Request, output *InputService13TestShapeInputService13TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation1Request(input *InputService13TestShapeInputShape) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService13TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1084,8 +1112,8 @@ func (c *InputService13ProtocolTest) InputService13TestCaseOperation1(input *Inp
 const opInputService13TestCaseOperation2 = "OperationName"
 
 // InputService13TestCaseOperation2Request generates a request for the InputService13TestCaseOperation2 operation.
-func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(input *InputService13TestShapeInputShape) (req *service.Request, output *InputService13TestShapeInputService13TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService13ProtocolTest) InputService13TestCaseOperation2Request(input *InputService13TestShapeInputShape) (req *request.Request, output *InputService13TestShapeInputService13TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name:       opInputService13TestCaseOperation2,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1140,9 +1168,11 @@ type InputService14ProtocolTest struct {
 // New returns a new InputService14ProtocolTest client.
 func NewInputService14ProtocolTest(config *aws.Config) *InputService14ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice14protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice14protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -1158,8 +1188,8 @@ func NewInputService14ProtocolTest(config *aws.Config) *InputService14ProtocolTe
 
 // newRequest creates a new request for a InputService14ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService14ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService14ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -1167,8 +1197,8 @@ func (c *InputService14ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService14TestCaseOperation1 = "OperationName"
 
 // InputService14TestCaseOperation1Request generates a request for the InputService14TestCaseOperation1 operation.
-func (c *InputService14ProtocolTest) InputService14TestCaseOperation1Request(input *InputService14TestShapeInputShape) (req *service.Request, output *InputService14TestShapeInputService14TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService14ProtocolTest) InputService14TestCaseOperation1Request(input *InputService14TestShapeInputShape) (req *request.Request, output *InputService14TestShapeInputService14TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService14TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1193,8 +1223,8 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation1(input *Inp
 const opInputService14TestCaseOperation2 = "OperationName"
 
 // InputService14TestCaseOperation2Request generates a request for the InputService14TestCaseOperation2 operation.
-func (c *InputService14ProtocolTest) InputService14TestCaseOperation2Request(input *InputService14TestShapeInputShape) (req *service.Request, output *InputService14TestShapeInputService14TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService14ProtocolTest) InputService14TestCaseOperation2Request(input *InputService14TestShapeInputShape) (req *request.Request, output *InputService14TestShapeInputService14TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name:       opInputService14TestCaseOperation2,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1219,8 +1249,8 @@ func (c *InputService14ProtocolTest) InputService14TestCaseOperation2(input *Inp
 const opInputService14TestCaseOperation3 = "OperationName"
 
 // InputService14TestCaseOperation3Request generates a request for the InputService14TestCaseOperation3 operation.
-func (c *InputService14ProtocolTest) InputService14TestCaseOperation3Request(input *InputService14TestShapeInputShape) (req *service.Request, output *InputService14TestShapeInputService14TestCaseOperation3Output) {
-	op := &service.Operation{
+func (c *InputService14ProtocolTest) InputService14TestCaseOperation3Request(input *InputService14TestShapeInputShape) (req *request.Request, output *InputService14TestShapeInputService14TestCaseOperation3Output) {
+	op := &request.Operation{
 		Name:       opInputService14TestCaseOperation3,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1293,9 +1323,11 @@ type InputService15ProtocolTest struct {
 // New returns a new InputService15ProtocolTest client.
 func NewInputService15ProtocolTest(config *aws.Config) *InputService15ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice15protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice15protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -1311,8 +1343,8 @@ func NewInputService15ProtocolTest(config *aws.Config) *InputService15ProtocolTe
 
 // newRequest creates a new request for a InputService15ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService15ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService15ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -1320,8 +1352,8 @@ func (c *InputService15ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService15TestCaseOperation1 = "OperationName"
 
 // InputService15TestCaseOperation1Request generates a request for the InputService15TestCaseOperation1 operation.
-func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(input *InputService15TestShapeInputService15TestCaseOperation1Input) (req *service.Request, output *InputService15TestShapeInputService15TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService15ProtocolTest) InputService15TestCaseOperation1Request(input *InputService15TestShapeInputService15TestCaseOperation1Input) (req *request.Request, output *InputService15TestShapeInputService15TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService15TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1390,9 +1422,11 @@ type InputService16ProtocolTest struct {
 // New returns a new InputService16ProtocolTest client.
 func NewInputService16ProtocolTest(config *aws.Config) *InputService16ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice16protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice16protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -1408,8 +1442,8 @@ func NewInputService16ProtocolTest(config *aws.Config) *InputService16ProtocolTe
 
 // newRequest creates a new request for a InputService16ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService16ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService16ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -1417,8 +1451,8 @@ func (c *InputService16ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService16TestCaseOperation1 = "OperationName"
 
 // InputService16TestCaseOperation1Request generates a request for the InputService16TestCaseOperation1 operation.
-func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(input *InputService16TestShapeInputService16TestCaseOperation1Input) (req *service.Request, output *InputService16TestShapeInputService16TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService16ProtocolTest) InputService16TestCaseOperation1Request(input *InputService16TestShapeInputService16TestCaseOperation1Input) (req *request.Request, output *InputService16TestShapeInputService16TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService16TestCaseOperation1,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -1467,9 +1501,11 @@ type InputService17ProtocolTest struct {
 // New returns a new InputService17ProtocolTest client.
 func NewInputService17ProtocolTest(config *aws.Config) *InputService17ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice17protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice17protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -1485,8 +1521,8 @@ func NewInputService17ProtocolTest(config *aws.Config) *InputService17ProtocolTe
 
 // newRequest creates a new request for a InputService17ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService17ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService17ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -1494,8 +1530,8 @@ func (c *InputService17ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService17TestCaseOperation1 = "OperationName"
 
 // InputService17TestCaseOperation1Request generates a request for the InputService17TestCaseOperation1 operation.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(input *InputService17TestShapeInputShape) (req *service.Request, output *InputService17TestShapeInputService17TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation1Request(input *InputService17TestShapeInputShape) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService17TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -1520,8 +1556,8 @@ func (c *InputService17ProtocolTest) InputService17TestCaseOperation1(input *Inp
 const opInputService17TestCaseOperation2 = "OperationName"
 
 // InputService17TestCaseOperation2Request generates a request for the InputService17TestCaseOperation2 operation.
-func (c *InputService17ProtocolTest) InputService17TestCaseOperation2Request(input *InputService17TestShapeInputShape) (req *service.Request, output *InputService17TestShapeInputService17TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService17ProtocolTest) InputService17TestCaseOperation2Request(input *InputService17TestShapeInputShape) (req *request.Request, output *InputService17TestShapeInputService17TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name:       opInputService17TestCaseOperation2,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path?abc=mno",
@@ -1576,9 +1612,11 @@ type InputService18ProtocolTest struct {
 // New returns a new InputService18ProtocolTest client.
 func NewInputService18ProtocolTest(config *aws.Config) *InputService18ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice18protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice18protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -1594,8 +1632,8 @@ func NewInputService18ProtocolTest(config *aws.Config) *InputService18ProtocolTe
 
 // newRequest creates a new request for a InputService18ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService18ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService18ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -1603,8 +1641,8 @@ func (c *InputService18ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService18TestCaseOperation1 = "OperationName"
 
 // InputService18TestCaseOperation1Request generates a request for the InputService18TestCaseOperation1 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(input *InputService18TestShapeInputShape) (req *service.Request, output *InputService18TestShapeInputService18TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation1Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -1629,8 +1667,8 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation1(input *Inp
 const opInputService18TestCaseOperation2 = "OperationName"
 
 // InputService18TestCaseOperation2Request generates a request for the InputService18TestCaseOperation2 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(input *InputService18TestShapeInputShape) (req *service.Request, output *InputService18TestShapeInputService18TestCaseOperation2Output) {
-	op := &service.Operation{
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation2Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation2Output) {
+	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation2,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -1655,8 +1693,8 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation2(input *Inp
 const opInputService18TestCaseOperation3 = "OperationName"
 
 // InputService18TestCaseOperation3Request generates a request for the InputService18TestCaseOperation3 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputShape) (req *service.Request, output *InputService18TestShapeInputService18TestCaseOperation3Output) {
-	op := &service.Operation{
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation3Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation3Output) {
+	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation3,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -1681,8 +1719,8 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation3(input *Inp
 const opInputService18TestCaseOperation4 = "OperationName"
 
 // InputService18TestCaseOperation4Request generates a request for the InputService18TestCaseOperation4 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputShape) (req *service.Request, output *InputService18TestShapeInputService18TestCaseOperation4Output) {
-	op := &service.Operation{
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation4Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation4Output) {
+	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation4,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -1707,8 +1745,8 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation4(input *Inp
 const opInputService18TestCaseOperation5 = "OperationName"
 
 // InputService18TestCaseOperation5Request generates a request for the InputService18TestCaseOperation5 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation5Request(input *InputService18TestShapeInputShape) (req *service.Request, output *InputService18TestShapeInputService18TestCaseOperation5Output) {
-	op := &service.Operation{
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation5Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation5Output) {
+	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation5,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -1733,8 +1771,8 @@ func (c *InputService18ProtocolTest) InputService18TestCaseOperation5(input *Inp
 const opInputService18TestCaseOperation6 = "OperationName"
 
 // InputService18TestCaseOperation6Request generates a request for the InputService18TestCaseOperation6 operation.
-func (c *InputService18ProtocolTest) InputService18TestCaseOperation6Request(input *InputService18TestShapeInputShape) (req *service.Request, output *InputService18TestShapeInputService18TestCaseOperation6Output) {
-	op := &service.Operation{
+func (c *InputService18ProtocolTest) InputService18TestCaseOperation6Request(input *InputService18TestShapeInputShape) (req *request.Request, output *InputService18TestShapeInputService18TestCaseOperation6Output) {
+	op := &request.Operation{
 		Name:       opInputService18TestCaseOperation6,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",
@@ -1837,9 +1875,11 @@ type InputService19ProtocolTest struct {
 // New returns a new InputService19ProtocolTest client.
 func NewInputService19ProtocolTest(config *aws.Config) *InputService19ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "inputservice19protocoltest",
-		APIVersion:  "2014-01-01",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "inputservice19protocoltest",
+			APIVersion:  "2014-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -1855,8 +1895,8 @@ func NewInputService19ProtocolTest(config *aws.Config) *InputService19ProtocolTe
 
 // newRequest creates a new request for a InputService19ProtocolTest operation and runs any
 // custom request initialization.
-func (c *InputService19ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *InputService19ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -1864,8 +1904,8 @@ func (c *InputService19ProtocolTest) newRequest(op *service.Operation, params, d
 const opInputService19TestCaseOperation1 = "OperationName"
 
 // InputService19TestCaseOperation1Request generates a request for the InputService19TestCaseOperation1 operation.
-func (c *InputService19ProtocolTest) InputService19TestCaseOperation1Request(input *InputService19TestShapeInputService19TestCaseOperation1Input) (req *service.Request, output *InputService19TestShapeInputService19TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *InputService19ProtocolTest) InputService19TestCaseOperation1Request(input *InputService19TestShapeInputService19TestCaseOperation1Input) (req *request.Request, output *InputService19TestShapeInputService19TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name:       opInputService19TestCaseOperation1,
 		HTTPMethod: "POST",
 		HTTPPath:   "/path",

--- a/internal/protocol/restxml/build_test.go
+++ b/internal/protocol/restxml/build_test.go
@@ -41,7 +41,7 @@ type InputService1ProtocolTest struct {
 // New returns a new InputService1ProtocolTest client.
 func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice1protocoltest",
 			APIVersion:  "2014-01-01",
@@ -62,7 +62,7 @@ func NewInputService1ProtocolTest(config *aws.Config) *InputService1ProtocolTest
 // newRequest creates a new request for a InputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -154,7 +154,7 @@ type InputService2ProtocolTest struct {
 // New returns a new InputService2ProtocolTest client.
 func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice2protocoltest",
 			APIVersion:  "2014-01-01",
@@ -175,7 +175,7 @@ func NewInputService2ProtocolTest(config *aws.Config) *InputService2ProtocolTest
 // newRequest creates a new request for a InputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -237,7 +237,7 @@ type InputService3ProtocolTest struct {
 // New returns a new InputService3ProtocolTest client.
 func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice3protocoltest",
 			APIVersion:  "2014-01-01",
@@ -258,7 +258,7 @@ func NewInputService3ProtocolTest(config *aws.Config) *InputService3ProtocolTest
 // newRequest creates a new request for a InputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -328,7 +328,7 @@ type InputService4ProtocolTest struct {
 // New returns a new InputService4ProtocolTest client.
 func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice4protocoltest",
 			APIVersion:  "2014-01-01",
@@ -349,7 +349,7 @@ func NewInputService4ProtocolTest(config *aws.Config) *InputService4ProtocolTest
 // newRequest creates a new request for a InputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -419,7 +419,7 @@ type InputService5ProtocolTest struct {
 // New returns a new InputService5ProtocolTest client.
 func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice5protocoltest",
 			APIVersion:  "2014-01-01",
@@ -440,7 +440,7 @@ func NewInputService5ProtocolTest(config *aws.Config) *InputService5ProtocolTest
 // newRequest creates a new request for a InputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -496,7 +496,7 @@ type InputService6ProtocolTest struct {
 // New returns a new InputService6ProtocolTest client.
 func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice6protocoltest",
 			APIVersion:  "2014-01-01",
@@ -517,7 +517,7 @@ func NewInputService6ProtocolTest(config *aws.Config) *InputService6ProtocolTest
 // newRequest creates a new request for a InputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -573,7 +573,7 @@ type InputService7ProtocolTest struct {
 // New returns a new InputService7ProtocolTest client.
 func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice7protocoltest",
 			APIVersion:  "2014-01-01",
@@ -594,7 +594,7 @@ func NewInputService7ProtocolTest(config *aws.Config) *InputService7ProtocolTest
 // newRequest creates a new request for a InputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -650,7 +650,7 @@ type InputService8ProtocolTest struct {
 // New returns a new InputService8ProtocolTest client.
 func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice8protocoltest",
 			APIVersion:  "2014-01-01",
@@ -671,7 +671,7 @@ func NewInputService8ProtocolTest(config *aws.Config) *InputService8ProtocolTest
 // newRequest creates a new request for a InputService8ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -727,7 +727,7 @@ type InputService9ProtocolTest struct {
 // New returns a new InputService9ProtocolTest client.
 func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice9protocoltest",
 			APIVersion:  "2014-01-01",
@@ -748,7 +748,7 @@ func NewInputService9ProtocolTest(config *aws.Config) *InputService9ProtocolTest
 // newRequest creates a new request for a InputService9ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -814,7 +814,7 @@ type InputService10ProtocolTest struct {
 // New returns a new InputService10ProtocolTest client.
 func NewInputService10ProtocolTest(config *aws.Config) *InputService10ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice10protocoltest",
 			APIVersion:  "2014-01-01",
@@ -835,7 +835,7 @@ func NewInputService10ProtocolTest(config *aws.Config) *InputService10ProtocolTe
 // newRequest creates a new request for a InputService10ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService10ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -903,7 +903,7 @@ type InputService11ProtocolTest struct {
 // New returns a new InputService11ProtocolTest client.
 func NewInputService11ProtocolTest(config *aws.Config) *InputService11ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice11protocoltest",
 			APIVersion:  "2014-01-01",
@@ -924,7 +924,7 @@ func NewInputService11ProtocolTest(config *aws.Config) *InputService11ProtocolTe
 // newRequest creates a new request for a InputService11ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -980,7 +980,7 @@ type InputService12ProtocolTest struct {
 // New returns a new InputService12ProtocolTest client.
 func NewInputService12ProtocolTest(config *aws.Config) *InputService12ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice12protocoltest",
 			APIVersion:  "2014-01-01",
@@ -1001,7 +1001,7 @@ func NewInputService12ProtocolTest(config *aws.Config) *InputService12ProtocolTe
 // newRequest creates a new request for a InputService12ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -1057,7 +1057,7 @@ type InputService13ProtocolTest struct {
 // New returns a new InputService13ProtocolTest client.
 func NewInputService13ProtocolTest(config *aws.Config) *InputService13ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice13protocoltest",
 			APIVersion:  "2014-01-01",
@@ -1078,7 +1078,7 @@ func NewInputService13ProtocolTest(config *aws.Config) *InputService13ProtocolTe
 // newRequest creates a new request for a InputService13ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService13ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -1168,7 +1168,7 @@ type InputService14ProtocolTest struct {
 // New returns a new InputService14ProtocolTest client.
 func NewInputService14ProtocolTest(config *aws.Config) *InputService14ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice14protocoltest",
 			APIVersion:  "2014-01-01",
@@ -1189,7 +1189,7 @@ func NewInputService14ProtocolTest(config *aws.Config) *InputService14ProtocolTe
 // newRequest creates a new request for a InputService14ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService14ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -1323,7 +1323,7 @@ type InputService15ProtocolTest struct {
 // New returns a new InputService15ProtocolTest client.
 func NewInputService15ProtocolTest(config *aws.Config) *InputService15ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice15protocoltest",
 			APIVersion:  "2014-01-01",
@@ -1344,7 +1344,7 @@ func NewInputService15ProtocolTest(config *aws.Config) *InputService15ProtocolTe
 // newRequest creates a new request for a InputService15ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService15ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -1422,7 +1422,7 @@ type InputService16ProtocolTest struct {
 // New returns a new InputService16ProtocolTest client.
 func NewInputService16ProtocolTest(config *aws.Config) *InputService16ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice16protocoltest",
 			APIVersion:  "2014-01-01",
@@ -1443,7 +1443,7 @@ func NewInputService16ProtocolTest(config *aws.Config) *InputService16ProtocolTe
 // newRequest creates a new request for a InputService16ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService16ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -1501,7 +1501,7 @@ type InputService17ProtocolTest struct {
 // New returns a new InputService17ProtocolTest client.
 func NewInputService17ProtocolTest(config *aws.Config) *InputService17ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice17protocoltest",
 			APIVersion:  "2014-01-01",
@@ -1522,7 +1522,7 @@ func NewInputService17ProtocolTest(config *aws.Config) *InputService17ProtocolTe
 // newRequest creates a new request for a InputService17ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService17ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -1612,7 +1612,7 @@ type InputService18ProtocolTest struct {
 // New returns a new InputService18ProtocolTest client.
 func NewInputService18ProtocolTest(config *aws.Config) *InputService18ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice18protocoltest",
 			APIVersion:  "2014-01-01",
@@ -1633,7 +1633,7 @@ func NewInputService18ProtocolTest(config *aws.Config) *InputService18ProtocolTe
 // newRequest creates a new request for a InputService18ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService18ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -1875,7 +1875,7 @@ type InputService19ProtocolTest struct {
 // New returns a new InputService19ProtocolTest client.
 func NewInputService19ProtocolTest(config *aws.Config) *InputService19ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "inputservice19protocoltest",
 			APIVersion:  "2014-01-01",
@@ -1896,7 +1896,7 @@ func NewInputService19ProtocolTest(config *aws.Config) *InputService19ProtocolTe
 // newRequest creates a new request for a InputService19ProtocolTest operation and runs any
 // custom request initialization.
 func (c *InputService19ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/restxml/restxml.go
+++ b/internal/protocol/restxml/restxml.go
@@ -10,14 +10,14 @@ import (
 	"encoding/xml"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/protocol/rest"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 )
 
 // Build builds a request payload for the REST XML protocol.
-func Build(r *service.Request) {
+func Build(r *request.Request) {
 	rest.Build(r)
 
 	if t := rest.PayloadType(r.Params); t == "structure" || t == "" {
@@ -32,7 +32,7 @@ func Build(r *service.Request) {
 }
 
 // Unmarshal unmarshals a payload response for the REST XML protocol.
-func Unmarshal(r *service.Request) {
+func Unmarshal(r *request.Request) {
 	if t := rest.PayloadType(r.Data); t == "structure" || t == "" {
 		defer r.HTTPResponse.Body.Close()
 		decoder := xml.NewDecoder(r.HTTPResponse.Body)
@@ -45,11 +45,11 @@ func Unmarshal(r *service.Request) {
 }
 
 // UnmarshalMeta unmarshals response headers for the REST XML protocol.
-func UnmarshalMeta(r *service.Request) {
+func UnmarshalMeta(r *request.Request) {
 	rest.Unmarshal(r)
 }
 
 // UnmarshalError unmarshals a response error for the REST XML protocol.
-func UnmarshalError(r *service.Request) {
+func UnmarshalError(r *request.Request) {
 	query.UnmarshalError(r)
 }

--- a/internal/protocol/restxml/unmarshal_test.go
+++ b/internal/protocol/restxml/unmarshal_test.go
@@ -41,7 +41,7 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice1protocoltest",
 			APIVersion:  "",
@@ -62,7 +62,7 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -168,7 +168,7 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice2protocoltest",
 			APIVersion:  "",
@@ -189,7 +189,7 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -243,7 +243,7 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice3protocoltest",
 			APIVersion:  "",
@@ -264,7 +264,7 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -318,7 +318,7 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice4protocoltest",
 			APIVersion:  "",
@@ -339,7 +339,7 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -393,7 +393,7 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice5protocoltest",
 			APIVersion:  "",
@@ -414,7 +414,7 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -468,7 +468,7 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice6protocoltest",
 			APIVersion:  "",
@@ -489,7 +489,7 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -553,7 +553,7 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice7protocoltest",
 			APIVersion:  "",
@@ -574,7 +574,7 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -628,7 +628,7 @@ type OutputService8ProtocolTest struct {
 // New returns a new OutputService8ProtocolTest client.
 func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice8protocoltest",
 			APIVersion:  "",
@@ -649,7 +649,7 @@ func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTe
 // newRequest creates a new request for a OutputService8ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -703,7 +703,7 @@ type OutputService9ProtocolTest struct {
 // New returns a new OutputService9ProtocolTest client.
 func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice9protocoltest",
 			APIVersion:  "",
@@ -724,7 +724,7 @@ func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTe
 // newRequest creates a new request for a OutputService9ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -790,7 +790,7 @@ type OutputService10ProtocolTest struct {
 // New returns a new OutputService10ProtocolTest client.
 func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice10protocoltest",
 			APIVersion:  "",
@@ -811,7 +811,7 @@ func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10Protocol
 // newRequest creates a new request for a OutputService10ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService10ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -865,7 +865,7 @@ type OutputService11ProtocolTest struct {
 // New returns a new OutputService11ProtocolTest client.
 func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice11protocoltest",
 			APIVersion:  "",
@@ -886,7 +886,7 @@ func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11Protocol
 // newRequest creates a new request for a OutputService11ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }
@@ -956,7 +956,7 @@ type OutputService12ProtocolTest struct {
 // New returns a new OutputService12ProtocolTest client.
 func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12ProtocolTest {
 	service := &service.Service{
-		Service: serviceinfo.ServiceInfo{
+		ServiceInfo: serviceinfo.ServiceInfo{
 			Config:      defaults.DefaultConfig.Merge(config),
 			ServiceName: "outputservice12protocoltest",
 			APIVersion:  "",
@@ -977,7 +977,7 @@ func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12Protocol
 // newRequest creates a new request for a OutputService12ProtocolTest operation and runs any
 // custom request initialization.
 func (c *OutputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
-	req := c.NewRequest(c.Service, op, params, data)
+	req := c.NewRequest(op, params, data)
 
 	return req
 }

--- a/internal/protocol/restxml/unmarshal_test.go
+++ b/internal/protocol/restxml/unmarshal_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restxml"
 	"github.com/aws/aws-sdk-go/internal/protocol/xml/xmlutil"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
@@ -39,9 +41,11 @@ type OutputService1ProtocolTest struct {
 // New returns a new OutputService1ProtocolTest client.
 func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice1protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice1protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func NewOutputService1ProtocolTest(config *aws.Config) *OutputService1ProtocolTe
 
 // newRequest creates a new request for a OutputService1ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService1ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -66,8 +70,8 @@ func (c *OutputService1ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService1TestCaseOperation1 = "OperationName"
 
 // OutputService1TestCaseOperation1Request generates a request for the OutputService1TestCaseOperation1 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *service.Request, output *OutputService1TestShapeOutputShape) {
-	op := &service.Operation{
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1Request(input *OutputService1TestShapeOutputService1TestCaseOperation1Input) (req *request.Request, output *OutputService1TestShapeOutputShape) {
+	op := &request.Operation{
 		Name: opOutputService1TestCaseOperation1,
 	}
 
@@ -90,8 +94,8 @@ func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation1(input *Out
 const opOutputService1TestCaseOperation2 = "OperationName"
 
 // OutputService1TestCaseOperation2Request generates a request for the OutputService1TestCaseOperation2 operation.
-func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (req *service.Request, output *OutputService1TestShapeOutputShape) {
-	op := &service.Operation{
+func (c *OutputService1ProtocolTest) OutputService1TestCaseOperation2Request(input *OutputService1TestShapeOutputService1TestCaseOperation2Input) (req *request.Request, output *OutputService1TestShapeOutputShape) {
+	op := &request.Operation{
 		Name: opOutputService1TestCaseOperation2,
 	}
 
@@ -164,9 +168,11 @@ type OutputService2ProtocolTest struct {
 // New returns a new OutputService2ProtocolTest client.
 func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice2protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice2protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -182,8 +188,8 @@ func NewOutputService2ProtocolTest(config *aws.Config) *OutputService2ProtocolTe
 
 // newRequest creates a new request for a OutputService2ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService2ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -191,8 +197,8 @@ func (c *OutputService2ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService2TestCaseOperation1 = "OperationName"
 
 // OutputService2TestCaseOperation1Request generates a request for the OutputService2TestCaseOperation1 operation.
-func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *service.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService2ProtocolTest) OutputService2TestCaseOperation1Request(input *OutputService2TestShapeOutputService2TestCaseOperation1Input) (req *request.Request, output *OutputService2TestShapeOutputService2TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService2TestCaseOperation1,
 	}
 
@@ -237,9 +243,11 @@ type OutputService3ProtocolTest struct {
 // New returns a new OutputService3ProtocolTest client.
 func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice3protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice3protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -255,8 +263,8 @@ func NewOutputService3ProtocolTest(config *aws.Config) *OutputService3ProtocolTe
 
 // newRequest creates a new request for a OutputService3ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService3ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -264,8 +272,8 @@ func (c *OutputService3ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService3TestCaseOperation1 = "OperationName"
 
 // OutputService3TestCaseOperation1Request generates a request for the OutputService3TestCaseOperation1 operation.
-func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *service.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService3ProtocolTest) OutputService3TestCaseOperation1Request(input *OutputService3TestShapeOutputService3TestCaseOperation1Input) (req *request.Request, output *OutputService3TestShapeOutputService3TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService3TestCaseOperation1,
 	}
 
@@ -310,9 +318,11 @@ type OutputService4ProtocolTest struct {
 // New returns a new OutputService4ProtocolTest client.
 func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice4protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice4protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -328,8 +338,8 @@ func NewOutputService4ProtocolTest(config *aws.Config) *OutputService4ProtocolTe
 
 // newRequest creates a new request for a OutputService4ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService4ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -337,8 +347,8 @@ func (c *OutputService4ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService4TestCaseOperation1 = "OperationName"
 
 // OutputService4TestCaseOperation1Request generates a request for the OutputService4TestCaseOperation1 operation.
-func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *service.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService4ProtocolTest) OutputService4TestCaseOperation1Request(input *OutputService4TestShapeOutputService4TestCaseOperation1Input) (req *request.Request, output *OutputService4TestShapeOutputService4TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService4TestCaseOperation1,
 	}
 
@@ -383,9 +393,11 @@ type OutputService5ProtocolTest struct {
 // New returns a new OutputService5ProtocolTest client.
 func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice5protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice5protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -401,8 +413,8 @@ func NewOutputService5ProtocolTest(config *aws.Config) *OutputService5ProtocolTe
 
 // newRequest creates a new request for a OutputService5ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService5ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -410,8 +422,8 @@ func (c *OutputService5ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService5TestCaseOperation1 = "OperationName"
 
 // OutputService5TestCaseOperation1Request generates a request for the OutputService5TestCaseOperation1 operation.
-func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *service.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService5ProtocolTest) OutputService5TestCaseOperation1Request(input *OutputService5TestShapeOutputService5TestCaseOperation1Input) (req *request.Request, output *OutputService5TestShapeOutputService5TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService5TestCaseOperation1,
 	}
 
@@ -456,9 +468,11 @@ type OutputService6ProtocolTest struct {
 // New returns a new OutputService6ProtocolTest client.
 func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice6protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice6protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -474,8 +488,8 @@ func NewOutputService6ProtocolTest(config *aws.Config) *OutputService6ProtocolTe
 
 // newRequest creates a new request for a OutputService6ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService6ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -483,8 +497,8 @@ func (c *OutputService6ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService6TestCaseOperation1 = "OperationName"
 
 // OutputService6TestCaseOperation1Request generates a request for the OutputService6TestCaseOperation1 operation.
-func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *service.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService6ProtocolTest) OutputService6TestCaseOperation1Request(input *OutputService6TestShapeOutputService6TestCaseOperation1Input) (req *request.Request, output *OutputService6TestShapeOutputService6TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService6TestCaseOperation1,
 	}
 
@@ -539,9 +553,11 @@ type OutputService7ProtocolTest struct {
 // New returns a new OutputService7ProtocolTest client.
 func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice7protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice7protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -557,8 +573,8 @@ func NewOutputService7ProtocolTest(config *aws.Config) *OutputService7ProtocolTe
 
 // newRequest creates a new request for a OutputService7ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService7ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -566,8 +582,8 @@ func (c *OutputService7ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService7TestCaseOperation1 = "OperationName"
 
 // OutputService7TestCaseOperation1Request generates a request for the OutputService7TestCaseOperation1 operation.
-func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *service.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService7ProtocolTest) OutputService7TestCaseOperation1Request(input *OutputService7TestShapeOutputService7TestCaseOperation1Input) (req *request.Request, output *OutputService7TestShapeOutputService7TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService7TestCaseOperation1,
 	}
 
@@ -612,9 +628,11 @@ type OutputService8ProtocolTest struct {
 // New returns a new OutputService8ProtocolTest client.
 func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice8protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice8protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -630,8 +648,8 @@ func NewOutputService8ProtocolTest(config *aws.Config) *OutputService8ProtocolTe
 
 // newRequest creates a new request for a OutputService8ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService8ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService8ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -639,8 +657,8 @@ func (c *OutputService8ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService8TestCaseOperation1 = "OperationName"
 
 // OutputService8TestCaseOperation1Request generates a request for the OutputService8TestCaseOperation1 operation.
-func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1Request(input *OutputService8TestShapeOutputService8TestCaseOperation1Input) (req *service.Request, output *OutputService8TestShapeOutputService8TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService8ProtocolTest) OutputService8TestCaseOperation1Request(input *OutputService8TestShapeOutputService8TestCaseOperation1Input) (req *request.Request, output *OutputService8TestShapeOutputService8TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService8TestCaseOperation1,
 	}
 
@@ -685,9 +703,11 @@ type OutputService9ProtocolTest struct {
 // New returns a new OutputService9ProtocolTest client.
 func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice9protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice9protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -703,8 +723,8 @@ func NewOutputService9ProtocolTest(config *aws.Config) *OutputService9ProtocolTe
 
 // newRequest creates a new request for a OutputService9ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService9ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService9ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -712,8 +732,8 @@ func (c *OutputService9ProtocolTest) newRequest(op *service.Operation, params, d
 const opOutputService9TestCaseOperation1 = "OperationName"
 
 // OutputService9TestCaseOperation1Request generates a request for the OutputService9TestCaseOperation1 operation.
-func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1Request(input *OutputService9TestShapeOutputService9TestCaseOperation1Input) (req *service.Request, output *OutputService9TestShapeOutputService9TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService9ProtocolTest) OutputService9TestCaseOperation1Request(input *OutputService9TestShapeOutputService9TestCaseOperation1Input) (req *request.Request, output *OutputService9TestShapeOutputService9TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService9TestCaseOperation1,
 	}
 
@@ -770,9 +790,11 @@ type OutputService10ProtocolTest struct {
 // New returns a new OutputService10ProtocolTest client.
 func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice10protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice10protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -788,8 +810,8 @@ func NewOutputService10ProtocolTest(config *aws.Config) *OutputService10Protocol
 
 // newRequest creates a new request for a OutputService10ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService10ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService10ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -797,8 +819,8 @@ func (c *OutputService10ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService10TestCaseOperation1 = "OperationName"
 
 // OutputService10TestCaseOperation1Request generates a request for the OutputService10TestCaseOperation1 operation.
-func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1Request(input *OutputService10TestShapeOutputService10TestCaseOperation1Input) (req *service.Request, output *OutputService10TestShapeOutputService10TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService10ProtocolTest) OutputService10TestCaseOperation1Request(input *OutputService10TestShapeOutputService10TestCaseOperation1Input) (req *request.Request, output *OutputService10TestShapeOutputService10TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService10TestCaseOperation1,
 	}
 
@@ -843,9 +865,11 @@ type OutputService11ProtocolTest struct {
 // New returns a new OutputService11ProtocolTest client.
 func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice11protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice11protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -861,8 +885,8 @@ func NewOutputService11ProtocolTest(config *aws.Config) *OutputService11Protocol
 
 // newRequest creates a new request for a OutputService11ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService11ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService11ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -870,8 +894,8 @@ func (c *OutputService11ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService11TestCaseOperation1 = "OperationName"
 
 // OutputService11TestCaseOperation1Request generates a request for the OutputService11TestCaseOperation1 operation.
-func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *service.Request, output *OutputService11TestShapeOutputService11TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService11ProtocolTest) OutputService11TestCaseOperation1Request(input *OutputService11TestShapeOutputService11TestCaseOperation1Input) (req *request.Request, output *OutputService11TestShapeOutputService11TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService11TestCaseOperation1,
 	}
 
@@ -932,9 +956,11 @@ type OutputService12ProtocolTest struct {
 // New returns a new OutputService12ProtocolTest client.
 func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12ProtocolTest {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "outputservice12protocoltest",
-		APIVersion:  "",
+		Service: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "outputservice12protocoltest",
+			APIVersion:  "",
+		},
 	}
 	service.Initialize()
 
@@ -950,8 +976,8 @@ func NewOutputService12ProtocolTest(config *aws.Config) *OutputService12Protocol
 
 // newRequest creates a new request for a OutputService12ProtocolTest operation and runs any
 // custom request initialization.
-func (c *OutputService12ProtocolTest) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OutputService12ProtocolTest) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(c.Service, op, params, data)
 
 	return req
 }
@@ -959,8 +985,8 @@ func (c *OutputService12ProtocolTest) newRequest(op *service.Operation, params, 
 const opOutputService12TestCaseOperation1 = "OperationName"
 
 // OutputService12TestCaseOperation1Request generates a request for the OutputService12TestCaseOperation1 operation.
-func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1Request(input *OutputService12TestShapeOutputService12TestCaseOperation1Input) (req *service.Request, output *OutputService12TestShapeOutputService12TestCaseOperation1Output) {
-	op := &service.Operation{
+func (c *OutputService12ProtocolTest) OutputService12TestCaseOperation1Request(input *OutputService12TestShapeOutputService12TestCaseOperation1Input) (req *request.Request, output *OutputService12TestShapeOutputService12TestCaseOperation1Output) {
+	op := &request.Operation{
 		Name: opOutputService12TestCaseOperation1,
 	}
 

--- a/internal/signer/v4/v4.go
+++ b/internal/signer/v4/v4.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/protocol/rest"
 )
 
@@ -64,7 +64,7 @@ type signer struct {
 // Will sign the requests with the service config's Credentials object
 // Signing is skipped if the credentials is the credentials.AnonymousCredentials
 // object.
-func Sign(req *service.Request) {
+func Sign(req *request.Request) {
 	// If the request does not need to be signed ignore the signing of the
 	// request if the AnonymousCredentials object is used.
 	if req.Service.Config.Credentials == credentials.AnonymousCredentials {

--- a/internal/signer/v4/v4_test.go
+++ b/internal/signer/v4/v4_test.go
@@ -117,8 +117,8 @@ func TestSignPrecomputedBodyChecksum(t *testing.T) {
 }
 
 func TestAnonymousCredentials(t *testing.T) {
-	r := service.NewRequest(
-		service.NewService(&aws.Config{Credentials: credentials.AnonymousCredentials}),
+	svc := service.New(&aws.Config{Credentials: credentials.AnonymousCredentials})
+	svc.NewRequest(
 		&service.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
@@ -141,11 +141,11 @@ func TestAnonymousCredentials(t *testing.T) {
 }
 
 func TestIgnoreResignRequestWithValidCreds(t *testing.T) {
-	r := service.NewRequest(
-		service.NewService(&aws.Config{
-			Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
-			Region:      aws.String("us-west-2"),
-		}),
+	svc := service.New(&aws.Config{
+		Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
+		Region:      aws.String("us-west-2"),
+	})
+	r := svc.NewRequest(
 		&service.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
@@ -163,11 +163,11 @@ func TestIgnoreResignRequestWithValidCreds(t *testing.T) {
 }
 
 func TestIgnorePreResignRequestWithValidCreds(t *testing.T) {
-	r := service.NewRequest(
-		service.NewService(&aws.Config{
-			Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
-			Region:      aws.String("us-west-2"),
-		}),
+	svc := service.New(&aws.Config{
+		Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
+		Region:      aws.String("us-west-2"),
+	})
+	r := svc.NewRequest(
 		&service.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
@@ -187,8 +187,8 @@ func TestIgnorePreResignRequestWithValidCreds(t *testing.T) {
 
 func TestResignRequestExpiredCreds(t *testing.T) {
 	creds := credentials.NewStaticCredentials("AKID", "SECRET", "SESSION")
-	r := service.NewRequest(
-		service.NewService(&aws.Config{Credentials: creds}),
+	svc := service.New(&aws.Config{Credentials: creds})
+	r := svc.NewRequest(
 		&service.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
@@ -209,8 +209,8 @@ func TestResignRequestExpiredCreds(t *testing.T) {
 func TestPreResignRequestExpiredCreds(t *testing.T) {
 	provider := &credentials.StaticProvider{credentials.Value{"AKID", "SECRET", "SESSION"}}
 	creds := credentials.NewCredentials(provider)
-	r := service.NewRequest(
-		service.NewService(&aws.Config{Credentials: creds}),
+	svc := service.New(&aws.Config{Credentials: creds})
+	r := svc.NewRequest(
 		&service.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",

--- a/internal/signer/v4/v4_test.go
+++ b/internal/signer/v4/v4_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
 	"github.com/stretchr/testify/assert"
 )
@@ -118,8 +119,8 @@ func TestSignPrecomputedBodyChecksum(t *testing.T) {
 
 func TestAnonymousCredentials(t *testing.T) {
 	svc := service.New(&aws.Config{Credentials: credentials.AnonymousCredentials})
-	svc.NewRequest(
-		&service.Operation{
+	r := svc.NewRequest(
+		&request.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
 			HTTPPath:   "/",
@@ -146,7 +147,7 @@ func TestIgnoreResignRequestWithValidCreds(t *testing.T) {
 		Region:      aws.String("us-west-2"),
 	})
 	r := svc.NewRequest(
-		&service.Operation{
+		&request.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
 			HTTPPath:   "/",
@@ -168,7 +169,7 @@ func TestIgnorePreResignRequestWithValidCreds(t *testing.T) {
 		Region:      aws.String("us-west-2"),
 	})
 	r := svc.NewRequest(
-		&service.Operation{
+		&request.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
 			HTTPPath:   "/",
@@ -189,7 +190,7 @@ func TestResignRequestExpiredCreds(t *testing.T) {
 	creds := credentials.NewStaticCredentials("AKID", "SECRET", "SESSION")
 	svc := service.New(&aws.Config{Credentials: creds})
 	r := svc.NewRequest(
-		&service.Operation{
+		&request.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
 			HTTPPath:   "/",
@@ -211,7 +212,7 @@ func TestPreResignRequestExpiredCreds(t *testing.T) {
 	creds := credentials.NewCredentials(provider)
 	svc := service.New(&aws.Config{Credentials: creds})
 	r := svc.NewRequest(
-		&service.Operation{
+		&request.Operation{
 			Name:       "BatchGetItem",
 			HTTPMethod: "POST",
 			HTTPPath:   "/",

--- a/internal/test/integration/s3/s3manager/integration_test.go
+++ b/internal/test/integration/s3/s3manager/integration_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/integration"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -131,7 +131,7 @@ func TestUploadFailCleanup(t *testing.T) {
 
 	// Break checksum on 2nd part so it fails
 	part := 0
-	svc.Handlers.Build.PushBack(func(r *service.Request) {
+	svc.Handlers.Build.PushBack(func(r *request.Request) {
 		if r.Operation.Name == "UploadPart" {
 			if part == 1 {
 				r.HTTPRequest.Header.Set("X-Amz-Content-Sha256", "000")

--- a/internal/test/perf/dynamodb/dynamodb_live_test.go
+++ b/internal/test/perf/dynamodb/dynamodb_live_test.go
@@ -55,4 +55,3 @@ func benchPutItemParallel(p, c int, b *testing.B) {
 		}
 	})
 }
-

--- a/internal/test/perf/dynamodb/dynamodb_test.go
+++ b/internal/test/perf/dynamodb/dynamodb_test.go
@@ -3,15 +3,15 @@
 package dynamodb
 
 import (
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"io"
-	"net/http"
 )
 
 type noopReadCloser struct{}
@@ -27,6 +27,7 @@ var noopBody = &noopReadCloser{}
 
 func BenchmarkPutItem(b *testing.B) {
 	cfg := aws.Config{
+		Region:      aws.String("us-east-1"),
 		DisableSSL:  aws.Bool(true),
 		Credentials: credentials.NewStaticCredentials("AKID", "SECRET", ""),
 	}
@@ -35,7 +36,7 @@ func BenchmarkPutItem(b *testing.B) {
 
 	svc := dynamodb.New(&cfg)
 	svc.Handlers.Send.Clear()
-	svc.Handlers.Send.PushBack(func(r *service.Request) {
+	svc.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: http.StatusOK,
 			Status:     http.StatusText(http.StatusOK),

--- a/internal/test/perf/dynamodb/stub.go
+++ b/internal/test/perf/dynamodb/stub.go
@@ -1,8 +1,8 @@
 package dynamodb
 
 import (
-	"net/http/httptest"
 	"net/http"
+	"net/http/httptest"
 )
 
 type dbItem struct {

--- a/internal/test/perf/protocol/ec2query_build_test.go
+++ b/internal/test/perf/protocol/ec2query_build_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
 	"github.com/aws/aws-sdk-go/internal/protocol/ec2query"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -66,12 +67,12 @@ func BenchmarkEC2QueryBuild_Simple_ec2AttachNetworkInterface(b *testing.B) {
 }
 
 func benchEC2QueryBuild(b *testing.B, opName string, params interface{}) {
-	svc := service.NewService(nil)
+	svc := service.New(nil)
 	svc.ServiceName = "ec2"
 	svc.APIVersion = "2015-04-15"
 
 	for i := 0; i < b.N; i++ {
-		r := service.NewRequest(svc, &service.Operation{
+		r := svc.NewRequest(&request.Operation{
 			Name:       opName,
 			HTTPMethod: "POST",
 			HTTPPath:   "/",

--- a/internal/test/perf/protocol/jsonrpc_build_test.go
+++ b/internal/test/perf/protocol/jsonrpc_build_test.go
@@ -3,25 +3,26 @@
 package protocol
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
-	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/protocol/json/jsonutil"
+	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"encoding/json"
-	"bytes"
 )
 
 func BenchmarkJSONRPCBuild_Simple_dynamodbPutItem(b *testing.B) {
-	svc := service.NewService(nil)
+	svc := service.New(nil)
 
 	params := getDynamodbPutItemParams(b)
 
 	for i := 0; i < b.N; i++ {
-		r := service.NewRequest(svc, &service.Operation{Name: "Operation"}, params, nil)
+		r := svc.NewRequest(&request.Operation{Name: "Operation"}, params, nil)
 		jsonrpc.Build(r)
 		if r.Error != nil {
 			b.Fatal("Unexpected error", r.Error)
@@ -30,12 +31,12 @@ func BenchmarkJSONRPCBuild_Simple_dynamodbPutItem(b *testing.B) {
 }
 
 func BenchmarkJSONUtilBuild_Simple_dynamodbPutItem(b *testing.B) {
-	svc := service.NewService(nil)
+	svc := service.New(nil)
 
 	params := getDynamodbPutItemParams(b)
 
 	for i := 0; i < b.N; i++ {
-		r := service.NewRequest(svc, &service.Operation{Name: "Operation"}, params, nil)
+		r := svc.NewRequest(&request.Operation{Name: "Operation"}, params, nil)
 		_, err := jsonutil.BuildJSON(r.Params)
 		if err != nil {
 			b.Fatal("Unexpected error", err)

--- a/internal/test/perf/protocol/restjson_build_test.go
+++ b/internal/test/perf/protocol/restjson_build_test.go
@@ -3,24 +3,25 @@
 package protocol
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
 	"github.com/aws/aws-sdk-go/internal/protocol/rest"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
-	"bytes"
-	"encoding/json"
 )
 
 func BenchmarkRESTJSONBuild_Complex_elastictranscoderCreateJobInput(b *testing.B) {
-	svc := service.NewService(nil)
+	svc := service.New(nil)
 	svc.ServiceName = "elastictranscoder"
 	svc.APIVersion = "2012-09-25"
 
 	for i := 0; i < b.N; i++ {
-		r := service.NewRequest(svc, &service.Operation{Name: "CreateJobInput"}, restjsonBuildParms, nil)
+		r := svc.NewRequest(&request.Operation{Name: "CreateJobInput"}, restjsonBuildParms, nil)
 		restjson.Build(r)
 		if r.Error != nil {
 			b.Fatal("Unexpected error", r.Error)
@@ -29,12 +30,12 @@ func BenchmarkRESTJSONBuild_Complex_elastictranscoderCreateJobInput(b *testing.B
 }
 
 func BenchmarkRESTBuild_Complex_elastictranscoderCreateJobInput(b *testing.B) {
-	svc := service.NewService(nil)
+	svc := service.New(nil)
 	svc.ServiceName = "elastictranscoder"
 	svc.APIVersion = "2012-09-25"
 
 	for i := 0; i < b.N; i++ {
-		r := service.NewRequest(svc, &service.Operation{Name: "CreateJobInput"}, restjsonBuildParms, nil)
+		r := svc.NewRequest(&request.Operation{Name: "CreateJobInput"}, restjsonBuildParms, nil)
 		rest.Build(r)
 		if r.Error != nil {
 			b.Fatal("Unexpected error", r.Error)
@@ -55,7 +56,7 @@ func BenchmarkEncodingJSONMarshal_Complex_elastictranscoderCreateJobInput(b *tes
 }
 
 func BenchmarkRESTJSONBuild_Simple_elastictranscoderListJobsByPipeline(b *testing.B) {
-	svc := service.NewService(nil)
+	svc := service.New(nil)
 	svc.ServiceName = "elastictranscoder"
 	svc.APIVersion = "2012-09-25"
 
@@ -66,7 +67,7 @@ func BenchmarkRESTJSONBuild_Simple_elastictranscoderListJobsByPipeline(b *testin
 	}
 
 	for i := 0; i < b.N; i++ {
-		r := service.NewRequest(svc, &service.Operation{Name: "ListJobsByPipeline"}, params, nil)
+		r := svc.NewRequest(&request.Operation{Name: "ListJobsByPipeline"}, params, nil)
 		restjson.Build(r)
 		if r.Error != nil {
 			b.Fatal("Unexpected error", r.Error)
@@ -75,7 +76,7 @@ func BenchmarkRESTJSONBuild_Simple_elastictranscoderListJobsByPipeline(b *testin
 }
 
 func BenchmarkRESTBuild_Simple_elastictranscoderListJobsByPipeline(b *testing.B) {
-	svc := service.NewService(nil)
+	svc := service.New(nil)
 	svc.ServiceName = "elastictranscoder"
 	svc.APIVersion = "2012-09-25"
 
@@ -86,14 +87,13 @@ func BenchmarkRESTBuild_Simple_elastictranscoderListJobsByPipeline(b *testing.B)
 	}
 
 	for i := 0; i < b.N; i++ {
-		r := service.NewRequest(svc, &service.Operation{Name: "ListJobsByPipeline"}, params, nil)
+		r := svc.NewRequest(&request.Operation{Name: "ListJobsByPipeline"}, params, nil)
 		rest.Build(r)
 		if r.Error != nil {
 			b.Fatal("Unexpected error", r.Error)
 		}
 	}
 }
-
 
 func BenchmarkEncodingJSONMarshal_Simple_elastictranscoderListJobsByPipeline(b *testing.B) {
 	params := &elastictranscoder.ListJobsByPipelineInput{

--- a/internal/test/perf/protocol/restxml_build_test.go
+++ b/internal/test/perf/protocol/restxml_build_test.go
@@ -5,18 +5,19 @@ package protocol
 import (
 	"testing"
 
+	"bytes"
+	"encoding/xml"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
 	"github.com/aws/aws-sdk-go/internal/protocol/restxml"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
-	"bytes"
-	"encoding/xml"
 )
 
 func BenchmarkRESTXMLBuild_Complex_cloudfrontCreateDistribution(b *testing.B) {
 	params := restxmlBuildCreateDistroParms
 
-	op := &service.Operation{
+	op := &request.Operation{
 		Name:       "CreateDistribution",
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-04-17/distribution/{DistributionId}/invalidation",
@@ -30,7 +31,7 @@ func BenchmarkRESTXMLBuild_Simple_cloudfrontDeleteStreamingDistribution(b *testi
 		Id:      aws.String("string"), // Required
 		IfMatch: aws.String("string"),
 	}
-	op := &service.Operation{
+	op := &request.Operation{
 		Name:       "DeleteStreamingDistribution",
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-04-17/streaming-distribution/{Id}",
@@ -53,13 +54,13 @@ func BenchmarkEncodingXMLMarshal_Simple_cloudfrontDeleteStreamingDistribution(b 
 	}
 }
 
-func benchRESTXMLBuild(b *testing.B, op *service.Operation, params interface{}) {
-	svc := service.NewService(nil)
+func benchRESTXMLBuild(b *testing.B, op *request.Operation, params interface{}) {
+	svc := service.New(nil)
 	svc.ServiceName = "cloudfront"
 	svc.APIVersion = "2015-04-17"
 
 	for i := 0; i < b.N; i++ {
-		r := service.NewRequest(svc, op, params, nil)
+		r := svc.NewRequest(op, params, nil)
 		restxml.Build(r)
 		if r.Error != nil {
 			b.Fatal("Unexpected error", r.Error)

--- a/internal/test/perf/s3/s3manager/stub.go
+++ b/internal/test/perf/s3/s3manager/stub.go
@@ -1,1 +1,0 @@
-package s3manager

--- a/service/autoscaling/api.go
+++ b/service/autoscaling/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAttachInstances = "AttachInstances"
 
 // AttachInstancesRequest generates a request for the AttachInstances operation.
-func (c *AutoScaling) AttachInstancesRequest(input *AttachInstancesInput) (req *service.Request, output *AttachInstancesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) AttachInstancesRequest(input *AttachInstancesInput) (req *request.Request, output *AttachInstancesOutput) {
+	op := &request.Operation{
 		Name:       opAttachInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -44,8 +44,8 @@ func (c *AutoScaling) AttachInstances(input *AttachInstancesInput) (*AttachInsta
 const opAttachLoadBalancers = "AttachLoadBalancers"
 
 // AttachLoadBalancersRequest generates a request for the AttachLoadBalancers operation.
-func (c *AutoScaling) AttachLoadBalancersRequest(input *AttachLoadBalancersInput) (req *service.Request, output *AttachLoadBalancersOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) AttachLoadBalancersRequest(input *AttachLoadBalancersInput) (req *request.Request, output *AttachLoadBalancersOutput) {
+	op := &request.Operation{
 		Name:       opAttachLoadBalancers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -78,8 +78,8 @@ func (c *AutoScaling) AttachLoadBalancers(input *AttachLoadBalancersInput) (*Att
 const opCompleteLifecycleAction = "CompleteLifecycleAction"
 
 // CompleteLifecycleActionRequest generates a request for the CompleteLifecycleAction operation.
-func (c *AutoScaling) CompleteLifecycleActionRequest(input *CompleteLifecycleActionInput) (req *service.Request, output *CompleteLifecycleActionOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) CompleteLifecycleActionRequest(input *CompleteLifecycleActionInput) (req *request.Request, output *CompleteLifecycleActionOutput) {
+	op := &request.Operation{
 		Name:       opCompleteLifecycleAction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -119,8 +119,8 @@ func (c *AutoScaling) CompleteLifecycleAction(input *CompleteLifecycleActionInpu
 const opCreateAutoScalingGroup = "CreateAutoScalingGroup"
 
 // CreateAutoScalingGroupRequest generates a request for the CreateAutoScalingGroup operation.
-func (c *AutoScaling) CreateAutoScalingGroupRequest(input *CreateAutoScalingGroupInput) (req *service.Request, output *CreateAutoScalingGroupOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) CreateAutoScalingGroupRequest(input *CreateAutoScalingGroupInput) (req *request.Request, output *CreateAutoScalingGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateAutoScalingGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -153,8 +153,8 @@ func (c *AutoScaling) CreateAutoScalingGroup(input *CreateAutoScalingGroupInput)
 const opCreateLaunchConfiguration = "CreateLaunchConfiguration"
 
 // CreateLaunchConfigurationRequest generates a request for the CreateLaunchConfiguration operation.
-func (c *AutoScaling) CreateLaunchConfigurationRequest(input *CreateLaunchConfigurationInput) (req *service.Request, output *CreateLaunchConfigurationOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) CreateLaunchConfigurationRequest(input *CreateLaunchConfigurationInput) (req *request.Request, output *CreateLaunchConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opCreateLaunchConfiguration,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -187,8 +187,8 @@ func (c *AutoScaling) CreateLaunchConfiguration(input *CreateLaunchConfiguration
 const opCreateOrUpdateTags = "CreateOrUpdateTags"
 
 // CreateOrUpdateTagsRequest generates a request for the CreateOrUpdateTags operation.
-func (c *AutoScaling) CreateOrUpdateTagsRequest(input *CreateOrUpdateTagsInput) (req *service.Request, output *CreateOrUpdateTagsOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) CreateOrUpdateTagsRequest(input *CreateOrUpdateTagsInput) (req *request.Request, output *CreateOrUpdateTagsOutput) {
+	op := &request.Operation{
 		Name:       opCreateOrUpdateTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -227,8 +227,8 @@ func (c *AutoScaling) CreateOrUpdateTags(input *CreateOrUpdateTagsInput) (*Creat
 const opDeleteAutoScalingGroup = "DeleteAutoScalingGroup"
 
 // DeleteAutoScalingGroupRequest generates a request for the DeleteAutoScalingGroup operation.
-func (c *AutoScaling) DeleteAutoScalingGroupRequest(input *DeleteAutoScalingGroupInput) (req *service.Request, output *DeleteAutoScalingGroupOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DeleteAutoScalingGroupRequest(input *DeleteAutoScalingGroupInput) (req *request.Request, output *DeleteAutoScalingGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteAutoScalingGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -259,8 +259,8 @@ func (c *AutoScaling) DeleteAutoScalingGroup(input *DeleteAutoScalingGroupInput)
 const opDeleteLaunchConfiguration = "DeleteLaunchConfiguration"
 
 // DeleteLaunchConfigurationRequest generates a request for the DeleteLaunchConfiguration operation.
-func (c *AutoScaling) DeleteLaunchConfigurationRequest(input *DeleteLaunchConfigurationInput) (req *service.Request, output *DeleteLaunchConfigurationOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DeleteLaunchConfigurationRequest(input *DeleteLaunchConfigurationInput) (req *request.Request, output *DeleteLaunchConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLaunchConfiguration,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -290,8 +290,8 @@ func (c *AutoScaling) DeleteLaunchConfiguration(input *DeleteLaunchConfiguration
 const opDeleteLifecycleHook = "DeleteLifecycleHook"
 
 // DeleteLifecycleHookRequest generates a request for the DeleteLifecycleHook operation.
-func (c *AutoScaling) DeleteLifecycleHookRequest(input *DeleteLifecycleHookInput) (req *service.Request, output *DeleteLifecycleHookOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DeleteLifecycleHookRequest(input *DeleteLifecycleHookInput) (req *request.Request, output *DeleteLifecycleHookOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLifecycleHook,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -320,8 +320,8 @@ func (c *AutoScaling) DeleteLifecycleHook(input *DeleteLifecycleHookInput) (*Del
 const opDeleteNotificationConfiguration = "DeleteNotificationConfiguration"
 
 // DeleteNotificationConfigurationRequest generates a request for the DeleteNotificationConfiguration operation.
-func (c *AutoScaling) DeleteNotificationConfigurationRequest(input *DeleteNotificationConfigurationInput) (req *service.Request, output *DeleteNotificationConfigurationOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DeleteNotificationConfigurationRequest(input *DeleteNotificationConfigurationInput) (req *request.Request, output *DeleteNotificationConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteNotificationConfiguration,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -347,8 +347,8 @@ func (c *AutoScaling) DeleteNotificationConfiguration(input *DeleteNotificationC
 const opDeletePolicy = "DeletePolicy"
 
 // DeletePolicyRequest generates a request for the DeletePolicy operation.
-func (c *AutoScaling) DeletePolicyRequest(input *DeletePolicyInput) (req *service.Request, output *DeletePolicyOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DeletePolicyRequest(input *DeletePolicyInput) (req *request.Request, output *DeletePolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeletePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -374,8 +374,8 @@ func (c *AutoScaling) DeletePolicy(input *DeletePolicyInput) (*DeletePolicyOutpu
 const opDeleteScheduledAction = "DeleteScheduledAction"
 
 // DeleteScheduledActionRequest generates a request for the DeleteScheduledAction operation.
-func (c *AutoScaling) DeleteScheduledActionRequest(input *DeleteScheduledActionInput) (req *service.Request, output *DeleteScheduledActionOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DeleteScheduledActionRequest(input *DeleteScheduledActionInput) (req *request.Request, output *DeleteScheduledActionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteScheduledAction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -401,8 +401,8 @@ func (c *AutoScaling) DeleteScheduledAction(input *DeleteScheduledActionInput) (
 const opDeleteTags = "DeleteTags"
 
 // DeleteTagsRequest generates a request for the DeleteTags operation.
-func (c *AutoScaling) DeleteTagsRequest(input *DeleteTagsInput) (req *service.Request, output *DeleteTagsOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DeleteTagsRequest(input *DeleteTagsInput) (req *request.Request, output *DeleteTagsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -428,8 +428,8 @@ func (c *AutoScaling) DeleteTags(input *DeleteTagsInput) (*DeleteTagsOutput, err
 const opDescribeAccountLimits = "DescribeAccountLimits"
 
 // DescribeAccountLimitsRequest generates a request for the DescribeAccountLimits operation.
-func (c *AutoScaling) DescribeAccountLimitsRequest(input *DescribeAccountLimitsInput) (req *service.Request, output *DescribeAccountLimitsOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeAccountLimitsRequest(input *DescribeAccountLimitsInput) (req *request.Request, output *DescribeAccountLimitsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAccountLimits,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -459,8 +459,8 @@ func (c *AutoScaling) DescribeAccountLimits(input *DescribeAccountLimitsInput) (
 const opDescribeAdjustmentTypes = "DescribeAdjustmentTypes"
 
 // DescribeAdjustmentTypesRequest generates a request for the DescribeAdjustmentTypes operation.
-func (c *AutoScaling) DescribeAdjustmentTypesRequest(input *DescribeAdjustmentTypesInput) (req *service.Request, output *DescribeAdjustmentTypesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeAdjustmentTypesRequest(input *DescribeAdjustmentTypesInput) (req *request.Request, output *DescribeAdjustmentTypesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAdjustmentTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -486,12 +486,12 @@ func (c *AutoScaling) DescribeAdjustmentTypes(input *DescribeAdjustmentTypesInpu
 const opDescribeAutoScalingGroups = "DescribeAutoScalingGroups"
 
 // DescribeAutoScalingGroupsRequest generates a request for the DescribeAutoScalingGroups operation.
-func (c *AutoScaling) DescribeAutoScalingGroupsRequest(input *DescribeAutoScalingGroupsInput) (req *service.Request, output *DescribeAutoScalingGroupsOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeAutoScalingGroupsRequest(input *DescribeAutoScalingGroupsInput) (req *request.Request, output *DescribeAutoScalingGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAutoScalingGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -527,12 +527,12 @@ func (c *AutoScaling) DescribeAutoScalingGroupsPages(input *DescribeAutoScalingG
 const opDescribeAutoScalingInstances = "DescribeAutoScalingInstances"
 
 // DescribeAutoScalingInstancesRequest generates a request for the DescribeAutoScalingInstances operation.
-func (c *AutoScaling) DescribeAutoScalingInstancesRequest(input *DescribeAutoScalingInstancesInput) (req *service.Request, output *DescribeAutoScalingInstancesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeAutoScalingInstancesRequest(input *DescribeAutoScalingInstancesInput) (req *request.Request, output *DescribeAutoScalingInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAutoScalingInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -568,8 +568,8 @@ func (c *AutoScaling) DescribeAutoScalingInstancesPages(input *DescribeAutoScali
 const opDescribeAutoScalingNotificationTypes = "DescribeAutoScalingNotificationTypes"
 
 // DescribeAutoScalingNotificationTypesRequest generates a request for the DescribeAutoScalingNotificationTypes operation.
-func (c *AutoScaling) DescribeAutoScalingNotificationTypesRequest(input *DescribeAutoScalingNotificationTypesInput) (req *service.Request, output *DescribeAutoScalingNotificationTypesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeAutoScalingNotificationTypesRequest(input *DescribeAutoScalingNotificationTypesInput) (req *request.Request, output *DescribeAutoScalingNotificationTypesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAutoScalingNotificationTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -595,12 +595,12 @@ func (c *AutoScaling) DescribeAutoScalingNotificationTypes(input *DescribeAutoSc
 const opDescribeLaunchConfigurations = "DescribeLaunchConfigurations"
 
 // DescribeLaunchConfigurationsRequest generates a request for the DescribeLaunchConfigurations operation.
-func (c *AutoScaling) DescribeLaunchConfigurationsRequest(input *DescribeLaunchConfigurationsInput) (req *service.Request, output *DescribeLaunchConfigurationsOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeLaunchConfigurationsRequest(input *DescribeLaunchConfigurationsInput) (req *request.Request, output *DescribeLaunchConfigurationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLaunchConfigurations,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -636,8 +636,8 @@ func (c *AutoScaling) DescribeLaunchConfigurationsPages(input *DescribeLaunchCon
 const opDescribeLifecycleHookTypes = "DescribeLifecycleHookTypes"
 
 // DescribeLifecycleHookTypesRequest generates a request for the DescribeLifecycleHookTypes operation.
-func (c *AutoScaling) DescribeLifecycleHookTypesRequest(input *DescribeLifecycleHookTypesInput) (req *service.Request, output *DescribeLifecycleHookTypesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeLifecycleHookTypesRequest(input *DescribeLifecycleHookTypesInput) (req *request.Request, output *DescribeLifecycleHookTypesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLifecycleHookTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -663,8 +663,8 @@ func (c *AutoScaling) DescribeLifecycleHookTypes(input *DescribeLifecycleHookTyp
 const opDescribeLifecycleHooks = "DescribeLifecycleHooks"
 
 // DescribeLifecycleHooksRequest generates a request for the DescribeLifecycleHooks operation.
-func (c *AutoScaling) DescribeLifecycleHooksRequest(input *DescribeLifecycleHooksInput) (req *service.Request, output *DescribeLifecycleHooksOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeLifecycleHooksRequest(input *DescribeLifecycleHooksInput) (req *request.Request, output *DescribeLifecycleHooksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLifecycleHooks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -690,8 +690,8 @@ func (c *AutoScaling) DescribeLifecycleHooks(input *DescribeLifecycleHooksInput)
 const opDescribeLoadBalancers = "DescribeLoadBalancers"
 
 // DescribeLoadBalancersRequest generates a request for the DescribeLoadBalancers operation.
-func (c *AutoScaling) DescribeLoadBalancersRequest(input *DescribeLoadBalancersInput) (req *service.Request, output *DescribeLoadBalancersOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeLoadBalancersRequest(input *DescribeLoadBalancersInput) (req *request.Request, output *DescribeLoadBalancersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLoadBalancers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -717,8 +717,8 @@ func (c *AutoScaling) DescribeLoadBalancers(input *DescribeLoadBalancersInput) (
 const opDescribeMetricCollectionTypes = "DescribeMetricCollectionTypes"
 
 // DescribeMetricCollectionTypesRequest generates a request for the DescribeMetricCollectionTypes operation.
-func (c *AutoScaling) DescribeMetricCollectionTypesRequest(input *DescribeMetricCollectionTypesInput) (req *service.Request, output *DescribeMetricCollectionTypesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeMetricCollectionTypesRequest(input *DescribeMetricCollectionTypesInput) (req *request.Request, output *DescribeMetricCollectionTypesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeMetricCollectionTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -747,12 +747,12 @@ func (c *AutoScaling) DescribeMetricCollectionTypes(input *DescribeMetricCollect
 const opDescribeNotificationConfigurations = "DescribeNotificationConfigurations"
 
 // DescribeNotificationConfigurationsRequest generates a request for the DescribeNotificationConfigurations operation.
-func (c *AutoScaling) DescribeNotificationConfigurationsRequest(input *DescribeNotificationConfigurationsInput) (req *service.Request, output *DescribeNotificationConfigurationsOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeNotificationConfigurationsRequest(input *DescribeNotificationConfigurationsInput) (req *request.Request, output *DescribeNotificationConfigurationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeNotificationConfigurations,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -788,12 +788,12 @@ func (c *AutoScaling) DescribeNotificationConfigurationsPages(input *DescribeNot
 const opDescribePolicies = "DescribePolicies"
 
 // DescribePoliciesRequest generates a request for the DescribePolicies operation.
-func (c *AutoScaling) DescribePoliciesRequest(input *DescribePoliciesInput) (req *service.Request, output *DescribePoliciesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribePoliciesRequest(input *DescribePoliciesInput) (req *request.Request, output *DescribePoliciesOutput) {
+	op := &request.Operation{
 		Name:       opDescribePolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -828,12 +828,12 @@ func (c *AutoScaling) DescribePoliciesPages(input *DescribePoliciesInput, fn fun
 const opDescribeScalingActivities = "DescribeScalingActivities"
 
 // DescribeScalingActivitiesRequest generates a request for the DescribeScalingActivities operation.
-func (c *AutoScaling) DescribeScalingActivitiesRequest(input *DescribeScalingActivitiesInput) (req *service.Request, output *DescribeScalingActivitiesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeScalingActivitiesRequest(input *DescribeScalingActivitiesInput) (req *request.Request, output *DescribeScalingActivitiesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeScalingActivities,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -871,8 +871,8 @@ func (c *AutoScaling) DescribeScalingActivitiesPages(input *DescribeScalingActiv
 const opDescribeScalingProcessTypes = "DescribeScalingProcessTypes"
 
 // DescribeScalingProcessTypesRequest generates a request for the DescribeScalingProcessTypes operation.
-func (c *AutoScaling) DescribeScalingProcessTypesRequest(input *DescribeScalingProcessTypesInput) (req *service.Request, output *DescribeScalingProcessTypesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeScalingProcessTypesRequest(input *DescribeScalingProcessTypesInput) (req *request.Request, output *DescribeScalingProcessTypesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeScalingProcessTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -898,12 +898,12 @@ func (c *AutoScaling) DescribeScalingProcessTypes(input *DescribeScalingProcessT
 const opDescribeScheduledActions = "DescribeScheduledActions"
 
 // DescribeScheduledActionsRequest generates a request for the DescribeScheduledActions operation.
-func (c *AutoScaling) DescribeScheduledActionsRequest(input *DescribeScheduledActionsInput) (req *service.Request, output *DescribeScheduledActionsOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeScheduledActionsRequest(input *DescribeScheduledActionsInput) (req *request.Request, output *DescribeScheduledActionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeScheduledActions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -939,12 +939,12 @@ func (c *AutoScaling) DescribeScheduledActionsPages(input *DescribeScheduledActi
 const opDescribeTags = "DescribeTags"
 
 // DescribeTagsRequest generates a request for the DescribeTags operation.
-func (c *AutoScaling) DescribeTagsRequest(input *DescribeTagsInput) (req *service.Request, output *DescribeTagsOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeTagsRequest(input *DescribeTagsInput) (req *request.Request, output *DescribeTagsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -988,8 +988,8 @@ func (c *AutoScaling) DescribeTagsPages(input *DescribeTagsInput, fn func(p *Des
 const opDescribeTerminationPolicyTypes = "DescribeTerminationPolicyTypes"
 
 // DescribeTerminationPolicyTypesRequest generates a request for the DescribeTerminationPolicyTypes operation.
-func (c *AutoScaling) DescribeTerminationPolicyTypesRequest(input *DescribeTerminationPolicyTypesInput) (req *service.Request, output *DescribeTerminationPolicyTypesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DescribeTerminationPolicyTypesRequest(input *DescribeTerminationPolicyTypesInput) (req *request.Request, output *DescribeTerminationPolicyTypesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTerminationPolicyTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1015,8 +1015,8 @@ func (c *AutoScaling) DescribeTerminationPolicyTypes(input *DescribeTerminationP
 const opDetachInstances = "DetachInstances"
 
 // DetachInstancesRequest generates a request for the DetachInstances operation.
-func (c *AutoScaling) DetachInstancesRequest(input *DetachInstancesInput) (req *service.Request, output *DetachInstancesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DetachInstancesRequest(input *DetachInstancesInput) (req *request.Request, output *DetachInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDetachInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1048,8 +1048,8 @@ func (c *AutoScaling) DetachInstances(input *DetachInstancesInput) (*DetachInsta
 const opDetachLoadBalancers = "DetachLoadBalancers"
 
 // DetachLoadBalancersRequest generates a request for the DetachLoadBalancers operation.
-func (c *AutoScaling) DetachLoadBalancersRequest(input *DetachLoadBalancersInput) (req *service.Request, output *DetachLoadBalancersOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DetachLoadBalancersRequest(input *DetachLoadBalancersInput) (req *request.Request, output *DetachLoadBalancersOutput) {
+	op := &request.Operation{
 		Name:       opDetachLoadBalancers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1080,8 +1080,8 @@ func (c *AutoScaling) DetachLoadBalancers(input *DetachLoadBalancersInput) (*Det
 const opDisableMetricsCollection = "DisableMetricsCollection"
 
 // DisableMetricsCollectionRequest generates a request for the DisableMetricsCollection operation.
-func (c *AutoScaling) DisableMetricsCollectionRequest(input *DisableMetricsCollectionInput) (req *service.Request, output *DisableMetricsCollectionOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) DisableMetricsCollectionRequest(input *DisableMetricsCollectionInput) (req *request.Request, output *DisableMetricsCollectionOutput) {
+	op := &request.Operation{
 		Name:       opDisableMetricsCollection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1108,8 +1108,8 @@ func (c *AutoScaling) DisableMetricsCollection(input *DisableMetricsCollectionIn
 const opEnableMetricsCollection = "EnableMetricsCollection"
 
 // EnableMetricsCollectionRequest generates a request for the EnableMetricsCollection operation.
-func (c *AutoScaling) EnableMetricsCollectionRequest(input *EnableMetricsCollectionInput) (req *service.Request, output *EnableMetricsCollectionOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) EnableMetricsCollectionRequest(input *EnableMetricsCollectionInput) (req *request.Request, output *EnableMetricsCollectionOutput) {
+	op := &request.Operation{
 		Name:       opEnableMetricsCollection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1139,8 +1139,8 @@ func (c *AutoScaling) EnableMetricsCollection(input *EnableMetricsCollectionInpu
 const opEnterStandby = "EnterStandby"
 
 // EnterStandbyRequest generates a request for the EnterStandby operation.
-func (c *AutoScaling) EnterStandbyRequest(input *EnterStandbyInput) (req *service.Request, output *EnterStandbyOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) EnterStandbyRequest(input *EnterStandbyInput) (req *request.Request, output *EnterStandbyOutput) {
+	op := &request.Operation{
 		Name:       opEnterStandby,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1169,8 +1169,8 @@ func (c *AutoScaling) EnterStandby(input *EnterStandbyInput) (*EnterStandbyOutpu
 const opExecutePolicy = "ExecutePolicy"
 
 // ExecutePolicyRequest generates a request for the ExecutePolicy operation.
-func (c *AutoScaling) ExecutePolicyRequest(input *ExecutePolicyInput) (req *service.Request, output *ExecutePolicyOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) ExecutePolicyRequest(input *ExecutePolicyInput) (req *request.Request, output *ExecutePolicyOutput) {
+	op := &request.Operation{
 		Name:       opExecutePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1196,8 +1196,8 @@ func (c *AutoScaling) ExecutePolicy(input *ExecutePolicyInput) (*ExecutePolicyOu
 const opExitStandby = "ExitStandby"
 
 // ExitStandbyRequest generates a request for the ExitStandby operation.
-func (c *AutoScaling) ExitStandbyRequest(input *ExitStandbyInput) (req *service.Request, output *ExitStandbyOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) ExitStandbyRequest(input *ExitStandbyInput) (req *request.Request, output *ExitStandbyOutput) {
+	op := &request.Operation{
 		Name:       opExitStandby,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1226,8 +1226,8 @@ func (c *AutoScaling) ExitStandby(input *ExitStandbyInput) (*ExitStandbyOutput, 
 const opPutLifecycleHook = "PutLifecycleHook"
 
 // PutLifecycleHookRequest generates a request for the PutLifecycleHook operation.
-func (c *AutoScaling) PutLifecycleHookRequest(input *PutLifecycleHookInput) (req *service.Request, output *PutLifecycleHookOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) PutLifecycleHookRequest(input *PutLifecycleHookInput) (req *request.Request, output *PutLifecycleHookOutput) {
+	op := &request.Operation{
 		Name:       opPutLifecycleHook,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1275,8 +1275,8 @@ func (c *AutoScaling) PutLifecycleHook(input *PutLifecycleHookInput) (*PutLifecy
 const opPutNotificationConfiguration = "PutNotificationConfiguration"
 
 // PutNotificationConfigurationRequest generates a request for the PutNotificationConfiguration operation.
-func (c *AutoScaling) PutNotificationConfigurationRequest(input *PutNotificationConfigurationInput) (req *service.Request, output *PutNotificationConfigurationOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) PutNotificationConfigurationRequest(input *PutNotificationConfigurationInput) (req *request.Request, output *PutNotificationConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opPutNotificationConfiguration,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1310,8 +1310,8 @@ func (c *AutoScaling) PutNotificationConfiguration(input *PutNotificationConfigu
 const opPutScalingPolicy = "PutScalingPolicy"
 
 // PutScalingPolicyRequest generates a request for the PutScalingPolicy operation.
-func (c *AutoScaling) PutScalingPolicyRequest(input *PutScalingPolicyInput) (req *service.Request, output *PutScalingPolicyOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) PutScalingPolicyRequest(input *PutScalingPolicyInput) (req *request.Request, output *PutScalingPolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutScalingPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1345,8 +1345,8 @@ func (c *AutoScaling) PutScalingPolicy(input *PutScalingPolicyInput) (*PutScalin
 const opPutScheduledUpdateGroupAction = "PutScheduledUpdateGroupAction"
 
 // PutScheduledUpdateGroupActionRequest generates a request for the PutScheduledUpdateGroupAction operation.
-func (c *AutoScaling) PutScheduledUpdateGroupActionRequest(input *PutScheduledUpdateGroupActionInput) (req *service.Request, output *PutScheduledUpdateGroupActionOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) PutScheduledUpdateGroupActionRequest(input *PutScheduledUpdateGroupActionInput) (req *request.Request, output *PutScheduledUpdateGroupActionOutput) {
+	op := &request.Operation{
 		Name:       opPutScheduledUpdateGroupAction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1377,8 +1377,8 @@ func (c *AutoScaling) PutScheduledUpdateGroupAction(input *PutScheduledUpdateGro
 const opRecordLifecycleActionHeartbeat = "RecordLifecycleActionHeartbeat"
 
 // RecordLifecycleActionHeartbeatRequest generates a request for the RecordLifecycleActionHeartbeat operation.
-func (c *AutoScaling) RecordLifecycleActionHeartbeatRequest(input *RecordLifecycleActionHeartbeatInput) (req *service.Request, output *RecordLifecycleActionHeartbeatOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) RecordLifecycleActionHeartbeatRequest(input *RecordLifecycleActionHeartbeatInput) (req *request.Request, output *RecordLifecycleActionHeartbeatOutput) {
+	op := &request.Operation{
 		Name:       opRecordLifecycleActionHeartbeat,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1419,8 +1419,8 @@ func (c *AutoScaling) RecordLifecycleActionHeartbeat(input *RecordLifecycleActio
 const opResumeProcesses = "ResumeProcesses"
 
 // ResumeProcessesRequest generates a request for the ResumeProcesses operation.
-func (c *AutoScaling) ResumeProcessesRequest(input *ScalingProcessQuery) (req *service.Request, output *ResumeProcessesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) ResumeProcessesRequest(input *ScalingProcessQuery) (req *request.Request, output *ResumeProcessesOutput) {
+	op := &request.Operation{
 		Name:       opResumeProcesses,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1450,8 +1450,8 @@ func (c *AutoScaling) ResumeProcesses(input *ScalingProcessQuery) (*ResumeProces
 const opSetDesiredCapacity = "SetDesiredCapacity"
 
 // SetDesiredCapacityRequest generates a request for the SetDesiredCapacity operation.
-func (c *AutoScaling) SetDesiredCapacityRequest(input *SetDesiredCapacityInput) (req *service.Request, output *SetDesiredCapacityOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) SetDesiredCapacityRequest(input *SetDesiredCapacityInput) (req *request.Request, output *SetDesiredCapacityOutput) {
+	op := &request.Operation{
 		Name:       opSetDesiredCapacity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1480,8 +1480,8 @@ func (c *AutoScaling) SetDesiredCapacity(input *SetDesiredCapacityInput) (*SetDe
 const opSetInstanceHealth = "SetInstanceHealth"
 
 // SetInstanceHealthRequest generates a request for the SetInstanceHealth operation.
-func (c *AutoScaling) SetInstanceHealthRequest(input *SetInstanceHealthInput) (req *service.Request, output *SetInstanceHealthOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) SetInstanceHealthRequest(input *SetInstanceHealthInput) (req *request.Request, output *SetInstanceHealthOutput) {
+	op := &request.Operation{
 		Name:       opSetInstanceHealth,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1510,8 +1510,8 @@ func (c *AutoScaling) SetInstanceHealth(input *SetInstanceHealthInput) (*SetInst
 const opSuspendProcesses = "SuspendProcesses"
 
 // SuspendProcessesRequest generates a request for the SuspendProcesses operation.
-func (c *AutoScaling) SuspendProcessesRequest(input *ScalingProcessQuery) (req *service.Request, output *SuspendProcessesOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) SuspendProcessesRequest(input *ScalingProcessQuery) (req *request.Request, output *SuspendProcessesOutput) {
+	op := &request.Operation{
 		Name:       opSuspendProcesses,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1547,8 +1547,8 @@ func (c *AutoScaling) SuspendProcesses(input *ScalingProcessQuery) (*SuspendProc
 const opTerminateInstanceInAutoScalingGroup = "TerminateInstanceInAutoScalingGroup"
 
 // TerminateInstanceInAutoScalingGroupRequest generates a request for the TerminateInstanceInAutoScalingGroup operation.
-func (c *AutoScaling) TerminateInstanceInAutoScalingGroupRequest(input *TerminateInstanceInAutoScalingGroupInput) (req *service.Request, output *TerminateInstanceInAutoScalingGroupOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) TerminateInstanceInAutoScalingGroupRequest(input *TerminateInstanceInAutoScalingGroupInput) (req *request.Request, output *TerminateInstanceInAutoScalingGroupOutput) {
+	op := &request.Operation{
 		Name:       opTerminateInstanceInAutoScalingGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1578,8 +1578,8 @@ func (c *AutoScaling) TerminateInstanceInAutoScalingGroup(input *TerminateInstan
 const opUpdateAutoScalingGroup = "UpdateAutoScalingGroup"
 
 // UpdateAutoScalingGroupRequest generates a request for the UpdateAutoScalingGroup operation.
-func (c *AutoScaling) UpdateAutoScalingGroupRequest(input *UpdateAutoScalingGroupInput) (req *service.Request, output *UpdateAutoScalingGroupOutput) {
-	op := &service.Operation{
+func (c *AutoScaling) UpdateAutoScalingGroupRequest(input *UpdateAutoScalingGroupInput) (req *request.Request, output *UpdateAutoScalingGroupOutput) {
+	op := &request.Operation{
 		Name:       opUpdateAutoScalingGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/autoscaling/autoscalingiface/interface.go
+++ b/service/autoscaling/autoscalingiface/interface.go
@@ -4,217 +4,217 @@
 package autoscalingiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
 
 // AutoScalingAPI is the interface type for autoscaling.AutoScaling.
 type AutoScalingAPI interface {
-	AttachInstancesRequest(*autoscaling.AttachInstancesInput) (*service.Request, *autoscaling.AttachInstancesOutput)
+	AttachInstancesRequest(*autoscaling.AttachInstancesInput) (*request.Request, *autoscaling.AttachInstancesOutput)
 
 	AttachInstances(*autoscaling.AttachInstancesInput) (*autoscaling.AttachInstancesOutput, error)
 
-	AttachLoadBalancersRequest(*autoscaling.AttachLoadBalancersInput) (*service.Request, *autoscaling.AttachLoadBalancersOutput)
+	AttachLoadBalancersRequest(*autoscaling.AttachLoadBalancersInput) (*request.Request, *autoscaling.AttachLoadBalancersOutput)
 
 	AttachLoadBalancers(*autoscaling.AttachLoadBalancersInput) (*autoscaling.AttachLoadBalancersOutput, error)
 
-	CompleteLifecycleActionRequest(*autoscaling.CompleteLifecycleActionInput) (*service.Request, *autoscaling.CompleteLifecycleActionOutput)
+	CompleteLifecycleActionRequest(*autoscaling.CompleteLifecycleActionInput) (*request.Request, *autoscaling.CompleteLifecycleActionOutput)
 
 	CompleteLifecycleAction(*autoscaling.CompleteLifecycleActionInput) (*autoscaling.CompleteLifecycleActionOutput, error)
 
-	CreateAutoScalingGroupRequest(*autoscaling.CreateAutoScalingGroupInput) (*service.Request, *autoscaling.CreateAutoScalingGroupOutput)
+	CreateAutoScalingGroupRequest(*autoscaling.CreateAutoScalingGroupInput) (*request.Request, *autoscaling.CreateAutoScalingGroupOutput)
 
 	CreateAutoScalingGroup(*autoscaling.CreateAutoScalingGroupInput) (*autoscaling.CreateAutoScalingGroupOutput, error)
 
-	CreateLaunchConfigurationRequest(*autoscaling.CreateLaunchConfigurationInput) (*service.Request, *autoscaling.CreateLaunchConfigurationOutput)
+	CreateLaunchConfigurationRequest(*autoscaling.CreateLaunchConfigurationInput) (*request.Request, *autoscaling.CreateLaunchConfigurationOutput)
 
 	CreateLaunchConfiguration(*autoscaling.CreateLaunchConfigurationInput) (*autoscaling.CreateLaunchConfigurationOutput, error)
 
-	CreateOrUpdateTagsRequest(*autoscaling.CreateOrUpdateTagsInput) (*service.Request, *autoscaling.CreateOrUpdateTagsOutput)
+	CreateOrUpdateTagsRequest(*autoscaling.CreateOrUpdateTagsInput) (*request.Request, *autoscaling.CreateOrUpdateTagsOutput)
 
 	CreateOrUpdateTags(*autoscaling.CreateOrUpdateTagsInput) (*autoscaling.CreateOrUpdateTagsOutput, error)
 
-	DeleteAutoScalingGroupRequest(*autoscaling.DeleteAutoScalingGroupInput) (*service.Request, *autoscaling.DeleteAutoScalingGroupOutput)
+	DeleteAutoScalingGroupRequest(*autoscaling.DeleteAutoScalingGroupInput) (*request.Request, *autoscaling.DeleteAutoScalingGroupOutput)
 
 	DeleteAutoScalingGroup(*autoscaling.DeleteAutoScalingGroupInput) (*autoscaling.DeleteAutoScalingGroupOutput, error)
 
-	DeleteLaunchConfigurationRequest(*autoscaling.DeleteLaunchConfigurationInput) (*service.Request, *autoscaling.DeleteLaunchConfigurationOutput)
+	DeleteLaunchConfigurationRequest(*autoscaling.DeleteLaunchConfigurationInput) (*request.Request, *autoscaling.DeleteLaunchConfigurationOutput)
 
 	DeleteLaunchConfiguration(*autoscaling.DeleteLaunchConfigurationInput) (*autoscaling.DeleteLaunchConfigurationOutput, error)
 
-	DeleteLifecycleHookRequest(*autoscaling.DeleteLifecycleHookInput) (*service.Request, *autoscaling.DeleteLifecycleHookOutput)
+	DeleteLifecycleHookRequest(*autoscaling.DeleteLifecycleHookInput) (*request.Request, *autoscaling.DeleteLifecycleHookOutput)
 
 	DeleteLifecycleHook(*autoscaling.DeleteLifecycleHookInput) (*autoscaling.DeleteLifecycleHookOutput, error)
 
-	DeleteNotificationConfigurationRequest(*autoscaling.DeleteNotificationConfigurationInput) (*service.Request, *autoscaling.DeleteNotificationConfigurationOutput)
+	DeleteNotificationConfigurationRequest(*autoscaling.DeleteNotificationConfigurationInput) (*request.Request, *autoscaling.DeleteNotificationConfigurationOutput)
 
 	DeleteNotificationConfiguration(*autoscaling.DeleteNotificationConfigurationInput) (*autoscaling.DeleteNotificationConfigurationOutput, error)
 
-	DeletePolicyRequest(*autoscaling.DeletePolicyInput) (*service.Request, *autoscaling.DeletePolicyOutput)
+	DeletePolicyRequest(*autoscaling.DeletePolicyInput) (*request.Request, *autoscaling.DeletePolicyOutput)
 
 	DeletePolicy(*autoscaling.DeletePolicyInput) (*autoscaling.DeletePolicyOutput, error)
 
-	DeleteScheduledActionRequest(*autoscaling.DeleteScheduledActionInput) (*service.Request, *autoscaling.DeleteScheduledActionOutput)
+	DeleteScheduledActionRequest(*autoscaling.DeleteScheduledActionInput) (*request.Request, *autoscaling.DeleteScheduledActionOutput)
 
 	DeleteScheduledAction(*autoscaling.DeleteScheduledActionInput) (*autoscaling.DeleteScheduledActionOutput, error)
 
-	DeleteTagsRequest(*autoscaling.DeleteTagsInput) (*service.Request, *autoscaling.DeleteTagsOutput)
+	DeleteTagsRequest(*autoscaling.DeleteTagsInput) (*request.Request, *autoscaling.DeleteTagsOutput)
 
 	DeleteTags(*autoscaling.DeleteTagsInput) (*autoscaling.DeleteTagsOutput, error)
 
-	DescribeAccountLimitsRequest(*autoscaling.DescribeAccountLimitsInput) (*service.Request, *autoscaling.DescribeAccountLimitsOutput)
+	DescribeAccountLimitsRequest(*autoscaling.DescribeAccountLimitsInput) (*request.Request, *autoscaling.DescribeAccountLimitsOutput)
 
 	DescribeAccountLimits(*autoscaling.DescribeAccountLimitsInput) (*autoscaling.DescribeAccountLimitsOutput, error)
 
-	DescribeAdjustmentTypesRequest(*autoscaling.DescribeAdjustmentTypesInput) (*service.Request, *autoscaling.DescribeAdjustmentTypesOutput)
+	DescribeAdjustmentTypesRequest(*autoscaling.DescribeAdjustmentTypesInput) (*request.Request, *autoscaling.DescribeAdjustmentTypesOutput)
 
 	DescribeAdjustmentTypes(*autoscaling.DescribeAdjustmentTypesInput) (*autoscaling.DescribeAdjustmentTypesOutput, error)
 
-	DescribeAutoScalingGroupsRequest(*autoscaling.DescribeAutoScalingGroupsInput) (*service.Request, *autoscaling.DescribeAutoScalingGroupsOutput)
+	DescribeAutoScalingGroupsRequest(*autoscaling.DescribeAutoScalingGroupsInput) (*request.Request, *autoscaling.DescribeAutoScalingGroupsOutput)
 
 	DescribeAutoScalingGroups(*autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
 
 	DescribeAutoScalingGroupsPages(*autoscaling.DescribeAutoScalingGroupsInput, func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error
 
-	DescribeAutoScalingInstancesRequest(*autoscaling.DescribeAutoScalingInstancesInput) (*service.Request, *autoscaling.DescribeAutoScalingInstancesOutput)
+	DescribeAutoScalingInstancesRequest(*autoscaling.DescribeAutoScalingInstancesInput) (*request.Request, *autoscaling.DescribeAutoScalingInstancesOutput)
 
 	DescribeAutoScalingInstances(*autoscaling.DescribeAutoScalingInstancesInput) (*autoscaling.DescribeAutoScalingInstancesOutput, error)
 
 	DescribeAutoScalingInstancesPages(*autoscaling.DescribeAutoScalingInstancesInput, func(*autoscaling.DescribeAutoScalingInstancesOutput, bool) bool) error
 
-	DescribeAutoScalingNotificationTypesRequest(*autoscaling.DescribeAutoScalingNotificationTypesInput) (*service.Request, *autoscaling.DescribeAutoScalingNotificationTypesOutput)
+	DescribeAutoScalingNotificationTypesRequest(*autoscaling.DescribeAutoScalingNotificationTypesInput) (*request.Request, *autoscaling.DescribeAutoScalingNotificationTypesOutput)
 
 	DescribeAutoScalingNotificationTypes(*autoscaling.DescribeAutoScalingNotificationTypesInput) (*autoscaling.DescribeAutoScalingNotificationTypesOutput, error)
 
-	DescribeLaunchConfigurationsRequest(*autoscaling.DescribeLaunchConfigurationsInput) (*service.Request, *autoscaling.DescribeLaunchConfigurationsOutput)
+	DescribeLaunchConfigurationsRequest(*autoscaling.DescribeLaunchConfigurationsInput) (*request.Request, *autoscaling.DescribeLaunchConfigurationsOutput)
 
 	DescribeLaunchConfigurations(*autoscaling.DescribeLaunchConfigurationsInput) (*autoscaling.DescribeLaunchConfigurationsOutput, error)
 
 	DescribeLaunchConfigurationsPages(*autoscaling.DescribeLaunchConfigurationsInput, func(*autoscaling.DescribeLaunchConfigurationsOutput, bool) bool) error
 
-	DescribeLifecycleHookTypesRequest(*autoscaling.DescribeLifecycleHookTypesInput) (*service.Request, *autoscaling.DescribeLifecycleHookTypesOutput)
+	DescribeLifecycleHookTypesRequest(*autoscaling.DescribeLifecycleHookTypesInput) (*request.Request, *autoscaling.DescribeLifecycleHookTypesOutput)
 
 	DescribeLifecycleHookTypes(*autoscaling.DescribeLifecycleHookTypesInput) (*autoscaling.DescribeLifecycleHookTypesOutput, error)
 
-	DescribeLifecycleHooksRequest(*autoscaling.DescribeLifecycleHooksInput) (*service.Request, *autoscaling.DescribeLifecycleHooksOutput)
+	DescribeLifecycleHooksRequest(*autoscaling.DescribeLifecycleHooksInput) (*request.Request, *autoscaling.DescribeLifecycleHooksOutput)
 
 	DescribeLifecycleHooks(*autoscaling.DescribeLifecycleHooksInput) (*autoscaling.DescribeLifecycleHooksOutput, error)
 
-	DescribeLoadBalancersRequest(*autoscaling.DescribeLoadBalancersInput) (*service.Request, *autoscaling.DescribeLoadBalancersOutput)
+	DescribeLoadBalancersRequest(*autoscaling.DescribeLoadBalancersInput) (*request.Request, *autoscaling.DescribeLoadBalancersOutput)
 
 	DescribeLoadBalancers(*autoscaling.DescribeLoadBalancersInput) (*autoscaling.DescribeLoadBalancersOutput, error)
 
-	DescribeMetricCollectionTypesRequest(*autoscaling.DescribeMetricCollectionTypesInput) (*service.Request, *autoscaling.DescribeMetricCollectionTypesOutput)
+	DescribeMetricCollectionTypesRequest(*autoscaling.DescribeMetricCollectionTypesInput) (*request.Request, *autoscaling.DescribeMetricCollectionTypesOutput)
 
 	DescribeMetricCollectionTypes(*autoscaling.DescribeMetricCollectionTypesInput) (*autoscaling.DescribeMetricCollectionTypesOutput, error)
 
-	DescribeNotificationConfigurationsRequest(*autoscaling.DescribeNotificationConfigurationsInput) (*service.Request, *autoscaling.DescribeNotificationConfigurationsOutput)
+	DescribeNotificationConfigurationsRequest(*autoscaling.DescribeNotificationConfigurationsInput) (*request.Request, *autoscaling.DescribeNotificationConfigurationsOutput)
 
 	DescribeNotificationConfigurations(*autoscaling.DescribeNotificationConfigurationsInput) (*autoscaling.DescribeNotificationConfigurationsOutput, error)
 
 	DescribeNotificationConfigurationsPages(*autoscaling.DescribeNotificationConfigurationsInput, func(*autoscaling.DescribeNotificationConfigurationsOutput, bool) bool) error
 
-	DescribePoliciesRequest(*autoscaling.DescribePoliciesInput) (*service.Request, *autoscaling.DescribePoliciesOutput)
+	DescribePoliciesRequest(*autoscaling.DescribePoliciesInput) (*request.Request, *autoscaling.DescribePoliciesOutput)
 
 	DescribePolicies(*autoscaling.DescribePoliciesInput) (*autoscaling.DescribePoliciesOutput, error)
 
 	DescribePoliciesPages(*autoscaling.DescribePoliciesInput, func(*autoscaling.DescribePoliciesOutput, bool) bool) error
 
-	DescribeScalingActivitiesRequest(*autoscaling.DescribeScalingActivitiesInput) (*service.Request, *autoscaling.DescribeScalingActivitiesOutput)
+	DescribeScalingActivitiesRequest(*autoscaling.DescribeScalingActivitiesInput) (*request.Request, *autoscaling.DescribeScalingActivitiesOutput)
 
 	DescribeScalingActivities(*autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error)
 
 	DescribeScalingActivitiesPages(*autoscaling.DescribeScalingActivitiesInput, func(*autoscaling.DescribeScalingActivitiesOutput, bool) bool) error
 
-	DescribeScalingProcessTypesRequest(*autoscaling.DescribeScalingProcessTypesInput) (*service.Request, *autoscaling.DescribeScalingProcessTypesOutput)
+	DescribeScalingProcessTypesRequest(*autoscaling.DescribeScalingProcessTypesInput) (*request.Request, *autoscaling.DescribeScalingProcessTypesOutput)
 
 	DescribeScalingProcessTypes(*autoscaling.DescribeScalingProcessTypesInput) (*autoscaling.DescribeScalingProcessTypesOutput, error)
 
-	DescribeScheduledActionsRequest(*autoscaling.DescribeScheduledActionsInput) (*service.Request, *autoscaling.DescribeScheduledActionsOutput)
+	DescribeScheduledActionsRequest(*autoscaling.DescribeScheduledActionsInput) (*request.Request, *autoscaling.DescribeScheduledActionsOutput)
 
 	DescribeScheduledActions(*autoscaling.DescribeScheduledActionsInput) (*autoscaling.DescribeScheduledActionsOutput, error)
 
 	DescribeScheduledActionsPages(*autoscaling.DescribeScheduledActionsInput, func(*autoscaling.DescribeScheduledActionsOutput, bool) bool) error
 
-	DescribeTagsRequest(*autoscaling.DescribeTagsInput) (*service.Request, *autoscaling.DescribeTagsOutput)
+	DescribeTagsRequest(*autoscaling.DescribeTagsInput) (*request.Request, *autoscaling.DescribeTagsOutput)
 
 	DescribeTags(*autoscaling.DescribeTagsInput) (*autoscaling.DescribeTagsOutput, error)
 
 	DescribeTagsPages(*autoscaling.DescribeTagsInput, func(*autoscaling.DescribeTagsOutput, bool) bool) error
 
-	DescribeTerminationPolicyTypesRequest(*autoscaling.DescribeTerminationPolicyTypesInput) (*service.Request, *autoscaling.DescribeTerminationPolicyTypesOutput)
+	DescribeTerminationPolicyTypesRequest(*autoscaling.DescribeTerminationPolicyTypesInput) (*request.Request, *autoscaling.DescribeTerminationPolicyTypesOutput)
 
 	DescribeTerminationPolicyTypes(*autoscaling.DescribeTerminationPolicyTypesInput) (*autoscaling.DescribeTerminationPolicyTypesOutput, error)
 
-	DetachInstancesRequest(*autoscaling.DetachInstancesInput) (*service.Request, *autoscaling.DetachInstancesOutput)
+	DetachInstancesRequest(*autoscaling.DetachInstancesInput) (*request.Request, *autoscaling.DetachInstancesOutput)
 
 	DetachInstances(*autoscaling.DetachInstancesInput) (*autoscaling.DetachInstancesOutput, error)
 
-	DetachLoadBalancersRequest(*autoscaling.DetachLoadBalancersInput) (*service.Request, *autoscaling.DetachLoadBalancersOutput)
+	DetachLoadBalancersRequest(*autoscaling.DetachLoadBalancersInput) (*request.Request, *autoscaling.DetachLoadBalancersOutput)
 
 	DetachLoadBalancers(*autoscaling.DetachLoadBalancersInput) (*autoscaling.DetachLoadBalancersOutput, error)
 
-	DisableMetricsCollectionRequest(*autoscaling.DisableMetricsCollectionInput) (*service.Request, *autoscaling.DisableMetricsCollectionOutput)
+	DisableMetricsCollectionRequest(*autoscaling.DisableMetricsCollectionInput) (*request.Request, *autoscaling.DisableMetricsCollectionOutput)
 
 	DisableMetricsCollection(*autoscaling.DisableMetricsCollectionInput) (*autoscaling.DisableMetricsCollectionOutput, error)
 
-	EnableMetricsCollectionRequest(*autoscaling.EnableMetricsCollectionInput) (*service.Request, *autoscaling.EnableMetricsCollectionOutput)
+	EnableMetricsCollectionRequest(*autoscaling.EnableMetricsCollectionInput) (*request.Request, *autoscaling.EnableMetricsCollectionOutput)
 
 	EnableMetricsCollection(*autoscaling.EnableMetricsCollectionInput) (*autoscaling.EnableMetricsCollectionOutput, error)
 
-	EnterStandbyRequest(*autoscaling.EnterStandbyInput) (*service.Request, *autoscaling.EnterStandbyOutput)
+	EnterStandbyRequest(*autoscaling.EnterStandbyInput) (*request.Request, *autoscaling.EnterStandbyOutput)
 
 	EnterStandby(*autoscaling.EnterStandbyInput) (*autoscaling.EnterStandbyOutput, error)
 
-	ExecutePolicyRequest(*autoscaling.ExecutePolicyInput) (*service.Request, *autoscaling.ExecutePolicyOutput)
+	ExecutePolicyRequest(*autoscaling.ExecutePolicyInput) (*request.Request, *autoscaling.ExecutePolicyOutput)
 
 	ExecutePolicy(*autoscaling.ExecutePolicyInput) (*autoscaling.ExecutePolicyOutput, error)
 
-	ExitStandbyRequest(*autoscaling.ExitStandbyInput) (*service.Request, *autoscaling.ExitStandbyOutput)
+	ExitStandbyRequest(*autoscaling.ExitStandbyInput) (*request.Request, *autoscaling.ExitStandbyOutput)
 
 	ExitStandby(*autoscaling.ExitStandbyInput) (*autoscaling.ExitStandbyOutput, error)
 
-	PutLifecycleHookRequest(*autoscaling.PutLifecycleHookInput) (*service.Request, *autoscaling.PutLifecycleHookOutput)
+	PutLifecycleHookRequest(*autoscaling.PutLifecycleHookInput) (*request.Request, *autoscaling.PutLifecycleHookOutput)
 
 	PutLifecycleHook(*autoscaling.PutLifecycleHookInput) (*autoscaling.PutLifecycleHookOutput, error)
 
-	PutNotificationConfigurationRequest(*autoscaling.PutNotificationConfigurationInput) (*service.Request, *autoscaling.PutNotificationConfigurationOutput)
+	PutNotificationConfigurationRequest(*autoscaling.PutNotificationConfigurationInput) (*request.Request, *autoscaling.PutNotificationConfigurationOutput)
 
 	PutNotificationConfiguration(*autoscaling.PutNotificationConfigurationInput) (*autoscaling.PutNotificationConfigurationOutput, error)
 
-	PutScalingPolicyRequest(*autoscaling.PutScalingPolicyInput) (*service.Request, *autoscaling.PutScalingPolicyOutput)
+	PutScalingPolicyRequest(*autoscaling.PutScalingPolicyInput) (*request.Request, *autoscaling.PutScalingPolicyOutput)
 
 	PutScalingPolicy(*autoscaling.PutScalingPolicyInput) (*autoscaling.PutScalingPolicyOutput, error)
 
-	PutScheduledUpdateGroupActionRequest(*autoscaling.PutScheduledUpdateGroupActionInput) (*service.Request, *autoscaling.PutScheduledUpdateGroupActionOutput)
+	PutScheduledUpdateGroupActionRequest(*autoscaling.PutScheduledUpdateGroupActionInput) (*request.Request, *autoscaling.PutScheduledUpdateGroupActionOutput)
 
 	PutScheduledUpdateGroupAction(*autoscaling.PutScheduledUpdateGroupActionInput) (*autoscaling.PutScheduledUpdateGroupActionOutput, error)
 
-	RecordLifecycleActionHeartbeatRequest(*autoscaling.RecordLifecycleActionHeartbeatInput) (*service.Request, *autoscaling.RecordLifecycleActionHeartbeatOutput)
+	RecordLifecycleActionHeartbeatRequest(*autoscaling.RecordLifecycleActionHeartbeatInput) (*request.Request, *autoscaling.RecordLifecycleActionHeartbeatOutput)
 
 	RecordLifecycleActionHeartbeat(*autoscaling.RecordLifecycleActionHeartbeatInput) (*autoscaling.RecordLifecycleActionHeartbeatOutput, error)
 
-	ResumeProcessesRequest(*autoscaling.ScalingProcessQuery) (*service.Request, *autoscaling.ResumeProcessesOutput)
+	ResumeProcessesRequest(*autoscaling.ScalingProcessQuery) (*request.Request, *autoscaling.ResumeProcessesOutput)
 
 	ResumeProcesses(*autoscaling.ScalingProcessQuery) (*autoscaling.ResumeProcessesOutput, error)
 
-	SetDesiredCapacityRequest(*autoscaling.SetDesiredCapacityInput) (*service.Request, *autoscaling.SetDesiredCapacityOutput)
+	SetDesiredCapacityRequest(*autoscaling.SetDesiredCapacityInput) (*request.Request, *autoscaling.SetDesiredCapacityOutput)
 
 	SetDesiredCapacity(*autoscaling.SetDesiredCapacityInput) (*autoscaling.SetDesiredCapacityOutput, error)
 
-	SetInstanceHealthRequest(*autoscaling.SetInstanceHealthInput) (*service.Request, *autoscaling.SetInstanceHealthOutput)
+	SetInstanceHealthRequest(*autoscaling.SetInstanceHealthInput) (*request.Request, *autoscaling.SetInstanceHealthOutput)
 
 	SetInstanceHealth(*autoscaling.SetInstanceHealthInput) (*autoscaling.SetInstanceHealthOutput, error)
 
-	SuspendProcessesRequest(*autoscaling.ScalingProcessQuery) (*service.Request, *autoscaling.SuspendProcessesOutput)
+	SuspendProcessesRequest(*autoscaling.ScalingProcessQuery) (*request.Request, *autoscaling.SuspendProcessesOutput)
 
 	SuspendProcesses(*autoscaling.ScalingProcessQuery) (*autoscaling.SuspendProcessesOutput, error)
 
-	TerminateInstanceInAutoScalingGroupRequest(*autoscaling.TerminateInstanceInAutoScalingGroupInput) (*service.Request, *autoscaling.TerminateInstanceInAutoScalingGroupOutput)
+	TerminateInstanceInAutoScalingGroupRequest(*autoscaling.TerminateInstanceInAutoScalingGroupInput) (*request.Request, *autoscaling.TerminateInstanceInAutoScalingGroupOutput)
 
 	TerminateInstanceInAutoScalingGroup(*autoscaling.TerminateInstanceInAutoScalingGroupInput) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error)
 
-	UpdateAutoScalingGroupRequest(*autoscaling.UpdateAutoScalingGroupInput) (*service.Request, *autoscaling.UpdateAutoScalingGroupOutput)
+	UpdateAutoScalingGroupRequest(*autoscaling.UpdateAutoScalingGroupInput) (*request.Request, *autoscaling.UpdateAutoScalingGroupOutput)
 
 	UpdateAutoScalingGroup(*autoscaling.UpdateAutoScalingGroupInput) (*autoscaling.UpdateAutoScalingGroupOutput, error)
 }

--- a/service/autoscaling/service.go
+++ b/service/autoscaling/service.go
@@ -5,7 +5,9 @@ package autoscaling
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -21,14 +23,16 @@ type AutoScaling struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new AutoScaling client.
 func New(config *aws.Config) *AutoScaling {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "autoscaling",
-		APIVersion:  "2011-01-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "autoscaling",
+			APIVersion:  "2011-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -49,8 +53,8 @@ func New(config *aws.Config) *AutoScaling {
 
 // newRequest creates a new request for a AutoScaling operation and runs any
 // custom request initialization.
-func (c *AutoScaling) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *AutoScaling) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cloudformation/api.go
+++ b/service/cloudformation/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCancelUpdateStack = "CancelUpdateStack"
 
 // CancelUpdateStackRequest generates a request for the CancelUpdateStack operation.
-func (c *CloudFormation) CancelUpdateStackRequest(input *CancelUpdateStackInput) (req *service.Request, output *CancelUpdateStackOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) CancelUpdateStackRequest(input *CancelUpdateStackInput) (req *request.Request, output *CancelUpdateStackOutput) {
+	op := &request.Operation{
 		Name:       opCancelUpdateStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -43,8 +43,8 @@ func (c *CloudFormation) CancelUpdateStack(input *CancelUpdateStackInput) (*Canc
 const opCreateStack = "CreateStack"
 
 // CreateStackRequest generates a request for the CreateStack operation.
-func (c *CloudFormation) CreateStackRequest(input *CreateStackInput) (req *service.Request, output *CreateStackOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) CreateStackRequest(input *CreateStackInput) (req *request.Request, output *CreateStackOutput) {
+	op := &request.Operation{
 		Name:       opCreateStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -72,8 +72,8 @@ func (c *CloudFormation) CreateStack(input *CreateStackInput) (*CreateStackOutpu
 const opDeleteStack = "DeleteStack"
 
 // DeleteStackRequest generates a request for the DeleteStack operation.
-func (c *CloudFormation) DeleteStackRequest(input *DeleteStackInput) (req *service.Request, output *DeleteStackOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) DeleteStackRequest(input *DeleteStackInput) (req *request.Request, output *DeleteStackOutput) {
+	op := &request.Operation{
 		Name:       opDeleteStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -101,12 +101,12 @@ func (c *CloudFormation) DeleteStack(input *DeleteStackInput) (*DeleteStackOutpu
 const opDescribeStackEvents = "DescribeStackEvents"
 
 // DescribeStackEventsRequest generates a request for the DescribeStackEvents operation.
-func (c *CloudFormation) DescribeStackEventsRequest(input *DescribeStackEventsInput) (req *service.Request, output *DescribeStackEventsOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) DescribeStackEventsRequest(input *DescribeStackEventsInput) (req *request.Request, output *DescribeStackEventsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStackEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -146,8 +146,8 @@ func (c *CloudFormation) DescribeStackEventsPages(input *DescribeStackEventsInpu
 const opDescribeStackResource = "DescribeStackResource"
 
 // DescribeStackResourceRequest generates a request for the DescribeStackResource operation.
-func (c *CloudFormation) DescribeStackResourceRequest(input *DescribeStackResourceInput) (req *service.Request, output *DescribeStackResourceOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) DescribeStackResourceRequest(input *DescribeStackResourceInput) (req *request.Request, output *DescribeStackResourceOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStackResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -176,8 +176,8 @@ func (c *CloudFormation) DescribeStackResource(input *DescribeStackResourceInput
 const opDescribeStackResources = "DescribeStackResources"
 
 // DescribeStackResourcesRequest generates a request for the DescribeStackResources operation.
-func (c *CloudFormation) DescribeStackResourcesRequest(input *DescribeStackResourcesInput) (req *service.Request, output *DescribeStackResourcesOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) DescribeStackResourcesRequest(input *DescribeStackResourcesInput) (req *request.Request, output *DescribeStackResourcesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStackResources,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -219,12 +219,12 @@ func (c *CloudFormation) DescribeStackResources(input *DescribeStackResourcesInp
 const opDescribeStacks = "DescribeStacks"
 
 // DescribeStacksRequest generates a request for the DescribeStacks operation.
-func (c *CloudFormation) DescribeStacksRequest(input *DescribeStacksInput) (req *service.Request, output *DescribeStacksOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) DescribeStacksRequest(input *DescribeStacksInput) (req *request.Request, output *DescribeStacksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStacks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -260,8 +260,8 @@ func (c *CloudFormation) DescribeStacksPages(input *DescribeStacksInput, fn func
 const opEstimateTemplateCost = "EstimateTemplateCost"
 
 // EstimateTemplateCostRequest generates a request for the EstimateTemplateCost operation.
-func (c *CloudFormation) EstimateTemplateCostRequest(input *EstimateTemplateCostInput) (req *service.Request, output *EstimateTemplateCostOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) EstimateTemplateCostRequest(input *EstimateTemplateCostInput) (req *request.Request, output *EstimateTemplateCostOutput) {
+	op := &request.Operation{
 		Name:       opEstimateTemplateCost,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -289,8 +289,8 @@ func (c *CloudFormation) EstimateTemplateCost(input *EstimateTemplateCostInput) 
 const opGetStackPolicy = "GetStackPolicy"
 
 // GetStackPolicyRequest generates a request for the GetStackPolicy operation.
-func (c *CloudFormation) GetStackPolicyRequest(input *GetStackPolicyInput) (req *service.Request, output *GetStackPolicyOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) GetStackPolicyRequest(input *GetStackPolicyInput) (req *request.Request, output *GetStackPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetStackPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -317,8 +317,8 @@ func (c *CloudFormation) GetStackPolicy(input *GetStackPolicyInput) (*GetStackPo
 const opGetTemplate = "GetTemplate"
 
 // GetTemplateRequest generates a request for the GetTemplate operation.
-func (c *CloudFormation) GetTemplateRequest(input *GetTemplateInput) (req *service.Request, output *GetTemplateOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) GetTemplateRequest(input *GetTemplateInput) (req *request.Request, output *GetTemplateOutput) {
+	op := &request.Operation{
 		Name:       opGetTemplate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -350,8 +350,8 @@ func (c *CloudFormation) GetTemplate(input *GetTemplateInput) (*GetTemplateOutpu
 const opGetTemplateSummary = "GetTemplateSummary"
 
 // GetTemplateSummaryRequest generates a request for the GetTemplateSummary operation.
-func (c *CloudFormation) GetTemplateSummaryRequest(input *GetTemplateSummaryInput) (req *service.Request, output *GetTemplateSummaryOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) GetTemplateSummaryRequest(input *GetTemplateSummaryInput) (req *request.Request, output *GetTemplateSummaryOutput) {
+	op := &request.Operation{
 		Name:       opGetTemplateSummary,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -386,12 +386,12 @@ func (c *CloudFormation) GetTemplateSummary(input *GetTemplateSummaryInput) (*Ge
 const opListStackResources = "ListStackResources"
 
 // ListStackResourcesRequest generates a request for the ListStackResources operation.
-func (c *CloudFormation) ListStackResourcesRequest(input *ListStackResourcesInput) (req *service.Request, output *ListStackResourcesOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) ListStackResourcesRequest(input *ListStackResourcesInput) (req *request.Request, output *ListStackResourcesOutput) {
+	op := &request.Operation{
 		Name:       opListStackResources,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -429,12 +429,12 @@ func (c *CloudFormation) ListStackResourcesPages(input *ListStackResourcesInput,
 const opListStacks = "ListStacks"
 
 // ListStacksRequest generates a request for the ListStacks operation.
-func (c *CloudFormation) ListStacksRequest(input *ListStacksInput) (req *service.Request, output *ListStacksOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) ListStacksRequest(input *ListStacksInput) (req *request.Request, output *ListStacksOutput) {
+	op := &request.Operation{
 		Name:       opListStacks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -473,8 +473,8 @@ func (c *CloudFormation) ListStacksPages(input *ListStacksInput, fn func(p *List
 const opSetStackPolicy = "SetStackPolicy"
 
 // SetStackPolicyRequest generates a request for the SetStackPolicy operation.
-func (c *CloudFormation) SetStackPolicyRequest(input *SetStackPolicyInput) (req *service.Request, output *SetStackPolicyOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) SetStackPolicyRequest(input *SetStackPolicyInput) (req *request.Request, output *SetStackPolicyOutput) {
+	op := &request.Operation{
 		Name:       opSetStackPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -500,8 +500,8 @@ func (c *CloudFormation) SetStackPolicy(input *SetStackPolicyInput) (*SetStackPo
 const opSignalResource = "SignalResource"
 
 // SignalResourceRequest generates a request for the SignalResource operation.
-func (c *CloudFormation) SignalResourceRequest(input *SignalResourceInput) (req *service.Request, output *SignalResourceOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) SignalResourceRequest(input *SignalResourceInput) (req *request.Request, output *SignalResourceOutput) {
+	op := &request.Operation{
 		Name:       opSignalResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -532,8 +532,8 @@ func (c *CloudFormation) SignalResource(input *SignalResourceInput) (*SignalReso
 const opUpdateStack = "UpdateStack"
 
 // UpdateStackRequest generates a request for the UpdateStack operation.
-func (c *CloudFormation) UpdateStackRequest(input *UpdateStackInput) (req *service.Request, output *UpdateStackOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) UpdateStackRequest(input *UpdateStackInput) (req *request.Request, output *UpdateStackOutput) {
+	op := &request.Operation{
 		Name:       opUpdateStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -570,8 +570,8 @@ func (c *CloudFormation) UpdateStack(input *UpdateStackInput) (*UpdateStackOutpu
 const opValidateTemplate = "ValidateTemplate"
 
 // ValidateTemplateRequest generates a request for the ValidateTemplate operation.
-func (c *CloudFormation) ValidateTemplateRequest(input *ValidateTemplateInput) (req *service.Request, output *ValidateTemplateOutput) {
-	op := &service.Operation{
+func (c *CloudFormation) ValidateTemplateRequest(input *ValidateTemplateInput) (req *request.Request, output *ValidateTemplateOutput) {
+	op := &request.Operation{
 		Name:       opValidateTemplate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/cloudformation/cloudformationiface/interface.go
+++ b/service/cloudformation/cloudformationiface/interface.go
@@ -4,85 +4,85 @@
 package cloudformationiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
 // CloudFormationAPI is the interface type for cloudformation.CloudFormation.
 type CloudFormationAPI interface {
-	CancelUpdateStackRequest(*cloudformation.CancelUpdateStackInput) (*service.Request, *cloudformation.CancelUpdateStackOutput)
+	CancelUpdateStackRequest(*cloudformation.CancelUpdateStackInput) (*request.Request, *cloudformation.CancelUpdateStackOutput)
 
 	CancelUpdateStack(*cloudformation.CancelUpdateStackInput) (*cloudformation.CancelUpdateStackOutput, error)
 
-	CreateStackRequest(*cloudformation.CreateStackInput) (*service.Request, *cloudformation.CreateStackOutput)
+	CreateStackRequest(*cloudformation.CreateStackInput) (*request.Request, *cloudformation.CreateStackOutput)
 
 	CreateStack(*cloudformation.CreateStackInput) (*cloudformation.CreateStackOutput, error)
 
-	DeleteStackRequest(*cloudformation.DeleteStackInput) (*service.Request, *cloudformation.DeleteStackOutput)
+	DeleteStackRequest(*cloudformation.DeleteStackInput) (*request.Request, *cloudformation.DeleteStackOutput)
 
 	DeleteStack(*cloudformation.DeleteStackInput) (*cloudformation.DeleteStackOutput, error)
 
-	DescribeStackEventsRequest(*cloudformation.DescribeStackEventsInput) (*service.Request, *cloudformation.DescribeStackEventsOutput)
+	DescribeStackEventsRequest(*cloudformation.DescribeStackEventsInput) (*request.Request, *cloudformation.DescribeStackEventsOutput)
 
 	DescribeStackEvents(*cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error)
 
 	DescribeStackEventsPages(*cloudformation.DescribeStackEventsInput, func(*cloudformation.DescribeStackEventsOutput, bool) bool) error
 
-	DescribeStackResourceRequest(*cloudformation.DescribeStackResourceInput) (*service.Request, *cloudformation.DescribeStackResourceOutput)
+	DescribeStackResourceRequest(*cloudformation.DescribeStackResourceInput) (*request.Request, *cloudformation.DescribeStackResourceOutput)
 
 	DescribeStackResource(*cloudformation.DescribeStackResourceInput) (*cloudformation.DescribeStackResourceOutput, error)
 
-	DescribeStackResourcesRequest(*cloudformation.DescribeStackResourcesInput) (*service.Request, *cloudformation.DescribeStackResourcesOutput)
+	DescribeStackResourcesRequest(*cloudformation.DescribeStackResourcesInput) (*request.Request, *cloudformation.DescribeStackResourcesOutput)
 
 	DescribeStackResources(*cloudformation.DescribeStackResourcesInput) (*cloudformation.DescribeStackResourcesOutput, error)
 
-	DescribeStacksRequest(*cloudformation.DescribeStacksInput) (*service.Request, *cloudformation.DescribeStacksOutput)
+	DescribeStacksRequest(*cloudformation.DescribeStacksInput) (*request.Request, *cloudformation.DescribeStacksOutput)
 
 	DescribeStacks(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
 
 	DescribeStacksPages(*cloudformation.DescribeStacksInput, func(*cloudformation.DescribeStacksOutput, bool) bool) error
 
-	EstimateTemplateCostRequest(*cloudformation.EstimateTemplateCostInput) (*service.Request, *cloudformation.EstimateTemplateCostOutput)
+	EstimateTemplateCostRequest(*cloudformation.EstimateTemplateCostInput) (*request.Request, *cloudformation.EstimateTemplateCostOutput)
 
 	EstimateTemplateCost(*cloudformation.EstimateTemplateCostInput) (*cloudformation.EstimateTemplateCostOutput, error)
 
-	GetStackPolicyRequest(*cloudformation.GetStackPolicyInput) (*service.Request, *cloudformation.GetStackPolicyOutput)
+	GetStackPolicyRequest(*cloudformation.GetStackPolicyInput) (*request.Request, *cloudformation.GetStackPolicyOutput)
 
 	GetStackPolicy(*cloudformation.GetStackPolicyInput) (*cloudformation.GetStackPolicyOutput, error)
 
-	GetTemplateRequest(*cloudformation.GetTemplateInput) (*service.Request, *cloudformation.GetTemplateOutput)
+	GetTemplateRequest(*cloudformation.GetTemplateInput) (*request.Request, *cloudformation.GetTemplateOutput)
 
 	GetTemplate(*cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error)
 
-	GetTemplateSummaryRequest(*cloudformation.GetTemplateSummaryInput) (*service.Request, *cloudformation.GetTemplateSummaryOutput)
+	GetTemplateSummaryRequest(*cloudformation.GetTemplateSummaryInput) (*request.Request, *cloudformation.GetTemplateSummaryOutput)
 
 	GetTemplateSummary(*cloudformation.GetTemplateSummaryInput) (*cloudformation.GetTemplateSummaryOutput, error)
 
-	ListStackResourcesRequest(*cloudformation.ListStackResourcesInput) (*service.Request, *cloudformation.ListStackResourcesOutput)
+	ListStackResourcesRequest(*cloudformation.ListStackResourcesInput) (*request.Request, *cloudformation.ListStackResourcesOutput)
 
 	ListStackResources(*cloudformation.ListStackResourcesInput) (*cloudformation.ListStackResourcesOutput, error)
 
 	ListStackResourcesPages(*cloudformation.ListStackResourcesInput, func(*cloudformation.ListStackResourcesOutput, bool) bool) error
 
-	ListStacksRequest(*cloudformation.ListStacksInput) (*service.Request, *cloudformation.ListStacksOutput)
+	ListStacksRequest(*cloudformation.ListStacksInput) (*request.Request, *cloudformation.ListStacksOutput)
 
 	ListStacks(*cloudformation.ListStacksInput) (*cloudformation.ListStacksOutput, error)
 
 	ListStacksPages(*cloudformation.ListStacksInput, func(*cloudformation.ListStacksOutput, bool) bool) error
 
-	SetStackPolicyRequest(*cloudformation.SetStackPolicyInput) (*service.Request, *cloudformation.SetStackPolicyOutput)
+	SetStackPolicyRequest(*cloudformation.SetStackPolicyInput) (*request.Request, *cloudformation.SetStackPolicyOutput)
 
 	SetStackPolicy(*cloudformation.SetStackPolicyInput) (*cloudformation.SetStackPolicyOutput, error)
 
-	SignalResourceRequest(*cloudformation.SignalResourceInput) (*service.Request, *cloudformation.SignalResourceOutput)
+	SignalResourceRequest(*cloudformation.SignalResourceInput) (*request.Request, *cloudformation.SignalResourceOutput)
 
 	SignalResource(*cloudformation.SignalResourceInput) (*cloudformation.SignalResourceOutput, error)
 
-	UpdateStackRequest(*cloudformation.UpdateStackInput) (*service.Request, *cloudformation.UpdateStackOutput)
+	UpdateStackRequest(*cloudformation.UpdateStackInput) (*request.Request, *cloudformation.UpdateStackOutput)
 
 	UpdateStack(*cloudformation.UpdateStackInput) (*cloudformation.UpdateStackOutput, error)
 
-	ValidateTemplateRequest(*cloudformation.ValidateTemplateInput) (*service.Request, *cloudformation.ValidateTemplateOutput)
+	ValidateTemplateRequest(*cloudformation.ValidateTemplateInput) (*request.Request, *cloudformation.ValidateTemplateOutput)
 
 	ValidateTemplate(*cloudformation.ValidateTemplateInput) (*cloudformation.ValidateTemplateOutput, error)
 }

--- a/service/cloudformation/service.go
+++ b/service/cloudformation/service.go
@@ -5,7 +5,9 @@ package cloudformation
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -36,14 +38,16 @@ type CloudFormation struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CloudFormation client.
 func New(config *aws.Config) *CloudFormation {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "cloudformation",
-		APIVersion:  "2010-05-15",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "cloudformation",
+			APIVersion:  "2010-05-15",
+		},
 	}
 	service.Initialize()
 
@@ -64,8 +68,8 @@ func New(config *aws.Config) *CloudFormation {
 
 // newRequest creates a new request for a CloudFormation operation and runs any
 // custom request initialization.
-func (c *CloudFormation) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CloudFormation) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cloudfront/api.go
+++ b/service/cloudfront/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateCloudFrontOriginAccessIdentity = "CreateCloudFrontOriginAccessIdentity2015_04_17"
 
 // CreateCloudFrontOriginAccessIdentityRequest generates a request for the CreateCloudFrontOriginAccessIdentity operation.
-func (c *CloudFront) CreateCloudFrontOriginAccessIdentityRequest(input *CreateCloudFrontOriginAccessIdentityInput) (req *service.Request, output *CreateCloudFrontOriginAccessIdentityOutput) {
-	op := &service.Operation{
+func (c *CloudFront) CreateCloudFrontOriginAccessIdentityRequest(input *CreateCloudFrontOriginAccessIdentityInput) (req *request.Request, output *CreateCloudFrontOriginAccessIdentityOutput) {
+	op := &request.Operation{
 		Name:       opCreateCloudFrontOriginAccessIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-04-17/origin-access-identity/cloudfront",
@@ -40,8 +40,8 @@ func (c *CloudFront) CreateCloudFrontOriginAccessIdentity(input *CreateCloudFron
 const opCreateDistribution = "CreateDistribution2015_04_17"
 
 // CreateDistributionRequest generates a request for the CreateDistribution operation.
-func (c *CloudFront) CreateDistributionRequest(input *CreateDistributionInput) (req *service.Request, output *CreateDistributionOutput) {
-	op := &service.Operation{
+func (c *CloudFront) CreateDistributionRequest(input *CreateDistributionInput) (req *request.Request, output *CreateDistributionOutput) {
+	op := &request.Operation{
 		Name:       opCreateDistribution,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-04-17/distribution",
@@ -67,8 +67,8 @@ func (c *CloudFront) CreateDistribution(input *CreateDistributionInput) (*Create
 const opCreateInvalidation = "CreateInvalidation2015_04_17"
 
 // CreateInvalidationRequest generates a request for the CreateInvalidation operation.
-func (c *CloudFront) CreateInvalidationRequest(input *CreateInvalidationInput) (req *service.Request, output *CreateInvalidationOutput) {
-	op := &service.Operation{
+func (c *CloudFront) CreateInvalidationRequest(input *CreateInvalidationInput) (req *request.Request, output *CreateInvalidationOutput) {
+	op := &request.Operation{
 		Name:       opCreateInvalidation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-04-17/distribution/{DistributionId}/invalidation",
@@ -94,8 +94,8 @@ func (c *CloudFront) CreateInvalidation(input *CreateInvalidationInput) (*Create
 const opCreateStreamingDistribution = "CreateStreamingDistribution2015_04_17"
 
 // CreateStreamingDistributionRequest generates a request for the CreateStreamingDistribution operation.
-func (c *CloudFront) CreateStreamingDistributionRequest(input *CreateStreamingDistributionInput) (req *service.Request, output *CreateStreamingDistributionOutput) {
-	op := &service.Operation{
+func (c *CloudFront) CreateStreamingDistributionRequest(input *CreateStreamingDistributionInput) (req *request.Request, output *CreateStreamingDistributionOutput) {
+	op := &request.Operation{
 		Name:       opCreateStreamingDistribution,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-04-17/streaming-distribution",
@@ -121,8 +121,8 @@ func (c *CloudFront) CreateStreamingDistribution(input *CreateStreamingDistribut
 const opDeleteCloudFrontOriginAccessIdentity = "DeleteCloudFrontOriginAccessIdentity2015_04_17"
 
 // DeleteCloudFrontOriginAccessIdentityRequest generates a request for the DeleteCloudFrontOriginAccessIdentity operation.
-func (c *CloudFront) DeleteCloudFrontOriginAccessIdentityRequest(input *DeleteCloudFrontOriginAccessIdentityInput) (req *service.Request, output *DeleteCloudFrontOriginAccessIdentityOutput) {
-	op := &service.Operation{
+func (c *CloudFront) DeleteCloudFrontOriginAccessIdentityRequest(input *DeleteCloudFrontOriginAccessIdentityInput) (req *request.Request, output *DeleteCloudFrontOriginAccessIdentityOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCloudFrontOriginAccessIdentity,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-04-17/origin-access-identity/cloudfront/{Id}",
@@ -148,8 +148,8 @@ func (c *CloudFront) DeleteCloudFrontOriginAccessIdentity(input *DeleteCloudFron
 const opDeleteDistribution = "DeleteDistribution2015_04_17"
 
 // DeleteDistributionRequest generates a request for the DeleteDistribution operation.
-func (c *CloudFront) DeleteDistributionRequest(input *DeleteDistributionInput) (req *service.Request, output *DeleteDistributionOutput) {
-	op := &service.Operation{
+func (c *CloudFront) DeleteDistributionRequest(input *DeleteDistributionInput) (req *request.Request, output *DeleteDistributionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDistribution,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-04-17/distribution/{Id}",
@@ -175,8 +175,8 @@ func (c *CloudFront) DeleteDistribution(input *DeleteDistributionInput) (*Delete
 const opDeleteStreamingDistribution = "DeleteStreamingDistribution2015_04_17"
 
 // DeleteStreamingDistributionRequest generates a request for the DeleteStreamingDistribution operation.
-func (c *CloudFront) DeleteStreamingDistributionRequest(input *DeleteStreamingDistributionInput) (req *service.Request, output *DeleteStreamingDistributionOutput) {
-	op := &service.Operation{
+func (c *CloudFront) DeleteStreamingDistributionRequest(input *DeleteStreamingDistributionInput) (req *request.Request, output *DeleteStreamingDistributionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteStreamingDistribution,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-04-17/streaming-distribution/{Id}",
@@ -202,8 +202,8 @@ func (c *CloudFront) DeleteStreamingDistribution(input *DeleteStreamingDistribut
 const opGetCloudFrontOriginAccessIdentity = "GetCloudFrontOriginAccessIdentity2015_04_17"
 
 // GetCloudFrontOriginAccessIdentityRequest generates a request for the GetCloudFrontOriginAccessIdentity operation.
-func (c *CloudFront) GetCloudFrontOriginAccessIdentityRequest(input *GetCloudFrontOriginAccessIdentityInput) (req *service.Request, output *GetCloudFrontOriginAccessIdentityOutput) {
-	op := &service.Operation{
+func (c *CloudFront) GetCloudFrontOriginAccessIdentityRequest(input *GetCloudFrontOriginAccessIdentityInput) (req *request.Request, output *GetCloudFrontOriginAccessIdentityOutput) {
+	op := &request.Operation{
 		Name:       opGetCloudFrontOriginAccessIdentity,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/origin-access-identity/cloudfront/{Id}",
@@ -229,8 +229,8 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentity(input *GetCloudFrontOrigi
 const opGetCloudFrontOriginAccessIdentityConfig = "GetCloudFrontOriginAccessIdentityConfig2015_04_17"
 
 // GetCloudFrontOriginAccessIdentityConfigRequest generates a request for the GetCloudFrontOriginAccessIdentityConfig operation.
-func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfigRequest(input *GetCloudFrontOriginAccessIdentityConfigInput) (req *service.Request, output *GetCloudFrontOriginAccessIdentityConfigOutput) {
-	op := &service.Operation{
+func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfigRequest(input *GetCloudFrontOriginAccessIdentityConfigInput) (req *request.Request, output *GetCloudFrontOriginAccessIdentityConfigOutput) {
+	op := &request.Operation{
 		Name:       opGetCloudFrontOriginAccessIdentityConfig,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/origin-access-identity/cloudfront/{Id}/config",
@@ -256,8 +256,8 @@ func (c *CloudFront) GetCloudFrontOriginAccessIdentityConfig(input *GetCloudFron
 const opGetDistribution = "GetDistribution2015_04_17"
 
 // GetDistributionRequest generates a request for the GetDistribution operation.
-func (c *CloudFront) GetDistributionRequest(input *GetDistributionInput) (req *service.Request, output *GetDistributionOutput) {
-	op := &service.Operation{
+func (c *CloudFront) GetDistributionRequest(input *GetDistributionInput) (req *request.Request, output *GetDistributionOutput) {
+	op := &request.Operation{
 		Name:       opGetDistribution,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/distribution/{Id}",
@@ -283,8 +283,8 @@ func (c *CloudFront) GetDistribution(input *GetDistributionInput) (*GetDistribut
 const opGetDistributionConfig = "GetDistributionConfig2015_04_17"
 
 // GetDistributionConfigRequest generates a request for the GetDistributionConfig operation.
-func (c *CloudFront) GetDistributionConfigRequest(input *GetDistributionConfigInput) (req *service.Request, output *GetDistributionConfigOutput) {
-	op := &service.Operation{
+func (c *CloudFront) GetDistributionConfigRequest(input *GetDistributionConfigInput) (req *request.Request, output *GetDistributionConfigOutput) {
+	op := &request.Operation{
 		Name:       opGetDistributionConfig,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/distribution/{Id}/config",
@@ -310,8 +310,8 @@ func (c *CloudFront) GetDistributionConfig(input *GetDistributionConfigInput) (*
 const opGetInvalidation = "GetInvalidation2015_04_17"
 
 // GetInvalidationRequest generates a request for the GetInvalidation operation.
-func (c *CloudFront) GetInvalidationRequest(input *GetInvalidationInput) (req *service.Request, output *GetInvalidationOutput) {
-	op := &service.Operation{
+func (c *CloudFront) GetInvalidationRequest(input *GetInvalidationInput) (req *request.Request, output *GetInvalidationOutput) {
+	op := &request.Operation{
 		Name:       opGetInvalidation,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/distribution/{DistributionId}/invalidation/{Id}",
@@ -337,8 +337,8 @@ func (c *CloudFront) GetInvalidation(input *GetInvalidationInput) (*GetInvalidat
 const opGetStreamingDistribution = "GetStreamingDistribution2015_04_17"
 
 // GetStreamingDistributionRequest generates a request for the GetStreamingDistribution operation.
-func (c *CloudFront) GetStreamingDistributionRequest(input *GetStreamingDistributionInput) (req *service.Request, output *GetStreamingDistributionOutput) {
-	op := &service.Operation{
+func (c *CloudFront) GetStreamingDistributionRequest(input *GetStreamingDistributionInput) (req *request.Request, output *GetStreamingDistributionOutput) {
+	op := &request.Operation{
 		Name:       opGetStreamingDistribution,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/streaming-distribution/{Id}",
@@ -364,8 +364,8 @@ func (c *CloudFront) GetStreamingDistribution(input *GetStreamingDistributionInp
 const opGetStreamingDistributionConfig = "GetStreamingDistributionConfig2015_04_17"
 
 // GetStreamingDistributionConfigRequest generates a request for the GetStreamingDistributionConfig operation.
-func (c *CloudFront) GetStreamingDistributionConfigRequest(input *GetStreamingDistributionConfigInput) (req *service.Request, output *GetStreamingDistributionConfigOutput) {
-	op := &service.Operation{
+func (c *CloudFront) GetStreamingDistributionConfigRequest(input *GetStreamingDistributionConfigInput) (req *request.Request, output *GetStreamingDistributionConfigOutput) {
+	op := &request.Operation{
 		Name:       opGetStreamingDistributionConfig,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/streaming-distribution/{Id}/config",
@@ -391,12 +391,12 @@ func (c *CloudFront) GetStreamingDistributionConfig(input *GetStreamingDistribut
 const opListCloudFrontOriginAccessIdentities = "ListCloudFrontOriginAccessIdentities2015_04_17"
 
 // ListCloudFrontOriginAccessIdentitiesRequest generates a request for the ListCloudFrontOriginAccessIdentities operation.
-func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesRequest(input *ListCloudFrontOriginAccessIdentitiesInput) (req *service.Request, output *ListCloudFrontOriginAccessIdentitiesOutput) {
-	op := &service.Operation{
+func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesRequest(input *ListCloudFrontOriginAccessIdentitiesInput) (req *request.Request, output *ListCloudFrontOriginAccessIdentitiesOutput) {
+	op := &request.Operation{
 		Name:       opListCloudFrontOriginAccessIdentities,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/origin-access-identity/cloudfront",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"CloudFrontOriginAccessIdentityList.NextMarker"},
 			LimitToken:      "MaxItems",
@@ -431,12 +431,12 @@ func (c *CloudFront) ListCloudFrontOriginAccessIdentitiesPages(input *ListCloudF
 const opListDistributions = "ListDistributions2015_04_17"
 
 // ListDistributionsRequest generates a request for the ListDistributions operation.
-func (c *CloudFront) ListDistributionsRequest(input *ListDistributionsInput) (req *service.Request, output *ListDistributionsOutput) {
-	op := &service.Operation{
+func (c *CloudFront) ListDistributionsRequest(input *ListDistributionsInput) (req *request.Request, output *ListDistributionsOutput) {
+	op := &request.Operation{
 		Name:       opListDistributions,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/distribution",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"DistributionList.NextMarker"},
 			LimitToken:      "MaxItems",
@@ -471,12 +471,12 @@ func (c *CloudFront) ListDistributionsPages(input *ListDistributionsInput, fn fu
 const opListInvalidations = "ListInvalidations2015_04_17"
 
 // ListInvalidationsRequest generates a request for the ListInvalidations operation.
-func (c *CloudFront) ListInvalidationsRequest(input *ListInvalidationsInput) (req *service.Request, output *ListInvalidationsOutput) {
-	op := &service.Operation{
+func (c *CloudFront) ListInvalidationsRequest(input *ListInvalidationsInput) (req *request.Request, output *ListInvalidationsOutput) {
+	op := &request.Operation{
 		Name:       opListInvalidations,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/distribution/{DistributionId}/invalidation",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"InvalidationList.NextMarker"},
 			LimitToken:      "MaxItems",
@@ -511,12 +511,12 @@ func (c *CloudFront) ListInvalidationsPages(input *ListInvalidationsInput, fn fu
 const opListStreamingDistributions = "ListStreamingDistributions2015_04_17"
 
 // ListStreamingDistributionsRequest generates a request for the ListStreamingDistributions operation.
-func (c *CloudFront) ListStreamingDistributionsRequest(input *ListStreamingDistributionsInput) (req *service.Request, output *ListStreamingDistributionsOutput) {
-	op := &service.Operation{
+func (c *CloudFront) ListStreamingDistributionsRequest(input *ListStreamingDistributionsInput) (req *request.Request, output *ListStreamingDistributionsOutput) {
+	op := &request.Operation{
 		Name:       opListStreamingDistributions,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-04-17/streaming-distribution",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"StreamingDistributionList.NextMarker"},
 			LimitToken:      "MaxItems",
@@ -551,8 +551,8 @@ func (c *CloudFront) ListStreamingDistributionsPages(input *ListStreamingDistrib
 const opUpdateCloudFrontOriginAccessIdentity = "UpdateCloudFrontOriginAccessIdentity2015_04_17"
 
 // UpdateCloudFrontOriginAccessIdentityRequest generates a request for the UpdateCloudFrontOriginAccessIdentity operation.
-func (c *CloudFront) UpdateCloudFrontOriginAccessIdentityRequest(input *UpdateCloudFrontOriginAccessIdentityInput) (req *service.Request, output *UpdateCloudFrontOriginAccessIdentityOutput) {
-	op := &service.Operation{
+func (c *CloudFront) UpdateCloudFrontOriginAccessIdentityRequest(input *UpdateCloudFrontOriginAccessIdentityInput) (req *request.Request, output *UpdateCloudFrontOriginAccessIdentityOutput) {
+	op := &request.Operation{
 		Name:       opUpdateCloudFrontOriginAccessIdentity,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2015-04-17/origin-access-identity/cloudfront/{Id}/config",
@@ -578,8 +578,8 @@ func (c *CloudFront) UpdateCloudFrontOriginAccessIdentity(input *UpdateCloudFron
 const opUpdateDistribution = "UpdateDistribution2015_04_17"
 
 // UpdateDistributionRequest generates a request for the UpdateDistribution operation.
-func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (req *service.Request, output *UpdateDistributionOutput) {
-	op := &service.Operation{
+func (c *CloudFront) UpdateDistributionRequest(input *UpdateDistributionInput) (req *request.Request, output *UpdateDistributionOutput) {
+	op := &request.Operation{
 		Name:       opUpdateDistribution,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2015-04-17/distribution/{Id}/config",
@@ -605,8 +605,8 @@ func (c *CloudFront) UpdateDistribution(input *UpdateDistributionInput) (*Update
 const opUpdateStreamingDistribution = "UpdateStreamingDistribution2015_04_17"
 
 // UpdateStreamingDistributionRequest generates a request for the UpdateStreamingDistribution operation.
-func (c *CloudFront) UpdateStreamingDistributionRequest(input *UpdateStreamingDistributionInput) (req *service.Request, output *UpdateStreamingDistributionOutput) {
-	op := &service.Operation{
+func (c *CloudFront) UpdateStreamingDistributionRequest(input *UpdateStreamingDistributionInput) (req *request.Request, output *UpdateStreamingDistributionOutput) {
+	op := &request.Operation{
 		Name:       opUpdateStreamingDistribution,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2015-04-17/streaming-distribution/{Id}/config",

--- a/service/cloudfront/cloudfrontiface/interface.go
+++ b/service/cloudfront/cloudfrontiface/interface.go
@@ -4,101 +4,101 @@
 package cloudfrontiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 )
 
 // CloudFrontAPI is the interface type for cloudfront.CloudFront.
 type CloudFrontAPI interface {
-	CreateCloudFrontOriginAccessIdentityRequest(*cloudfront.CreateCloudFrontOriginAccessIdentityInput) (*service.Request, *cloudfront.CreateCloudFrontOriginAccessIdentityOutput)
+	CreateCloudFrontOriginAccessIdentityRequest(*cloudfront.CreateCloudFrontOriginAccessIdentityInput) (*request.Request, *cloudfront.CreateCloudFrontOriginAccessIdentityOutput)
 
 	CreateCloudFrontOriginAccessIdentity(*cloudfront.CreateCloudFrontOriginAccessIdentityInput) (*cloudfront.CreateCloudFrontOriginAccessIdentityOutput, error)
 
-	CreateDistributionRequest(*cloudfront.CreateDistributionInput) (*service.Request, *cloudfront.CreateDistributionOutput)
+	CreateDistributionRequest(*cloudfront.CreateDistributionInput) (*request.Request, *cloudfront.CreateDistributionOutput)
 
 	CreateDistribution(*cloudfront.CreateDistributionInput) (*cloudfront.CreateDistributionOutput, error)
 
-	CreateInvalidationRequest(*cloudfront.CreateInvalidationInput) (*service.Request, *cloudfront.CreateInvalidationOutput)
+	CreateInvalidationRequest(*cloudfront.CreateInvalidationInput) (*request.Request, *cloudfront.CreateInvalidationOutput)
 
 	CreateInvalidation(*cloudfront.CreateInvalidationInput) (*cloudfront.CreateInvalidationOutput, error)
 
-	CreateStreamingDistributionRequest(*cloudfront.CreateStreamingDistributionInput) (*service.Request, *cloudfront.CreateStreamingDistributionOutput)
+	CreateStreamingDistributionRequest(*cloudfront.CreateStreamingDistributionInput) (*request.Request, *cloudfront.CreateStreamingDistributionOutput)
 
 	CreateStreamingDistribution(*cloudfront.CreateStreamingDistributionInput) (*cloudfront.CreateStreamingDistributionOutput, error)
 
-	DeleteCloudFrontOriginAccessIdentityRequest(*cloudfront.DeleteCloudFrontOriginAccessIdentityInput) (*service.Request, *cloudfront.DeleteCloudFrontOriginAccessIdentityOutput)
+	DeleteCloudFrontOriginAccessIdentityRequest(*cloudfront.DeleteCloudFrontOriginAccessIdentityInput) (*request.Request, *cloudfront.DeleteCloudFrontOriginAccessIdentityOutput)
 
 	DeleteCloudFrontOriginAccessIdentity(*cloudfront.DeleteCloudFrontOriginAccessIdentityInput) (*cloudfront.DeleteCloudFrontOriginAccessIdentityOutput, error)
 
-	DeleteDistributionRequest(*cloudfront.DeleteDistributionInput) (*service.Request, *cloudfront.DeleteDistributionOutput)
+	DeleteDistributionRequest(*cloudfront.DeleteDistributionInput) (*request.Request, *cloudfront.DeleteDistributionOutput)
 
 	DeleteDistribution(*cloudfront.DeleteDistributionInput) (*cloudfront.DeleteDistributionOutput, error)
 
-	DeleteStreamingDistributionRequest(*cloudfront.DeleteStreamingDistributionInput) (*service.Request, *cloudfront.DeleteStreamingDistributionOutput)
+	DeleteStreamingDistributionRequest(*cloudfront.DeleteStreamingDistributionInput) (*request.Request, *cloudfront.DeleteStreamingDistributionOutput)
 
 	DeleteStreamingDistribution(*cloudfront.DeleteStreamingDistributionInput) (*cloudfront.DeleteStreamingDistributionOutput, error)
 
-	GetCloudFrontOriginAccessIdentityRequest(*cloudfront.GetCloudFrontOriginAccessIdentityInput) (*service.Request, *cloudfront.GetCloudFrontOriginAccessIdentityOutput)
+	GetCloudFrontOriginAccessIdentityRequest(*cloudfront.GetCloudFrontOriginAccessIdentityInput) (*request.Request, *cloudfront.GetCloudFrontOriginAccessIdentityOutput)
 
 	GetCloudFrontOriginAccessIdentity(*cloudfront.GetCloudFrontOriginAccessIdentityInput) (*cloudfront.GetCloudFrontOriginAccessIdentityOutput, error)
 
-	GetCloudFrontOriginAccessIdentityConfigRequest(*cloudfront.GetCloudFrontOriginAccessIdentityConfigInput) (*service.Request, *cloudfront.GetCloudFrontOriginAccessIdentityConfigOutput)
+	GetCloudFrontOriginAccessIdentityConfigRequest(*cloudfront.GetCloudFrontOriginAccessIdentityConfigInput) (*request.Request, *cloudfront.GetCloudFrontOriginAccessIdentityConfigOutput)
 
 	GetCloudFrontOriginAccessIdentityConfig(*cloudfront.GetCloudFrontOriginAccessIdentityConfigInput) (*cloudfront.GetCloudFrontOriginAccessIdentityConfigOutput, error)
 
-	GetDistributionRequest(*cloudfront.GetDistributionInput) (*service.Request, *cloudfront.GetDistributionOutput)
+	GetDistributionRequest(*cloudfront.GetDistributionInput) (*request.Request, *cloudfront.GetDistributionOutput)
 
 	GetDistribution(*cloudfront.GetDistributionInput) (*cloudfront.GetDistributionOutput, error)
 
-	GetDistributionConfigRequest(*cloudfront.GetDistributionConfigInput) (*service.Request, *cloudfront.GetDistributionConfigOutput)
+	GetDistributionConfigRequest(*cloudfront.GetDistributionConfigInput) (*request.Request, *cloudfront.GetDistributionConfigOutput)
 
 	GetDistributionConfig(*cloudfront.GetDistributionConfigInput) (*cloudfront.GetDistributionConfigOutput, error)
 
-	GetInvalidationRequest(*cloudfront.GetInvalidationInput) (*service.Request, *cloudfront.GetInvalidationOutput)
+	GetInvalidationRequest(*cloudfront.GetInvalidationInput) (*request.Request, *cloudfront.GetInvalidationOutput)
 
 	GetInvalidation(*cloudfront.GetInvalidationInput) (*cloudfront.GetInvalidationOutput, error)
 
-	GetStreamingDistributionRequest(*cloudfront.GetStreamingDistributionInput) (*service.Request, *cloudfront.GetStreamingDistributionOutput)
+	GetStreamingDistributionRequest(*cloudfront.GetStreamingDistributionInput) (*request.Request, *cloudfront.GetStreamingDistributionOutput)
 
 	GetStreamingDistribution(*cloudfront.GetStreamingDistributionInput) (*cloudfront.GetStreamingDistributionOutput, error)
 
-	GetStreamingDistributionConfigRequest(*cloudfront.GetStreamingDistributionConfigInput) (*service.Request, *cloudfront.GetStreamingDistributionConfigOutput)
+	GetStreamingDistributionConfigRequest(*cloudfront.GetStreamingDistributionConfigInput) (*request.Request, *cloudfront.GetStreamingDistributionConfigOutput)
 
 	GetStreamingDistributionConfig(*cloudfront.GetStreamingDistributionConfigInput) (*cloudfront.GetStreamingDistributionConfigOutput, error)
 
-	ListCloudFrontOriginAccessIdentitiesRequest(*cloudfront.ListCloudFrontOriginAccessIdentitiesInput) (*service.Request, *cloudfront.ListCloudFrontOriginAccessIdentitiesOutput)
+	ListCloudFrontOriginAccessIdentitiesRequest(*cloudfront.ListCloudFrontOriginAccessIdentitiesInput) (*request.Request, *cloudfront.ListCloudFrontOriginAccessIdentitiesOutput)
 
 	ListCloudFrontOriginAccessIdentities(*cloudfront.ListCloudFrontOriginAccessIdentitiesInput) (*cloudfront.ListCloudFrontOriginAccessIdentitiesOutput, error)
 
 	ListCloudFrontOriginAccessIdentitiesPages(*cloudfront.ListCloudFrontOriginAccessIdentitiesInput, func(*cloudfront.ListCloudFrontOriginAccessIdentitiesOutput, bool) bool) error
 
-	ListDistributionsRequest(*cloudfront.ListDistributionsInput) (*service.Request, *cloudfront.ListDistributionsOutput)
+	ListDistributionsRequest(*cloudfront.ListDistributionsInput) (*request.Request, *cloudfront.ListDistributionsOutput)
 
 	ListDistributions(*cloudfront.ListDistributionsInput) (*cloudfront.ListDistributionsOutput, error)
 
 	ListDistributionsPages(*cloudfront.ListDistributionsInput, func(*cloudfront.ListDistributionsOutput, bool) bool) error
 
-	ListInvalidationsRequest(*cloudfront.ListInvalidationsInput) (*service.Request, *cloudfront.ListInvalidationsOutput)
+	ListInvalidationsRequest(*cloudfront.ListInvalidationsInput) (*request.Request, *cloudfront.ListInvalidationsOutput)
 
 	ListInvalidations(*cloudfront.ListInvalidationsInput) (*cloudfront.ListInvalidationsOutput, error)
 
 	ListInvalidationsPages(*cloudfront.ListInvalidationsInput, func(*cloudfront.ListInvalidationsOutput, bool) bool) error
 
-	ListStreamingDistributionsRequest(*cloudfront.ListStreamingDistributionsInput) (*service.Request, *cloudfront.ListStreamingDistributionsOutput)
+	ListStreamingDistributionsRequest(*cloudfront.ListStreamingDistributionsInput) (*request.Request, *cloudfront.ListStreamingDistributionsOutput)
 
 	ListStreamingDistributions(*cloudfront.ListStreamingDistributionsInput) (*cloudfront.ListStreamingDistributionsOutput, error)
 
 	ListStreamingDistributionsPages(*cloudfront.ListStreamingDistributionsInput, func(*cloudfront.ListStreamingDistributionsOutput, bool) bool) error
 
-	UpdateCloudFrontOriginAccessIdentityRequest(*cloudfront.UpdateCloudFrontOriginAccessIdentityInput) (*service.Request, *cloudfront.UpdateCloudFrontOriginAccessIdentityOutput)
+	UpdateCloudFrontOriginAccessIdentityRequest(*cloudfront.UpdateCloudFrontOriginAccessIdentityInput) (*request.Request, *cloudfront.UpdateCloudFrontOriginAccessIdentityOutput)
 
 	UpdateCloudFrontOriginAccessIdentity(*cloudfront.UpdateCloudFrontOriginAccessIdentityInput) (*cloudfront.UpdateCloudFrontOriginAccessIdentityOutput, error)
 
-	UpdateDistributionRequest(*cloudfront.UpdateDistributionInput) (*service.Request, *cloudfront.UpdateDistributionOutput)
+	UpdateDistributionRequest(*cloudfront.UpdateDistributionInput) (*request.Request, *cloudfront.UpdateDistributionOutput)
 
 	UpdateDistribution(*cloudfront.UpdateDistributionInput) (*cloudfront.UpdateDistributionOutput, error)
 
-	UpdateStreamingDistributionRequest(*cloudfront.UpdateStreamingDistributionInput) (*service.Request, *cloudfront.UpdateStreamingDistributionOutput)
+	UpdateStreamingDistributionRequest(*cloudfront.UpdateStreamingDistributionInput) (*request.Request, *cloudfront.UpdateStreamingDistributionOutput)
 
 	UpdateStreamingDistribution(*cloudfront.UpdateStreamingDistributionInput) (*cloudfront.UpdateStreamingDistributionOutput, error)
 }

--- a/service/cloudfront/service.go
+++ b/service/cloudfront/service.go
@@ -5,7 +5,9 @@ package cloudfront
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restxml"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -19,14 +21,16 @@ type CloudFront struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CloudFront client.
 func New(config *aws.Config) *CloudFront {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "cloudfront",
-		APIVersion:  "2015-04-17",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "cloudfront",
+			APIVersion:  "2015-04-17",
+		},
 	}
 	service.Initialize()
 
@@ -47,8 +51,8 @@ func New(config *aws.Config) *CloudFront {
 
 // newRequest creates a new request for a CloudFront operation and runs any
 // custom request initialization.
-func (c *CloudFront) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CloudFront) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cloudhsm/api.go
+++ b/service/cloudhsm/api.go
@@ -5,14 +5,14 @@ package cloudhsm
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateHapg = "CreateHapg"
 
 // CreateHapgRequest generates a request for the CreateHapg operation.
-func (c *CloudHSM) CreateHapgRequest(input *CreateHapgInput) (req *service.Request, output *CreateHapgOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) CreateHapgRequest(input *CreateHapgInput) (req *request.Request, output *CreateHapgOutput) {
+	op := &request.Operation{
 		Name:       opCreateHapg,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -39,8 +39,8 @@ func (c *CloudHSM) CreateHapg(input *CreateHapgInput) (*CreateHapgOutput, error)
 const opCreateHsm = "CreateHsm"
 
 // CreateHsmRequest generates a request for the CreateHsm operation.
-func (c *CloudHSM) CreateHsmRequest(input *CreateHsmInput) (req *service.Request, output *CreateHsmOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) CreateHsmRequest(input *CreateHsmInput) (req *request.Request, output *CreateHsmOutput) {
+	op := &request.Operation{
 		Name:       opCreateHsm,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -76,8 +76,8 @@ func (c *CloudHSM) CreateHsm(input *CreateHsmInput) (*CreateHsmOutput, error) {
 const opCreateLunaClient = "CreateLunaClient"
 
 // CreateLunaClientRequest generates a request for the CreateLunaClient operation.
-func (c *CloudHSM) CreateLunaClientRequest(input *CreateLunaClientInput) (req *service.Request, output *CreateLunaClientOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) CreateLunaClientRequest(input *CreateLunaClientInput) (req *request.Request, output *CreateLunaClientOutput) {
+	op := &request.Operation{
 		Name:       opCreateLunaClient,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -103,8 +103,8 @@ func (c *CloudHSM) CreateLunaClient(input *CreateLunaClientInput) (*CreateLunaCl
 const opDeleteHapg = "DeleteHapg"
 
 // DeleteHapgRequest generates a request for the DeleteHapg operation.
-func (c *CloudHSM) DeleteHapgRequest(input *DeleteHapgInput) (req *service.Request, output *DeleteHapgOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) DeleteHapgRequest(input *DeleteHapgInput) (req *request.Request, output *DeleteHapgOutput) {
+	op := &request.Operation{
 		Name:       opDeleteHapg,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -130,8 +130,8 @@ func (c *CloudHSM) DeleteHapg(input *DeleteHapgInput) (*DeleteHapgOutput, error)
 const opDeleteHsm = "DeleteHsm"
 
 // DeleteHsmRequest generates a request for the DeleteHsm operation.
-func (c *CloudHSM) DeleteHsmRequest(input *DeleteHsmInput) (req *service.Request, output *DeleteHsmOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) DeleteHsmRequest(input *DeleteHsmInput) (req *request.Request, output *DeleteHsmOutput) {
+	op := &request.Operation{
 		Name:       opDeleteHsm,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -158,8 +158,8 @@ func (c *CloudHSM) DeleteHsm(input *DeleteHsmInput) (*DeleteHsmOutput, error) {
 const opDeleteLunaClient = "DeleteLunaClient"
 
 // DeleteLunaClientRequest generates a request for the DeleteLunaClient operation.
-func (c *CloudHSM) DeleteLunaClientRequest(input *DeleteLunaClientInput) (req *service.Request, output *DeleteLunaClientOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) DeleteLunaClientRequest(input *DeleteLunaClientInput) (req *request.Request, output *DeleteLunaClientOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLunaClient,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -185,8 +185,8 @@ func (c *CloudHSM) DeleteLunaClient(input *DeleteLunaClientInput) (*DeleteLunaCl
 const opDescribeHapg = "DescribeHapg"
 
 // DescribeHapgRequest generates a request for the DescribeHapg operation.
-func (c *CloudHSM) DescribeHapgRequest(input *DescribeHapgInput) (req *service.Request, output *DescribeHapgOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) DescribeHapgRequest(input *DescribeHapgInput) (req *request.Request, output *DescribeHapgOutput) {
+	op := &request.Operation{
 		Name:       opDescribeHapg,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -212,8 +212,8 @@ func (c *CloudHSM) DescribeHapg(input *DescribeHapgInput) (*DescribeHapgOutput, 
 const opDescribeHsm = "DescribeHsm"
 
 // DescribeHsmRequest generates a request for the DescribeHsm operation.
-func (c *CloudHSM) DescribeHsmRequest(input *DescribeHsmInput) (req *service.Request, output *DescribeHsmOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) DescribeHsmRequest(input *DescribeHsmInput) (req *request.Request, output *DescribeHsmOutput) {
+	op := &request.Operation{
 		Name:       opDescribeHsm,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -240,8 +240,8 @@ func (c *CloudHSM) DescribeHsm(input *DescribeHsmInput) (*DescribeHsmOutput, err
 const opDescribeLunaClient = "DescribeLunaClient"
 
 // DescribeLunaClientRequest generates a request for the DescribeLunaClient operation.
-func (c *CloudHSM) DescribeLunaClientRequest(input *DescribeLunaClientInput) (req *service.Request, output *DescribeLunaClientOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) DescribeLunaClientRequest(input *DescribeLunaClientInput) (req *request.Request, output *DescribeLunaClientOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLunaClient,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -267,8 +267,8 @@ func (c *CloudHSM) DescribeLunaClient(input *DescribeLunaClientInput) (*Describe
 const opGetConfig = "GetConfig"
 
 // GetConfigRequest generates a request for the GetConfig operation.
-func (c *CloudHSM) GetConfigRequest(input *GetConfigInput) (req *service.Request, output *GetConfigOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) GetConfigRequest(input *GetConfigInput) (req *request.Request, output *GetConfigOutput) {
+	op := &request.Operation{
 		Name:       opGetConfig,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -295,8 +295,8 @@ func (c *CloudHSM) GetConfig(input *GetConfigInput) (*GetConfigOutput, error) {
 const opListAvailableZones = "ListAvailableZones"
 
 // ListAvailableZonesRequest generates a request for the ListAvailableZones operation.
-func (c *CloudHSM) ListAvailableZonesRequest(input *ListAvailableZonesInput) (req *service.Request, output *ListAvailableZonesOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) ListAvailableZonesRequest(input *ListAvailableZonesInput) (req *request.Request, output *ListAvailableZonesOutput) {
+	op := &request.Operation{
 		Name:       opListAvailableZones,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -322,8 +322,8 @@ func (c *CloudHSM) ListAvailableZones(input *ListAvailableZonesInput) (*ListAvai
 const opListHapgs = "ListHapgs"
 
 // ListHapgsRequest generates a request for the ListHapgs operation.
-func (c *CloudHSM) ListHapgsRequest(input *ListHapgsInput) (req *service.Request, output *ListHapgsOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) ListHapgsRequest(input *ListHapgsInput) (req *request.Request, output *ListHapgsOutput) {
+	op := &request.Operation{
 		Name:       opListHapgs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -354,8 +354,8 @@ func (c *CloudHSM) ListHapgs(input *ListHapgsInput) (*ListHapgsOutput, error) {
 const opListHsms = "ListHsms"
 
 // ListHsmsRequest generates a request for the ListHsms operation.
-func (c *CloudHSM) ListHsmsRequest(input *ListHsmsInput) (req *service.Request, output *ListHsmsOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) ListHsmsRequest(input *ListHsmsInput) (req *request.Request, output *ListHsmsOutput) {
+	op := &request.Operation{
 		Name:       opListHsms,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -387,8 +387,8 @@ func (c *CloudHSM) ListHsms(input *ListHsmsInput) (*ListHsmsOutput, error) {
 const opListLunaClients = "ListLunaClients"
 
 // ListLunaClientsRequest generates a request for the ListLunaClients operation.
-func (c *CloudHSM) ListLunaClientsRequest(input *ListLunaClientsInput) (req *service.Request, output *ListLunaClientsOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) ListLunaClientsRequest(input *ListLunaClientsInput) (req *request.Request, output *ListLunaClientsOutput) {
+	op := &request.Operation{
 		Name:       opListLunaClients,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -419,8 +419,8 @@ func (c *CloudHSM) ListLunaClients(input *ListLunaClientsInput) (*ListLunaClient
 const opModifyHapg = "ModifyHapg"
 
 // ModifyHapgRequest generates a request for the ModifyHapg operation.
-func (c *CloudHSM) ModifyHapgRequest(input *ModifyHapgInput) (req *service.Request, output *ModifyHapgOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) ModifyHapgRequest(input *ModifyHapgInput) (req *request.Request, output *ModifyHapgOutput) {
+	op := &request.Operation{
 		Name:       opModifyHapg,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -446,8 +446,8 @@ func (c *CloudHSM) ModifyHapg(input *ModifyHapgInput) (*ModifyHapgOutput, error)
 const opModifyHsm = "ModifyHsm"
 
 // ModifyHsmRequest generates a request for the ModifyHsm operation.
-func (c *CloudHSM) ModifyHsmRequest(input *ModifyHsmInput) (req *service.Request, output *ModifyHsmOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) ModifyHsmRequest(input *ModifyHsmInput) (req *request.Request, output *ModifyHsmOutput) {
+	op := &request.Operation{
 		Name:       opModifyHsm,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -479,8 +479,8 @@ func (c *CloudHSM) ModifyHsm(input *ModifyHsmInput) (*ModifyHsmOutput, error) {
 const opModifyLunaClient = "ModifyLunaClient"
 
 // ModifyLunaClientRequest generates a request for the ModifyLunaClient operation.
-func (c *CloudHSM) ModifyLunaClientRequest(input *ModifyLunaClientInput) (req *service.Request, output *ModifyLunaClientOutput) {
-	op := &service.Operation{
+func (c *CloudHSM) ModifyLunaClientRequest(input *ModifyLunaClientInput) (req *request.Request, output *ModifyLunaClientOutput) {
+	op := &request.Operation{
 		Name:       opModifyLunaClient,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/cloudhsm/cloudhsmiface/interface.go
+++ b/service/cloudhsm/cloudhsmiface/interface.go
@@ -4,77 +4,77 @@
 package cloudhsmiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudhsm"
 )
 
 // CloudHSMAPI is the interface type for cloudhsm.CloudHSM.
 type CloudHSMAPI interface {
-	CreateHapgRequest(*cloudhsm.CreateHapgInput) (*service.Request, *cloudhsm.CreateHapgOutput)
+	CreateHapgRequest(*cloudhsm.CreateHapgInput) (*request.Request, *cloudhsm.CreateHapgOutput)
 
 	CreateHapg(*cloudhsm.CreateHapgInput) (*cloudhsm.CreateHapgOutput, error)
 
-	CreateHsmRequest(*cloudhsm.CreateHsmInput) (*service.Request, *cloudhsm.CreateHsmOutput)
+	CreateHsmRequest(*cloudhsm.CreateHsmInput) (*request.Request, *cloudhsm.CreateHsmOutput)
 
 	CreateHsm(*cloudhsm.CreateHsmInput) (*cloudhsm.CreateHsmOutput, error)
 
-	CreateLunaClientRequest(*cloudhsm.CreateLunaClientInput) (*service.Request, *cloudhsm.CreateLunaClientOutput)
+	CreateLunaClientRequest(*cloudhsm.CreateLunaClientInput) (*request.Request, *cloudhsm.CreateLunaClientOutput)
 
 	CreateLunaClient(*cloudhsm.CreateLunaClientInput) (*cloudhsm.CreateLunaClientOutput, error)
 
-	DeleteHapgRequest(*cloudhsm.DeleteHapgInput) (*service.Request, *cloudhsm.DeleteHapgOutput)
+	DeleteHapgRequest(*cloudhsm.DeleteHapgInput) (*request.Request, *cloudhsm.DeleteHapgOutput)
 
 	DeleteHapg(*cloudhsm.DeleteHapgInput) (*cloudhsm.DeleteHapgOutput, error)
 
-	DeleteHsmRequest(*cloudhsm.DeleteHsmInput) (*service.Request, *cloudhsm.DeleteHsmOutput)
+	DeleteHsmRequest(*cloudhsm.DeleteHsmInput) (*request.Request, *cloudhsm.DeleteHsmOutput)
 
 	DeleteHsm(*cloudhsm.DeleteHsmInput) (*cloudhsm.DeleteHsmOutput, error)
 
-	DeleteLunaClientRequest(*cloudhsm.DeleteLunaClientInput) (*service.Request, *cloudhsm.DeleteLunaClientOutput)
+	DeleteLunaClientRequest(*cloudhsm.DeleteLunaClientInput) (*request.Request, *cloudhsm.DeleteLunaClientOutput)
 
 	DeleteLunaClient(*cloudhsm.DeleteLunaClientInput) (*cloudhsm.DeleteLunaClientOutput, error)
 
-	DescribeHapgRequest(*cloudhsm.DescribeHapgInput) (*service.Request, *cloudhsm.DescribeHapgOutput)
+	DescribeHapgRequest(*cloudhsm.DescribeHapgInput) (*request.Request, *cloudhsm.DescribeHapgOutput)
 
 	DescribeHapg(*cloudhsm.DescribeHapgInput) (*cloudhsm.DescribeHapgOutput, error)
 
-	DescribeHsmRequest(*cloudhsm.DescribeHsmInput) (*service.Request, *cloudhsm.DescribeHsmOutput)
+	DescribeHsmRequest(*cloudhsm.DescribeHsmInput) (*request.Request, *cloudhsm.DescribeHsmOutput)
 
 	DescribeHsm(*cloudhsm.DescribeHsmInput) (*cloudhsm.DescribeHsmOutput, error)
 
-	DescribeLunaClientRequest(*cloudhsm.DescribeLunaClientInput) (*service.Request, *cloudhsm.DescribeLunaClientOutput)
+	DescribeLunaClientRequest(*cloudhsm.DescribeLunaClientInput) (*request.Request, *cloudhsm.DescribeLunaClientOutput)
 
 	DescribeLunaClient(*cloudhsm.DescribeLunaClientInput) (*cloudhsm.DescribeLunaClientOutput, error)
 
-	GetConfigRequest(*cloudhsm.GetConfigInput) (*service.Request, *cloudhsm.GetConfigOutput)
+	GetConfigRequest(*cloudhsm.GetConfigInput) (*request.Request, *cloudhsm.GetConfigOutput)
 
 	GetConfig(*cloudhsm.GetConfigInput) (*cloudhsm.GetConfigOutput, error)
 
-	ListAvailableZonesRequest(*cloudhsm.ListAvailableZonesInput) (*service.Request, *cloudhsm.ListAvailableZonesOutput)
+	ListAvailableZonesRequest(*cloudhsm.ListAvailableZonesInput) (*request.Request, *cloudhsm.ListAvailableZonesOutput)
 
 	ListAvailableZones(*cloudhsm.ListAvailableZonesInput) (*cloudhsm.ListAvailableZonesOutput, error)
 
-	ListHapgsRequest(*cloudhsm.ListHapgsInput) (*service.Request, *cloudhsm.ListHapgsOutput)
+	ListHapgsRequest(*cloudhsm.ListHapgsInput) (*request.Request, *cloudhsm.ListHapgsOutput)
 
 	ListHapgs(*cloudhsm.ListHapgsInput) (*cloudhsm.ListHapgsOutput, error)
 
-	ListHsmsRequest(*cloudhsm.ListHsmsInput) (*service.Request, *cloudhsm.ListHsmsOutput)
+	ListHsmsRequest(*cloudhsm.ListHsmsInput) (*request.Request, *cloudhsm.ListHsmsOutput)
 
 	ListHsms(*cloudhsm.ListHsmsInput) (*cloudhsm.ListHsmsOutput, error)
 
-	ListLunaClientsRequest(*cloudhsm.ListLunaClientsInput) (*service.Request, *cloudhsm.ListLunaClientsOutput)
+	ListLunaClientsRequest(*cloudhsm.ListLunaClientsInput) (*request.Request, *cloudhsm.ListLunaClientsOutput)
 
 	ListLunaClients(*cloudhsm.ListLunaClientsInput) (*cloudhsm.ListLunaClientsOutput, error)
 
-	ModifyHapgRequest(*cloudhsm.ModifyHapgInput) (*service.Request, *cloudhsm.ModifyHapgOutput)
+	ModifyHapgRequest(*cloudhsm.ModifyHapgInput) (*request.Request, *cloudhsm.ModifyHapgOutput)
 
 	ModifyHapg(*cloudhsm.ModifyHapgInput) (*cloudhsm.ModifyHapgOutput, error)
 
-	ModifyHsmRequest(*cloudhsm.ModifyHsmInput) (*service.Request, *cloudhsm.ModifyHsmOutput)
+	ModifyHsmRequest(*cloudhsm.ModifyHsmInput) (*request.Request, *cloudhsm.ModifyHsmOutput)
 
 	ModifyHsm(*cloudhsm.ModifyHsmInput) (*cloudhsm.ModifyHsmOutput, error)
 
-	ModifyLunaClientRequest(*cloudhsm.ModifyLunaClientInput) (*service.Request, *cloudhsm.ModifyLunaClientOutput)
+	ModifyLunaClientRequest(*cloudhsm.ModifyLunaClientInput) (*request.Request, *cloudhsm.ModifyLunaClientOutput)
 
 	ModifyLunaClient(*cloudhsm.ModifyLunaClientInput) (*cloudhsm.ModifyLunaClientOutput, error)
 }

--- a/service/cloudhsm/service.go
+++ b/service/cloudhsm/service.go
@@ -5,7 +5,9 @@ package cloudhsm
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -18,16 +20,18 @@ type CloudHSM struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CloudHSM client.
 func New(config *aws.Config) *CloudHSM {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "cloudhsm",
-		APIVersion:   "2014-05-30",
-		JSONVersion:  "1.1",
-		TargetPrefix: "CloudHsmFrontendService",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "cloudhsm",
+			APIVersion:   "2014-05-30",
+			JSONVersion:  "1.1",
+			TargetPrefix: "CloudHsmFrontendService",
+		},
 	}
 	service.Initialize()
 
@@ -48,8 +52,8 @@ func New(config *aws.Config) *CloudHSM {
 
 // newRequest creates a new request for a CloudHSM operation and runs any
 // custom request initialization.
-func (c *CloudHSM) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CloudHSM) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cloudsearch/api.go
+++ b/service/cloudsearch/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opBuildSuggesters = "BuildSuggesters"
 
 // BuildSuggestersRequest generates a request for the BuildSuggesters operation.
-func (c *CloudSearch) BuildSuggestersRequest(input *BuildSuggestersInput) (req *service.Request, output *BuildSuggestersOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) BuildSuggestersRequest(input *BuildSuggestersInput) (req *request.Request, output *BuildSuggestersOutput) {
+	op := &request.Operation{
 		Name:       opBuildSuggesters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -42,8 +42,8 @@ func (c *CloudSearch) BuildSuggesters(input *BuildSuggestersInput) (*BuildSugges
 const opCreateDomain = "CreateDomain"
 
 // CreateDomainRequest generates a request for the CreateDomain operation.
-func (c *CloudSearch) CreateDomainRequest(input *CreateDomainInput) (req *service.Request, output *CreateDomainOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) CreateDomainRequest(input *CreateDomainInput) (req *request.Request, output *CreateDomainOutput) {
+	op := &request.Operation{
 		Name:       opCreateDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -71,8 +71,8 @@ func (c *CloudSearch) CreateDomain(input *CreateDomainInput) (*CreateDomainOutpu
 const opDefineAnalysisScheme = "DefineAnalysisScheme"
 
 // DefineAnalysisSchemeRequest generates a request for the DefineAnalysisScheme operation.
-func (c *CloudSearch) DefineAnalysisSchemeRequest(input *DefineAnalysisSchemeInput) (req *service.Request, output *DefineAnalysisSchemeOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DefineAnalysisSchemeRequest(input *DefineAnalysisSchemeInput) (req *request.Request, output *DefineAnalysisSchemeOutput) {
+	op := &request.Operation{
 		Name:       opDefineAnalysisScheme,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -101,8 +101,8 @@ func (c *CloudSearch) DefineAnalysisScheme(input *DefineAnalysisSchemeInput) (*D
 const opDefineExpression = "DefineExpression"
 
 // DefineExpressionRequest generates a request for the DefineExpression operation.
-func (c *CloudSearch) DefineExpressionRequest(input *DefineExpressionInput) (req *service.Request, output *DefineExpressionOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DefineExpressionRequest(input *DefineExpressionInput) (req *request.Request, output *DefineExpressionOutput) {
+	op := &request.Operation{
 		Name:       opDefineExpression,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -131,8 +131,8 @@ func (c *CloudSearch) DefineExpression(input *DefineExpressionInput) (*DefineExp
 const opDefineIndexField = "DefineIndexField"
 
 // DefineIndexFieldRequest generates a request for the DefineIndexField operation.
-func (c *CloudSearch) DefineIndexFieldRequest(input *DefineIndexFieldInput) (req *service.Request, output *DefineIndexFieldOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DefineIndexFieldRequest(input *DefineIndexFieldInput) (req *request.Request, output *DefineIndexFieldOutput) {
+	op := &request.Operation{
 		Name:       opDefineIndexField,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -165,8 +165,8 @@ func (c *CloudSearch) DefineIndexField(input *DefineIndexFieldInput) (*DefineInd
 const opDefineSuggester = "DefineSuggester"
 
 // DefineSuggesterRequest generates a request for the DefineSuggester operation.
-func (c *CloudSearch) DefineSuggesterRequest(input *DefineSuggesterInput) (req *service.Request, output *DefineSuggesterOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DefineSuggesterRequest(input *DefineSuggesterInput) (req *request.Request, output *DefineSuggesterOutput) {
+	op := &request.Operation{
 		Name:       opDefineSuggester,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -197,8 +197,8 @@ func (c *CloudSearch) DefineSuggester(input *DefineSuggesterInput) (*DefineSugge
 const opDeleteAnalysisScheme = "DeleteAnalysisScheme"
 
 // DeleteAnalysisSchemeRequest generates a request for the DeleteAnalysisScheme operation.
-func (c *CloudSearch) DeleteAnalysisSchemeRequest(input *DeleteAnalysisSchemeInput) (req *service.Request, output *DeleteAnalysisSchemeOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DeleteAnalysisSchemeRequest(input *DeleteAnalysisSchemeInput) (req *request.Request, output *DeleteAnalysisSchemeOutput) {
+	op := &request.Operation{
 		Name:       opDeleteAnalysisScheme,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -226,8 +226,8 @@ func (c *CloudSearch) DeleteAnalysisScheme(input *DeleteAnalysisSchemeInput) (*D
 const opDeleteDomain = "DeleteDomain"
 
 // DeleteDomainRequest generates a request for the DeleteDomain operation.
-func (c *CloudSearch) DeleteDomainRequest(input *DeleteDomainInput) (req *service.Request, output *DeleteDomainOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DeleteDomainRequest(input *DeleteDomainInput) (req *request.Request, output *DeleteDomainOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -256,8 +256,8 @@ func (c *CloudSearch) DeleteDomain(input *DeleteDomainInput) (*DeleteDomainOutpu
 const opDeleteExpression = "DeleteExpression"
 
 // DeleteExpressionRequest generates a request for the DeleteExpression operation.
-func (c *CloudSearch) DeleteExpressionRequest(input *DeleteExpressionInput) (req *service.Request, output *DeleteExpressionOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DeleteExpressionRequest(input *DeleteExpressionInput) (req *request.Request, output *DeleteExpressionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteExpression,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -285,8 +285,8 @@ func (c *CloudSearch) DeleteExpression(input *DeleteExpressionInput) (*DeleteExp
 const opDeleteIndexField = "DeleteIndexField"
 
 // DeleteIndexFieldRequest generates a request for the DeleteIndexField operation.
-func (c *CloudSearch) DeleteIndexFieldRequest(input *DeleteIndexFieldInput) (req *service.Request, output *DeleteIndexFieldOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DeleteIndexFieldRequest(input *DeleteIndexFieldInput) (req *request.Request, output *DeleteIndexFieldOutput) {
+	op := &request.Operation{
 		Name:       opDeleteIndexField,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -314,8 +314,8 @@ func (c *CloudSearch) DeleteIndexField(input *DeleteIndexFieldInput) (*DeleteInd
 const opDeleteSuggester = "DeleteSuggester"
 
 // DeleteSuggesterRequest generates a request for the DeleteSuggester operation.
-func (c *CloudSearch) DeleteSuggesterRequest(input *DeleteSuggesterInput) (req *service.Request, output *DeleteSuggesterOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DeleteSuggesterRequest(input *DeleteSuggesterInput) (req *request.Request, output *DeleteSuggesterOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSuggester,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -343,8 +343,8 @@ func (c *CloudSearch) DeleteSuggester(input *DeleteSuggesterInput) (*DeleteSugge
 const opDescribeAnalysisSchemes = "DescribeAnalysisSchemes"
 
 // DescribeAnalysisSchemesRequest generates a request for the DescribeAnalysisSchemes operation.
-func (c *CloudSearch) DescribeAnalysisSchemesRequest(input *DescribeAnalysisSchemesInput) (req *service.Request, output *DescribeAnalysisSchemesOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DescribeAnalysisSchemesRequest(input *DescribeAnalysisSchemesInput) (req *request.Request, output *DescribeAnalysisSchemesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAnalysisSchemes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -376,8 +376,8 @@ func (c *CloudSearch) DescribeAnalysisSchemes(input *DescribeAnalysisSchemesInpu
 const opDescribeAvailabilityOptions = "DescribeAvailabilityOptions"
 
 // DescribeAvailabilityOptionsRequest generates a request for the DescribeAvailabilityOptions operation.
-func (c *CloudSearch) DescribeAvailabilityOptionsRequest(input *DescribeAvailabilityOptionsInput) (req *service.Request, output *DescribeAvailabilityOptionsOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DescribeAvailabilityOptionsRequest(input *DescribeAvailabilityOptionsInput) (req *request.Request, output *DescribeAvailabilityOptionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAvailabilityOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -407,8 +407,8 @@ func (c *CloudSearch) DescribeAvailabilityOptions(input *DescribeAvailabilityOpt
 const opDescribeDomains = "DescribeDomains"
 
 // DescribeDomainsRequest generates a request for the DescribeDomains operation.
-func (c *CloudSearch) DescribeDomainsRequest(input *DescribeDomainsInput) (req *service.Request, output *DescribeDomainsOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DescribeDomainsRequest(input *DescribeDomainsInput) (req *request.Request, output *DescribeDomainsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDomains,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -439,8 +439,8 @@ func (c *CloudSearch) DescribeDomains(input *DescribeDomainsInput) (*DescribeDom
 const opDescribeExpressions = "DescribeExpressions"
 
 // DescribeExpressionsRequest generates a request for the DescribeExpressions operation.
-func (c *CloudSearch) DescribeExpressionsRequest(input *DescribeExpressionsInput) (req *service.Request, output *DescribeExpressionsOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DescribeExpressionsRequest(input *DescribeExpressionsInput) (req *request.Request, output *DescribeExpressionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeExpressions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -471,8 +471,8 @@ func (c *CloudSearch) DescribeExpressions(input *DescribeExpressionsInput) (*Des
 const opDescribeIndexFields = "DescribeIndexFields"
 
 // DescribeIndexFieldsRequest generates a request for the DescribeIndexFields operation.
-func (c *CloudSearch) DescribeIndexFieldsRequest(input *DescribeIndexFieldsInput) (req *service.Request, output *DescribeIndexFieldsOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DescribeIndexFieldsRequest(input *DescribeIndexFieldsInput) (req *request.Request, output *DescribeIndexFieldsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeIndexFields,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -503,8 +503,8 @@ func (c *CloudSearch) DescribeIndexFields(input *DescribeIndexFieldsInput) (*Des
 const opDescribeScalingParameters = "DescribeScalingParameters"
 
 // DescribeScalingParametersRequest generates a request for the DescribeScalingParameters operation.
-func (c *CloudSearch) DescribeScalingParametersRequest(input *DescribeScalingParametersInput) (req *service.Request, output *DescribeScalingParametersOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DescribeScalingParametersRequest(input *DescribeScalingParametersInput) (req *request.Request, output *DescribeScalingParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeScalingParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -533,8 +533,8 @@ func (c *CloudSearch) DescribeScalingParameters(input *DescribeScalingParameters
 const opDescribeServiceAccessPolicies = "DescribeServiceAccessPolicies"
 
 // DescribeServiceAccessPoliciesRequest generates a request for the DescribeServiceAccessPolicies operation.
-func (c *CloudSearch) DescribeServiceAccessPoliciesRequest(input *DescribeServiceAccessPoliciesInput) (req *service.Request, output *DescribeServiceAccessPoliciesOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DescribeServiceAccessPoliciesRequest(input *DescribeServiceAccessPoliciesInput) (req *request.Request, output *DescribeServiceAccessPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeServiceAccessPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -565,8 +565,8 @@ func (c *CloudSearch) DescribeServiceAccessPolicies(input *DescribeServiceAccess
 const opDescribeSuggesters = "DescribeSuggesters"
 
 // DescribeSuggestersRequest generates a request for the DescribeSuggesters operation.
-func (c *CloudSearch) DescribeSuggestersRequest(input *DescribeSuggestersInput) (req *service.Request, output *DescribeSuggestersOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) DescribeSuggestersRequest(input *DescribeSuggestersInput) (req *request.Request, output *DescribeSuggestersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSuggesters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -598,8 +598,8 @@ func (c *CloudSearch) DescribeSuggesters(input *DescribeSuggestersInput) (*Descr
 const opIndexDocuments = "IndexDocuments"
 
 // IndexDocumentsRequest generates a request for the IndexDocuments operation.
-func (c *CloudSearch) IndexDocumentsRequest(input *IndexDocumentsInput) (req *service.Request, output *IndexDocumentsOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) IndexDocumentsRequest(input *IndexDocumentsInput) (req *request.Request, output *IndexDocumentsOutput) {
+	op := &request.Operation{
 		Name:       opIndexDocuments,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -627,8 +627,8 @@ func (c *CloudSearch) IndexDocuments(input *IndexDocumentsInput) (*IndexDocument
 const opListDomainNames = "ListDomainNames"
 
 // ListDomainNamesRequest generates a request for the ListDomainNames operation.
-func (c *CloudSearch) ListDomainNamesRequest(input *ListDomainNamesInput) (req *service.Request, output *ListDomainNamesOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) ListDomainNamesRequest(input *ListDomainNamesInput) (req *request.Request, output *ListDomainNamesOutput) {
+	op := &request.Operation{
 		Name:       opListDomainNames,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -654,8 +654,8 @@ func (c *CloudSearch) ListDomainNames(input *ListDomainNamesInput) (*ListDomainN
 const opUpdateAvailabilityOptions = "UpdateAvailabilityOptions"
 
 // UpdateAvailabilityOptionsRequest generates a request for the UpdateAvailabilityOptions operation.
-func (c *CloudSearch) UpdateAvailabilityOptionsRequest(input *UpdateAvailabilityOptionsInput) (req *service.Request, output *UpdateAvailabilityOptionsOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) UpdateAvailabilityOptionsRequest(input *UpdateAvailabilityOptionsInput) (req *request.Request, output *UpdateAvailabilityOptionsOutput) {
+	op := &request.Operation{
 		Name:       opUpdateAvailabilityOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -686,8 +686,8 @@ func (c *CloudSearch) UpdateAvailabilityOptions(input *UpdateAvailabilityOptions
 const opUpdateScalingParameters = "UpdateScalingParameters"
 
 // UpdateScalingParametersRequest generates a request for the UpdateScalingParameters operation.
-func (c *CloudSearch) UpdateScalingParametersRequest(input *UpdateScalingParametersInput) (req *service.Request, output *UpdateScalingParametersOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) UpdateScalingParametersRequest(input *UpdateScalingParametersInput) (req *request.Request, output *UpdateScalingParametersOutput) {
+	op := &request.Operation{
 		Name:       opUpdateScalingParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -720,8 +720,8 @@ func (c *CloudSearch) UpdateScalingParameters(input *UpdateScalingParametersInpu
 const opUpdateServiceAccessPolicies = "UpdateServiceAccessPolicies"
 
 // UpdateServiceAccessPoliciesRequest generates a request for the UpdateServiceAccessPolicies operation.
-func (c *CloudSearch) UpdateServiceAccessPoliciesRequest(input *UpdateServiceAccessPoliciesInput) (req *service.Request, output *UpdateServiceAccessPoliciesOutput) {
-	op := &service.Operation{
+func (c *CloudSearch) UpdateServiceAccessPoliciesRequest(input *UpdateServiceAccessPoliciesInput) (req *request.Request, output *UpdateServiceAccessPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opUpdateServiceAccessPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/cloudsearch/cloudsearchiface/interface.go
+++ b/service/cloudsearch/cloudsearchiface/interface.go
@@ -4,105 +4,105 @@
 package cloudsearchiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudsearch"
 )
 
 // CloudSearchAPI is the interface type for cloudsearch.CloudSearch.
 type CloudSearchAPI interface {
-	BuildSuggestersRequest(*cloudsearch.BuildSuggestersInput) (*service.Request, *cloudsearch.BuildSuggestersOutput)
+	BuildSuggestersRequest(*cloudsearch.BuildSuggestersInput) (*request.Request, *cloudsearch.BuildSuggestersOutput)
 
 	BuildSuggesters(*cloudsearch.BuildSuggestersInput) (*cloudsearch.BuildSuggestersOutput, error)
 
-	CreateDomainRequest(*cloudsearch.CreateDomainInput) (*service.Request, *cloudsearch.CreateDomainOutput)
+	CreateDomainRequest(*cloudsearch.CreateDomainInput) (*request.Request, *cloudsearch.CreateDomainOutput)
 
 	CreateDomain(*cloudsearch.CreateDomainInput) (*cloudsearch.CreateDomainOutput, error)
 
-	DefineAnalysisSchemeRequest(*cloudsearch.DefineAnalysisSchemeInput) (*service.Request, *cloudsearch.DefineAnalysisSchemeOutput)
+	DefineAnalysisSchemeRequest(*cloudsearch.DefineAnalysisSchemeInput) (*request.Request, *cloudsearch.DefineAnalysisSchemeOutput)
 
 	DefineAnalysisScheme(*cloudsearch.DefineAnalysisSchemeInput) (*cloudsearch.DefineAnalysisSchemeOutput, error)
 
-	DefineExpressionRequest(*cloudsearch.DefineExpressionInput) (*service.Request, *cloudsearch.DefineExpressionOutput)
+	DefineExpressionRequest(*cloudsearch.DefineExpressionInput) (*request.Request, *cloudsearch.DefineExpressionOutput)
 
 	DefineExpression(*cloudsearch.DefineExpressionInput) (*cloudsearch.DefineExpressionOutput, error)
 
-	DefineIndexFieldRequest(*cloudsearch.DefineIndexFieldInput) (*service.Request, *cloudsearch.DefineIndexFieldOutput)
+	DefineIndexFieldRequest(*cloudsearch.DefineIndexFieldInput) (*request.Request, *cloudsearch.DefineIndexFieldOutput)
 
 	DefineIndexField(*cloudsearch.DefineIndexFieldInput) (*cloudsearch.DefineIndexFieldOutput, error)
 
-	DefineSuggesterRequest(*cloudsearch.DefineSuggesterInput) (*service.Request, *cloudsearch.DefineSuggesterOutput)
+	DefineSuggesterRequest(*cloudsearch.DefineSuggesterInput) (*request.Request, *cloudsearch.DefineSuggesterOutput)
 
 	DefineSuggester(*cloudsearch.DefineSuggesterInput) (*cloudsearch.DefineSuggesterOutput, error)
 
-	DeleteAnalysisSchemeRequest(*cloudsearch.DeleteAnalysisSchemeInput) (*service.Request, *cloudsearch.DeleteAnalysisSchemeOutput)
+	DeleteAnalysisSchemeRequest(*cloudsearch.DeleteAnalysisSchemeInput) (*request.Request, *cloudsearch.DeleteAnalysisSchemeOutput)
 
 	DeleteAnalysisScheme(*cloudsearch.DeleteAnalysisSchemeInput) (*cloudsearch.DeleteAnalysisSchemeOutput, error)
 
-	DeleteDomainRequest(*cloudsearch.DeleteDomainInput) (*service.Request, *cloudsearch.DeleteDomainOutput)
+	DeleteDomainRequest(*cloudsearch.DeleteDomainInput) (*request.Request, *cloudsearch.DeleteDomainOutput)
 
 	DeleteDomain(*cloudsearch.DeleteDomainInput) (*cloudsearch.DeleteDomainOutput, error)
 
-	DeleteExpressionRequest(*cloudsearch.DeleteExpressionInput) (*service.Request, *cloudsearch.DeleteExpressionOutput)
+	DeleteExpressionRequest(*cloudsearch.DeleteExpressionInput) (*request.Request, *cloudsearch.DeleteExpressionOutput)
 
 	DeleteExpression(*cloudsearch.DeleteExpressionInput) (*cloudsearch.DeleteExpressionOutput, error)
 
-	DeleteIndexFieldRequest(*cloudsearch.DeleteIndexFieldInput) (*service.Request, *cloudsearch.DeleteIndexFieldOutput)
+	DeleteIndexFieldRequest(*cloudsearch.DeleteIndexFieldInput) (*request.Request, *cloudsearch.DeleteIndexFieldOutput)
 
 	DeleteIndexField(*cloudsearch.DeleteIndexFieldInput) (*cloudsearch.DeleteIndexFieldOutput, error)
 
-	DeleteSuggesterRequest(*cloudsearch.DeleteSuggesterInput) (*service.Request, *cloudsearch.DeleteSuggesterOutput)
+	DeleteSuggesterRequest(*cloudsearch.DeleteSuggesterInput) (*request.Request, *cloudsearch.DeleteSuggesterOutput)
 
 	DeleteSuggester(*cloudsearch.DeleteSuggesterInput) (*cloudsearch.DeleteSuggesterOutput, error)
 
-	DescribeAnalysisSchemesRequest(*cloudsearch.DescribeAnalysisSchemesInput) (*service.Request, *cloudsearch.DescribeAnalysisSchemesOutput)
+	DescribeAnalysisSchemesRequest(*cloudsearch.DescribeAnalysisSchemesInput) (*request.Request, *cloudsearch.DescribeAnalysisSchemesOutput)
 
 	DescribeAnalysisSchemes(*cloudsearch.DescribeAnalysisSchemesInput) (*cloudsearch.DescribeAnalysisSchemesOutput, error)
 
-	DescribeAvailabilityOptionsRequest(*cloudsearch.DescribeAvailabilityOptionsInput) (*service.Request, *cloudsearch.DescribeAvailabilityOptionsOutput)
+	DescribeAvailabilityOptionsRequest(*cloudsearch.DescribeAvailabilityOptionsInput) (*request.Request, *cloudsearch.DescribeAvailabilityOptionsOutput)
 
 	DescribeAvailabilityOptions(*cloudsearch.DescribeAvailabilityOptionsInput) (*cloudsearch.DescribeAvailabilityOptionsOutput, error)
 
-	DescribeDomainsRequest(*cloudsearch.DescribeDomainsInput) (*service.Request, *cloudsearch.DescribeDomainsOutput)
+	DescribeDomainsRequest(*cloudsearch.DescribeDomainsInput) (*request.Request, *cloudsearch.DescribeDomainsOutput)
 
 	DescribeDomains(*cloudsearch.DescribeDomainsInput) (*cloudsearch.DescribeDomainsOutput, error)
 
-	DescribeExpressionsRequest(*cloudsearch.DescribeExpressionsInput) (*service.Request, *cloudsearch.DescribeExpressionsOutput)
+	DescribeExpressionsRequest(*cloudsearch.DescribeExpressionsInput) (*request.Request, *cloudsearch.DescribeExpressionsOutput)
 
 	DescribeExpressions(*cloudsearch.DescribeExpressionsInput) (*cloudsearch.DescribeExpressionsOutput, error)
 
-	DescribeIndexFieldsRequest(*cloudsearch.DescribeIndexFieldsInput) (*service.Request, *cloudsearch.DescribeIndexFieldsOutput)
+	DescribeIndexFieldsRequest(*cloudsearch.DescribeIndexFieldsInput) (*request.Request, *cloudsearch.DescribeIndexFieldsOutput)
 
 	DescribeIndexFields(*cloudsearch.DescribeIndexFieldsInput) (*cloudsearch.DescribeIndexFieldsOutput, error)
 
-	DescribeScalingParametersRequest(*cloudsearch.DescribeScalingParametersInput) (*service.Request, *cloudsearch.DescribeScalingParametersOutput)
+	DescribeScalingParametersRequest(*cloudsearch.DescribeScalingParametersInput) (*request.Request, *cloudsearch.DescribeScalingParametersOutput)
 
 	DescribeScalingParameters(*cloudsearch.DescribeScalingParametersInput) (*cloudsearch.DescribeScalingParametersOutput, error)
 
-	DescribeServiceAccessPoliciesRequest(*cloudsearch.DescribeServiceAccessPoliciesInput) (*service.Request, *cloudsearch.DescribeServiceAccessPoliciesOutput)
+	DescribeServiceAccessPoliciesRequest(*cloudsearch.DescribeServiceAccessPoliciesInput) (*request.Request, *cloudsearch.DescribeServiceAccessPoliciesOutput)
 
 	DescribeServiceAccessPolicies(*cloudsearch.DescribeServiceAccessPoliciesInput) (*cloudsearch.DescribeServiceAccessPoliciesOutput, error)
 
-	DescribeSuggestersRequest(*cloudsearch.DescribeSuggestersInput) (*service.Request, *cloudsearch.DescribeSuggestersOutput)
+	DescribeSuggestersRequest(*cloudsearch.DescribeSuggestersInput) (*request.Request, *cloudsearch.DescribeSuggestersOutput)
 
 	DescribeSuggesters(*cloudsearch.DescribeSuggestersInput) (*cloudsearch.DescribeSuggestersOutput, error)
 
-	IndexDocumentsRequest(*cloudsearch.IndexDocumentsInput) (*service.Request, *cloudsearch.IndexDocumentsOutput)
+	IndexDocumentsRequest(*cloudsearch.IndexDocumentsInput) (*request.Request, *cloudsearch.IndexDocumentsOutput)
 
 	IndexDocuments(*cloudsearch.IndexDocumentsInput) (*cloudsearch.IndexDocumentsOutput, error)
 
-	ListDomainNamesRequest(*cloudsearch.ListDomainNamesInput) (*service.Request, *cloudsearch.ListDomainNamesOutput)
+	ListDomainNamesRequest(*cloudsearch.ListDomainNamesInput) (*request.Request, *cloudsearch.ListDomainNamesOutput)
 
 	ListDomainNames(*cloudsearch.ListDomainNamesInput) (*cloudsearch.ListDomainNamesOutput, error)
 
-	UpdateAvailabilityOptionsRequest(*cloudsearch.UpdateAvailabilityOptionsInput) (*service.Request, *cloudsearch.UpdateAvailabilityOptionsOutput)
+	UpdateAvailabilityOptionsRequest(*cloudsearch.UpdateAvailabilityOptionsInput) (*request.Request, *cloudsearch.UpdateAvailabilityOptionsOutput)
 
 	UpdateAvailabilityOptions(*cloudsearch.UpdateAvailabilityOptionsInput) (*cloudsearch.UpdateAvailabilityOptionsOutput, error)
 
-	UpdateScalingParametersRequest(*cloudsearch.UpdateScalingParametersInput) (*service.Request, *cloudsearch.UpdateScalingParametersOutput)
+	UpdateScalingParametersRequest(*cloudsearch.UpdateScalingParametersInput) (*request.Request, *cloudsearch.UpdateScalingParametersOutput)
 
 	UpdateScalingParameters(*cloudsearch.UpdateScalingParametersInput) (*cloudsearch.UpdateScalingParametersOutput, error)
 
-	UpdateServiceAccessPoliciesRequest(*cloudsearch.UpdateServiceAccessPoliciesInput) (*service.Request, *cloudsearch.UpdateServiceAccessPoliciesOutput)
+	UpdateServiceAccessPoliciesRequest(*cloudsearch.UpdateServiceAccessPoliciesInput) (*request.Request, *cloudsearch.UpdateServiceAccessPoliciesOutput)
 
 	UpdateServiceAccessPolicies(*cloudsearch.UpdateServiceAccessPoliciesInput) (*cloudsearch.UpdateServiceAccessPoliciesOutput, error)
 }

--- a/service/cloudsearch/service.go
+++ b/service/cloudsearch/service.go
@@ -5,7 +5,9 @@ package cloudsearch
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -27,14 +29,16 @@ type CloudSearch struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CloudSearch client.
 func New(config *aws.Config) *CloudSearch {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "cloudsearch",
-		APIVersion:  "2013-01-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "cloudsearch",
+			APIVersion:  "2013-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -55,8 +59,8 @@ func New(config *aws.Config) *CloudSearch {
 
 // newRequest creates a new request for a CloudSearch operation and runs any
 // custom request initialization.
-func (c *CloudSearch) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CloudSearch) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cloudsearchdomain/api.go
+++ b/service/cloudsearchdomain/api.go
@@ -7,14 +7,14 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opSearch = "Search"
 
 // SearchRequest generates a request for the Search operation.
-func (c *CloudSearchDomain) SearchRequest(input *SearchInput) (req *service.Request, output *SearchOutput) {
-	op := &service.Operation{
+func (c *CloudSearchDomain) SearchRequest(input *SearchInput) (req *request.Request, output *SearchOutput) {
+	op := &request.Operation{
 		Name:       opSearch,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-01-01/search?format=sdk&pretty=true",
@@ -58,8 +58,8 @@ func (c *CloudSearchDomain) Search(input *SearchInput) (*SearchOutput, error) {
 const opSuggest = "Suggest"
 
 // SuggestRequest generates a request for the Suggest operation.
-func (c *CloudSearchDomain) SuggestRequest(input *SuggestInput) (req *service.Request, output *SuggestOutput) {
-	op := &service.Operation{
+func (c *CloudSearchDomain) SuggestRequest(input *SuggestInput) (req *request.Request, output *SuggestOutput) {
+	op := &request.Operation{
 		Name:       opSuggest,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-01-01/suggest?format=sdk&pretty=true",
@@ -101,8 +101,8 @@ func (c *CloudSearchDomain) Suggest(input *SuggestInput) (*SuggestOutput, error)
 const opUploadDocuments = "UploadDocuments"
 
 // UploadDocumentsRequest generates a request for the UploadDocuments operation.
-func (c *CloudSearchDomain) UploadDocumentsRequest(input *UploadDocumentsInput) (req *service.Request, output *UploadDocumentsOutput) {
-	op := &service.Operation{
+func (c *CloudSearchDomain) UploadDocumentsRequest(input *UploadDocumentsInput) (req *request.Request, output *UploadDocumentsOutput) {
+	op := &request.Operation{
 		Name:       opUploadDocuments,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-01-01/documents/batch?format=sdk",

--- a/service/cloudsearchdomain/cloudsearchdomainiface/interface.go
+++ b/service/cloudsearchdomain/cloudsearchdomainiface/interface.go
@@ -4,21 +4,21 @@
 package cloudsearchdomainiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudsearchdomain"
 )
 
 // CloudSearchDomainAPI is the interface type for cloudsearchdomain.CloudSearchDomain.
 type CloudSearchDomainAPI interface {
-	SearchRequest(*cloudsearchdomain.SearchInput) (*service.Request, *cloudsearchdomain.SearchOutput)
+	SearchRequest(*cloudsearchdomain.SearchInput) (*request.Request, *cloudsearchdomain.SearchOutput)
 
 	Search(*cloudsearchdomain.SearchInput) (*cloudsearchdomain.SearchOutput, error)
 
-	SuggestRequest(*cloudsearchdomain.SuggestInput) (*service.Request, *cloudsearchdomain.SuggestOutput)
+	SuggestRequest(*cloudsearchdomain.SuggestInput) (*request.Request, *cloudsearchdomain.SuggestOutput)
 
 	Suggest(*cloudsearchdomain.SuggestInput) (*cloudsearchdomain.SuggestOutput, error)
 
-	UploadDocumentsRequest(*cloudsearchdomain.UploadDocumentsInput) (*service.Request, *cloudsearchdomain.UploadDocumentsOutput)
+	UploadDocumentsRequest(*cloudsearchdomain.UploadDocumentsInput) (*request.Request, *cloudsearchdomain.UploadDocumentsOutput)
 
 	UploadDocuments(*cloudsearchdomain.UploadDocumentsInput) (*cloudsearchdomain.UploadDocumentsOutput, error)
 }

--- a/service/cloudsearchdomain/customizations_test.go
+++ b/service/cloudsearchdomain/customizations_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/service"
 	"github.com/aws/aws-sdk-go/service/cloudsearchdomain"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,7 +18,7 @@ func TestRequireEndpointIfRegionProvided(t *testing.T) {
 
 	assert.Equal(t, "", svc.Endpoint)
 	assert.Error(t, err)
-	assert.Equal(t, service.ErrMissingEndpoint, err)
+	assert.Equal(t, aws.ErrMissingEndpoint, err)
 }
 
 func TestRequireEndpointIfNoRegionProvided(t *testing.T) {
@@ -32,7 +31,7 @@ func TestRequireEndpointIfNoRegionProvided(t *testing.T) {
 
 	assert.Equal(t, "", svc.Endpoint)
 	assert.Error(t, err)
-	assert.Equal(t, service.ErrMissingEndpoint, err)
+	assert.Equal(t, aws.ErrMissingEndpoint, err)
 }
 
 func TestRequireEndpointUsed(t *testing.T) {

--- a/service/cloudsearchdomain/service.go
+++ b/service/cloudsearchdomain/service.go
@@ -5,7 +5,9 @@ package cloudsearchdomain
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -28,15 +30,17 @@ type CloudSearchDomain struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CloudSearchDomain client.
 func New(config *aws.Config) *CloudSearchDomain {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "cloudsearchdomain",
-		SigningName: "cloudsearch",
-		APIVersion:  "2013-01-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "cloudsearchdomain",
+			SigningName: "cloudsearch",
+			APIVersion:  "2013-01-01",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func New(config *aws.Config) *CloudSearchDomain {
 
 // newRequest creates a new request for a CloudSearchDomain operation and runs any
 // custom request initialization.
-func (c *CloudSearchDomain) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CloudSearchDomain) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cloudtrail/api.go
+++ b/service/cloudtrail/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateTrail = "CreateTrail"
 
 // CreateTrailRequest generates a request for the CreateTrail operation.
-func (c *CloudTrail) CreateTrailRequest(input *CreateTrailInput) (req *service.Request, output *CreateTrailOutput) {
-	op := &service.Operation{
+func (c *CloudTrail) CreateTrailRequest(input *CreateTrailInput) (req *request.Request, output *CreateTrailOutput) {
+	op := &request.Operation{
 		Name:       opCreateTrail,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -43,8 +43,8 @@ func (c *CloudTrail) CreateTrail(input *CreateTrailInput) (*CreateTrailOutput, e
 const opDeleteTrail = "DeleteTrail"
 
 // DeleteTrailRequest generates a request for the DeleteTrail operation.
-func (c *CloudTrail) DeleteTrailRequest(input *DeleteTrailInput) (req *service.Request, output *DeleteTrailOutput) {
-	op := &service.Operation{
+func (c *CloudTrail) DeleteTrailRequest(input *DeleteTrailInput) (req *request.Request, output *DeleteTrailOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTrail,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -70,8 +70,8 @@ func (c *CloudTrail) DeleteTrail(input *DeleteTrailInput) (*DeleteTrailOutput, e
 const opDescribeTrails = "DescribeTrails"
 
 // DescribeTrailsRequest generates a request for the DescribeTrails operation.
-func (c *CloudTrail) DescribeTrailsRequest(input *DescribeTrailsInput) (req *service.Request, output *DescribeTrailsOutput) {
-	op := &service.Operation{
+func (c *CloudTrail) DescribeTrailsRequest(input *DescribeTrailsInput) (req *request.Request, output *DescribeTrailsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTrails,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -98,8 +98,8 @@ func (c *CloudTrail) DescribeTrails(input *DescribeTrailsInput) (*DescribeTrails
 const opGetTrailStatus = "GetTrailStatus"
 
 // GetTrailStatusRequest generates a request for the GetTrailStatus operation.
-func (c *CloudTrail) GetTrailStatusRequest(input *GetTrailStatusInput) (req *service.Request, output *GetTrailStatusOutput) {
-	op := &service.Operation{
+func (c *CloudTrail) GetTrailStatusRequest(input *GetTrailStatusInput) (req *request.Request, output *GetTrailStatusOutput) {
+	op := &request.Operation{
 		Name:       opGetTrailStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -127,8 +127,8 @@ func (c *CloudTrail) GetTrailStatus(input *GetTrailStatusInput) (*GetTrailStatus
 const opLookupEvents = "LookupEvents"
 
 // LookupEventsRequest generates a request for the LookupEvents operation.
-func (c *CloudTrail) LookupEventsRequest(input *LookupEventsInput) (req *service.Request, output *LookupEventsOutput) {
-	op := &service.Operation{
+func (c *CloudTrail) LookupEventsRequest(input *LookupEventsInput) (req *request.Request, output *LookupEventsOutput) {
+	op := &request.Operation{
 		Name:       opLookupEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -167,8 +167,8 @@ func (c *CloudTrail) LookupEvents(input *LookupEventsInput) (*LookupEventsOutput
 const opStartLogging = "StartLogging"
 
 // StartLoggingRequest generates a request for the StartLogging operation.
-func (c *CloudTrail) StartLoggingRequest(input *StartLoggingInput) (req *service.Request, output *StartLoggingOutput) {
-	op := &service.Operation{
+func (c *CloudTrail) StartLoggingRequest(input *StartLoggingInput) (req *request.Request, output *StartLoggingOutput) {
+	op := &request.Operation{
 		Name:       opStartLogging,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -194,8 +194,8 @@ func (c *CloudTrail) StartLogging(input *StartLoggingInput) (*StartLoggingOutput
 const opStopLogging = "StopLogging"
 
 // StopLoggingRequest generates a request for the StopLogging operation.
-func (c *CloudTrail) StopLoggingRequest(input *StopLoggingInput) (req *service.Request, output *StopLoggingOutput) {
-	op := &service.Operation{
+func (c *CloudTrail) StopLoggingRequest(input *StopLoggingInput) (req *request.Request, output *StopLoggingOutput) {
+	op := &request.Operation{
 		Name:       opStopLogging,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -224,8 +224,8 @@ func (c *CloudTrail) StopLogging(input *StopLoggingInput) (*StopLoggingOutput, e
 const opUpdateTrail = "UpdateTrail"
 
 // UpdateTrailRequest generates a request for the UpdateTrail operation.
-func (c *CloudTrail) UpdateTrailRequest(input *UpdateTrailInput) (req *service.Request, output *UpdateTrailOutput) {
-	op := &service.Operation{
+func (c *CloudTrail) UpdateTrailRequest(input *UpdateTrailInput) (req *request.Request, output *UpdateTrailOutput) {
+	op := &request.Operation{
 		Name:       opUpdateTrail,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/cloudtrail/cloudtrailiface/interface.go
+++ b/service/cloudtrail/cloudtrailiface/interface.go
@@ -4,41 +4,41 @@
 package cloudtrailiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
 )
 
 // CloudTrailAPI is the interface type for cloudtrail.CloudTrail.
 type CloudTrailAPI interface {
-	CreateTrailRequest(*cloudtrail.CreateTrailInput) (*service.Request, *cloudtrail.CreateTrailOutput)
+	CreateTrailRequest(*cloudtrail.CreateTrailInput) (*request.Request, *cloudtrail.CreateTrailOutput)
 
 	CreateTrail(*cloudtrail.CreateTrailInput) (*cloudtrail.CreateTrailOutput, error)
 
-	DeleteTrailRequest(*cloudtrail.DeleteTrailInput) (*service.Request, *cloudtrail.DeleteTrailOutput)
+	DeleteTrailRequest(*cloudtrail.DeleteTrailInput) (*request.Request, *cloudtrail.DeleteTrailOutput)
 
 	DeleteTrail(*cloudtrail.DeleteTrailInput) (*cloudtrail.DeleteTrailOutput, error)
 
-	DescribeTrailsRequest(*cloudtrail.DescribeTrailsInput) (*service.Request, *cloudtrail.DescribeTrailsOutput)
+	DescribeTrailsRequest(*cloudtrail.DescribeTrailsInput) (*request.Request, *cloudtrail.DescribeTrailsOutput)
 
 	DescribeTrails(*cloudtrail.DescribeTrailsInput) (*cloudtrail.DescribeTrailsOutput, error)
 
-	GetTrailStatusRequest(*cloudtrail.GetTrailStatusInput) (*service.Request, *cloudtrail.GetTrailStatusOutput)
+	GetTrailStatusRequest(*cloudtrail.GetTrailStatusInput) (*request.Request, *cloudtrail.GetTrailStatusOutput)
 
 	GetTrailStatus(*cloudtrail.GetTrailStatusInput) (*cloudtrail.GetTrailStatusOutput, error)
 
-	LookupEventsRequest(*cloudtrail.LookupEventsInput) (*service.Request, *cloudtrail.LookupEventsOutput)
+	LookupEventsRequest(*cloudtrail.LookupEventsInput) (*request.Request, *cloudtrail.LookupEventsOutput)
 
 	LookupEvents(*cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error)
 
-	StartLoggingRequest(*cloudtrail.StartLoggingInput) (*service.Request, *cloudtrail.StartLoggingOutput)
+	StartLoggingRequest(*cloudtrail.StartLoggingInput) (*request.Request, *cloudtrail.StartLoggingOutput)
 
 	StartLogging(*cloudtrail.StartLoggingInput) (*cloudtrail.StartLoggingOutput, error)
 
-	StopLoggingRequest(*cloudtrail.StopLoggingInput) (*service.Request, *cloudtrail.StopLoggingOutput)
+	StopLoggingRequest(*cloudtrail.StopLoggingInput) (*request.Request, *cloudtrail.StopLoggingOutput)
 
 	StopLogging(*cloudtrail.StopLoggingInput) (*cloudtrail.StopLoggingOutput, error)
 
-	UpdateTrailRequest(*cloudtrail.UpdateTrailInput) (*service.Request, *cloudtrail.UpdateTrailOutput)
+	UpdateTrailRequest(*cloudtrail.UpdateTrailInput) (*request.Request, *cloudtrail.UpdateTrailOutput)
 
 	UpdateTrail(*cloudtrail.UpdateTrailInput) (*cloudtrail.UpdateTrailOutput, error)
 }

--- a/service/cloudtrail/service.go
+++ b/service/cloudtrail/service.go
@@ -5,7 +5,9 @@ package cloudtrail
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -37,16 +39,18 @@ type CloudTrail struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CloudTrail client.
 func New(config *aws.Config) *CloudTrail {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "cloudtrail",
-		APIVersion:   "2013-11-01",
-		JSONVersion:  "1.1",
-		TargetPrefix: "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "cloudtrail",
+			APIVersion:   "2013-11-01",
+			JSONVersion:  "1.1",
+			TargetPrefix: "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101",
+		},
 	}
 	service.Initialize()
 
@@ -67,8 +71,8 @@ func New(config *aws.Config) *CloudTrail {
 
 // newRequest creates a new request for a CloudTrail operation and runs any
 // custom request initialization.
-func (c *CloudTrail) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CloudTrail) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cloudwatch/api.go
+++ b/service/cloudwatch/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opDeleteAlarms = "DeleteAlarms"
 
 // DeleteAlarmsRequest generates a request for the DeleteAlarms operation.
-func (c *CloudWatch) DeleteAlarmsRequest(input *DeleteAlarmsInput) (req *service.Request, output *DeleteAlarmsOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) DeleteAlarmsRequest(input *DeleteAlarmsInput) (req *request.Request, output *DeleteAlarmsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteAlarms,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -40,12 +40,12 @@ func (c *CloudWatch) DeleteAlarms(input *DeleteAlarmsInput) (*DeleteAlarmsOutput
 const opDescribeAlarmHistory = "DescribeAlarmHistory"
 
 // DescribeAlarmHistoryRequest generates a request for the DescribeAlarmHistory operation.
-func (c *CloudWatch) DescribeAlarmHistoryRequest(input *DescribeAlarmHistoryInput) (req *service.Request, output *DescribeAlarmHistoryOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) DescribeAlarmHistoryRequest(input *DescribeAlarmHistoryInput) (req *request.Request, output *DescribeAlarmHistoryOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAlarmHistory,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -82,12 +82,12 @@ func (c *CloudWatch) DescribeAlarmHistoryPages(input *DescribeAlarmHistoryInput,
 const opDescribeAlarms = "DescribeAlarms"
 
 // DescribeAlarmsRequest generates a request for the DescribeAlarms operation.
-func (c *CloudWatch) DescribeAlarmsRequest(input *DescribeAlarmsInput) (req *service.Request, output *DescribeAlarmsOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) DescribeAlarmsRequest(input *DescribeAlarmsInput) (req *request.Request, output *DescribeAlarmsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAlarms,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -124,8 +124,8 @@ func (c *CloudWatch) DescribeAlarmsPages(input *DescribeAlarmsInput, fn func(p *
 const opDescribeAlarmsForMetric = "DescribeAlarmsForMetric"
 
 // DescribeAlarmsForMetricRequest generates a request for the DescribeAlarmsForMetric operation.
-func (c *CloudWatch) DescribeAlarmsForMetricRequest(input *DescribeAlarmsForMetricInput) (req *service.Request, output *DescribeAlarmsForMetricOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) DescribeAlarmsForMetricRequest(input *DescribeAlarmsForMetricInput) (req *request.Request, output *DescribeAlarmsForMetricOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAlarmsForMetric,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -152,8 +152,8 @@ func (c *CloudWatch) DescribeAlarmsForMetric(input *DescribeAlarmsForMetricInput
 const opDisableAlarmActions = "DisableAlarmActions"
 
 // DisableAlarmActionsRequest generates a request for the DisableAlarmActions operation.
-func (c *CloudWatch) DisableAlarmActionsRequest(input *DisableAlarmActionsInput) (req *service.Request, output *DisableAlarmActionsOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) DisableAlarmActionsRequest(input *DisableAlarmActionsInput) (req *request.Request, output *DisableAlarmActionsOutput) {
+	op := &request.Operation{
 		Name:       opDisableAlarmActions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -180,8 +180,8 @@ func (c *CloudWatch) DisableAlarmActions(input *DisableAlarmActionsInput) (*Disa
 const opEnableAlarmActions = "EnableAlarmActions"
 
 // EnableAlarmActionsRequest generates a request for the EnableAlarmActions operation.
-func (c *CloudWatch) EnableAlarmActionsRequest(input *EnableAlarmActionsInput) (req *service.Request, output *EnableAlarmActionsOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) EnableAlarmActionsRequest(input *EnableAlarmActionsInput) (req *request.Request, output *EnableAlarmActionsOutput) {
+	op := &request.Operation{
 		Name:       opEnableAlarmActions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -207,8 +207,8 @@ func (c *CloudWatch) EnableAlarmActions(input *EnableAlarmActionsInput) (*Enable
 const opGetMetricStatistics = "GetMetricStatistics"
 
 // GetMetricStatisticsRequest generates a request for the GetMetricStatistics operation.
-func (c *CloudWatch) GetMetricStatisticsRequest(input *GetMetricStatisticsInput) (req *service.Request, output *GetMetricStatisticsOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) GetMetricStatisticsRequest(input *GetMetricStatisticsInput) (req *request.Request, output *GetMetricStatisticsOutput) {
+	op := &request.Operation{
 		Name:       opGetMetricStatistics,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -259,12 +259,12 @@ func (c *CloudWatch) GetMetricStatistics(input *GetMetricStatisticsInput) (*GetM
 const opListMetrics = "ListMetrics"
 
 // ListMetricsRequest generates a request for the ListMetrics operation.
-func (c *CloudWatch) ListMetricsRequest(input *ListMetricsInput) (req *service.Request, output *ListMetricsOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) ListMetricsRequest(input *ListMetricsInput) (req *request.Request, output *ListMetricsOutput) {
+	op := &request.Operation{
 		Name:       opListMetrics,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -301,8 +301,8 @@ func (c *CloudWatch) ListMetricsPages(input *ListMetricsInput, fn func(p *ListMe
 const opPutMetricAlarm = "PutMetricAlarm"
 
 // PutMetricAlarmRequest generates a request for the PutMetricAlarm operation.
-func (c *CloudWatch) PutMetricAlarmRequest(input *PutMetricAlarmInput) (req *service.Request, output *PutMetricAlarmOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) PutMetricAlarmRequest(input *PutMetricAlarmInput) (req *request.Request, output *PutMetricAlarmOutput) {
+	op := &request.Operation{
 		Name:       opPutMetricAlarm,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -334,8 +334,8 @@ func (c *CloudWatch) PutMetricAlarm(input *PutMetricAlarmInput) (*PutMetricAlarm
 const opPutMetricData = "PutMetricData"
 
 // PutMetricDataRequest generates a request for the PutMetricData operation.
-func (c *CloudWatch) PutMetricDataRequest(input *PutMetricDataInput) (req *service.Request, output *PutMetricDataOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) PutMetricDataRequest(input *PutMetricDataInput) (req *request.Request, output *PutMetricDataOutput) {
+	op := &request.Operation{
 		Name:       opPutMetricData,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -374,8 +374,8 @@ func (c *CloudWatch) PutMetricData(input *PutMetricDataInput) (*PutMetricDataOut
 const opSetAlarmState = "SetAlarmState"
 
 // SetAlarmStateRequest generates a request for the SetAlarmState operation.
-func (c *CloudWatch) SetAlarmStateRequest(input *SetAlarmStateInput) (req *service.Request, output *SetAlarmStateOutput) {
-	op := &service.Operation{
+func (c *CloudWatch) SetAlarmStateRequest(input *SetAlarmStateInput) (req *request.Request, output *SetAlarmStateOutput) {
+	op := &request.Operation{
 		Name:       opSetAlarmState,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/cloudwatch/cloudwatchiface/interface.go
+++ b/service/cloudwatch/cloudwatchiface/interface.go
@@ -4,59 +4,59 @@
 package cloudwatchiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 )
 
 // CloudWatchAPI is the interface type for cloudwatch.CloudWatch.
 type CloudWatchAPI interface {
-	DeleteAlarmsRequest(*cloudwatch.DeleteAlarmsInput) (*service.Request, *cloudwatch.DeleteAlarmsOutput)
+	DeleteAlarmsRequest(*cloudwatch.DeleteAlarmsInput) (*request.Request, *cloudwatch.DeleteAlarmsOutput)
 
 	DeleteAlarms(*cloudwatch.DeleteAlarmsInput) (*cloudwatch.DeleteAlarmsOutput, error)
 
-	DescribeAlarmHistoryRequest(*cloudwatch.DescribeAlarmHistoryInput) (*service.Request, *cloudwatch.DescribeAlarmHistoryOutput)
+	DescribeAlarmHistoryRequest(*cloudwatch.DescribeAlarmHistoryInput) (*request.Request, *cloudwatch.DescribeAlarmHistoryOutput)
 
 	DescribeAlarmHistory(*cloudwatch.DescribeAlarmHistoryInput) (*cloudwatch.DescribeAlarmHistoryOutput, error)
 
 	DescribeAlarmHistoryPages(*cloudwatch.DescribeAlarmHistoryInput, func(*cloudwatch.DescribeAlarmHistoryOutput, bool) bool) error
 
-	DescribeAlarmsRequest(*cloudwatch.DescribeAlarmsInput) (*service.Request, *cloudwatch.DescribeAlarmsOutput)
+	DescribeAlarmsRequest(*cloudwatch.DescribeAlarmsInput) (*request.Request, *cloudwatch.DescribeAlarmsOutput)
 
 	DescribeAlarms(*cloudwatch.DescribeAlarmsInput) (*cloudwatch.DescribeAlarmsOutput, error)
 
 	DescribeAlarmsPages(*cloudwatch.DescribeAlarmsInput, func(*cloudwatch.DescribeAlarmsOutput, bool) bool) error
 
-	DescribeAlarmsForMetricRequest(*cloudwatch.DescribeAlarmsForMetricInput) (*service.Request, *cloudwatch.DescribeAlarmsForMetricOutput)
+	DescribeAlarmsForMetricRequest(*cloudwatch.DescribeAlarmsForMetricInput) (*request.Request, *cloudwatch.DescribeAlarmsForMetricOutput)
 
 	DescribeAlarmsForMetric(*cloudwatch.DescribeAlarmsForMetricInput) (*cloudwatch.DescribeAlarmsForMetricOutput, error)
 
-	DisableAlarmActionsRequest(*cloudwatch.DisableAlarmActionsInput) (*service.Request, *cloudwatch.DisableAlarmActionsOutput)
+	DisableAlarmActionsRequest(*cloudwatch.DisableAlarmActionsInput) (*request.Request, *cloudwatch.DisableAlarmActionsOutput)
 
 	DisableAlarmActions(*cloudwatch.DisableAlarmActionsInput) (*cloudwatch.DisableAlarmActionsOutput, error)
 
-	EnableAlarmActionsRequest(*cloudwatch.EnableAlarmActionsInput) (*service.Request, *cloudwatch.EnableAlarmActionsOutput)
+	EnableAlarmActionsRequest(*cloudwatch.EnableAlarmActionsInput) (*request.Request, *cloudwatch.EnableAlarmActionsOutput)
 
 	EnableAlarmActions(*cloudwatch.EnableAlarmActionsInput) (*cloudwatch.EnableAlarmActionsOutput, error)
 
-	GetMetricStatisticsRequest(*cloudwatch.GetMetricStatisticsInput) (*service.Request, *cloudwatch.GetMetricStatisticsOutput)
+	GetMetricStatisticsRequest(*cloudwatch.GetMetricStatisticsInput) (*request.Request, *cloudwatch.GetMetricStatisticsOutput)
 
 	GetMetricStatistics(*cloudwatch.GetMetricStatisticsInput) (*cloudwatch.GetMetricStatisticsOutput, error)
 
-	ListMetricsRequest(*cloudwatch.ListMetricsInput) (*service.Request, *cloudwatch.ListMetricsOutput)
+	ListMetricsRequest(*cloudwatch.ListMetricsInput) (*request.Request, *cloudwatch.ListMetricsOutput)
 
 	ListMetrics(*cloudwatch.ListMetricsInput) (*cloudwatch.ListMetricsOutput, error)
 
 	ListMetricsPages(*cloudwatch.ListMetricsInput, func(*cloudwatch.ListMetricsOutput, bool) bool) error
 
-	PutMetricAlarmRequest(*cloudwatch.PutMetricAlarmInput) (*service.Request, *cloudwatch.PutMetricAlarmOutput)
+	PutMetricAlarmRequest(*cloudwatch.PutMetricAlarmInput) (*request.Request, *cloudwatch.PutMetricAlarmOutput)
 
 	PutMetricAlarm(*cloudwatch.PutMetricAlarmInput) (*cloudwatch.PutMetricAlarmOutput, error)
 
-	PutMetricDataRequest(*cloudwatch.PutMetricDataInput) (*service.Request, *cloudwatch.PutMetricDataOutput)
+	PutMetricDataRequest(*cloudwatch.PutMetricDataInput) (*request.Request, *cloudwatch.PutMetricDataOutput)
 
 	PutMetricData(*cloudwatch.PutMetricDataInput) (*cloudwatch.PutMetricDataOutput, error)
 
-	SetAlarmStateRequest(*cloudwatch.SetAlarmStateInput) (*service.Request, *cloudwatch.SetAlarmStateOutput)
+	SetAlarmStateRequest(*cloudwatch.SetAlarmStateInput) (*request.Request, *cloudwatch.SetAlarmStateOutput)
 
 	SetAlarmState(*cloudwatch.SetAlarmStateInput) (*cloudwatch.SetAlarmStateOutput, error)
 }

--- a/service/cloudwatch/service.go
+++ b/service/cloudwatch/service.go
@@ -5,7 +5,9 @@ package cloudwatch
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -58,14 +60,16 @@ type CloudWatch struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CloudWatch client.
 func New(config *aws.Config) *CloudWatch {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "monitoring",
-		APIVersion:  "2010-08-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "monitoring",
+			APIVersion:  "2010-08-01",
+		},
 	}
 	service.Initialize()
 
@@ -86,8 +90,8 @@ func New(config *aws.Config) *CloudWatch {
 
 // newRequest creates a new request for a CloudWatch operation and runs any
 // custom request initialization.
-func (c *CloudWatch) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CloudWatch) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cloudwatchlogs/api.go
+++ b/service/cloudwatchlogs/api.go
@@ -5,14 +5,14 @@ package cloudwatchlogs
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateLogGroup = "CreateLogGroup"
 
 // CreateLogGroupRequest generates a request for the CreateLogGroup operation.
-func (c *CloudWatchLogs) CreateLogGroupRequest(input *CreateLogGroupInput) (req *service.Request, output *CreateLogGroupOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) CreateLogGroupRequest(input *CreateLogGroupInput) (req *request.Request, output *CreateLogGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateLogGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -44,8 +44,8 @@ func (c *CloudWatchLogs) CreateLogGroup(input *CreateLogGroupInput) (*CreateLogG
 const opCreateLogStream = "CreateLogStream"
 
 // CreateLogStreamRequest generates a request for the CreateLogStream operation.
-func (c *CloudWatchLogs) CreateLogStreamRequest(input *CreateLogStreamInput) (req *service.Request, output *CreateLogStreamOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) CreateLogStreamRequest(input *CreateLogStreamInput) (req *request.Request, output *CreateLogStreamOutput) {
+	op := &request.Operation{
 		Name:       opCreateLogStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -77,8 +77,8 @@ func (c *CloudWatchLogs) CreateLogStream(input *CreateLogStreamInput) (*CreateLo
 const opDeleteDestination = "DeleteDestination"
 
 // DeleteDestinationRequest generates a request for the DeleteDestination operation.
-func (c *CloudWatchLogs) DeleteDestinationRequest(input *DeleteDestinationInput) (req *service.Request, output *DeleteDestinationOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DeleteDestinationRequest(input *DeleteDestinationInput) (req *request.Request, output *DeleteDestinationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDestination,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -106,8 +106,8 @@ func (c *CloudWatchLogs) DeleteDestination(input *DeleteDestinationInput) (*Dele
 const opDeleteLogGroup = "DeleteLogGroup"
 
 // DeleteLogGroupRequest generates a request for the DeleteLogGroup operation.
-func (c *CloudWatchLogs) DeleteLogGroupRequest(input *DeleteLogGroupInput) (req *service.Request, output *DeleteLogGroupOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DeleteLogGroupRequest(input *DeleteLogGroupInput) (req *request.Request, output *DeleteLogGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLogGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -134,8 +134,8 @@ func (c *CloudWatchLogs) DeleteLogGroup(input *DeleteLogGroupInput) (*DeleteLogG
 const opDeleteLogStream = "DeleteLogStream"
 
 // DeleteLogStreamRequest generates a request for the DeleteLogStream operation.
-func (c *CloudWatchLogs) DeleteLogStreamRequest(input *DeleteLogStreamInput) (req *service.Request, output *DeleteLogStreamOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DeleteLogStreamRequest(input *DeleteLogStreamInput) (req *request.Request, output *DeleteLogStreamOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLogStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -162,8 +162,8 @@ func (c *CloudWatchLogs) DeleteLogStream(input *DeleteLogStreamInput) (*DeleteLo
 const opDeleteMetricFilter = "DeleteMetricFilter"
 
 // DeleteMetricFilterRequest generates a request for the DeleteMetricFilter operation.
-func (c *CloudWatchLogs) DeleteMetricFilterRequest(input *DeleteMetricFilterInput) (req *service.Request, output *DeleteMetricFilterOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DeleteMetricFilterRequest(input *DeleteMetricFilterInput) (req *request.Request, output *DeleteMetricFilterOutput) {
+	op := &request.Operation{
 		Name:       opDeleteMetricFilter,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -189,8 +189,8 @@ func (c *CloudWatchLogs) DeleteMetricFilter(input *DeleteMetricFilterInput) (*De
 const opDeleteRetentionPolicy = "DeleteRetentionPolicy"
 
 // DeleteRetentionPolicyRequest generates a request for the DeleteRetentionPolicy operation.
-func (c *CloudWatchLogs) DeleteRetentionPolicyRequest(input *DeleteRetentionPolicyInput) (req *service.Request, output *DeleteRetentionPolicyOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DeleteRetentionPolicyRequest(input *DeleteRetentionPolicyInput) (req *request.Request, output *DeleteRetentionPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteRetentionPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -217,8 +217,8 @@ func (c *CloudWatchLogs) DeleteRetentionPolicy(input *DeleteRetentionPolicyInput
 const opDeleteSubscriptionFilter = "DeleteSubscriptionFilter"
 
 // DeleteSubscriptionFilterRequest generates a request for the DeleteSubscriptionFilter operation.
-func (c *CloudWatchLogs) DeleteSubscriptionFilterRequest(input *DeleteSubscriptionFilterInput) (req *service.Request, output *DeleteSubscriptionFilterOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DeleteSubscriptionFilterRequest(input *DeleteSubscriptionFilterInput) (req *request.Request, output *DeleteSubscriptionFilterOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSubscriptionFilter,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -244,8 +244,8 @@ func (c *CloudWatchLogs) DeleteSubscriptionFilter(input *DeleteSubscriptionFilte
 const opDescribeDestinations = "DescribeDestinations"
 
 // DescribeDestinationsRequest generates a request for the DescribeDestinations operation.
-func (c *CloudWatchLogs) DescribeDestinationsRequest(input *DescribeDestinationsInput) (req *service.Request, output *DescribeDestinationsOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DescribeDestinationsRequest(input *DescribeDestinationsInput) (req *request.Request, output *DescribeDestinationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDestinations,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -278,12 +278,12 @@ func (c *CloudWatchLogs) DescribeDestinations(input *DescribeDestinationsInput) 
 const opDescribeLogGroups = "DescribeLogGroups"
 
 // DescribeLogGroupsRequest generates a request for the DescribeLogGroups operation.
-func (c *CloudWatchLogs) DescribeLogGroupsRequest(input *DescribeLogGroupsInput) (req *service.Request, output *DescribeLogGroupsOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DescribeLogGroupsRequest(input *DescribeLogGroupsInput) (req *request.Request, output *DescribeLogGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLogGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "limit",
@@ -325,12 +325,12 @@ func (c *CloudWatchLogs) DescribeLogGroupsPages(input *DescribeLogGroupsInput, f
 const opDescribeLogStreams = "DescribeLogStreams"
 
 // DescribeLogStreamsRequest generates a request for the DescribeLogStreams operation.
-func (c *CloudWatchLogs) DescribeLogStreamsRequest(input *DescribeLogStreamsInput) (req *service.Request, output *DescribeLogStreamsOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DescribeLogStreamsRequest(input *DescribeLogStreamsInput) (req *request.Request, output *DescribeLogStreamsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLogStreams,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "limit",
@@ -373,12 +373,12 @@ func (c *CloudWatchLogs) DescribeLogStreamsPages(input *DescribeLogStreamsInput,
 const opDescribeMetricFilters = "DescribeMetricFilters"
 
 // DescribeMetricFiltersRequest generates a request for the DescribeMetricFilters operation.
-func (c *CloudWatchLogs) DescribeMetricFiltersRequest(input *DescribeMetricFiltersInput) (req *service.Request, output *DescribeMetricFiltersOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DescribeMetricFiltersRequest(input *DescribeMetricFiltersInput) (req *request.Request, output *DescribeMetricFiltersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeMetricFilters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "limit",
@@ -419,8 +419,8 @@ func (c *CloudWatchLogs) DescribeMetricFiltersPages(input *DescribeMetricFilters
 const opDescribeSubscriptionFilters = "DescribeSubscriptionFilters"
 
 // DescribeSubscriptionFiltersRequest generates a request for the DescribeSubscriptionFilters operation.
-func (c *CloudWatchLogs) DescribeSubscriptionFiltersRequest(input *DescribeSubscriptionFiltersInput) (req *service.Request, output *DescribeSubscriptionFiltersOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) DescribeSubscriptionFiltersRequest(input *DescribeSubscriptionFiltersInput) (req *request.Request, output *DescribeSubscriptionFiltersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSubscriptionFilters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -453,8 +453,8 @@ func (c *CloudWatchLogs) DescribeSubscriptionFilters(input *DescribeSubscription
 const opFilterLogEvents = "FilterLogEvents"
 
 // FilterLogEventsRequest generates a request for the FilterLogEvents operation.
-func (c *CloudWatchLogs) FilterLogEventsRequest(input *FilterLogEventsInput) (req *service.Request, output *FilterLogEventsOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) FilterLogEventsRequest(input *FilterLogEventsInput) (req *request.Request, output *FilterLogEventsOutput) {
+	op := &request.Operation{
 		Name:       opFilterLogEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -493,12 +493,12 @@ func (c *CloudWatchLogs) FilterLogEvents(input *FilterLogEventsInput) (*FilterLo
 const opGetLogEvents = "GetLogEvents"
 
 // GetLogEventsRequest generates a request for the GetLogEvents operation.
-func (c *CloudWatchLogs) GetLogEventsRequest(input *GetLogEventsInput) (req *service.Request, output *GetLogEventsOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) GetLogEventsRequest(input *GetLogEventsInput) (req *request.Request, output *GetLogEventsOutput) {
+	op := &request.Operation{
 		Name:       opGetLogEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextForwardToken"},
 			LimitToken:      "limit",
@@ -542,8 +542,8 @@ func (c *CloudWatchLogs) GetLogEventsPages(input *GetLogEventsInput, fn func(p *
 const opPutDestination = "PutDestination"
 
 // PutDestinationRequest generates a request for the PutDestination operation.
-func (c *CloudWatchLogs) PutDestinationRequest(input *PutDestinationInput) (req *service.Request, output *PutDestinationOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) PutDestinationRequest(input *PutDestinationInput) (req *request.Request, output *PutDestinationOutput) {
+	op := &request.Operation{
 		Name:       opPutDestination,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -579,8 +579,8 @@ func (c *CloudWatchLogs) PutDestination(input *PutDestinationInput) (*PutDestina
 const opPutDestinationPolicy = "PutDestinationPolicy"
 
 // PutDestinationPolicyRequest generates a request for the PutDestinationPolicy operation.
-func (c *CloudWatchLogs) PutDestinationPolicyRequest(input *PutDestinationPolicyInput) (req *service.Request, output *PutDestinationPolicyOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) PutDestinationPolicyRequest(input *PutDestinationPolicyInput) (req *request.Request, output *PutDestinationPolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutDestinationPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -609,8 +609,8 @@ func (c *CloudWatchLogs) PutDestinationPolicy(input *PutDestinationPolicyInput) 
 const opPutLogEvents = "PutLogEvents"
 
 // PutLogEventsRequest generates a request for the PutLogEvents operation.
-func (c *CloudWatchLogs) PutLogEventsRequest(input *PutLogEventsInput) (req *service.Request, output *PutLogEventsOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) PutLogEventsRequest(input *PutLogEventsInput) (req *request.Request, output *PutLogEventsOutput) {
+	op := &request.Operation{
 		Name:       opPutLogEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -648,8 +648,8 @@ func (c *CloudWatchLogs) PutLogEvents(input *PutLogEventsInput) (*PutLogEventsOu
 const opPutMetricFilter = "PutMetricFilter"
 
 // PutMetricFilterRequest generates a request for the PutMetricFilter operation.
-func (c *CloudWatchLogs) PutMetricFilterRequest(input *PutMetricFilterInput) (req *service.Request, output *PutMetricFilterOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) PutMetricFilterRequest(input *PutMetricFilterInput) (req *request.Request, output *PutMetricFilterOutput) {
+	op := &request.Operation{
 		Name:       opPutMetricFilter,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -680,8 +680,8 @@ func (c *CloudWatchLogs) PutMetricFilter(input *PutMetricFilterInput) (*PutMetri
 const opPutRetentionPolicy = "PutRetentionPolicy"
 
 // PutRetentionPolicyRequest generates a request for the PutRetentionPolicy operation.
-func (c *CloudWatchLogs) PutRetentionPolicyRequest(input *PutRetentionPolicyInput) (req *service.Request, output *PutRetentionPolicyOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) PutRetentionPolicyRequest(input *PutRetentionPolicyInput) (req *request.Request, output *PutRetentionPolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutRetentionPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -709,8 +709,8 @@ func (c *CloudWatchLogs) PutRetentionPolicy(input *PutRetentionPolicyInput) (*Pu
 const opPutSubscriptionFilter = "PutSubscriptionFilter"
 
 // PutSubscriptionFilterRequest generates a request for the PutSubscriptionFilter operation.
-func (c *CloudWatchLogs) PutSubscriptionFilterRequest(input *PutSubscriptionFilterInput) (req *service.Request, output *PutSubscriptionFilterOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) PutSubscriptionFilterRequest(input *PutSubscriptionFilterInput) (req *request.Request, output *PutSubscriptionFilterOutput) {
+	op := &request.Operation{
 		Name:       opPutSubscriptionFilter,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -745,8 +745,8 @@ func (c *CloudWatchLogs) PutSubscriptionFilter(input *PutSubscriptionFilterInput
 const opTestMetricFilter = "TestMetricFilter"
 
 // TestMetricFilterRequest generates a request for the TestMetricFilter operation.
-func (c *CloudWatchLogs) TestMetricFilterRequest(input *TestMetricFilterInput) (req *service.Request, output *TestMetricFilterOutput) {
-	op := &service.Operation{
+func (c *CloudWatchLogs) TestMetricFilterRequest(input *TestMetricFilterInput) (req *request.Request, output *TestMetricFilterOutput) {
+	op := &request.Operation{
 		Name:       opTestMetricFilter,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/cloudwatchlogs/cloudwatchlogsiface/interface.go
+++ b/service/cloudwatchlogs/cloudwatchlogsiface/interface.go
@@ -4,105 +4,105 @@
 package cloudwatchlogsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
 
 // CloudWatchLogsAPI is the interface type for cloudwatchlogs.CloudWatchLogs.
 type CloudWatchLogsAPI interface {
-	CreateLogGroupRequest(*cloudwatchlogs.CreateLogGroupInput) (*service.Request, *cloudwatchlogs.CreateLogGroupOutput)
+	CreateLogGroupRequest(*cloudwatchlogs.CreateLogGroupInput) (*request.Request, *cloudwatchlogs.CreateLogGroupOutput)
 
 	CreateLogGroup(*cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error)
 
-	CreateLogStreamRequest(*cloudwatchlogs.CreateLogStreamInput) (*service.Request, *cloudwatchlogs.CreateLogStreamOutput)
+	CreateLogStreamRequest(*cloudwatchlogs.CreateLogStreamInput) (*request.Request, *cloudwatchlogs.CreateLogStreamOutput)
 
 	CreateLogStream(*cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error)
 
-	DeleteDestinationRequest(*cloudwatchlogs.DeleteDestinationInput) (*service.Request, *cloudwatchlogs.DeleteDestinationOutput)
+	DeleteDestinationRequest(*cloudwatchlogs.DeleteDestinationInput) (*request.Request, *cloudwatchlogs.DeleteDestinationOutput)
 
 	DeleteDestination(*cloudwatchlogs.DeleteDestinationInput) (*cloudwatchlogs.DeleteDestinationOutput, error)
 
-	DeleteLogGroupRequest(*cloudwatchlogs.DeleteLogGroupInput) (*service.Request, *cloudwatchlogs.DeleteLogGroupOutput)
+	DeleteLogGroupRequest(*cloudwatchlogs.DeleteLogGroupInput) (*request.Request, *cloudwatchlogs.DeleteLogGroupOutput)
 
 	DeleteLogGroup(*cloudwatchlogs.DeleteLogGroupInput) (*cloudwatchlogs.DeleteLogGroupOutput, error)
 
-	DeleteLogStreamRequest(*cloudwatchlogs.DeleteLogStreamInput) (*service.Request, *cloudwatchlogs.DeleteLogStreamOutput)
+	DeleteLogStreamRequest(*cloudwatchlogs.DeleteLogStreamInput) (*request.Request, *cloudwatchlogs.DeleteLogStreamOutput)
 
 	DeleteLogStream(*cloudwatchlogs.DeleteLogStreamInput) (*cloudwatchlogs.DeleteLogStreamOutput, error)
 
-	DeleteMetricFilterRequest(*cloudwatchlogs.DeleteMetricFilterInput) (*service.Request, *cloudwatchlogs.DeleteMetricFilterOutput)
+	DeleteMetricFilterRequest(*cloudwatchlogs.DeleteMetricFilterInput) (*request.Request, *cloudwatchlogs.DeleteMetricFilterOutput)
 
 	DeleteMetricFilter(*cloudwatchlogs.DeleteMetricFilterInput) (*cloudwatchlogs.DeleteMetricFilterOutput, error)
 
-	DeleteRetentionPolicyRequest(*cloudwatchlogs.DeleteRetentionPolicyInput) (*service.Request, *cloudwatchlogs.DeleteRetentionPolicyOutput)
+	DeleteRetentionPolicyRequest(*cloudwatchlogs.DeleteRetentionPolicyInput) (*request.Request, *cloudwatchlogs.DeleteRetentionPolicyOutput)
 
 	DeleteRetentionPolicy(*cloudwatchlogs.DeleteRetentionPolicyInput) (*cloudwatchlogs.DeleteRetentionPolicyOutput, error)
 
-	DeleteSubscriptionFilterRequest(*cloudwatchlogs.DeleteSubscriptionFilterInput) (*service.Request, *cloudwatchlogs.DeleteSubscriptionFilterOutput)
+	DeleteSubscriptionFilterRequest(*cloudwatchlogs.DeleteSubscriptionFilterInput) (*request.Request, *cloudwatchlogs.DeleteSubscriptionFilterOutput)
 
 	DeleteSubscriptionFilter(*cloudwatchlogs.DeleteSubscriptionFilterInput) (*cloudwatchlogs.DeleteSubscriptionFilterOutput, error)
 
-	DescribeDestinationsRequest(*cloudwatchlogs.DescribeDestinationsInput) (*service.Request, *cloudwatchlogs.DescribeDestinationsOutput)
+	DescribeDestinationsRequest(*cloudwatchlogs.DescribeDestinationsInput) (*request.Request, *cloudwatchlogs.DescribeDestinationsOutput)
 
 	DescribeDestinations(*cloudwatchlogs.DescribeDestinationsInput) (*cloudwatchlogs.DescribeDestinationsOutput, error)
 
-	DescribeLogGroupsRequest(*cloudwatchlogs.DescribeLogGroupsInput) (*service.Request, *cloudwatchlogs.DescribeLogGroupsOutput)
+	DescribeLogGroupsRequest(*cloudwatchlogs.DescribeLogGroupsInput) (*request.Request, *cloudwatchlogs.DescribeLogGroupsOutput)
 
 	DescribeLogGroups(*cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
 
 	DescribeLogGroupsPages(*cloudwatchlogs.DescribeLogGroupsInput, func(*cloudwatchlogs.DescribeLogGroupsOutput, bool) bool) error
 
-	DescribeLogStreamsRequest(*cloudwatchlogs.DescribeLogStreamsInput) (*service.Request, *cloudwatchlogs.DescribeLogStreamsOutput)
+	DescribeLogStreamsRequest(*cloudwatchlogs.DescribeLogStreamsInput) (*request.Request, *cloudwatchlogs.DescribeLogStreamsOutput)
 
 	DescribeLogStreams(*cloudwatchlogs.DescribeLogStreamsInput) (*cloudwatchlogs.DescribeLogStreamsOutput, error)
 
 	DescribeLogStreamsPages(*cloudwatchlogs.DescribeLogStreamsInput, func(*cloudwatchlogs.DescribeLogStreamsOutput, bool) bool) error
 
-	DescribeMetricFiltersRequest(*cloudwatchlogs.DescribeMetricFiltersInput) (*service.Request, *cloudwatchlogs.DescribeMetricFiltersOutput)
+	DescribeMetricFiltersRequest(*cloudwatchlogs.DescribeMetricFiltersInput) (*request.Request, *cloudwatchlogs.DescribeMetricFiltersOutput)
 
 	DescribeMetricFilters(*cloudwatchlogs.DescribeMetricFiltersInput) (*cloudwatchlogs.DescribeMetricFiltersOutput, error)
 
 	DescribeMetricFiltersPages(*cloudwatchlogs.DescribeMetricFiltersInput, func(*cloudwatchlogs.DescribeMetricFiltersOutput, bool) bool) error
 
-	DescribeSubscriptionFiltersRequest(*cloudwatchlogs.DescribeSubscriptionFiltersInput) (*service.Request, *cloudwatchlogs.DescribeSubscriptionFiltersOutput)
+	DescribeSubscriptionFiltersRequest(*cloudwatchlogs.DescribeSubscriptionFiltersInput) (*request.Request, *cloudwatchlogs.DescribeSubscriptionFiltersOutput)
 
 	DescribeSubscriptionFilters(*cloudwatchlogs.DescribeSubscriptionFiltersInput) (*cloudwatchlogs.DescribeSubscriptionFiltersOutput, error)
 
-	FilterLogEventsRequest(*cloudwatchlogs.FilterLogEventsInput) (*service.Request, *cloudwatchlogs.FilterLogEventsOutput)
+	FilterLogEventsRequest(*cloudwatchlogs.FilterLogEventsInput) (*request.Request, *cloudwatchlogs.FilterLogEventsOutput)
 
 	FilterLogEvents(*cloudwatchlogs.FilterLogEventsInput) (*cloudwatchlogs.FilterLogEventsOutput, error)
 
-	GetLogEventsRequest(*cloudwatchlogs.GetLogEventsInput) (*service.Request, *cloudwatchlogs.GetLogEventsOutput)
+	GetLogEventsRequest(*cloudwatchlogs.GetLogEventsInput) (*request.Request, *cloudwatchlogs.GetLogEventsOutput)
 
 	GetLogEvents(*cloudwatchlogs.GetLogEventsInput) (*cloudwatchlogs.GetLogEventsOutput, error)
 
 	GetLogEventsPages(*cloudwatchlogs.GetLogEventsInput, func(*cloudwatchlogs.GetLogEventsOutput, bool) bool) error
 
-	PutDestinationRequest(*cloudwatchlogs.PutDestinationInput) (*service.Request, *cloudwatchlogs.PutDestinationOutput)
+	PutDestinationRequest(*cloudwatchlogs.PutDestinationInput) (*request.Request, *cloudwatchlogs.PutDestinationOutput)
 
 	PutDestination(*cloudwatchlogs.PutDestinationInput) (*cloudwatchlogs.PutDestinationOutput, error)
 
-	PutDestinationPolicyRequest(*cloudwatchlogs.PutDestinationPolicyInput) (*service.Request, *cloudwatchlogs.PutDestinationPolicyOutput)
+	PutDestinationPolicyRequest(*cloudwatchlogs.PutDestinationPolicyInput) (*request.Request, *cloudwatchlogs.PutDestinationPolicyOutput)
 
 	PutDestinationPolicy(*cloudwatchlogs.PutDestinationPolicyInput) (*cloudwatchlogs.PutDestinationPolicyOutput, error)
 
-	PutLogEventsRequest(*cloudwatchlogs.PutLogEventsInput) (*service.Request, *cloudwatchlogs.PutLogEventsOutput)
+	PutLogEventsRequest(*cloudwatchlogs.PutLogEventsInput) (*request.Request, *cloudwatchlogs.PutLogEventsOutput)
 
 	PutLogEvents(*cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error)
 
-	PutMetricFilterRequest(*cloudwatchlogs.PutMetricFilterInput) (*service.Request, *cloudwatchlogs.PutMetricFilterOutput)
+	PutMetricFilterRequest(*cloudwatchlogs.PutMetricFilterInput) (*request.Request, *cloudwatchlogs.PutMetricFilterOutput)
 
 	PutMetricFilter(*cloudwatchlogs.PutMetricFilterInput) (*cloudwatchlogs.PutMetricFilterOutput, error)
 
-	PutRetentionPolicyRequest(*cloudwatchlogs.PutRetentionPolicyInput) (*service.Request, *cloudwatchlogs.PutRetentionPolicyOutput)
+	PutRetentionPolicyRequest(*cloudwatchlogs.PutRetentionPolicyInput) (*request.Request, *cloudwatchlogs.PutRetentionPolicyOutput)
 
 	PutRetentionPolicy(*cloudwatchlogs.PutRetentionPolicyInput) (*cloudwatchlogs.PutRetentionPolicyOutput, error)
 
-	PutSubscriptionFilterRequest(*cloudwatchlogs.PutSubscriptionFilterInput) (*service.Request, *cloudwatchlogs.PutSubscriptionFilterOutput)
+	PutSubscriptionFilterRequest(*cloudwatchlogs.PutSubscriptionFilterInput) (*request.Request, *cloudwatchlogs.PutSubscriptionFilterOutput)
 
 	PutSubscriptionFilter(*cloudwatchlogs.PutSubscriptionFilterInput) (*cloudwatchlogs.PutSubscriptionFilterOutput, error)
 
-	TestMetricFilterRequest(*cloudwatchlogs.TestMetricFilterInput) (*service.Request, *cloudwatchlogs.TestMetricFilterOutput)
+	TestMetricFilterRequest(*cloudwatchlogs.TestMetricFilterInput) (*request.Request, *cloudwatchlogs.TestMetricFilterOutput)
 
 	TestMetricFilter(*cloudwatchlogs.TestMetricFilterInput) (*cloudwatchlogs.TestMetricFilterOutput, error)
 }

--- a/service/cloudwatchlogs/service.go
+++ b/service/cloudwatchlogs/service.go
@@ -5,7 +5,9 @@ package cloudwatchlogs
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -50,16 +52,18 @@ type CloudWatchLogs struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CloudWatchLogs client.
 func New(config *aws.Config) *CloudWatchLogs {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "logs",
-		APIVersion:   "2014-03-28",
-		JSONVersion:  "1.1",
-		TargetPrefix: "Logs_20140328",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "logs",
+			APIVersion:   "2014-03-28",
+			JSONVersion:  "1.1",
+			TargetPrefix: "Logs_20140328",
+		},
 	}
 	service.Initialize()
 
@@ -80,8 +84,8 @@ func New(config *aws.Config) *CloudWatchLogs {
 
 // newRequest creates a new request for a CloudWatchLogs operation and runs any
 // custom request initialization.
-func (c *CloudWatchLogs) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CloudWatchLogs) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/codecommit/api.go
+++ b/service/codecommit/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opBatchGetRepositories = "BatchGetRepositories"
 
 // BatchGetRepositoriesRequest generates a request for the BatchGetRepositories operation.
-func (c *CodeCommit) BatchGetRepositoriesRequest(input *BatchGetRepositoriesInput) (req *service.Request, output *BatchGetRepositoriesOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) BatchGetRepositoriesRequest(input *BatchGetRepositoriesInput) (req *request.Request, output *BatchGetRepositoriesOutput) {
+	op := &request.Operation{
 		Name:       opBatchGetRepositories,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -46,8 +46,8 @@ func (c *CodeCommit) BatchGetRepositories(input *BatchGetRepositoriesInput) (*Ba
 const opCreateBranch = "CreateBranch"
 
 // CreateBranchRequest generates a request for the CreateBranch operation.
-func (c *CodeCommit) CreateBranchRequest(input *CreateBranchInput) (req *service.Request, output *CreateBranchOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) CreateBranchRequest(input *CreateBranchInput) (req *request.Request, output *CreateBranchOutput) {
+	op := &request.Operation{
 		Name:       opCreateBranch,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -76,8 +76,8 @@ func (c *CodeCommit) CreateBranch(input *CreateBranchInput) (*CreateBranchOutput
 const opCreateRepository = "CreateRepository"
 
 // CreateRepositoryRequest generates a request for the CreateRepository operation.
-func (c *CodeCommit) CreateRepositoryRequest(input *CreateRepositoryInput) (req *service.Request, output *CreateRepositoryOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) CreateRepositoryRequest(input *CreateRepositoryInput) (req *request.Request, output *CreateRepositoryOutput) {
+	op := &request.Operation{
 		Name:       opCreateRepository,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -103,8 +103,8 @@ func (c *CodeCommit) CreateRepository(input *CreateRepositoryInput) (*CreateRepo
 const opDeleteRepository = "DeleteRepository"
 
 // DeleteRepositoryRequest generates a request for the DeleteRepository operation.
-func (c *CodeCommit) DeleteRepositoryRequest(input *DeleteRepositoryInput) (req *service.Request, output *DeleteRepositoryOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) DeleteRepositoryRequest(input *DeleteRepositoryInput) (req *request.Request, output *DeleteRepositoryOutput) {
+	op := &request.Operation{
 		Name:       opDeleteRepository,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -135,8 +135,8 @@ func (c *CodeCommit) DeleteRepository(input *DeleteRepositoryInput) (*DeleteRepo
 const opGetBranch = "GetBranch"
 
 // GetBranchRequest generates a request for the GetBranch operation.
-func (c *CodeCommit) GetBranchRequest(input *GetBranchInput) (req *service.Request, output *GetBranchOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) GetBranchRequest(input *GetBranchInput) (req *request.Request, output *GetBranchOutput) {
+	op := &request.Operation{
 		Name:       opGetBranch,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -163,8 +163,8 @@ func (c *CodeCommit) GetBranch(input *GetBranchInput) (*GetBranchOutput, error) 
 const opGetRepository = "GetRepository"
 
 // GetRepositoryRequest generates a request for the GetRepository operation.
-func (c *CodeCommit) GetRepositoryRequest(input *GetRepositoryInput) (req *service.Request, output *GetRepositoryOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) GetRepositoryRequest(input *GetRepositoryInput) (req *request.Request, output *GetRepositoryOutput) {
+	op := &request.Operation{
 		Name:       opGetRepository,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -196,8 +196,8 @@ func (c *CodeCommit) GetRepository(input *GetRepositoryInput) (*GetRepositoryOut
 const opListBranches = "ListBranches"
 
 // ListBranchesRequest generates a request for the ListBranches operation.
-func (c *CodeCommit) ListBranchesRequest(input *ListBranchesInput) (req *service.Request, output *ListBranchesOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) ListBranchesRequest(input *ListBranchesInput) (req *request.Request, output *ListBranchesOutput) {
+	op := &request.Operation{
 		Name:       opListBranches,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -223,8 +223,8 @@ func (c *CodeCommit) ListBranches(input *ListBranchesInput) (*ListBranchesOutput
 const opListRepositories = "ListRepositories"
 
 // ListRepositoriesRequest generates a request for the ListRepositories operation.
-func (c *CodeCommit) ListRepositoriesRequest(input *ListRepositoriesInput) (req *service.Request, output *ListRepositoriesOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) ListRepositoriesRequest(input *ListRepositoriesInput) (req *request.Request, output *ListRepositoriesOutput) {
+	op := &request.Operation{
 		Name:       opListRepositories,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -250,8 +250,8 @@ func (c *CodeCommit) ListRepositories(input *ListRepositoriesInput) (*ListReposi
 const opUpdateDefaultBranch = "UpdateDefaultBranch"
 
 // UpdateDefaultBranchRequest generates a request for the UpdateDefaultBranch operation.
-func (c *CodeCommit) UpdateDefaultBranchRequest(input *UpdateDefaultBranchInput) (req *service.Request, output *UpdateDefaultBranchOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) UpdateDefaultBranchRequest(input *UpdateDefaultBranchInput) (req *request.Request, output *UpdateDefaultBranchOutput) {
+	op := &request.Operation{
 		Name:       opUpdateDefaultBranch,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -281,8 +281,8 @@ func (c *CodeCommit) UpdateDefaultBranch(input *UpdateDefaultBranchInput) (*Upda
 const opUpdateRepositoryDescription = "UpdateRepositoryDescription"
 
 // UpdateRepositoryDescriptionRequest generates a request for the UpdateRepositoryDescription operation.
-func (c *CodeCommit) UpdateRepositoryDescriptionRequest(input *UpdateRepositoryDescriptionInput) (req *service.Request, output *UpdateRepositoryDescriptionOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) UpdateRepositoryDescriptionRequest(input *UpdateRepositoryDescriptionInput) (req *request.Request, output *UpdateRepositoryDescriptionOutput) {
+	op := &request.Operation{
 		Name:       opUpdateRepositoryDescription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -314,8 +314,8 @@ func (c *CodeCommit) UpdateRepositoryDescription(input *UpdateRepositoryDescript
 const opUpdateRepositoryName = "UpdateRepositoryName"
 
 // UpdateRepositoryNameRequest generates a request for the UpdateRepositoryName operation.
-func (c *CodeCommit) UpdateRepositoryNameRequest(input *UpdateRepositoryNameInput) (req *service.Request, output *UpdateRepositoryNameOutput) {
-	op := &service.Operation{
+func (c *CodeCommit) UpdateRepositoryNameRequest(input *UpdateRepositoryNameInput) (req *request.Request, output *UpdateRepositoryNameOutput) {
+	op := &request.Operation{
 		Name:       opUpdateRepositoryName,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/codecommit/codecommitiface/interface.go
+++ b/service/codecommit/codecommitiface/interface.go
@@ -4,53 +4,53 @@
 package codecommitiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/codecommit"
 )
 
 // CodeCommitAPI is the interface type for codecommit.CodeCommit.
 type CodeCommitAPI interface {
-	BatchGetRepositoriesRequest(*codecommit.BatchGetRepositoriesInput) (*service.Request, *codecommit.BatchGetRepositoriesOutput)
+	BatchGetRepositoriesRequest(*codecommit.BatchGetRepositoriesInput) (*request.Request, *codecommit.BatchGetRepositoriesOutput)
 
 	BatchGetRepositories(*codecommit.BatchGetRepositoriesInput) (*codecommit.BatchGetRepositoriesOutput, error)
 
-	CreateBranchRequest(*codecommit.CreateBranchInput) (*service.Request, *codecommit.CreateBranchOutput)
+	CreateBranchRequest(*codecommit.CreateBranchInput) (*request.Request, *codecommit.CreateBranchOutput)
 
 	CreateBranch(*codecommit.CreateBranchInput) (*codecommit.CreateBranchOutput, error)
 
-	CreateRepositoryRequest(*codecommit.CreateRepositoryInput) (*service.Request, *codecommit.CreateRepositoryOutput)
+	CreateRepositoryRequest(*codecommit.CreateRepositoryInput) (*request.Request, *codecommit.CreateRepositoryOutput)
 
 	CreateRepository(*codecommit.CreateRepositoryInput) (*codecommit.CreateRepositoryOutput, error)
 
-	DeleteRepositoryRequest(*codecommit.DeleteRepositoryInput) (*service.Request, *codecommit.DeleteRepositoryOutput)
+	DeleteRepositoryRequest(*codecommit.DeleteRepositoryInput) (*request.Request, *codecommit.DeleteRepositoryOutput)
 
 	DeleteRepository(*codecommit.DeleteRepositoryInput) (*codecommit.DeleteRepositoryOutput, error)
 
-	GetBranchRequest(*codecommit.GetBranchInput) (*service.Request, *codecommit.GetBranchOutput)
+	GetBranchRequest(*codecommit.GetBranchInput) (*request.Request, *codecommit.GetBranchOutput)
 
 	GetBranch(*codecommit.GetBranchInput) (*codecommit.GetBranchOutput, error)
 
-	GetRepositoryRequest(*codecommit.GetRepositoryInput) (*service.Request, *codecommit.GetRepositoryOutput)
+	GetRepositoryRequest(*codecommit.GetRepositoryInput) (*request.Request, *codecommit.GetRepositoryOutput)
 
 	GetRepository(*codecommit.GetRepositoryInput) (*codecommit.GetRepositoryOutput, error)
 
-	ListBranchesRequest(*codecommit.ListBranchesInput) (*service.Request, *codecommit.ListBranchesOutput)
+	ListBranchesRequest(*codecommit.ListBranchesInput) (*request.Request, *codecommit.ListBranchesOutput)
 
 	ListBranches(*codecommit.ListBranchesInput) (*codecommit.ListBranchesOutput, error)
 
-	ListRepositoriesRequest(*codecommit.ListRepositoriesInput) (*service.Request, *codecommit.ListRepositoriesOutput)
+	ListRepositoriesRequest(*codecommit.ListRepositoriesInput) (*request.Request, *codecommit.ListRepositoriesOutput)
 
 	ListRepositories(*codecommit.ListRepositoriesInput) (*codecommit.ListRepositoriesOutput, error)
 
-	UpdateDefaultBranchRequest(*codecommit.UpdateDefaultBranchInput) (*service.Request, *codecommit.UpdateDefaultBranchOutput)
+	UpdateDefaultBranchRequest(*codecommit.UpdateDefaultBranchInput) (*request.Request, *codecommit.UpdateDefaultBranchOutput)
 
 	UpdateDefaultBranch(*codecommit.UpdateDefaultBranchInput) (*codecommit.UpdateDefaultBranchOutput, error)
 
-	UpdateRepositoryDescriptionRequest(*codecommit.UpdateRepositoryDescriptionInput) (*service.Request, *codecommit.UpdateRepositoryDescriptionOutput)
+	UpdateRepositoryDescriptionRequest(*codecommit.UpdateRepositoryDescriptionInput) (*request.Request, *codecommit.UpdateRepositoryDescriptionOutput)
 
 	UpdateRepositoryDescription(*codecommit.UpdateRepositoryDescriptionInput) (*codecommit.UpdateRepositoryDescriptionOutput, error)
 
-	UpdateRepositoryNameRequest(*codecommit.UpdateRepositoryNameInput) (*service.Request, *codecommit.UpdateRepositoryNameOutput)
+	UpdateRepositoryNameRequest(*codecommit.UpdateRepositoryNameInput) (*request.Request, *codecommit.UpdateRepositoryNameOutput)
 
 	UpdateRepositoryName(*codecommit.UpdateRepositoryNameInput) (*codecommit.UpdateRepositoryNameOutput, error)
 }

--- a/service/codecommit/service.go
+++ b/service/codecommit/service.go
@@ -5,7 +5,9 @@ package codecommit
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -25,16 +27,18 @@ type CodeCommit struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CodeCommit client.
 func New(config *aws.Config) *CodeCommit {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "codecommit",
-		APIVersion:   "2015-04-13",
-		JSONVersion:  "1.1",
-		TargetPrefix: "CodeCommit_20150413",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "codecommit",
+			APIVersion:   "2015-04-13",
+			JSONVersion:  "1.1",
+			TargetPrefix: "CodeCommit_20150413",
+		},
 	}
 	service.Initialize()
 
@@ -55,8 +59,8 @@ func New(config *aws.Config) *CodeCommit {
 
 // newRequest creates a new request for a CodeCommit operation and runs any
 // custom request initialization.
-func (c *CodeCommit) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CodeCommit) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/codedeploy/api.go
+++ b/service/codedeploy/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddTagsToOnPremisesInstances = "AddTagsToOnPremisesInstances"
 
 // AddTagsToOnPremisesInstancesRequest generates a request for the AddTagsToOnPremisesInstances operation.
-func (c *CodeDeploy) AddTagsToOnPremisesInstancesRequest(input *AddTagsToOnPremisesInstancesInput) (req *service.Request, output *AddTagsToOnPremisesInstancesOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) AddTagsToOnPremisesInstancesRequest(input *AddTagsToOnPremisesInstancesInput) (req *request.Request, output *AddTagsToOnPremisesInstancesOutput) {
+	op := &request.Operation{
 		Name:       opAddTagsToOnPremisesInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -40,8 +40,8 @@ func (c *CodeDeploy) AddTagsToOnPremisesInstances(input *AddTagsToOnPremisesInst
 const opBatchGetApplications = "BatchGetApplications"
 
 // BatchGetApplicationsRequest generates a request for the BatchGetApplications operation.
-func (c *CodeDeploy) BatchGetApplicationsRequest(input *BatchGetApplicationsInput) (req *service.Request, output *BatchGetApplicationsOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) BatchGetApplicationsRequest(input *BatchGetApplicationsInput) (req *request.Request, output *BatchGetApplicationsOutput) {
+	op := &request.Operation{
 		Name:       opBatchGetApplications,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -67,8 +67,8 @@ func (c *CodeDeploy) BatchGetApplications(input *BatchGetApplicationsInput) (*Ba
 const opBatchGetDeployments = "BatchGetDeployments"
 
 // BatchGetDeploymentsRequest generates a request for the BatchGetDeployments operation.
-func (c *CodeDeploy) BatchGetDeploymentsRequest(input *BatchGetDeploymentsInput) (req *service.Request, output *BatchGetDeploymentsOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) BatchGetDeploymentsRequest(input *BatchGetDeploymentsInput) (req *request.Request, output *BatchGetDeploymentsOutput) {
+	op := &request.Operation{
 		Name:       opBatchGetDeployments,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -94,8 +94,8 @@ func (c *CodeDeploy) BatchGetDeployments(input *BatchGetDeploymentsInput) (*Batc
 const opBatchGetOnPremisesInstances = "BatchGetOnPremisesInstances"
 
 // BatchGetOnPremisesInstancesRequest generates a request for the BatchGetOnPremisesInstances operation.
-func (c *CodeDeploy) BatchGetOnPremisesInstancesRequest(input *BatchGetOnPremisesInstancesInput) (req *service.Request, output *BatchGetOnPremisesInstancesOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) BatchGetOnPremisesInstancesRequest(input *BatchGetOnPremisesInstancesInput) (req *request.Request, output *BatchGetOnPremisesInstancesOutput) {
+	op := &request.Operation{
 		Name:       opBatchGetOnPremisesInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -121,8 +121,8 @@ func (c *CodeDeploy) BatchGetOnPremisesInstances(input *BatchGetOnPremisesInstan
 const opCreateApplication = "CreateApplication"
 
 // CreateApplicationRequest generates a request for the CreateApplication operation.
-func (c *CodeDeploy) CreateApplicationRequest(input *CreateApplicationInput) (req *service.Request, output *CreateApplicationOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) CreateApplicationRequest(input *CreateApplicationInput) (req *request.Request, output *CreateApplicationOutput) {
+	op := &request.Operation{
 		Name:       opCreateApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -148,8 +148,8 @@ func (c *CodeDeploy) CreateApplication(input *CreateApplicationInput) (*CreateAp
 const opCreateDeployment = "CreateDeployment"
 
 // CreateDeploymentRequest generates a request for the CreateDeployment operation.
-func (c *CodeDeploy) CreateDeploymentRequest(input *CreateDeploymentInput) (req *service.Request, output *CreateDeploymentOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) CreateDeploymentRequest(input *CreateDeploymentInput) (req *request.Request, output *CreateDeploymentOutput) {
+	op := &request.Operation{
 		Name:       opCreateDeployment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -175,8 +175,8 @@ func (c *CodeDeploy) CreateDeployment(input *CreateDeploymentInput) (*CreateDepl
 const opCreateDeploymentConfig = "CreateDeploymentConfig"
 
 // CreateDeploymentConfigRequest generates a request for the CreateDeploymentConfig operation.
-func (c *CodeDeploy) CreateDeploymentConfigRequest(input *CreateDeploymentConfigInput) (req *service.Request, output *CreateDeploymentConfigOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) CreateDeploymentConfigRequest(input *CreateDeploymentConfigInput) (req *request.Request, output *CreateDeploymentConfigOutput) {
+	op := &request.Operation{
 		Name:       opCreateDeploymentConfig,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -202,8 +202,8 @@ func (c *CodeDeploy) CreateDeploymentConfig(input *CreateDeploymentConfigInput) 
 const opCreateDeploymentGroup = "CreateDeploymentGroup"
 
 // CreateDeploymentGroupRequest generates a request for the CreateDeploymentGroup operation.
-func (c *CodeDeploy) CreateDeploymentGroupRequest(input *CreateDeploymentGroupInput) (req *service.Request, output *CreateDeploymentGroupOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) CreateDeploymentGroupRequest(input *CreateDeploymentGroupInput) (req *request.Request, output *CreateDeploymentGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateDeploymentGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -229,8 +229,8 @@ func (c *CodeDeploy) CreateDeploymentGroup(input *CreateDeploymentGroupInput) (*
 const opDeleteApplication = "DeleteApplication"
 
 // DeleteApplicationRequest generates a request for the DeleteApplication operation.
-func (c *CodeDeploy) DeleteApplicationRequest(input *DeleteApplicationInput) (req *service.Request, output *DeleteApplicationOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) DeleteApplicationRequest(input *DeleteApplicationInput) (req *request.Request, output *DeleteApplicationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -256,8 +256,8 @@ func (c *CodeDeploy) DeleteApplication(input *DeleteApplicationInput) (*DeleteAp
 const opDeleteDeploymentConfig = "DeleteDeploymentConfig"
 
 // DeleteDeploymentConfigRequest generates a request for the DeleteDeploymentConfig operation.
-func (c *CodeDeploy) DeleteDeploymentConfigRequest(input *DeleteDeploymentConfigInput) (req *service.Request, output *DeleteDeploymentConfigOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) DeleteDeploymentConfigRequest(input *DeleteDeploymentConfigInput) (req *request.Request, output *DeleteDeploymentConfigOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDeploymentConfig,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -286,8 +286,8 @@ func (c *CodeDeploy) DeleteDeploymentConfig(input *DeleteDeploymentConfigInput) 
 const opDeleteDeploymentGroup = "DeleteDeploymentGroup"
 
 // DeleteDeploymentGroupRequest generates a request for the DeleteDeploymentGroup operation.
-func (c *CodeDeploy) DeleteDeploymentGroupRequest(input *DeleteDeploymentGroupInput) (req *service.Request, output *DeleteDeploymentGroupOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) DeleteDeploymentGroupRequest(input *DeleteDeploymentGroupInput) (req *request.Request, output *DeleteDeploymentGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDeploymentGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -313,8 +313,8 @@ func (c *CodeDeploy) DeleteDeploymentGroup(input *DeleteDeploymentGroupInput) (*
 const opDeregisterOnPremisesInstance = "DeregisterOnPremisesInstance"
 
 // DeregisterOnPremisesInstanceRequest generates a request for the DeregisterOnPremisesInstance operation.
-func (c *CodeDeploy) DeregisterOnPremisesInstanceRequest(input *DeregisterOnPremisesInstanceInput) (req *service.Request, output *DeregisterOnPremisesInstanceOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) DeregisterOnPremisesInstanceRequest(input *DeregisterOnPremisesInstanceInput) (req *request.Request, output *DeregisterOnPremisesInstanceOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterOnPremisesInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -340,8 +340,8 @@ func (c *CodeDeploy) DeregisterOnPremisesInstance(input *DeregisterOnPremisesIns
 const opGetApplication = "GetApplication"
 
 // GetApplicationRequest generates a request for the GetApplication operation.
-func (c *CodeDeploy) GetApplicationRequest(input *GetApplicationInput) (req *service.Request, output *GetApplicationOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) GetApplicationRequest(input *GetApplicationInput) (req *request.Request, output *GetApplicationOutput) {
+	op := &request.Operation{
 		Name:       opGetApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -367,8 +367,8 @@ func (c *CodeDeploy) GetApplication(input *GetApplicationInput) (*GetApplication
 const opGetApplicationRevision = "GetApplicationRevision"
 
 // GetApplicationRevisionRequest generates a request for the GetApplicationRevision operation.
-func (c *CodeDeploy) GetApplicationRevisionRequest(input *GetApplicationRevisionInput) (req *service.Request, output *GetApplicationRevisionOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) GetApplicationRevisionRequest(input *GetApplicationRevisionInput) (req *request.Request, output *GetApplicationRevisionOutput) {
+	op := &request.Operation{
 		Name:       opGetApplicationRevision,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -394,8 +394,8 @@ func (c *CodeDeploy) GetApplicationRevision(input *GetApplicationRevisionInput) 
 const opGetDeployment = "GetDeployment"
 
 // GetDeploymentRequest generates a request for the GetDeployment operation.
-func (c *CodeDeploy) GetDeploymentRequest(input *GetDeploymentInput) (req *service.Request, output *GetDeploymentOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) GetDeploymentRequest(input *GetDeploymentInput) (req *request.Request, output *GetDeploymentOutput) {
+	op := &request.Operation{
 		Name:       opGetDeployment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -421,8 +421,8 @@ func (c *CodeDeploy) GetDeployment(input *GetDeploymentInput) (*GetDeploymentOut
 const opGetDeploymentConfig = "GetDeploymentConfig"
 
 // GetDeploymentConfigRequest generates a request for the GetDeploymentConfig operation.
-func (c *CodeDeploy) GetDeploymentConfigRequest(input *GetDeploymentConfigInput) (req *service.Request, output *GetDeploymentConfigOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) GetDeploymentConfigRequest(input *GetDeploymentConfigInput) (req *request.Request, output *GetDeploymentConfigOutput) {
+	op := &request.Operation{
 		Name:       opGetDeploymentConfig,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -448,8 +448,8 @@ func (c *CodeDeploy) GetDeploymentConfig(input *GetDeploymentConfigInput) (*GetD
 const opGetDeploymentGroup = "GetDeploymentGroup"
 
 // GetDeploymentGroupRequest generates a request for the GetDeploymentGroup operation.
-func (c *CodeDeploy) GetDeploymentGroupRequest(input *GetDeploymentGroupInput) (req *service.Request, output *GetDeploymentGroupOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) GetDeploymentGroupRequest(input *GetDeploymentGroupInput) (req *request.Request, output *GetDeploymentGroupOutput) {
+	op := &request.Operation{
 		Name:       opGetDeploymentGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -475,8 +475,8 @@ func (c *CodeDeploy) GetDeploymentGroup(input *GetDeploymentGroupInput) (*GetDep
 const opGetDeploymentInstance = "GetDeploymentInstance"
 
 // GetDeploymentInstanceRequest generates a request for the GetDeploymentInstance operation.
-func (c *CodeDeploy) GetDeploymentInstanceRequest(input *GetDeploymentInstanceInput) (req *service.Request, output *GetDeploymentInstanceOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) GetDeploymentInstanceRequest(input *GetDeploymentInstanceInput) (req *request.Request, output *GetDeploymentInstanceOutput) {
+	op := &request.Operation{
 		Name:       opGetDeploymentInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -502,8 +502,8 @@ func (c *CodeDeploy) GetDeploymentInstance(input *GetDeploymentInstanceInput) (*
 const opGetOnPremisesInstance = "GetOnPremisesInstance"
 
 // GetOnPremisesInstanceRequest generates a request for the GetOnPremisesInstance operation.
-func (c *CodeDeploy) GetOnPremisesInstanceRequest(input *GetOnPremisesInstanceInput) (req *service.Request, output *GetOnPremisesInstanceOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) GetOnPremisesInstanceRequest(input *GetOnPremisesInstanceInput) (req *request.Request, output *GetOnPremisesInstanceOutput) {
+	op := &request.Operation{
 		Name:       opGetOnPremisesInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -529,12 +529,12 @@ func (c *CodeDeploy) GetOnPremisesInstance(input *GetOnPremisesInstanceInput) (*
 const opListApplicationRevisions = "ListApplicationRevisions"
 
 // ListApplicationRevisionsRequest generates a request for the ListApplicationRevisions operation.
-func (c *CodeDeploy) ListApplicationRevisionsRequest(input *ListApplicationRevisionsInput) (req *service.Request, output *ListApplicationRevisionsOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) ListApplicationRevisionsRequest(input *ListApplicationRevisionsInput) (req *request.Request, output *ListApplicationRevisionsOutput) {
+	op := &request.Operation{
 		Name:       opListApplicationRevisions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -569,12 +569,12 @@ func (c *CodeDeploy) ListApplicationRevisionsPages(input *ListApplicationRevisio
 const opListApplications = "ListApplications"
 
 // ListApplicationsRequest generates a request for the ListApplications operation.
-func (c *CodeDeploy) ListApplicationsRequest(input *ListApplicationsInput) (req *service.Request, output *ListApplicationsOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) ListApplicationsRequest(input *ListApplicationsInput) (req *request.Request, output *ListApplicationsOutput) {
+	op := &request.Operation{
 		Name:       opListApplications,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -609,12 +609,12 @@ func (c *CodeDeploy) ListApplicationsPages(input *ListApplicationsInput, fn func
 const opListDeploymentConfigs = "ListDeploymentConfigs"
 
 // ListDeploymentConfigsRequest generates a request for the ListDeploymentConfigs operation.
-func (c *CodeDeploy) ListDeploymentConfigsRequest(input *ListDeploymentConfigsInput) (req *service.Request, output *ListDeploymentConfigsOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) ListDeploymentConfigsRequest(input *ListDeploymentConfigsInput) (req *request.Request, output *ListDeploymentConfigsOutput) {
+	op := &request.Operation{
 		Name:       opListDeploymentConfigs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -649,12 +649,12 @@ func (c *CodeDeploy) ListDeploymentConfigsPages(input *ListDeploymentConfigsInpu
 const opListDeploymentGroups = "ListDeploymentGroups"
 
 // ListDeploymentGroupsRequest generates a request for the ListDeploymentGroups operation.
-func (c *CodeDeploy) ListDeploymentGroupsRequest(input *ListDeploymentGroupsInput) (req *service.Request, output *ListDeploymentGroupsOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) ListDeploymentGroupsRequest(input *ListDeploymentGroupsInput) (req *request.Request, output *ListDeploymentGroupsOutput) {
+	op := &request.Operation{
 		Name:       opListDeploymentGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -690,12 +690,12 @@ func (c *CodeDeploy) ListDeploymentGroupsPages(input *ListDeploymentGroupsInput,
 const opListDeploymentInstances = "ListDeploymentInstances"
 
 // ListDeploymentInstancesRequest generates a request for the ListDeploymentInstances operation.
-func (c *CodeDeploy) ListDeploymentInstancesRequest(input *ListDeploymentInstancesInput) (req *service.Request, output *ListDeploymentInstancesOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) ListDeploymentInstancesRequest(input *ListDeploymentInstancesInput) (req *request.Request, output *ListDeploymentInstancesOutput) {
+	op := &request.Operation{
 		Name:       opListDeploymentInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -731,12 +731,12 @@ func (c *CodeDeploy) ListDeploymentInstancesPages(input *ListDeploymentInstances
 const opListDeployments = "ListDeployments"
 
 // ListDeploymentsRequest generates a request for the ListDeployments operation.
-func (c *CodeDeploy) ListDeploymentsRequest(input *ListDeploymentsInput) (req *service.Request, output *ListDeploymentsOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) ListDeploymentsRequest(input *ListDeploymentsInput) (req *request.Request, output *ListDeploymentsOutput) {
+	op := &request.Operation{
 		Name:       opListDeployments,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -772,8 +772,8 @@ func (c *CodeDeploy) ListDeploymentsPages(input *ListDeploymentsInput, fn func(p
 const opListOnPremisesInstances = "ListOnPremisesInstances"
 
 // ListOnPremisesInstancesRequest generates a request for the ListOnPremisesInstances operation.
-func (c *CodeDeploy) ListOnPremisesInstancesRequest(input *ListOnPremisesInstancesInput) (req *service.Request, output *ListOnPremisesInstancesOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) ListOnPremisesInstancesRequest(input *ListOnPremisesInstancesInput) (req *request.Request, output *ListOnPremisesInstancesOutput) {
+	op := &request.Operation{
 		Name:       opListOnPremisesInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -803,8 +803,8 @@ func (c *CodeDeploy) ListOnPremisesInstances(input *ListOnPremisesInstancesInput
 const opRegisterApplicationRevision = "RegisterApplicationRevision"
 
 // RegisterApplicationRevisionRequest generates a request for the RegisterApplicationRevision operation.
-func (c *CodeDeploy) RegisterApplicationRevisionRequest(input *RegisterApplicationRevisionInput) (req *service.Request, output *RegisterApplicationRevisionOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) RegisterApplicationRevisionRequest(input *RegisterApplicationRevisionInput) (req *request.Request, output *RegisterApplicationRevisionOutput) {
+	op := &request.Operation{
 		Name:       opRegisterApplicationRevision,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -830,8 +830,8 @@ func (c *CodeDeploy) RegisterApplicationRevision(input *RegisterApplicationRevis
 const opRegisterOnPremisesInstance = "RegisterOnPremisesInstance"
 
 // RegisterOnPremisesInstanceRequest generates a request for the RegisterOnPremisesInstance operation.
-func (c *CodeDeploy) RegisterOnPremisesInstanceRequest(input *RegisterOnPremisesInstanceInput) (req *service.Request, output *RegisterOnPremisesInstanceOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) RegisterOnPremisesInstanceRequest(input *RegisterOnPremisesInstanceInput) (req *request.Request, output *RegisterOnPremisesInstanceOutput) {
+	op := &request.Operation{
 		Name:       opRegisterOnPremisesInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -857,8 +857,8 @@ func (c *CodeDeploy) RegisterOnPremisesInstance(input *RegisterOnPremisesInstanc
 const opRemoveTagsFromOnPremisesInstances = "RemoveTagsFromOnPremisesInstances"
 
 // RemoveTagsFromOnPremisesInstancesRequest generates a request for the RemoveTagsFromOnPremisesInstances operation.
-func (c *CodeDeploy) RemoveTagsFromOnPremisesInstancesRequest(input *RemoveTagsFromOnPremisesInstancesInput) (req *service.Request, output *RemoveTagsFromOnPremisesInstancesOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) RemoveTagsFromOnPremisesInstancesRequest(input *RemoveTagsFromOnPremisesInstancesInput) (req *request.Request, output *RemoveTagsFromOnPremisesInstancesOutput) {
+	op := &request.Operation{
 		Name:       opRemoveTagsFromOnPremisesInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -884,8 +884,8 @@ func (c *CodeDeploy) RemoveTagsFromOnPremisesInstances(input *RemoveTagsFromOnPr
 const opStopDeployment = "StopDeployment"
 
 // StopDeploymentRequest generates a request for the StopDeployment operation.
-func (c *CodeDeploy) StopDeploymentRequest(input *StopDeploymentInput) (req *service.Request, output *StopDeploymentOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) StopDeploymentRequest(input *StopDeploymentInput) (req *request.Request, output *StopDeploymentOutput) {
+	op := &request.Operation{
 		Name:       opStopDeployment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -911,8 +911,8 @@ func (c *CodeDeploy) StopDeployment(input *StopDeploymentInput) (*StopDeployment
 const opUpdateApplication = "UpdateApplication"
 
 // UpdateApplicationRequest generates a request for the UpdateApplication operation.
-func (c *CodeDeploy) UpdateApplicationRequest(input *UpdateApplicationInput) (req *service.Request, output *UpdateApplicationOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) UpdateApplicationRequest(input *UpdateApplicationInput) (req *request.Request, output *UpdateApplicationOutput) {
+	op := &request.Operation{
 		Name:       opUpdateApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -938,8 +938,8 @@ func (c *CodeDeploy) UpdateApplication(input *UpdateApplicationInput) (*UpdateAp
 const opUpdateDeploymentGroup = "UpdateDeploymentGroup"
 
 // UpdateDeploymentGroupRequest generates a request for the UpdateDeploymentGroup operation.
-func (c *CodeDeploy) UpdateDeploymentGroupRequest(input *UpdateDeploymentGroupInput) (req *service.Request, output *UpdateDeploymentGroupOutput) {
-	op := &service.Operation{
+func (c *CodeDeploy) UpdateDeploymentGroupRequest(input *UpdateDeploymentGroupInput) (req *request.Request, output *UpdateDeploymentGroupOutput) {
+	op := &request.Operation{
 		Name:       opUpdateDeploymentGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/codedeploy/codedeployiface/interface.go
+++ b/service/codedeploy/codedeployiface/interface.go
@@ -4,149 +4,149 @@
 package codedeployiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 )
 
 // CodeDeployAPI is the interface type for codedeploy.CodeDeploy.
 type CodeDeployAPI interface {
-	AddTagsToOnPremisesInstancesRequest(*codedeploy.AddTagsToOnPremisesInstancesInput) (*service.Request, *codedeploy.AddTagsToOnPremisesInstancesOutput)
+	AddTagsToOnPremisesInstancesRequest(*codedeploy.AddTagsToOnPremisesInstancesInput) (*request.Request, *codedeploy.AddTagsToOnPremisesInstancesOutput)
 
 	AddTagsToOnPremisesInstances(*codedeploy.AddTagsToOnPremisesInstancesInput) (*codedeploy.AddTagsToOnPremisesInstancesOutput, error)
 
-	BatchGetApplicationsRequest(*codedeploy.BatchGetApplicationsInput) (*service.Request, *codedeploy.BatchGetApplicationsOutput)
+	BatchGetApplicationsRequest(*codedeploy.BatchGetApplicationsInput) (*request.Request, *codedeploy.BatchGetApplicationsOutput)
 
 	BatchGetApplications(*codedeploy.BatchGetApplicationsInput) (*codedeploy.BatchGetApplicationsOutput, error)
 
-	BatchGetDeploymentsRequest(*codedeploy.BatchGetDeploymentsInput) (*service.Request, *codedeploy.BatchGetDeploymentsOutput)
+	BatchGetDeploymentsRequest(*codedeploy.BatchGetDeploymentsInput) (*request.Request, *codedeploy.BatchGetDeploymentsOutput)
 
 	BatchGetDeployments(*codedeploy.BatchGetDeploymentsInput) (*codedeploy.BatchGetDeploymentsOutput, error)
 
-	BatchGetOnPremisesInstancesRequest(*codedeploy.BatchGetOnPremisesInstancesInput) (*service.Request, *codedeploy.BatchGetOnPremisesInstancesOutput)
+	BatchGetOnPremisesInstancesRequest(*codedeploy.BatchGetOnPremisesInstancesInput) (*request.Request, *codedeploy.BatchGetOnPremisesInstancesOutput)
 
 	BatchGetOnPremisesInstances(*codedeploy.BatchGetOnPremisesInstancesInput) (*codedeploy.BatchGetOnPremisesInstancesOutput, error)
 
-	CreateApplicationRequest(*codedeploy.CreateApplicationInput) (*service.Request, *codedeploy.CreateApplicationOutput)
+	CreateApplicationRequest(*codedeploy.CreateApplicationInput) (*request.Request, *codedeploy.CreateApplicationOutput)
 
 	CreateApplication(*codedeploy.CreateApplicationInput) (*codedeploy.CreateApplicationOutput, error)
 
-	CreateDeploymentRequest(*codedeploy.CreateDeploymentInput) (*service.Request, *codedeploy.CreateDeploymentOutput)
+	CreateDeploymentRequest(*codedeploy.CreateDeploymentInput) (*request.Request, *codedeploy.CreateDeploymentOutput)
 
 	CreateDeployment(*codedeploy.CreateDeploymentInput) (*codedeploy.CreateDeploymentOutput, error)
 
-	CreateDeploymentConfigRequest(*codedeploy.CreateDeploymentConfigInput) (*service.Request, *codedeploy.CreateDeploymentConfigOutput)
+	CreateDeploymentConfigRequest(*codedeploy.CreateDeploymentConfigInput) (*request.Request, *codedeploy.CreateDeploymentConfigOutput)
 
 	CreateDeploymentConfig(*codedeploy.CreateDeploymentConfigInput) (*codedeploy.CreateDeploymentConfigOutput, error)
 
-	CreateDeploymentGroupRequest(*codedeploy.CreateDeploymentGroupInput) (*service.Request, *codedeploy.CreateDeploymentGroupOutput)
+	CreateDeploymentGroupRequest(*codedeploy.CreateDeploymentGroupInput) (*request.Request, *codedeploy.CreateDeploymentGroupOutput)
 
 	CreateDeploymentGroup(*codedeploy.CreateDeploymentGroupInput) (*codedeploy.CreateDeploymentGroupOutput, error)
 
-	DeleteApplicationRequest(*codedeploy.DeleteApplicationInput) (*service.Request, *codedeploy.DeleteApplicationOutput)
+	DeleteApplicationRequest(*codedeploy.DeleteApplicationInput) (*request.Request, *codedeploy.DeleteApplicationOutput)
 
 	DeleteApplication(*codedeploy.DeleteApplicationInput) (*codedeploy.DeleteApplicationOutput, error)
 
-	DeleteDeploymentConfigRequest(*codedeploy.DeleteDeploymentConfigInput) (*service.Request, *codedeploy.DeleteDeploymentConfigOutput)
+	DeleteDeploymentConfigRequest(*codedeploy.DeleteDeploymentConfigInput) (*request.Request, *codedeploy.DeleteDeploymentConfigOutput)
 
 	DeleteDeploymentConfig(*codedeploy.DeleteDeploymentConfigInput) (*codedeploy.DeleteDeploymentConfigOutput, error)
 
-	DeleteDeploymentGroupRequest(*codedeploy.DeleteDeploymentGroupInput) (*service.Request, *codedeploy.DeleteDeploymentGroupOutput)
+	DeleteDeploymentGroupRequest(*codedeploy.DeleteDeploymentGroupInput) (*request.Request, *codedeploy.DeleteDeploymentGroupOutput)
 
 	DeleteDeploymentGroup(*codedeploy.DeleteDeploymentGroupInput) (*codedeploy.DeleteDeploymentGroupOutput, error)
 
-	DeregisterOnPremisesInstanceRequest(*codedeploy.DeregisterOnPremisesInstanceInput) (*service.Request, *codedeploy.DeregisterOnPremisesInstanceOutput)
+	DeregisterOnPremisesInstanceRequest(*codedeploy.DeregisterOnPremisesInstanceInput) (*request.Request, *codedeploy.DeregisterOnPremisesInstanceOutput)
 
 	DeregisterOnPremisesInstance(*codedeploy.DeregisterOnPremisesInstanceInput) (*codedeploy.DeregisterOnPremisesInstanceOutput, error)
 
-	GetApplicationRequest(*codedeploy.GetApplicationInput) (*service.Request, *codedeploy.GetApplicationOutput)
+	GetApplicationRequest(*codedeploy.GetApplicationInput) (*request.Request, *codedeploy.GetApplicationOutput)
 
 	GetApplication(*codedeploy.GetApplicationInput) (*codedeploy.GetApplicationOutput, error)
 
-	GetApplicationRevisionRequest(*codedeploy.GetApplicationRevisionInput) (*service.Request, *codedeploy.GetApplicationRevisionOutput)
+	GetApplicationRevisionRequest(*codedeploy.GetApplicationRevisionInput) (*request.Request, *codedeploy.GetApplicationRevisionOutput)
 
 	GetApplicationRevision(*codedeploy.GetApplicationRevisionInput) (*codedeploy.GetApplicationRevisionOutput, error)
 
-	GetDeploymentRequest(*codedeploy.GetDeploymentInput) (*service.Request, *codedeploy.GetDeploymentOutput)
+	GetDeploymentRequest(*codedeploy.GetDeploymentInput) (*request.Request, *codedeploy.GetDeploymentOutput)
 
 	GetDeployment(*codedeploy.GetDeploymentInput) (*codedeploy.GetDeploymentOutput, error)
 
-	GetDeploymentConfigRequest(*codedeploy.GetDeploymentConfigInput) (*service.Request, *codedeploy.GetDeploymentConfigOutput)
+	GetDeploymentConfigRequest(*codedeploy.GetDeploymentConfigInput) (*request.Request, *codedeploy.GetDeploymentConfigOutput)
 
 	GetDeploymentConfig(*codedeploy.GetDeploymentConfigInput) (*codedeploy.GetDeploymentConfigOutput, error)
 
-	GetDeploymentGroupRequest(*codedeploy.GetDeploymentGroupInput) (*service.Request, *codedeploy.GetDeploymentGroupOutput)
+	GetDeploymentGroupRequest(*codedeploy.GetDeploymentGroupInput) (*request.Request, *codedeploy.GetDeploymentGroupOutput)
 
 	GetDeploymentGroup(*codedeploy.GetDeploymentGroupInput) (*codedeploy.GetDeploymentGroupOutput, error)
 
-	GetDeploymentInstanceRequest(*codedeploy.GetDeploymentInstanceInput) (*service.Request, *codedeploy.GetDeploymentInstanceOutput)
+	GetDeploymentInstanceRequest(*codedeploy.GetDeploymentInstanceInput) (*request.Request, *codedeploy.GetDeploymentInstanceOutput)
 
 	GetDeploymentInstance(*codedeploy.GetDeploymentInstanceInput) (*codedeploy.GetDeploymentInstanceOutput, error)
 
-	GetOnPremisesInstanceRequest(*codedeploy.GetOnPremisesInstanceInput) (*service.Request, *codedeploy.GetOnPremisesInstanceOutput)
+	GetOnPremisesInstanceRequest(*codedeploy.GetOnPremisesInstanceInput) (*request.Request, *codedeploy.GetOnPremisesInstanceOutput)
 
 	GetOnPremisesInstance(*codedeploy.GetOnPremisesInstanceInput) (*codedeploy.GetOnPremisesInstanceOutput, error)
 
-	ListApplicationRevisionsRequest(*codedeploy.ListApplicationRevisionsInput) (*service.Request, *codedeploy.ListApplicationRevisionsOutput)
+	ListApplicationRevisionsRequest(*codedeploy.ListApplicationRevisionsInput) (*request.Request, *codedeploy.ListApplicationRevisionsOutput)
 
 	ListApplicationRevisions(*codedeploy.ListApplicationRevisionsInput) (*codedeploy.ListApplicationRevisionsOutput, error)
 
 	ListApplicationRevisionsPages(*codedeploy.ListApplicationRevisionsInput, func(*codedeploy.ListApplicationRevisionsOutput, bool) bool) error
 
-	ListApplicationsRequest(*codedeploy.ListApplicationsInput) (*service.Request, *codedeploy.ListApplicationsOutput)
+	ListApplicationsRequest(*codedeploy.ListApplicationsInput) (*request.Request, *codedeploy.ListApplicationsOutput)
 
 	ListApplications(*codedeploy.ListApplicationsInput) (*codedeploy.ListApplicationsOutput, error)
 
 	ListApplicationsPages(*codedeploy.ListApplicationsInput, func(*codedeploy.ListApplicationsOutput, bool) bool) error
 
-	ListDeploymentConfigsRequest(*codedeploy.ListDeploymentConfigsInput) (*service.Request, *codedeploy.ListDeploymentConfigsOutput)
+	ListDeploymentConfigsRequest(*codedeploy.ListDeploymentConfigsInput) (*request.Request, *codedeploy.ListDeploymentConfigsOutput)
 
 	ListDeploymentConfigs(*codedeploy.ListDeploymentConfigsInput) (*codedeploy.ListDeploymentConfigsOutput, error)
 
 	ListDeploymentConfigsPages(*codedeploy.ListDeploymentConfigsInput, func(*codedeploy.ListDeploymentConfigsOutput, bool) bool) error
 
-	ListDeploymentGroupsRequest(*codedeploy.ListDeploymentGroupsInput) (*service.Request, *codedeploy.ListDeploymentGroupsOutput)
+	ListDeploymentGroupsRequest(*codedeploy.ListDeploymentGroupsInput) (*request.Request, *codedeploy.ListDeploymentGroupsOutput)
 
 	ListDeploymentGroups(*codedeploy.ListDeploymentGroupsInput) (*codedeploy.ListDeploymentGroupsOutput, error)
 
 	ListDeploymentGroupsPages(*codedeploy.ListDeploymentGroupsInput, func(*codedeploy.ListDeploymentGroupsOutput, bool) bool) error
 
-	ListDeploymentInstancesRequest(*codedeploy.ListDeploymentInstancesInput) (*service.Request, *codedeploy.ListDeploymentInstancesOutput)
+	ListDeploymentInstancesRequest(*codedeploy.ListDeploymentInstancesInput) (*request.Request, *codedeploy.ListDeploymentInstancesOutput)
 
 	ListDeploymentInstances(*codedeploy.ListDeploymentInstancesInput) (*codedeploy.ListDeploymentInstancesOutput, error)
 
 	ListDeploymentInstancesPages(*codedeploy.ListDeploymentInstancesInput, func(*codedeploy.ListDeploymentInstancesOutput, bool) bool) error
 
-	ListDeploymentsRequest(*codedeploy.ListDeploymentsInput) (*service.Request, *codedeploy.ListDeploymentsOutput)
+	ListDeploymentsRequest(*codedeploy.ListDeploymentsInput) (*request.Request, *codedeploy.ListDeploymentsOutput)
 
 	ListDeployments(*codedeploy.ListDeploymentsInput) (*codedeploy.ListDeploymentsOutput, error)
 
 	ListDeploymentsPages(*codedeploy.ListDeploymentsInput, func(*codedeploy.ListDeploymentsOutput, bool) bool) error
 
-	ListOnPremisesInstancesRequest(*codedeploy.ListOnPremisesInstancesInput) (*service.Request, *codedeploy.ListOnPremisesInstancesOutput)
+	ListOnPremisesInstancesRequest(*codedeploy.ListOnPremisesInstancesInput) (*request.Request, *codedeploy.ListOnPremisesInstancesOutput)
 
 	ListOnPremisesInstances(*codedeploy.ListOnPremisesInstancesInput) (*codedeploy.ListOnPremisesInstancesOutput, error)
 
-	RegisterApplicationRevisionRequest(*codedeploy.RegisterApplicationRevisionInput) (*service.Request, *codedeploy.RegisterApplicationRevisionOutput)
+	RegisterApplicationRevisionRequest(*codedeploy.RegisterApplicationRevisionInput) (*request.Request, *codedeploy.RegisterApplicationRevisionOutput)
 
 	RegisterApplicationRevision(*codedeploy.RegisterApplicationRevisionInput) (*codedeploy.RegisterApplicationRevisionOutput, error)
 
-	RegisterOnPremisesInstanceRequest(*codedeploy.RegisterOnPremisesInstanceInput) (*service.Request, *codedeploy.RegisterOnPremisesInstanceOutput)
+	RegisterOnPremisesInstanceRequest(*codedeploy.RegisterOnPremisesInstanceInput) (*request.Request, *codedeploy.RegisterOnPremisesInstanceOutput)
 
 	RegisterOnPremisesInstance(*codedeploy.RegisterOnPremisesInstanceInput) (*codedeploy.RegisterOnPremisesInstanceOutput, error)
 
-	RemoveTagsFromOnPremisesInstancesRequest(*codedeploy.RemoveTagsFromOnPremisesInstancesInput) (*service.Request, *codedeploy.RemoveTagsFromOnPremisesInstancesOutput)
+	RemoveTagsFromOnPremisesInstancesRequest(*codedeploy.RemoveTagsFromOnPremisesInstancesInput) (*request.Request, *codedeploy.RemoveTagsFromOnPremisesInstancesOutput)
 
 	RemoveTagsFromOnPremisesInstances(*codedeploy.RemoveTagsFromOnPremisesInstancesInput) (*codedeploy.RemoveTagsFromOnPremisesInstancesOutput, error)
 
-	StopDeploymentRequest(*codedeploy.StopDeploymentInput) (*service.Request, *codedeploy.StopDeploymentOutput)
+	StopDeploymentRequest(*codedeploy.StopDeploymentInput) (*request.Request, *codedeploy.StopDeploymentOutput)
 
 	StopDeployment(*codedeploy.StopDeploymentInput) (*codedeploy.StopDeploymentOutput, error)
 
-	UpdateApplicationRequest(*codedeploy.UpdateApplicationInput) (*service.Request, *codedeploy.UpdateApplicationOutput)
+	UpdateApplicationRequest(*codedeploy.UpdateApplicationInput) (*request.Request, *codedeploy.UpdateApplicationOutput)
 
 	UpdateApplication(*codedeploy.UpdateApplicationInput) (*codedeploy.UpdateApplicationOutput, error)
 
-	UpdateDeploymentGroupRequest(*codedeploy.UpdateDeploymentGroupInput) (*service.Request, *codedeploy.UpdateDeploymentGroupOutput)
+	UpdateDeploymentGroupRequest(*codedeploy.UpdateDeploymentGroupInput) (*request.Request, *codedeploy.UpdateDeploymentGroupOutput)
 
 	UpdateDeploymentGroup(*codedeploy.UpdateDeploymentGroupInput) (*codedeploy.UpdateDeploymentGroupOutput, error)
 }

--- a/service/codedeploy/service.go
+++ b/service/codedeploy/service.go
@@ -5,7 +5,9 @@ package codedeploy
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -67,16 +69,18 @@ type CodeDeploy struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CodeDeploy client.
 func New(config *aws.Config) *CodeDeploy {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "codedeploy",
-		APIVersion:   "2014-10-06",
-		JSONVersion:  "1.1",
-		TargetPrefix: "CodeDeploy_20141006",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "codedeploy",
+			APIVersion:   "2014-10-06",
+			JSONVersion:  "1.1",
+			TargetPrefix: "CodeDeploy_20141006",
+		},
 	}
 	service.Initialize()
 
@@ -97,8 +101,8 @@ func New(config *aws.Config) *CodeDeploy {
 
 // newRequest creates a new request for a CodeDeploy operation and runs any
 // custom request initialization.
-func (c *CodeDeploy) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CodeDeploy) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/codepipeline/api.go
+++ b/service/codepipeline/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAcknowledgeJob = "AcknowledgeJob"
 
 // AcknowledgeJobRequest generates a request for the AcknowledgeJob operation.
-func (c *CodePipeline) AcknowledgeJobRequest(input *AcknowledgeJobInput) (req *service.Request, output *AcknowledgeJobOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) AcknowledgeJobRequest(input *AcknowledgeJobInput) (req *request.Request, output *AcknowledgeJobOutput) {
+	op := &request.Operation{
 		Name:       opAcknowledgeJob,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -41,8 +41,8 @@ func (c *CodePipeline) AcknowledgeJob(input *AcknowledgeJobInput) (*AcknowledgeJ
 const opAcknowledgeThirdPartyJob = "AcknowledgeThirdPartyJob"
 
 // AcknowledgeThirdPartyJobRequest generates a request for the AcknowledgeThirdPartyJob operation.
-func (c *CodePipeline) AcknowledgeThirdPartyJobRequest(input *AcknowledgeThirdPartyJobInput) (req *service.Request, output *AcknowledgeThirdPartyJobOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) AcknowledgeThirdPartyJobRequest(input *AcknowledgeThirdPartyJobInput) (req *request.Request, output *AcknowledgeThirdPartyJobOutput) {
+	op := &request.Operation{
 		Name:       opAcknowledgeThirdPartyJob,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -69,8 +69,8 @@ func (c *CodePipeline) AcknowledgeThirdPartyJob(input *AcknowledgeThirdPartyJobI
 const opCreateCustomActionType = "CreateCustomActionType"
 
 // CreateCustomActionTypeRequest generates a request for the CreateCustomActionType operation.
-func (c *CodePipeline) CreateCustomActionTypeRequest(input *CreateCustomActionTypeInput) (req *service.Request, output *CreateCustomActionTypeOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) CreateCustomActionTypeRequest(input *CreateCustomActionTypeInput) (req *request.Request, output *CreateCustomActionTypeOutput) {
+	op := &request.Operation{
 		Name:       opCreateCustomActionType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -97,8 +97,8 @@ func (c *CodePipeline) CreateCustomActionType(input *CreateCustomActionTypeInput
 const opCreatePipeline = "CreatePipeline"
 
 // CreatePipelineRequest generates a request for the CreatePipeline operation.
-func (c *CodePipeline) CreatePipelineRequest(input *CreatePipelineInput) (req *service.Request, output *CreatePipelineOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) CreatePipelineRequest(input *CreatePipelineInput) (req *request.Request, output *CreatePipelineOutput) {
+	op := &request.Operation{
 		Name:       opCreatePipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -124,8 +124,8 @@ func (c *CodePipeline) CreatePipeline(input *CreatePipelineInput) (*CreatePipeli
 const opDeleteCustomActionType = "DeleteCustomActionType"
 
 // DeleteCustomActionTypeRequest generates a request for the DeleteCustomActionType operation.
-func (c *CodePipeline) DeleteCustomActionTypeRequest(input *DeleteCustomActionTypeInput) (req *service.Request, output *DeleteCustomActionTypeOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) DeleteCustomActionTypeRequest(input *DeleteCustomActionTypeInput) (req *request.Request, output *DeleteCustomActionTypeOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCustomActionType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -155,8 +155,8 @@ func (c *CodePipeline) DeleteCustomActionType(input *DeleteCustomActionTypeInput
 const opDeletePipeline = "DeletePipeline"
 
 // DeletePipelineRequest generates a request for the DeletePipeline operation.
-func (c *CodePipeline) DeletePipelineRequest(input *DeletePipelineInput) (req *service.Request, output *DeletePipelineOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) DeletePipelineRequest(input *DeletePipelineInput) (req *request.Request, output *DeletePipelineOutput) {
+	op := &request.Operation{
 		Name:       opDeletePipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -182,8 +182,8 @@ func (c *CodePipeline) DeletePipeline(input *DeletePipelineInput) (*DeletePipeli
 const opDisableStageTransition = "DisableStageTransition"
 
 // DisableStageTransitionRequest generates a request for the DisableStageTransition operation.
-func (c *CodePipeline) DisableStageTransitionRequest(input *DisableStageTransitionInput) (req *service.Request, output *DisableStageTransitionOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) DisableStageTransitionRequest(input *DisableStageTransitionInput) (req *request.Request, output *DisableStageTransitionOutput) {
+	op := &request.Operation{
 		Name:       opDisableStageTransition,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -210,8 +210,8 @@ func (c *CodePipeline) DisableStageTransition(input *DisableStageTransitionInput
 const opEnableStageTransition = "EnableStageTransition"
 
 // EnableStageTransitionRequest generates a request for the EnableStageTransition operation.
-func (c *CodePipeline) EnableStageTransitionRequest(input *EnableStageTransitionInput) (req *service.Request, output *EnableStageTransitionOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) EnableStageTransitionRequest(input *EnableStageTransitionInput) (req *request.Request, output *EnableStageTransitionOutput) {
+	op := &request.Operation{
 		Name:       opEnableStageTransition,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -237,8 +237,8 @@ func (c *CodePipeline) EnableStageTransition(input *EnableStageTransitionInput) 
 const opGetJobDetails = "GetJobDetails"
 
 // GetJobDetailsRequest generates a request for the GetJobDetails operation.
-func (c *CodePipeline) GetJobDetailsRequest(input *GetJobDetailsInput) (req *service.Request, output *GetJobDetailsOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) GetJobDetailsRequest(input *GetJobDetailsInput) (req *request.Request, output *GetJobDetailsOutput) {
+	op := &request.Operation{
 		Name:       opGetJobDetails,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -269,8 +269,8 @@ func (c *CodePipeline) GetJobDetails(input *GetJobDetailsInput) (*GetJobDetailsO
 const opGetPipeline = "GetPipeline"
 
 // GetPipelineRequest generates a request for the GetPipeline operation.
-func (c *CodePipeline) GetPipelineRequest(input *GetPipelineInput) (req *service.Request, output *GetPipelineOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) GetPipelineRequest(input *GetPipelineInput) (req *request.Request, output *GetPipelineOutput) {
+	op := &request.Operation{
 		Name:       opGetPipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -298,8 +298,8 @@ func (c *CodePipeline) GetPipeline(input *GetPipelineInput) (*GetPipelineOutput,
 const opGetPipelineState = "GetPipelineState"
 
 // GetPipelineStateRequest generates a request for the GetPipelineState operation.
-func (c *CodePipeline) GetPipelineStateRequest(input *GetPipelineStateInput) (req *service.Request, output *GetPipelineStateOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) GetPipelineStateRequest(input *GetPipelineStateInput) (req *request.Request, output *GetPipelineStateOutput) {
+	op := &request.Operation{
 		Name:       opGetPipelineState,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -326,8 +326,8 @@ func (c *CodePipeline) GetPipelineState(input *GetPipelineStateInput) (*GetPipel
 const opGetThirdPartyJobDetails = "GetThirdPartyJobDetails"
 
 // GetThirdPartyJobDetailsRequest generates a request for the GetThirdPartyJobDetails operation.
-func (c *CodePipeline) GetThirdPartyJobDetailsRequest(input *GetThirdPartyJobDetailsInput) (req *service.Request, output *GetThirdPartyJobDetailsOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) GetThirdPartyJobDetailsRequest(input *GetThirdPartyJobDetailsInput) (req *request.Request, output *GetThirdPartyJobDetailsOutput) {
+	op := &request.Operation{
 		Name:       opGetThirdPartyJobDetails,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -359,8 +359,8 @@ func (c *CodePipeline) GetThirdPartyJobDetails(input *GetThirdPartyJobDetailsInp
 const opListActionTypes = "ListActionTypes"
 
 // ListActionTypesRequest generates a request for the ListActionTypes operation.
-func (c *CodePipeline) ListActionTypesRequest(input *ListActionTypesInput) (req *service.Request, output *ListActionTypesOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) ListActionTypesRequest(input *ListActionTypesInput) (req *request.Request, output *ListActionTypesOutput) {
+	op := &request.Operation{
 		Name:       opListActionTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -387,8 +387,8 @@ func (c *CodePipeline) ListActionTypes(input *ListActionTypesInput) (*ListAction
 const opListPipelines = "ListPipelines"
 
 // ListPipelinesRequest generates a request for the ListPipelines operation.
-func (c *CodePipeline) ListPipelinesRequest(input *ListPipelinesInput) (req *service.Request, output *ListPipelinesOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) ListPipelinesRequest(input *ListPipelinesInput) (req *request.Request, output *ListPipelinesOutput) {
+	op := &request.Operation{
 		Name:       opListPipelines,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -414,8 +414,8 @@ func (c *CodePipeline) ListPipelines(input *ListPipelinesInput) (*ListPipelinesO
 const opPollForJobs = "PollForJobs"
 
 // PollForJobsRequest generates a request for the PollForJobs operation.
-func (c *CodePipeline) PollForJobsRequest(input *PollForJobsInput) (req *service.Request, output *PollForJobsOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) PollForJobsRequest(input *PollForJobsInput) (req *request.Request, output *PollForJobsOutput) {
+	op := &request.Operation{
 		Name:       opPollForJobs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -446,8 +446,8 @@ func (c *CodePipeline) PollForJobs(input *PollForJobsInput) (*PollForJobsOutput,
 const opPollForThirdPartyJobs = "PollForThirdPartyJobs"
 
 // PollForThirdPartyJobsRequest generates a request for the PollForThirdPartyJobs operation.
-func (c *CodePipeline) PollForThirdPartyJobsRequest(input *PollForThirdPartyJobsInput) (req *service.Request, output *PollForThirdPartyJobsOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) PollForThirdPartyJobsRequest(input *PollForThirdPartyJobsInput) (req *request.Request, output *PollForThirdPartyJobsOutput) {
+	op := &request.Operation{
 		Name:       opPollForThirdPartyJobs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -478,8 +478,8 @@ func (c *CodePipeline) PollForThirdPartyJobs(input *PollForThirdPartyJobsInput) 
 const opPutActionRevision = "PutActionRevision"
 
 // PutActionRevisionRequest generates a request for the PutActionRevision operation.
-func (c *CodePipeline) PutActionRevisionRequest(input *PutActionRevisionInput) (req *service.Request, output *PutActionRevisionOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) PutActionRevisionRequest(input *PutActionRevisionInput) (req *request.Request, output *PutActionRevisionOutput) {
+	op := &request.Operation{
 		Name:       opPutActionRevision,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -505,8 +505,8 @@ func (c *CodePipeline) PutActionRevision(input *PutActionRevisionInput) (*PutAct
 const opPutJobFailureResult = "PutJobFailureResult"
 
 // PutJobFailureResultRequest generates a request for the PutJobFailureResult operation.
-func (c *CodePipeline) PutJobFailureResultRequest(input *PutJobFailureResultInput) (req *service.Request, output *PutJobFailureResultOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) PutJobFailureResultRequest(input *PutJobFailureResultInput) (req *request.Request, output *PutJobFailureResultOutput) {
+	op := &request.Operation{
 		Name:       opPutJobFailureResult,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -533,8 +533,8 @@ func (c *CodePipeline) PutJobFailureResult(input *PutJobFailureResultInput) (*Pu
 const opPutJobSuccessResult = "PutJobSuccessResult"
 
 // PutJobSuccessResultRequest generates a request for the PutJobSuccessResult operation.
-func (c *CodePipeline) PutJobSuccessResultRequest(input *PutJobSuccessResultInput) (req *service.Request, output *PutJobSuccessResultOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) PutJobSuccessResultRequest(input *PutJobSuccessResultInput) (req *request.Request, output *PutJobSuccessResultOutput) {
+	op := &request.Operation{
 		Name:       opPutJobSuccessResult,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -561,8 +561,8 @@ func (c *CodePipeline) PutJobSuccessResult(input *PutJobSuccessResultInput) (*Pu
 const opPutThirdPartyJobFailureResult = "PutThirdPartyJobFailureResult"
 
 // PutThirdPartyJobFailureResultRequest generates a request for the PutThirdPartyJobFailureResult operation.
-func (c *CodePipeline) PutThirdPartyJobFailureResultRequest(input *PutThirdPartyJobFailureResultInput) (req *service.Request, output *PutThirdPartyJobFailureResultOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) PutThirdPartyJobFailureResultRequest(input *PutThirdPartyJobFailureResultInput) (req *request.Request, output *PutThirdPartyJobFailureResultOutput) {
+	op := &request.Operation{
 		Name:       opPutThirdPartyJobFailureResult,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -589,8 +589,8 @@ func (c *CodePipeline) PutThirdPartyJobFailureResult(input *PutThirdPartyJobFail
 const opPutThirdPartyJobSuccessResult = "PutThirdPartyJobSuccessResult"
 
 // PutThirdPartyJobSuccessResultRequest generates a request for the PutThirdPartyJobSuccessResult operation.
-func (c *CodePipeline) PutThirdPartyJobSuccessResultRequest(input *PutThirdPartyJobSuccessResultInput) (req *service.Request, output *PutThirdPartyJobSuccessResultOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) PutThirdPartyJobSuccessResultRequest(input *PutThirdPartyJobSuccessResultInput) (req *request.Request, output *PutThirdPartyJobSuccessResultOutput) {
+	op := &request.Operation{
 		Name:       opPutThirdPartyJobSuccessResult,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -617,8 +617,8 @@ func (c *CodePipeline) PutThirdPartyJobSuccessResult(input *PutThirdPartyJobSucc
 const opStartPipelineExecution = "StartPipelineExecution"
 
 // StartPipelineExecutionRequest generates a request for the StartPipelineExecution operation.
-func (c *CodePipeline) StartPipelineExecutionRequest(input *StartPipelineExecutionInput) (req *service.Request, output *StartPipelineExecutionOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) StartPipelineExecutionRequest(input *StartPipelineExecutionInput) (req *request.Request, output *StartPipelineExecutionOutput) {
+	op := &request.Operation{
 		Name:       opStartPipelineExecution,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -645,8 +645,8 @@ func (c *CodePipeline) StartPipelineExecution(input *StartPipelineExecutionInput
 const opUpdatePipeline = "UpdatePipeline"
 
 // UpdatePipelineRequest generates a request for the UpdatePipeline operation.
-func (c *CodePipeline) UpdatePipelineRequest(input *UpdatePipelineInput) (req *service.Request, output *UpdatePipelineOutput) {
-	op := &service.Operation{
+func (c *CodePipeline) UpdatePipelineRequest(input *UpdatePipelineInput) (req *request.Request, output *UpdatePipelineOutput) {
+	op := &request.Operation{
 		Name:       opUpdatePipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/codepipeline/codepipelineiface/interface.go
+++ b/service/codepipeline/codepipelineiface/interface.go
@@ -4,101 +4,101 @@
 package codepipelineiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
 )
 
 // CodePipelineAPI is the interface type for codepipeline.CodePipeline.
 type CodePipelineAPI interface {
-	AcknowledgeJobRequest(*codepipeline.AcknowledgeJobInput) (*service.Request, *codepipeline.AcknowledgeJobOutput)
+	AcknowledgeJobRequest(*codepipeline.AcknowledgeJobInput) (*request.Request, *codepipeline.AcknowledgeJobOutput)
 
 	AcknowledgeJob(*codepipeline.AcknowledgeJobInput) (*codepipeline.AcknowledgeJobOutput, error)
 
-	AcknowledgeThirdPartyJobRequest(*codepipeline.AcknowledgeThirdPartyJobInput) (*service.Request, *codepipeline.AcknowledgeThirdPartyJobOutput)
+	AcknowledgeThirdPartyJobRequest(*codepipeline.AcknowledgeThirdPartyJobInput) (*request.Request, *codepipeline.AcknowledgeThirdPartyJobOutput)
 
 	AcknowledgeThirdPartyJob(*codepipeline.AcknowledgeThirdPartyJobInput) (*codepipeline.AcknowledgeThirdPartyJobOutput, error)
 
-	CreateCustomActionTypeRequest(*codepipeline.CreateCustomActionTypeInput) (*service.Request, *codepipeline.CreateCustomActionTypeOutput)
+	CreateCustomActionTypeRequest(*codepipeline.CreateCustomActionTypeInput) (*request.Request, *codepipeline.CreateCustomActionTypeOutput)
 
 	CreateCustomActionType(*codepipeline.CreateCustomActionTypeInput) (*codepipeline.CreateCustomActionTypeOutput, error)
 
-	CreatePipelineRequest(*codepipeline.CreatePipelineInput) (*service.Request, *codepipeline.CreatePipelineOutput)
+	CreatePipelineRequest(*codepipeline.CreatePipelineInput) (*request.Request, *codepipeline.CreatePipelineOutput)
 
 	CreatePipeline(*codepipeline.CreatePipelineInput) (*codepipeline.CreatePipelineOutput, error)
 
-	DeleteCustomActionTypeRequest(*codepipeline.DeleteCustomActionTypeInput) (*service.Request, *codepipeline.DeleteCustomActionTypeOutput)
+	DeleteCustomActionTypeRequest(*codepipeline.DeleteCustomActionTypeInput) (*request.Request, *codepipeline.DeleteCustomActionTypeOutput)
 
 	DeleteCustomActionType(*codepipeline.DeleteCustomActionTypeInput) (*codepipeline.DeleteCustomActionTypeOutput, error)
 
-	DeletePipelineRequest(*codepipeline.DeletePipelineInput) (*service.Request, *codepipeline.DeletePipelineOutput)
+	DeletePipelineRequest(*codepipeline.DeletePipelineInput) (*request.Request, *codepipeline.DeletePipelineOutput)
 
 	DeletePipeline(*codepipeline.DeletePipelineInput) (*codepipeline.DeletePipelineOutput, error)
 
-	DisableStageTransitionRequest(*codepipeline.DisableStageTransitionInput) (*service.Request, *codepipeline.DisableStageTransitionOutput)
+	DisableStageTransitionRequest(*codepipeline.DisableStageTransitionInput) (*request.Request, *codepipeline.DisableStageTransitionOutput)
 
 	DisableStageTransition(*codepipeline.DisableStageTransitionInput) (*codepipeline.DisableStageTransitionOutput, error)
 
-	EnableStageTransitionRequest(*codepipeline.EnableStageTransitionInput) (*service.Request, *codepipeline.EnableStageTransitionOutput)
+	EnableStageTransitionRequest(*codepipeline.EnableStageTransitionInput) (*request.Request, *codepipeline.EnableStageTransitionOutput)
 
 	EnableStageTransition(*codepipeline.EnableStageTransitionInput) (*codepipeline.EnableStageTransitionOutput, error)
 
-	GetJobDetailsRequest(*codepipeline.GetJobDetailsInput) (*service.Request, *codepipeline.GetJobDetailsOutput)
+	GetJobDetailsRequest(*codepipeline.GetJobDetailsInput) (*request.Request, *codepipeline.GetJobDetailsOutput)
 
 	GetJobDetails(*codepipeline.GetJobDetailsInput) (*codepipeline.GetJobDetailsOutput, error)
 
-	GetPipelineRequest(*codepipeline.GetPipelineInput) (*service.Request, *codepipeline.GetPipelineOutput)
+	GetPipelineRequest(*codepipeline.GetPipelineInput) (*request.Request, *codepipeline.GetPipelineOutput)
 
 	GetPipeline(*codepipeline.GetPipelineInput) (*codepipeline.GetPipelineOutput, error)
 
-	GetPipelineStateRequest(*codepipeline.GetPipelineStateInput) (*service.Request, *codepipeline.GetPipelineStateOutput)
+	GetPipelineStateRequest(*codepipeline.GetPipelineStateInput) (*request.Request, *codepipeline.GetPipelineStateOutput)
 
 	GetPipelineState(*codepipeline.GetPipelineStateInput) (*codepipeline.GetPipelineStateOutput, error)
 
-	GetThirdPartyJobDetailsRequest(*codepipeline.GetThirdPartyJobDetailsInput) (*service.Request, *codepipeline.GetThirdPartyJobDetailsOutput)
+	GetThirdPartyJobDetailsRequest(*codepipeline.GetThirdPartyJobDetailsInput) (*request.Request, *codepipeline.GetThirdPartyJobDetailsOutput)
 
 	GetThirdPartyJobDetails(*codepipeline.GetThirdPartyJobDetailsInput) (*codepipeline.GetThirdPartyJobDetailsOutput, error)
 
-	ListActionTypesRequest(*codepipeline.ListActionTypesInput) (*service.Request, *codepipeline.ListActionTypesOutput)
+	ListActionTypesRequest(*codepipeline.ListActionTypesInput) (*request.Request, *codepipeline.ListActionTypesOutput)
 
 	ListActionTypes(*codepipeline.ListActionTypesInput) (*codepipeline.ListActionTypesOutput, error)
 
-	ListPipelinesRequest(*codepipeline.ListPipelinesInput) (*service.Request, *codepipeline.ListPipelinesOutput)
+	ListPipelinesRequest(*codepipeline.ListPipelinesInput) (*request.Request, *codepipeline.ListPipelinesOutput)
 
 	ListPipelines(*codepipeline.ListPipelinesInput) (*codepipeline.ListPipelinesOutput, error)
 
-	PollForJobsRequest(*codepipeline.PollForJobsInput) (*service.Request, *codepipeline.PollForJobsOutput)
+	PollForJobsRequest(*codepipeline.PollForJobsInput) (*request.Request, *codepipeline.PollForJobsOutput)
 
 	PollForJobs(*codepipeline.PollForJobsInput) (*codepipeline.PollForJobsOutput, error)
 
-	PollForThirdPartyJobsRequest(*codepipeline.PollForThirdPartyJobsInput) (*service.Request, *codepipeline.PollForThirdPartyJobsOutput)
+	PollForThirdPartyJobsRequest(*codepipeline.PollForThirdPartyJobsInput) (*request.Request, *codepipeline.PollForThirdPartyJobsOutput)
 
 	PollForThirdPartyJobs(*codepipeline.PollForThirdPartyJobsInput) (*codepipeline.PollForThirdPartyJobsOutput, error)
 
-	PutActionRevisionRequest(*codepipeline.PutActionRevisionInput) (*service.Request, *codepipeline.PutActionRevisionOutput)
+	PutActionRevisionRequest(*codepipeline.PutActionRevisionInput) (*request.Request, *codepipeline.PutActionRevisionOutput)
 
 	PutActionRevision(*codepipeline.PutActionRevisionInput) (*codepipeline.PutActionRevisionOutput, error)
 
-	PutJobFailureResultRequest(*codepipeline.PutJobFailureResultInput) (*service.Request, *codepipeline.PutJobFailureResultOutput)
+	PutJobFailureResultRequest(*codepipeline.PutJobFailureResultInput) (*request.Request, *codepipeline.PutJobFailureResultOutput)
 
 	PutJobFailureResult(*codepipeline.PutJobFailureResultInput) (*codepipeline.PutJobFailureResultOutput, error)
 
-	PutJobSuccessResultRequest(*codepipeline.PutJobSuccessResultInput) (*service.Request, *codepipeline.PutJobSuccessResultOutput)
+	PutJobSuccessResultRequest(*codepipeline.PutJobSuccessResultInput) (*request.Request, *codepipeline.PutJobSuccessResultOutput)
 
 	PutJobSuccessResult(*codepipeline.PutJobSuccessResultInput) (*codepipeline.PutJobSuccessResultOutput, error)
 
-	PutThirdPartyJobFailureResultRequest(*codepipeline.PutThirdPartyJobFailureResultInput) (*service.Request, *codepipeline.PutThirdPartyJobFailureResultOutput)
+	PutThirdPartyJobFailureResultRequest(*codepipeline.PutThirdPartyJobFailureResultInput) (*request.Request, *codepipeline.PutThirdPartyJobFailureResultOutput)
 
 	PutThirdPartyJobFailureResult(*codepipeline.PutThirdPartyJobFailureResultInput) (*codepipeline.PutThirdPartyJobFailureResultOutput, error)
 
-	PutThirdPartyJobSuccessResultRequest(*codepipeline.PutThirdPartyJobSuccessResultInput) (*service.Request, *codepipeline.PutThirdPartyJobSuccessResultOutput)
+	PutThirdPartyJobSuccessResultRequest(*codepipeline.PutThirdPartyJobSuccessResultInput) (*request.Request, *codepipeline.PutThirdPartyJobSuccessResultOutput)
 
 	PutThirdPartyJobSuccessResult(*codepipeline.PutThirdPartyJobSuccessResultInput) (*codepipeline.PutThirdPartyJobSuccessResultOutput, error)
 
-	StartPipelineExecutionRequest(*codepipeline.StartPipelineExecutionInput) (*service.Request, *codepipeline.StartPipelineExecutionOutput)
+	StartPipelineExecutionRequest(*codepipeline.StartPipelineExecutionInput) (*request.Request, *codepipeline.StartPipelineExecutionOutput)
 
 	StartPipelineExecution(*codepipeline.StartPipelineExecutionInput) (*codepipeline.StartPipelineExecutionOutput, error)
 
-	UpdatePipelineRequest(*codepipeline.UpdatePipelineInput) (*service.Request, *codepipeline.UpdatePipelineOutput)
+	UpdatePipelineRequest(*codepipeline.UpdatePipelineInput) (*request.Request, *codepipeline.UpdatePipelineOutput)
 
 	UpdatePipeline(*codepipeline.UpdatePipelineInput) (*codepipeline.UpdatePipelineOutput, error)
 }

--- a/service/codepipeline/service.go
+++ b/service/codepipeline/service.go
@@ -5,7 +5,9 @@ package codepipeline
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -90,17 +92,19 @@ type CodePipeline struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CodePipeline client.
 func New(config *aws.Config) *CodePipeline {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "codepipeline",
-		SigningName:  "codepipeline",
-		APIVersion:   "2015-07-09",
-		JSONVersion:  "1.1",
-		TargetPrefix: "CodePipeline_20150709",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "codepipeline",
+			SigningName:  "codepipeline",
+			APIVersion:   "2015-07-09",
+			JSONVersion:  "1.1",
+			TargetPrefix: "CodePipeline_20150709",
+		},
 	}
 	service.Initialize()
 
@@ -121,8 +125,8 @@ func New(config *aws.Config) *CodePipeline {
 
 // newRequest creates a new request for a CodePipeline operation and runs any
 // custom request initialization.
-func (c *CodePipeline) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CodePipeline) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cognitoidentity/api.go
+++ b/service/cognitoidentity/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateIdentityPool = "CreateIdentityPool"
 
 // CreateIdentityPoolRequest generates a request for the CreateIdentityPool operation.
-func (c *CognitoIdentity) CreateIdentityPoolRequest(input *CreateIdentityPoolInput) (req *service.Request, output *IdentityPool) {
-	op := &service.Operation{
+func (c *CognitoIdentity) CreateIdentityPoolRequest(input *CreateIdentityPoolInput) (req *request.Request, output *IdentityPool) {
+	op := &request.Operation{
 		Name:       opCreateIdentityPool,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -42,8 +42,8 @@ func (c *CognitoIdentity) CreateIdentityPool(input *CreateIdentityPoolInput) (*I
 const opDeleteIdentities = "DeleteIdentities"
 
 // DeleteIdentitiesRequest generates a request for the DeleteIdentities operation.
-func (c *CognitoIdentity) DeleteIdentitiesRequest(input *DeleteIdentitiesInput) (req *service.Request, output *DeleteIdentitiesOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) DeleteIdentitiesRequest(input *DeleteIdentitiesInput) (req *request.Request, output *DeleteIdentitiesOutput) {
+	op := &request.Operation{
 		Name:       opDeleteIdentities,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -72,8 +72,8 @@ func (c *CognitoIdentity) DeleteIdentities(input *DeleteIdentitiesInput) (*Delet
 const opDeleteIdentityPool = "DeleteIdentityPool"
 
 // DeleteIdentityPoolRequest generates a request for the DeleteIdentityPool operation.
-func (c *CognitoIdentity) DeleteIdentityPoolRequest(input *DeleteIdentityPoolInput) (req *service.Request, output *DeleteIdentityPoolOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) DeleteIdentityPoolRequest(input *DeleteIdentityPoolInput) (req *request.Request, output *DeleteIdentityPoolOutput) {
+	op := &request.Operation{
 		Name:       opDeleteIdentityPool,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -102,8 +102,8 @@ func (c *CognitoIdentity) DeleteIdentityPool(input *DeleteIdentityPoolInput) (*D
 const opDescribeIdentity = "DescribeIdentity"
 
 // DescribeIdentityRequest generates a request for the DescribeIdentity operation.
-func (c *CognitoIdentity) DescribeIdentityRequest(input *DescribeIdentityInput) (req *service.Request, output *IdentityDescription) {
-	op := &service.Operation{
+func (c *CognitoIdentity) DescribeIdentityRequest(input *DescribeIdentityInput) (req *request.Request, output *IdentityDescription) {
+	op := &request.Operation{
 		Name:       opDescribeIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -132,8 +132,8 @@ func (c *CognitoIdentity) DescribeIdentity(input *DescribeIdentityInput) (*Ident
 const opDescribeIdentityPool = "DescribeIdentityPool"
 
 // DescribeIdentityPoolRequest generates a request for the DescribeIdentityPool operation.
-func (c *CognitoIdentity) DescribeIdentityPoolRequest(input *DescribeIdentityPoolInput) (req *service.Request, output *IdentityPool) {
-	op := &service.Operation{
+func (c *CognitoIdentity) DescribeIdentityPoolRequest(input *DescribeIdentityPoolInput) (req *request.Request, output *IdentityPool) {
+	op := &request.Operation{
 		Name:       opDescribeIdentityPool,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -162,8 +162,8 @@ func (c *CognitoIdentity) DescribeIdentityPool(input *DescribeIdentityPoolInput)
 const opGetCredentialsForIdentity = "GetCredentialsForIdentity"
 
 // GetCredentialsForIdentityRequest generates a request for the GetCredentialsForIdentity operation.
-func (c *CognitoIdentity) GetCredentialsForIdentityRequest(input *GetCredentialsForIdentityInput) (req *service.Request, output *GetCredentialsForIdentityOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) GetCredentialsForIdentityRequest(input *GetCredentialsForIdentityInput) (req *request.Request, output *GetCredentialsForIdentityOutput) {
+	op := &request.Operation{
 		Name:       opGetCredentialsForIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -194,8 +194,8 @@ func (c *CognitoIdentity) GetCredentialsForIdentity(input *GetCredentialsForIden
 const opGetId = "GetId"
 
 // GetIdRequest generates a request for the GetId operation.
-func (c *CognitoIdentity) GetIdRequest(input *GetIdInput) (req *service.Request, output *GetIdOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) GetIdRequest(input *GetIdInput) (req *request.Request, output *GetIdOutput) {
+	op := &request.Operation{
 		Name:       opGetId,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -226,8 +226,8 @@ func (c *CognitoIdentity) GetId(input *GetIdInput) (*GetIdOutput, error) {
 const opGetIdentityPoolRoles = "GetIdentityPoolRoles"
 
 // GetIdentityPoolRolesRequest generates a request for the GetIdentityPoolRoles operation.
-func (c *CognitoIdentity) GetIdentityPoolRolesRequest(input *GetIdentityPoolRolesInput) (req *service.Request, output *GetIdentityPoolRolesOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) GetIdentityPoolRolesRequest(input *GetIdentityPoolRolesInput) (req *request.Request, output *GetIdentityPoolRolesOutput) {
+	op := &request.Operation{
 		Name:       opGetIdentityPoolRoles,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -255,8 +255,8 @@ func (c *CognitoIdentity) GetIdentityPoolRoles(input *GetIdentityPoolRolesInput)
 const opGetOpenIdToken = "GetOpenIdToken"
 
 // GetOpenIdTokenRequest generates a request for the GetOpenIdToken operation.
-func (c *CognitoIdentity) GetOpenIdTokenRequest(input *GetOpenIdTokenInput) (req *service.Request, output *GetOpenIdTokenOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) GetOpenIdTokenRequest(input *GetOpenIdTokenInput) (req *request.Request, output *GetOpenIdTokenOutput) {
+	op := &request.Operation{
 		Name:       opGetOpenIdToken,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -288,8 +288,8 @@ func (c *CognitoIdentity) GetOpenIdToken(input *GetOpenIdTokenInput) (*GetOpenId
 const opGetOpenIdTokenForDeveloperIdentity = "GetOpenIdTokenForDeveloperIdentity"
 
 // GetOpenIdTokenForDeveloperIdentityRequest generates a request for the GetOpenIdTokenForDeveloperIdentity operation.
-func (c *CognitoIdentity) GetOpenIdTokenForDeveloperIdentityRequest(input *GetOpenIdTokenForDeveloperIdentityInput) (req *service.Request, output *GetOpenIdTokenForDeveloperIdentityOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) GetOpenIdTokenForDeveloperIdentityRequest(input *GetOpenIdTokenForDeveloperIdentityInput) (req *request.Request, output *GetOpenIdTokenForDeveloperIdentityOutput) {
+	op := &request.Operation{
 		Name:       opGetOpenIdTokenForDeveloperIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -330,8 +330,8 @@ func (c *CognitoIdentity) GetOpenIdTokenForDeveloperIdentity(input *GetOpenIdTok
 const opListIdentities = "ListIdentities"
 
 // ListIdentitiesRequest generates a request for the ListIdentities operation.
-func (c *CognitoIdentity) ListIdentitiesRequest(input *ListIdentitiesInput) (req *service.Request, output *ListIdentitiesOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) ListIdentitiesRequest(input *ListIdentitiesInput) (req *request.Request, output *ListIdentitiesOutput) {
+	op := &request.Operation{
 		Name:       opListIdentities,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -359,8 +359,8 @@ func (c *CognitoIdentity) ListIdentities(input *ListIdentitiesInput) (*ListIdent
 const opListIdentityPools = "ListIdentityPools"
 
 // ListIdentityPoolsRequest generates a request for the ListIdentityPools operation.
-func (c *CognitoIdentity) ListIdentityPoolsRequest(input *ListIdentityPoolsInput) (req *service.Request, output *ListIdentityPoolsOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) ListIdentityPoolsRequest(input *ListIdentityPoolsInput) (req *request.Request, output *ListIdentityPoolsOutput) {
+	op := &request.Operation{
 		Name:       opListIdentityPools,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -388,8 +388,8 @@ func (c *CognitoIdentity) ListIdentityPools(input *ListIdentityPoolsInput) (*Lis
 const opLookupDeveloperIdentity = "LookupDeveloperIdentity"
 
 // LookupDeveloperIdentityRequest generates a request for the LookupDeveloperIdentity operation.
-func (c *CognitoIdentity) LookupDeveloperIdentityRequest(input *LookupDeveloperIdentityInput) (req *service.Request, output *LookupDeveloperIdentityOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) LookupDeveloperIdentityRequest(input *LookupDeveloperIdentityInput) (req *request.Request, output *LookupDeveloperIdentityOutput) {
+	op := &request.Operation{
 		Name:       opLookupDeveloperIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -424,8 +424,8 @@ func (c *CognitoIdentity) LookupDeveloperIdentity(input *LookupDeveloperIdentity
 const opMergeDeveloperIdentities = "MergeDeveloperIdentities"
 
 // MergeDeveloperIdentitiesRequest generates a request for the MergeDeveloperIdentities operation.
-func (c *CognitoIdentity) MergeDeveloperIdentitiesRequest(input *MergeDeveloperIdentitiesInput) (req *service.Request, output *MergeDeveloperIdentitiesOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) MergeDeveloperIdentitiesRequest(input *MergeDeveloperIdentitiesInput) (req *request.Request, output *MergeDeveloperIdentitiesOutput) {
+	op := &request.Operation{
 		Name:       opMergeDeveloperIdentities,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -459,8 +459,8 @@ func (c *CognitoIdentity) MergeDeveloperIdentities(input *MergeDeveloperIdentiti
 const opSetIdentityPoolRoles = "SetIdentityPoolRoles"
 
 // SetIdentityPoolRolesRequest generates a request for the SetIdentityPoolRoles operation.
-func (c *CognitoIdentity) SetIdentityPoolRolesRequest(input *SetIdentityPoolRolesInput) (req *service.Request, output *SetIdentityPoolRolesOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) SetIdentityPoolRolesRequest(input *SetIdentityPoolRolesInput) (req *request.Request, output *SetIdentityPoolRolesOutput) {
+	op := &request.Operation{
 		Name:       opSetIdentityPoolRoles,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -489,8 +489,8 @@ func (c *CognitoIdentity) SetIdentityPoolRoles(input *SetIdentityPoolRolesInput)
 const opUnlinkDeveloperIdentity = "UnlinkDeveloperIdentity"
 
 // UnlinkDeveloperIdentityRequest generates a request for the UnlinkDeveloperIdentity operation.
-func (c *CognitoIdentity) UnlinkDeveloperIdentityRequest(input *UnlinkDeveloperIdentityInput) (req *service.Request, output *UnlinkDeveloperIdentityOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) UnlinkDeveloperIdentityRequest(input *UnlinkDeveloperIdentityInput) (req *request.Request, output *UnlinkDeveloperIdentityOutput) {
+	op := &request.Operation{
 		Name:       opUnlinkDeveloperIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -521,8 +521,8 @@ func (c *CognitoIdentity) UnlinkDeveloperIdentity(input *UnlinkDeveloperIdentity
 const opUnlinkIdentity = "UnlinkIdentity"
 
 // UnlinkIdentityRequest generates a request for the UnlinkIdentity operation.
-func (c *CognitoIdentity) UnlinkIdentityRequest(input *UnlinkIdentityInput) (req *service.Request, output *UnlinkIdentityOutput) {
-	op := &service.Operation{
+func (c *CognitoIdentity) UnlinkIdentityRequest(input *UnlinkIdentityInput) (req *request.Request, output *UnlinkIdentityOutput) {
+	op := &request.Operation{
 		Name:       opUnlinkIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -552,8 +552,8 @@ func (c *CognitoIdentity) UnlinkIdentity(input *UnlinkIdentityInput) (*UnlinkIde
 const opUpdateIdentityPool = "UpdateIdentityPool"
 
 // UpdateIdentityPoolRequest generates a request for the UpdateIdentityPool operation.
-func (c *CognitoIdentity) UpdateIdentityPoolRequest(input *IdentityPool) (req *service.Request, output *IdentityPool) {
-	op := &service.Operation{
+func (c *CognitoIdentity) UpdateIdentityPoolRequest(input *IdentityPool) (req *request.Request, output *IdentityPool) {
+	op := &request.Operation{
 		Name:       opUpdateIdentityPool,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/cognitoidentity/cognitoidentityiface/interface.go
+++ b/service/cognitoidentity/cognitoidentityiface/interface.go
@@ -4,81 +4,81 @@
 package cognitoidentityiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cognitoidentity"
 )
 
 // CognitoIdentityAPI is the interface type for cognitoidentity.CognitoIdentity.
 type CognitoIdentityAPI interface {
-	CreateIdentityPoolRequest(*cognitoidentity.CreateIdentityPoolInput) (*service.Request, *cognitoidentity.IdentityPool)
+	CreateIdentityPoolRequest(*cognitoidentity.CreateIdentityPoolInput) (*request.Request, *cognitoidentity.IdentityPool)
 
 	CreateIdentityPool(*cognitoidentity.CreateIdentityPoolInput) (*cognitoidentity.IdentityPool, error)
 
-	DeleteIdentitiesRequest(*cognitoidentity.DeleteIdentitiesInput) (*service.Request, *cognitoidentity.DeleteIdentitiesOutput)
+	DeleteIdentitiesRequest(*cognitoidentity.DeleteIdentitiesInput) (*request.Request, *cognitoidentity.DeleteIdentitiesOutput)
 
 	DeleteIdentities(*cognitoidentity.DeleteIdentitiesInput) (*cognitoidentity.DeleteIdentitiesOutput, error)
 
-	DeleteIdentityPoolRequest(*cognitoidentity.DeleteIdentityPoolInput) (*service.Request, *cognitoidentity.DeleteIdentityPoolOutput)
+	DeleteIdentityPoolRequest(*cognitoidentity.DeleteIdentityPoolInput) (*request.Request, *cognitoidentity.DeleteIdentityPoolOutput)
 
 	DeleteIdentityPool(*cognitoidentity.DeleteIdentityPoolInput) (*cognitoidentity.DeleteIdentityPoolOutput, error)
 
-	DescribeIdentityRequest(*cognitoidentity.DescribeIdentityInput) (*service.Request, *cognitoidentity.IdentityDescription)
+	DescribeIdentityRequest(*cognitoidentity.DescribeIdentityInput) (*request.Request, *cognitoidentity.IdentityDescription)
 
 	DescribeIdentity(*cognitoidentity.DescribeIdentityInput) (*cognitoidentity.IdentityDescription, error)
 
-	DescribeIdentityPoolRequest(*cognitoidentity.DescribeIdentityPoolInput) (*service.Request, *cognitoidentity.IdentityPool)
+	DescribeIdentityPoolRequest(*cognitoidentity.DescribeIdentityPoolInput) (*request.Request, *cognitoidentity.IdentityPool)
 
 	DescribeIdentityPool(*cognitoidentity.DescribeIdentityPoolInput) (*cognitoidentity.IdentityPool, error)
 
-	GetCredentialsForIdentityRequest(*cognitoidentity.GetCredentialsForIdentityInput) (*service.Request, *cognitoidentity.GetCredentialsForIdentityOutput)
+	GetCredentialsForIdentityRequest(*cognitoidentity.GetCredentialsForIdentityInput) (*request.Request, *cognitoidentity.GetCredentialsForIdentityOutput)
 
 	GetCredentialsForIdentity(*cognitoidentity.GetCredentialsForIdentityInput) (*cognitoidentity.GetCredentialsForIdentityOutput, error)
 
-	GetIdRequest(*cognitoidentity.GetIdInput) (*service.Request, *cognitoidentity.GetIdOutput)
+	GetIdRequest(*cognitoidentity.GetIdInput) (*request.Request, *cognitoidentity.GetIdOutput)
 
 	GetId(*cognitoidentity.GetIdInput) (*cognitoidentity.GetIdOutput, error)
 
-	GetIdentityPoolRolesRequest(*cognitoidentity.GetIdentityPoolRolesInput) (*service.Request, *cognitoidentity.GetIdentityPoolRolesOutput)
+	GetIdentityPoolRolesRequest(*cognitoidentity.GetIdentityPoolRolesInput) (*request.Request, *cognitoidentity.GetIdentityPoolRolesOutput)
 
 	GetIdentityPoolRoles(*cognitoidentity.GetIdentityPoolRolesInput) (*cognitoidentity.GetIdentityPoolRolesOutput, error)
 
-	GetOpenIdTokenRequest(*cognitoidentity.GetOpenIdTokenInput) (*service.Request, *cognitoidentity.GetOpenIdTokenOutput)
+	GetOpenIdTokenRequest(*cognitoidentity.GetOpenIdTokenInput) (*request.Request, *cognitoidentity.GetOpenIdTokenOutput)
 
 	GetOpenIdToken(*cognitoidentity.GetOpenIdTokenInput) (*cognitoidentity.GetOpenIdTokenOutput, error)
 
-	GetOpenIdTokenForDeveloperIdentityRequest(*cognitoidentity.GetOpenIdTokenForDeveloperIdentityInput) (*service.Request, *cognitoidentity.GetOpenIdTokenForDeveloperIdentityOutput)
+	GetOpenIdTokenForDeveloperIdentityRequest(*cognitoidentity.GetOpenIdTokenForDeveloperIdentityInput) (*request.Request, *cognitoidentity.GetOpenIdTokenForDeveloperIdentityOutput)
 
 	GetOpenIdTokenForDeveloperIdentity(*cognitoidentity.GetOpenIdTokenForDeveloperIdentityInput) (*cognitoidentity.GetOpenIdTokenForDeveloperIdentityOutput, error)
 
-	ListIdentitiesRequest(*cognitoidentity.ListIdentitiesInput) (*service.Request, *cognitoidentity.ListIdentitiesOutput)
+	ListIdentitiesRequest(*cognitoidentity.ListIdentitiesInput) (*request.Request, *cognitoidentity.ListIdentitiesOutput)
 
 	ListIdentities(*cognitoidentity.ListIdentitiesInput) (*cognitoidentity.ListIdentitiesOutput, error)
 
-	ListIdentityPoolsRequest(*cognitoidentity.ListIdentityPoolsInput) (*service.Request, *cognitoidentity.ListIdentityPoolsOutput)
+	ListIdentityPoolsRequest(*cognitoidentity.ListIdentityPoolsInput) (*request.Request, *cognitoidentity.ListIdentityPoolsOutput)
 
 	ListIdentityPools(*cognitoidentity.ListIdentityPoolsInput) (*cognitoidentity.ListIdentityPoolsOutput, error)
 
-	LookupDeveloperIdentityRequest(*cognitoidentity.LookupDeveloperIdentityInput) (*service.Request, *cognitoidentity.LookupDeveloperIdentityOutput)
+	LookupDeveloperIdentityRequest(*cognitoidentity.LookupDeveloperIdentityInput) (*request.Request, *cognitoidentity.LookupDeveloperIdentityOutput)
 
 	LookupDeveloperIdentity(*cognitoidentity.LookupDeveloperIdentityInput) (*cognitoidentity.LookupDeveloperIdentityOutput, error)
 
-	MergeDeveloperIdentitiesRequest(*cognitoidentity.MergeDeveloperIdentitiesInput) (*service.Request, *cognitoidentity.MergeDeveloperIdentitiesOutput)
+	MergeDeveloperIdentitiesRequest(*cognitoidentity.MergeDeveloperIdentitiesInput) (*request.Request, *cognitoidentity.MergeDeveloperIdentitiesOutput)
 
 	MergeDeveloperIdentities(*cognitoidentity.MergeDeveloperIdentitiesInput) (*cognitoidentity.MergeDeveloperIdentitiesOutput, error)
 
-	SetIdentityPoolRolesRequest(*cognitoidentity.SetIdentityPoolRolesInput) (*service.Request, *cognitoidentity.SetIdentityPoolRolesOutput)
+	SetIdentityPoolRolesRequest(*cognitoidentity.SetIdentityPoolRolesInput) (*request.Request, *cognitoidentity.SetIdentityPoolRolesOutput)
 
 	SetIdentityPoolRoles(*cognitoidentity.SetIdentityPoolRolesInput) (*cognitoidentity.SetIdentityPoolRolesOutput, error)
 
-	UnlinkDeveloperIdentityRequest(*cognitoidentity.UnlinkDeveloperIdentityInput) (*service.Request, *cognitoidentity.UnlinkDeveloperIdentityOutput)
+	UnlinkDeveloperIdentityRequest(*cognitoidentity.UnlinkDeveloperIdentityInput) (*request.Request, *cognitoidentity.UnlinkDeveloperIdentityOutput)
 
 	UnlinkDeveloperIdentity(*cognitoidentity.UnlinkDeveloperIdentityInput) (*cognitoidentity.UnlinkDeveloperIdentityOutput, error)
 
-	UnlinkIdentityRequest(*cognitoidentity.UnlinkIdentityInput) (*service.Request, *cognitoidentity.UnlinkIdentityOutput)
+	UnlinkIdentityRequest(*cognitoidentity.UnlinkIdentityInput) (*request.Request, *cognitoidentity.UnlinkIdentityOutput)
 
 	UnlinkIdentity(*cognitoidentity.UnlinkIdentityInput) (*cognitoidentity.UnlinkIdentityOutput, error)
 
-	UpdateIdentityPoolRequest(*cognitoidentity.IdentityPool) (*service.Request, *cognitoidentity.IdentityPool)
+	UpdateIdentityPoolRequest(*cognitoidentity.IdentityPool) (*request.Request, *cognitoidentity.IdentityPool)
 
 	UpdateIdentityPool(*cognitoidentity.IdentityPool) (*cognitoidentity.IdentityPool, error)
 }

--- a/service/cognitoidentity/customizations.go
+++ b/service/cognitoidentity/customizations.go
@@ -1,9 +1,9 @@
 package cognitoidentity
 
-import "github.com/aws/aws-sdk-go/aws/service"
+import "github.com/aws/aws-sdk-go/aws/request"
 
 func init() {
-	initRequest = func(r *service.Request) {
+	initRequest = func(r *request.Request) {
 		switch r.Operation.Name {
 		case opGetOpenIdToken, opGetId, opGetCredentialsForIdentity:
 			r.Handlers.Sign.Clear() // these operations are unsigned

--- a/service/cognitoidentity/service.go
+++ b/service/cognitoidentity/service.go
@@ -5,7 +5,9 @@ package cognitoidentity
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -50,16 +52,18 @@ type CognitoIdentity struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CognitoIdentity client.
 func New(config *aws.Config) *CognitoIdentity {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "cognito-identity",
-		APIVersion:   "2014-06-30",
-		JSONVersion:  "1.1",
-		TargetPrefix: "AWSCognitoIdentityService",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "cognito-identity",
+			APIVersion:   "2014-06-30",
+			JSONVersion:  "1.1",
+			TargetPrefix: "AWSCognitoIdentityService",
+		},
 	}
 	service.Initialize()
 
@@ -80,8 +84,8 @@ func New(config *aws.Config) *CognitoIdentity {
 
 // newRequest creates a new request for a CognitoIdentity operation and runs any
 // custom request initialization.
-func (c *CognitoIdentity) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CognitoIdentity) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/cognitosync/api.go
+++ b/service/cognitosync/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opBulkPublish = "BulkPublish"
 
 // BulkPublishRequest generates a request for the BulkPublish operation.
-func (c *CognitoSync) BulkPublishRequest(input *BulkPublishInput) (req *service.Request, output *BulkPublishOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) BulkPublishRequest(input *BulkPublishInput) (req *request.Request, output *BulkPublishOutput) {
+	op := &request.Operation{
 		Name:       opBulkPublish,
 		HTTPMethod: "POST",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/bulkpublish",
@@ -46,8 +46,8 @@ func (c *CognitoSync) BulkPublish(input *BulkPublishInput) (*BulkPublishOutput, 
 const opDeleteDataset = "DeleteDataset"
 
 // DeleteDatasetRequest generates a request for the DeleteDataset operation.
-func (c *CognitoSync) DeleteDatasetRequest(input *DeleteDatasetInput) (req *service.Request, output *DeleteDatasetOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) DeleteDatasetRequest(input *DeleteDatasetInput) (req *request.Request, output *DeleteDatasetOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDataset,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}",
@@ -79,8 +79,8 @@ func (c *CognitoSync) DeleteDataset(input *DeleteDatasetInput) (*DeleteDatasetOu
 const opDescribeDataset = "DescribeDataset"
 
 // DescribeDatasetRequest generates a request for the DescribeDataset operation.
-func (c *CognitoSync) DescribeDatasetRequest(input *DescribeDatasetInput) (req *service.Request, output *DescribeDatasetOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) DescribeDatasetRequest(input *DescribeDatasetInput) (req *request.Request, output *DescribeDatasetOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDataset,
 		HTTPMethod: "GET",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}",
@@ -112,8 +112,8 @@ func (c *CognitoSync) DescribeDataset(input *DescribeDatasetInput) (*DescribeDat
 const opDescribeIdentityPoolUsage = "DescribeIdentityPoolUsage"
 
 // DescribeIdentityPoolUsageRequest generates a request for the DescribeIdentityPoolUsage operation.
-func (c *CognitoSync) DescribeIdentityPoolUsageRequest(input *DescribeIdentityPoolUsageInput) (req *service.Request, output *DescribeIdentityPoolUsageOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) DescribeIdentityPoolUsageRequest(input *DescribeIdentityPoolUsageInput) (req *request.Request, output *DescribeIdentityPoolUsageOutput) {
+	op := &request.Operation{
 		Name:       opDescribeIdentityPoolUsage,
 		HTTPMethod: "GET",
 		HTTPPath:   "/identitypools/{IdentityPoolId}",
@@ -143,8 +143,8 @@ func (c *CognitoSync) DescribeIdentityPoolUsage(input *DescribeIdentityPoolUsage
 const opDescribeIdentityUsage = "DescribeIdentityUsage"
 
 // DescribeIdentityUsageRequest generates a request for the DescribeIdentityUsage operation.
-func (c *CognitoSync) DescribeIdentityUsageRequest(input *DescribeIdentityUsageInput) (req *service.Request, output *DescribeIdentityUsageOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) DescribeIdentityUsageRequest(input *DescribeIdentityUsageInput) (req *request.Request, output *DescribeIdentityUsageOutput) {
+	op := &request.Operation{
 		Name:       opDescribeIdentityUsage,
 		HTTPMethod: "GET",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identities/{IdentityId}",
@@ -174,8 +174,8 @@ func (c *CognitoSync) DescribeIdentityUsage(input *DescribeIdentityUsageInput) (
 const opGetBulkPublishDetails = "GetBulkPublishDetails"
 
 // GetBulkPublishDetailsRequest generates a request for the GetBulkPublishDetails operation.
-func (c *CognitoSync) GetBulkPublishDetailsRequest(input *GetBulkPublishDetailsInput) (req *service.Request, output *GetBulkPublishDetailsOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) GetBulkPublishDetailsRequest(input *GetBulkPublishDetailsInput) (req *request.Request, output *GetBulkPublishDetailsOutput) {
+	op := &request.Operation{
 		Name:       opGetBulkPublishDetails,
 		HTTPMethod: "POST",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/getBulkPublishDetails",
@@ -204,8 +204,8 @@ func (c *CognitoSync) GetBulkPublishDetails(input *GetBulkPublishDetailsInput) (
 const opGetCognitoEvents = "GetCognitoEvents"
 
 // GetCognitoEventsRequest generates a request for the GetCognitoEvents operation.
-func (c *CognitoSync) GetCognitoEventsRequest(input *GetCognitoEventsInput) (req *service.Request, output *GetCognitoEventsOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) GetCognitoEventsRequest(input *GetCognitoEventsInput) (req *request.Request, output *GetCognitoEventsOutput) {
+	op := &request.Operation{
 		Name:       opGetCognitoEvents,
 		HTTPMethod: "GET",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/events",
@@ -235,8 +235,8 @@ func (c *CognitoSync) GetCognitoEvents(input *GetCognitoEventsInput) (*GetCognit
 const opGetIdentityPoolConfiguration = "GetIdentityPoolConfiguration"
 
 // GetIdentityPoolConfigurationRequest generates a request for the GetIdentityPoolConfiguration operation.
-func (c *CognitoSync) GetIdentityPoolConfigurationRequest(input *GetIdentityPoolConfigurationInput) (req *service.Request, output *GetIdentityPoolConfigurationOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) GetIdentityPoolConfigurationRequest(input *GetIdentityPoolConfigurationInput) (req *request.Request, output *GetIdentityPoolConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opGetIdentityPoolConfiguration,
 		HTTPMethod: "GET",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/configuration",
@@ -265,8 +265,8 @@ func (c *CognitoSync) GetIdentityPoolConfiguration(input *GetIdentityPoolConfigu
 const opListDatasets = "ListDatasets"
 
 // ListDatasetsRequest generates a request for the ListDatasets operation.
-func (c *CognitoSync) ListDatasetsRequest(input *ListDatasetsInput) (req *service.Request, output *ListDatasetsOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) ListDatasetsRequest(input *ListDatasetsInput) (req *request.Request, output *ListDatasetsOutput) {
+	op := &request.Operation{
 		Name:       opListDatasets,
 		HTTPMethod: "GET",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets",
@@ -298,8 +298,8 @@ func (c *CognitoSync) ListDatasets(input *ListDatasetsInput) (*ListDatasetsOutpu
 const opListIdentityPoolUsage = "ListIdentityPoolUsage"
 
 // ListIdentityPoolUsageRequest generates a request for the ListIdentityPoolUsage operation.
-func (c *CognitoSync) ListIdentityPoolUsageRequest(input *ListIdentityPoolUsageInput) (req *service.Request, output *ListIdentityPoolUsageOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) ListIdentityPoolUsageRequest(input *ListIdentityPoolUsageInput) (req *request.Request, output *ListIdentityPoolUsageOutput) {
+	op := &request.Operation{
 		Name:       opListIdentityPoolUsage,
 		HTTPMethod: "GET",
 		HTTPPath:   "/identitypools",
@@ -329,8 +329,8 @@ func (c *CognitoSync) ListIdentityPoolUsage(input *ListIdentityPoolUsageInput) (
 const opListRecords = "ListRecords"
 
 // ListRecordsRequest generates a request for the ListRecords operation.
-func (c *CognitoSync) ListRecordsRequest(input *ListRecordsInput) (req *service.Request, output *ListRecordsOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) ListRecordsRequest(input *ListRecordsInput) (req *request.Request, output *ListRecordsOutput) {
+	op := &request.Operation{
 		Name:       opListRecords,
 		HTTPMethod: "GET",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/records",
@@ -363,8 +363,8 @@ func (c *CognitoSync) ListRecords(input *ListRecordsInput) (*ListRecordsOutput, 
 const opRegisterDevice = "RegisterDevice"
 
 // RegisterDeviceRequest generates a request for the RegisterDevice operation.
-func (c *CognitoSync) RegisterDeviceRequest(input *RegisterDeviceInput) (req *service.Request, output *RegisterDeviceOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) RegisterDeviceRequest(input *RegisterDeviceInput) (req *request.Request, output *RegisterDeviceOutput) {
+	op := &request.Operation{
 		Name:       opRegisterDevice,
 		HTTPMethod: "POST",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identity/{IdentityId}/device",
@@ -393,8 +393,8 @@ func (c *CognitoSync) RegisterDevice(input *RegisterDeviceInput) (*RegisterDevic
 const opSetCognitoEvents = "SetCognitoEvents"
 
 // SetCognitoEventsRequest generates a request for the SetCognitoEvents operation.
-func (c *CognitoSync) SetCognitoEventsRequest(input *SetCognitoEventsInput) (req *service.Request, output *SetCognitoEventsOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) SetCognitoEventsRequest(input *SetCognitoEventsInput) (req *request.Request, output *SetCognitoEventsOutput) {
+	op := &request.Operation{
 		Name:       opSetCognitoEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/events",
@@ -426,8 +426,8 @@ func (c *CognitoSync) SetCognitoEvents(input *SetCognitoEventsInput) (*SetCognit
 const opSetIdentityPoolConfiguration = "SetIdentityPoolConfiguration"
 
 // SetIdentityPoolConfigurationRequest generates a request for the SetIdentityPoolConfiguration operation.
-func (c *CognitoSync) SetIdentityPoolConfigurationRequest(input *SetIdentityPoolConfigurationInput) (req *service.Request, output *SetIdentityPoolConfigurationOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) SetIdentityPoolConfigurationRequest(input *SetIdentityPoolConfigurationInput) (req *request.Request, output *SetIdentityPoolConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opSetIdentityPoolConfiguration,
 		HTTPMethod: "POST",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/configuration",
@@ -456,8 +456,8 @@ func (c *CognitoSync) SetIdentityPoolConfiguration(input *SetIdentityPoolConfigu
 const opSubscribeToDataset = "SubscribeToDataset"
 
 // SubscribeToDatasetRequest generates a request for the SubscribeToDataset operation.
-func (c *CognitoSync) SubscribeToDatasetRequest(input *SubscribeToDatasetInput) (req *service.Request, output *SubscribeToDatasetOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) SubscribeToDatasetRequest(input *SubscribeToDatasetInput) (req *request.Request, output *SubscribeToDatasetOutput) {
+	op := &request.Operation{
 		Name:       opSubscribeToDataset,
 		HTTPMethod: "POST",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/subscriptions/{DeviceId}",
@@ -487,8 +487,8 @@ func (c *CognitoSync) SubscribeToDataset(input *SubscribeToDatasetInput) (*Subsc
 const opUnsubscribeFromDataset = "UnsubscribeFromDataset"
 
 // UnsubscribeFromDatasetRequest generates a request for the UnsubscribeFromDataset operation.
-func (c *CognitoSync) UnsubscribeFromDatasetRequest(input *UnsubscribeFromDatasetInput) (req *service.Request, output *UnsubscribeFromDatasetOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) UnsubscribeFromDatasetRequest(input *UnsubscribeFromDatasetInput) (req *request.Request, output *UnsubscribeFromDatasetOutput) {
+	op := &request.Operation{
 		Name:       opUnsubscribeFromDataset,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}/subscriptions/{DeviceId}",
@@ -518,8 +518,8 @@ func (c *CognitoSync) UnsubscribeFromDataset(input *UnsubscribeFromDatasetInput)
 const opUpdateRecords = "UpdateRecords"
 
 // UpdateRecordsRequest generates a request for the UpdateRecords operation.
-func (c *CognitoSync) UpdateRecordsRequest(input *UpdateRecordsInput) (req *service.Request, output *UpdateRecordsOutput) {
-	op := &service.Operation{
+func (c *CognitoSync) UpdateRecordsRequest(input *UpdateRecordsInput) (req *request.Request, output *UpdateRecordsOutput) {
+	op := &request.Operation{
 		Name:       opUpdateRecords,
 		HTTPMethod: "POST",
 		HTTPPath:   "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}",

--- a/service/cognitosync/cognitosynciface/interface.go
+++ b/service/cognitosync/cognitosynciface/interface.go
@@ -4,77 +4,77 @@
 package cognitosynciface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cognitosync"
 )
 
 // CognitoSyncAPI is the interface type for cognitosync.CognitoSync.
 type CognitoSyncAPI interface {
-	BulkPublishRequest(*cognitosync.BulkPublishInput) (*service.Request, *cognitosync.BulkPublishOutput)
+	BulkPublishRequest(*cognitosync.BulkPublishInput) (*request.Request, *cognitosync.BulkPublishOutput)
 
 	BulkPublish(*cognitosync.BulkPublishInput) (*cognitosync.BulkPublishOutput, error)
 
-	DeleteDatasetRequest(*cognitosync.DeleteDatasetInput) (*service.Request, *cognitosync.DeleteDatasetOutput)
+	DeleteDatasetRequest(*cognitosync.DeleteDatasetInput) (*request.Request, *cognitosync.DeleteDatasetOutput)
 
 	DeleteDataset(*cognitosync.DeleteDatasetInput) (*cognitosync.DeleteDatasetOutput, error)
 
-	DescribeDatasetRequest(*cognitosync.DescribeDatasetInput) (*service.Request, *cognitosync.DescribeDatasetOutput)
+	DescribeDatasetRequest(*cognitosync.DescribeDatasetInput) (*request.Request, *cognitosync.DescribeDatasetOutput)
 
 	DescribeDataset(*cognitosync.DescribeDatasetInput) (*cognitosync.DescribeDatasetOutput, error)
 
-	DescribeIdentityPoolUsageRequest(*cognitosync.DescribeIdentityPoolUsageInput) (*service.Request, *cognitosync.DescribeIdentityPoolUsageOutput)
+	DescribeIdentityPoolUsageRequest(*cognitosync.DescribeIdentityPoolUsageInput) (*request.Request, *cognitosync.DescribeIdentityPoolUsageOutput)
 
 	DescribeIdentityPoolUsage(*cognitosync.DescribeIdentityPoolUsageInput) (*cognitosync.DescribeIdentityPoolUsageOutput, error)
 
-	DescribeIdentityUsageRequest(*cognitosync.DescribeIdentityUsageInput) (*service.Request, *cognitosync.DescribeIdentityUsageOutput)
+	DescribeIdentityUsageRequest(*cognitosync.DescribeIdentityUsageInput) (*request.Request, *cognitosync.DescribeIdentityUsageOutput)
 
 	DescribeIdentityUsage(*cognitosync.DescribeIdentityUsageInput) (*cognitosync.DescribeIdentityUsageOutput, error)
 
-	GetBulkPublishDetailsRequest(*cognitosync.GetBulkPublishDetailsInput) (*service.Request, *cognitosync.GetBulkPublishDetailsOutput)
+	GetBulkPublishDetailsRequest(*cognitosync.GetBulkPublishDetailsInput) (*request.Request, *cognitosync.GetBulkPublishDetailsOutput)
 
 	GetBulkPublishDetails(*cognitosync.GetBulkPublishDetailsInput) (*cognitosync.GetBulkPublishDetailsOutput, error)
 
-	GetCognitoEventsRequest(*cognitosync.GetCognitoEventsInput) (*service.Request, *cognitosync.GetCognitoEventsOutput)
+	GetCognitoEventsRequest(*cognitosync.GetCognitoEventsInput) (*request.Request, *cognitosync.GetCognitoEventsOutput)
 
 	GetCognitoEvents(*cognitosync.GetCognitoEventsInput) (*cognitosync.GetCognitoEventsOutput, error)
 
-	GetIdentityPoolConfigurationRequest(*cognitosync.GetIdentityPoolConfigurationInput) (*service.Request, *cognitosync.GetIdentityPoolConfigurationOutput)
+	GetIdentityPoolConfigurationRequest(*cognitosync.GetIdentityPoolConfigurationInput) (*request.Request, *cognitosync.GetIdentityPoolConfigurationOutput)
 
 	GetIdentityPoolConfiguration(*cognitosync.GetIdentityPoolConfigurationInput) (*cognitosync.GetIdentityPoolConfigurationOutput, error)
 
-	ListDatasetsRequest(*cognitosync.ListDatasetsInput) (*service.Request, *cognitosync.ListDatasetsOutput)
+	ListDatasetsRequest(*cognitosync.ListDatasetsInput) (*request.Request, *cognitosync.ListDatasetsOutput)
 
 	ListDatasets(*cognitosync.ListDatasetsInput) (*cognitosync.ListDatasetsOutput, error)
 
-	ListIdentityPoolUsageRequest(*cognitosync.ListIdentityPoolUsageInput) (*service.Request, *cognitosync.ListIdentityPoolUsageOutput)
+	ListIdentityPoolUsageRequest(*cognitosync.ListIdentityPoolUsageInput) (*request.Request, *cognitosync.ListIdentityPoolUsageOutput)
 
 	ListIdentityPoolUsage(*cognitosync.ListIdentityPoolUsageInput) (*cognitosync.ListIdentityPoolUsageOutput, error)
 
-	ListRecordsRequest(*cognitosync.ListRecordsInput) (*service.Request, *cognitosync.ListRecordsOutput)
+	ListRecordsRequest(*cognitosync.ListRecordsInput) (*request.Request, *cognitosync.ListRecordsOutput)
 
 	ListRecords(*cognitosync.ListRecordsInput) (*cognitosync.ListRecordsOutput, error)
 
-	RegisterDeviceRequest(*cognitosync.RegisterDeviceInput) (*service.Request, *cognitosync.RegisterDeviceOutput)
+	RegisterDeviceRequest(*cognitosync.RegisterDeviceInput) (*request.Request, *cognitosync.RegisterDeviceOutput)
 
 	RegisterDevice(*cognitosync.RegisterDeviceInput) (*cognitosync.RegisterDeviceOutput, error)
 
-	SetCognitoEventsRequest(*cognitosync.SetCognitoEventsInput) (*service.Request, *cognitosync.SetCognitoEventsOutput)
+	SetCognitoEventsRequest(*cognitosync.SetCognitoEventsInput) (*request.Request, *cognitosync.SetCognitoEventsOutput)
 
 	SetCognitoEvents(*cognitosync.SetCognitoEventsInput) (*cognitosync.SetCognitoEventsOutput, error)
 
-	SetIdentityPoolConfigurationRequest(*cognitosync.SetIdentityPoolConfigurationInput) (*service.Request, *cognitosync.SetIdentityPoolConfigurationOutput)
+	SetIdentityPoolConfigurationRequest(*cognitosync.SetIdentityPoolConfigurationInput) (*request.Request, *cognitosync.SetIdentityPoolConfigurationOutput)
 
 	SetIdentityPoolConfiguration(*cognitosync.SetIdentityPoolConfigurationInput) (*cognitosync.SetIdentityPoolConfigurationOutput, error)
 
-	SubscribeToDatasetRequest(*cognitosync.SubscribeToDatasetInput) (*service.Request, *cognitosync.SubscribeToDatasetOutput)
+	SubscribeToDatasetRequest(*cognitosync.SubscribeToDatasetInput) (*request.Request, *cognitosync.SubscribeToDatasetOutput)
 
 	SubscribeToDataset(*cognitosync.SubscribeToDatasetInput) (*cognitosync.SubscribeToDatasetOutput, error)
 
-	UnsubscribeFromDatasetRequest(*cognitosync.UnsubscribeFromDatasetInput) (*service.Request, *cognitosync.UnsubscribeFromDatasetOutput)
+	UnsubscribeFromDatasetRequest(*cognitosync.UnsubscribeFromDatasetInput) (*request.Request, *cognitosync.UnsubscribeFromDatasetOutput)
 
 	UnsubscribeFromDataset(*cognitosync.UnsubscribeFromDatasetInput) (*cognitosync.UnsubscribeFromDatasetOutput, error)
 
-	UpdateRecordsRequest(*cognitosync.UpdateRecordsInput) (*service.Request, *cognitosync.UpdateRecordsOutput)
+	UpdateRecordsRequest(*cognitosync.UpdateRecordsInput) (*request.Request, *cognitosync.UpdateRecordsOutput)
 
 	UpdateRecords(*cognitosync.UpdateRecordsInput) (*cognitosync.UpdateRecordsOutput, error)
 }

--- a/service/cognitosync/service.go
+++ b/service/cognitosync/service.go
@@ -5,7 +5,9 @@ package cognitosync
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -36,14 +38,16 @@ type CognitoSync struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new CognitoSync client.
 func New(config *aws.Config) *CognitoSync {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "cognito-sync",
-		APIVersion:  "2014-06-30",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "cognito-sync",
+			APIVersion:  "2014-06-30",
+		},
 	}
 	service.Initialize()
 
@@ -64,8 +68,8 @@ func New(config *aws.Config) *CognitoSync {
 
 // newRequest creates a new request for a CognitoSync operation and runs any
 // custom request initialization.
-func (c *CognitoSync) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *CognitoSync) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/configservice/api.go
+++ b/service/configservice/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opDeleteDeliveryChannel = "DeleteDeliveryChannel"
 
 // DeleteDeliveryChannelRequest generates a request for the DeleteDeliveryChannel operation.
-func (c *ConfigService) DeleteDeliveryChannelRequest(input *DeleteDeliveryChannelInput) (req *service.Request, output *DeleteDeliveryChannelOutput) {
-	op := &service.Operation{
+func (c *ConfigService) DeleteDeliveryChannelRequest(input *DeleteDeliveryChannelInput) (req *request.Request, output *DeleteDeliveryChannelOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDeliveryChannel,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -45,8 +45,8 @@ func (c *ConfigService) DeleteDeliveryChannel(input *DeleteDeliveryChannelInput)
 const opDeliverConfigSnapshot = "DeliverConfigSnapshot"
 
 // DeliverConfigSnapshotRequest generates a request for the DeliverConfigSnapshot operation.
-func (c *ConfigService) DeliverConfigSnapshotRequest(input *DeliverConfigSnapshotInput) (req *service.Request, output *DeliverConfigSnapshotOutput) {
-	op := &service.Operation{
+func (c *ConfigService) DeliverConfigSnapshotRequest(input *DeliverConfigSnapshotInput) (req *request.Request, output *DeliverConfigSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opDeliverConfigSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -78,8 +78,8 @@ func (c *ConfigService) DeliverConfigSnapshot(input *DeliverConfigSnapshotInput)
 const opDescribeConfigurationRecorderStatus = "DescribeConfigurationRecorderStatus"
 
 // DescribeConfigurationRecorderStatusRequest generates a request for the DescribeConfigurationRecorderStatus operation.
-func (c *ConfigService) DescribeConfigurationRecorderStatusRequest(input *DescribeConfigurationRecorderStatusInput) (req *service.Request, output *DescribeConfigurationRecorderStatusOutput) {
-	op := &service.Operation{
+func (c *ConfigService) DescribeConfigurationRecorderStatusRequest(input *DescribeConfigurationRecorderStatusInput) (req *request.Request, output *DescribeConfigurationRecorderStatusOutput) {
+	op := &request.Operation{
 		Name:       opDescribeConfigurationRecorderStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -109,8 +109,8 @@ func (c *ConfigService) DescribeConfigurationRecorderStatus(input *DescribeConfi
 const opDescribeConfigurationRecorders = "DescribeConfigurationRecorders"
 
 // DescribeConfigurationRecordersRequest generates a request for the DescribeConfigurationRecorders operation.
-func (c *ConfigService) DescribeConfigurationRecordersRequest(input *DescribeConfigurationRecordersInput) (req *service.Request, output *DescribeConfigurationRecordersOutput) {
-	op := &service.Operation{
+func (c *ConfigService) DescribeConfigurationRecordersRequest(input *DescribeConfigurationRecordersInput) (req *request.Request, output *DescribeConfigurationRecordersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeConfigurationRecorders,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -140,8 +140,8 @@ func (c *ConfigService) DescribeConfigurationRecorders(input *DescribeConfigurat
 const opDescribeDeliveryChannelStatus = "DescribeDeliveryChannelStatus"
 
 // DescribeDeliveryChannelStatusRequest generates a request for the DescribeDeliveryChannelStatus operation.
-func (c *ConfigService) DescribeDeliveryChannelStatusRequest(input *DescribeDeliveryChannelStatusInput) (req *service.Request, output *DescribeDeliveryChannelStatusOutput) {
-	op := &service.Operation{
+func (c *ConfigService) DescribeDeliveryChannelStatusRequest(input *DescribeDeliveryChannelStatusInput) (req *request.Request, output *DescribeDeliveryChannelStatusOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDeliveryChannelStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -171,8 +171,8 @@ func (c *ConfigService) DescribeDeliveryChannelStatus(input *DescribeDeliveryCha
 const opDescribeDeliveryChannels = "DescribeDeliveryChannels"
 
 // DescribeDeliveryChannelsRequest generates a request for the DescribeDeliveryChannels operation.
-func (c *ConfigService) DescribeDeliveryChannelsRequest(input *DescribeDeliveryChannelsInput) (req *service.Request, output *DescribeDeliveryChannelsOutput) {
-	op := &service.Operation{
+func (c *ConfigService) DescribeDeliveryChannelsRequest(input *DescribeDeliveryChannelsInput) (req *request.Request, output *DescribeDeliveryChannelsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDeliveryChannels,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -202,12 +202,12 @@ func (c *ConfigService) DescribeDeliveryChannels(input *DescribeDeliveryChannels
 const opGetResourceConfigHistory = "GetResourceConfigHistory"
 
 // GetResourceConfigHistoryRequest generates a request for the GetResourceConfigHistory operation.
-func (c *ConfigService) GetResourceConfigHistoryRequest(input *GetResourceConfigHistoryInput) (req *service.Request, output *GetResourceConfigHistoryOutput) {
-	op := &service.Operation{
+func (c *ConfigService) GetResourceConfigHistoryRequest(input *GetResourceConfigHistoryInput) (req *request.Request, output *GetResourceConfigHistoryOutput) {
+	op := &request.Operation{
 		Name:       opGetResourceConfigHistory,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "limit",
@@ -250,8 +250,8 @@ func (c *ConfigService) GetResourceConfigHistoryPages(input *GetResourceConfigHi
 const opPutConfigurationRecorder = "PutConfigurationRecorder"
 
 // PutConfigurationRecorderRequest generates a request for the PutConfigurationRecorder operation.
-func (c *ConfigService) PutConfigurationRecorderRequest(input *PutConfigurationRecorderInput) (req *service.Request, output *PutConfigurationRecorderOutput) {
-	op := &service.Operation{
+func (c *ConfigService) PutConfigurationRecorderRequest(input *PutConfigurationRecorderInput) (req *request.Request, output *PutConfigurationRecorderOutput) {
+	op := &request.Operation{
 		Name:       opPutConfigurationRecorder,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -286,8 +286,8 @@ func (c *ConfigService) PutConfigurationRecorder(input *PutConfigurationRecorder
 const opPutDeliveryChannel = "PutDeliveryChannel"
 
 // PutDeliveryChannelRequest generates a request for the PutDeliveryChannel operation.
-func (c *ConfigService) PutDeliveryChannelRequest(input *PutDeliveryChannelInput) (req *service.Request, output *PutDeliveryChannelOutput) {
-	op := &service.Operation{
+func (c *ConfigService) PutDeliveryChannelRequest(input *PutDeliveryChannelInput) (req *request.Request, output *PutDeliveryChannelOutput) {
+	op := &request.Operation{
 		Name:       opPutDeliveryChannel,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -323,8 +323,8 @@ func (c *ConfigService) PutDeliveryChannel(input *PutDeliveryChannelInput) (*Put
 const opStartConfigurationRecorder = "StartConfigurationRecorder"
 
 // StartConfigurationRecorderRequest generates a request for the StartConfigurationRecorder operation.
-func (c *ConfigService) StartConfigurationRecorderRequest(input *StartConfigurationRecorderInput) (req *service.Request, output *StartConfigurationRecorderOutput) {
-	op := &service.Operation{
+func (c *ConfigService) StartConfigurationRecorderRequest(input *StartConfigurationRecorderInput) (req *request.Request, output *StartConfigurationRecorderOutput) {
+	op := &request.Operation{
 		Name:       opStartConfigurationRecorder,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -354,8 +354,8 @@ func (c *ConfigService) StartConfigurationRecorder(input *StartConfigurationReco
 const opStopConfigurationRecorder = "StopConfigurationRecorder"
 
 // StopConfigurationRecorderRequest generates a request for the StopConfigurationRecorder operation.
-func (c *ConfigService) StopConfigurationRecorderRequest(input *StopConfigurationRecorderInput) (req *service.Request, output *StopConfigurationRecorderOutput) {
-	op := &service.Operation{
+func (c *ConfigService) StopConfigurationRecorderRequest(input *StopConfigurationRecorderInput) (req *request.Request, output *StopConfigurationRecorderOutput) {
+	op := &request.Operation{
 		Name:       opStopConfigurationRecorder,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/configservice/configserviceiface/interface.go
+++ b/service/configservice/configserviceiface/interface.go
@@ -4,55 +4,55 @@
 package configserviceiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/configservice"
 )
 
 // ConfigServiceAPI is the interface type for configservice.ConfigService.
 type ConfigServiceAPI interface {
-	DeleteDeliveryChannelRequest(*configservice.DeleteDeliveryChannelInput) (*service.Request, *configservice.DeleteDeliveryChannelOutput)
+	DeleteDeliveryChannelRequest(*configservice.DeleteDeliveryChannelInput) (*request.Request, *configservice.DeleteDeliveryChannelOutput)
 
 	DeleteDeliveryChannel(*configservice.DeleteDeliveryChannelInput) (*configservice.DeleteDeliveryChannelOutput, error)
 
-	DeliverConfigSnapshotRequest(*configservice.DeliverConfigSnapshotInput) (*service.Request, *configservice.DeliverConfigSnapshotOutput)
+	DeliverConfigSnapshotRequest(*configservice.DeliverConfigSnapshotInput) (*request.Request, *configservice.DeliverConfigSnapshotOutput)
 
 	DeliverConfigSnapshot(*configservice.DeliverConfigSnapshotInput) (*configservice.DeliverConfigSnapshotOutput, error)
 
-	DescribeConfigurationRecorderStatusRequest(*configservice.DescribeConfigurationRecorderStatusInput) (*service.Request, *configservice.DescribeConfigurationRecorderStatusOutput)
+	DescribeConfigurationRecorderStatusRequest(*configservice.DescribeConfigurationRecorderStatusInput) (*request.Request, *configservice.DescribeConfigurationRecorderStatusOutput)
 
 	DescribeConfigurationRecorderStatus(*configservice.DescribeConfigurationRecorderStatusInput) (*configservice.DescribeConfigurationRecorderStatusOutput, error)
 
-	DescribeConfigurationRecordersRequest(*configservice.DescribeConfigurationRecordersInput) (*service.Request, *configservice.DescribeConfigurationRecordersOutput)
+	DescribeConfigurationRecordersRequest(*configservice.DescribeConfigurationRecordersInput) (*request.Request, *configservice.DescribeConfigurationRecordersOutput)
 
 	DescribeConfigurationRecorders(*configservice.DescribeConfigurationRecordersInput) (*configservice.DescribeConfigurationRecordersOutput, error)
 
-	DescribeDeliveryChannelStatusRequest(*configservice.DescribeDeliveryChannelStatusInput) (*service.Request, *configservice.DescribeDeliveryChannelStatusOutput)
+	DescribeDeliveryChannelStatusRequest(*configservice.DescribeDeliveryChannelStatusInput) (*request.Request, *configservice.DescribeDeliveryChannelStatusOutput)
 
 	DescribeDeliveryChannelStatus(*configservice.DescribeDeliveryChannelStatusInput) (*configservice.DescribeDeliveryChannelStatusOutput, error)
 
-	DescribeDeliveryChannelsRequest(*configservice.DescribeDeliveryChannelsInput) (*service.Request, *configservice.DescribeDeliveryChannelsOutput)
+	DescribeDeliveryChannelsRequest(*configservice.DescribeDeliveryChannelsInput) (*request.Request, *configservice.DescribeDeliveryChannelsOutput)
 
 	DescribeDeliveryChannels(*configservice.DescribeDeliveryChannelsInput) (*configservice.DescribeDeliveryChannelsOutput, error)
 
-	GetResourceConfigHistoryRequest(*configservice.GetResourceConfigHistoryInput) (*service.Request, *configservice.GetResourceConfigHistoryOutput)
+	GetResourceConfigHistoryRequest(*configservice.GetResourceConfigHistoryInput) (*request.Request, *configservice.GetResourceConfigHistoryOutput)
 
 	GetResourceConfigHistory(*configservice.GetResourceConfigHistoryInput) (*configservice.GetResourceConfigHistoryOutput, error)
 
 	GetResourceConfigHistoryPages(*configservice.GetResourceConfigHistoryInput, func(*configservice.GetResourceConfigHistoryOutput, bool) bool) error
 
-	PutConfigurationRecorderRequest(*configservice.PutConfigurationRecorderInput) (*service.Request, *configservice.PutConfigurationRecorderOutput)
+	PutConfigurationRecorderRequest(*configservice.PutConfigurationRecorderInput) (*request.Request, *configservice.PutConfigurationRecorderOutput)
 
 	PutConfigurationRecorder(*configservice.PutConfigurationRecorderInput) (*configservice.PutConfigurationRecorderOutput, error)
 
-	PutDeliveryChannelRequest(*configservice.PutDeliveryChannelInput) (*service.Request, *configservice.PutDeliveryChannelOutput)
+	PutDeliveryChannelRequest(*configservice.PutDeliveryChannelInput) (*request.Request, *configservice.PutDeliveryChannelOutput)
 
 	PutDeliveryChannel(*configservice.PutDeliveryChannelInput) (*configservice.PutDeliveryChannelOutput, error)
 
-	StartConfigurationRecorderRequest(*configservice.StartConfigurationRecorderInput) (*service.Request, *configservice.StartConfigurationRecorderOutput)
+	StartConfigurationRecorderRequest(*configservice.StartConfigurationRecorderInput) (*request.Request, *configservice.StartConfigurationRecorderOutput)
 
 	StartConfigurationRecorder(*configservice.StartConfigurationRecorderInput) (*configservice.StartConfigurationRecorderOutput, error)
 
-	StopConfigurationRecorderRequest(*configservice.StopConfigurationRecorderInput) (*service.Request, *configservice.StopConfigurationRecorderOutput)
+	StopConfigurationRecorderRequest(*configservice.StopConfigurationRecorderInput) (*request.Request, *configservice.StopConfigurationRecorderOutput)
 
 	StopConfigurationRecorder(*configservice.StopConfigurationRecorderInput) (*configservice.StopConfigurationRecorderOutput, error)
 }

--- a/service/configservice/service.go
+++ b/service/configservice/service.go
@@ -5,7 +5,9 @@ package configservice
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -42,16 +44,18 @@ type ConfigService struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new ConfigService client.
 func New(config *aws.Config) *ConfigService {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "config",
-		APIVersion:   "2014-11-12",
-		JSONVersion:  "1.1",
-		TargetPrefix: "StarlingDoveService",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "config",
+			APIVersion:   "2014-11-12",
+			JSONVersion:  "1.1",
+			TargetPrefix: "StarlingDoveService",
+		},
 	}
 	service.Initialize()
 
@@ -72,8 +76,8 @@ func New(config *aws.Config) *ConfigService {
 
 // newRequest creates a new request for a ConfigService operation and runs any
 // custom request initialization.
-func (c *ConfigService) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *ConfigService) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/datapipeline/api.go
+++ b/service/datapipeline/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opActivatePipeline = "ActivatePipeline"
 
 // ActivatePipelineRequest generates a request for the ActivatePipeline operation.
-func (c *DataPipeline) ActivatePipelineRequest(input *ActivatePipelineInput) (req *service.Request, output *ActivatePipelineOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) ActivatePipelineRequest(input *ActivatePipelineInput) (req *request.Request, output *ActivatePipelineOutput) {
+	op := &request.Operation{
 		Name:       opActivatePipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -47,8 +47,8 @@ func (c *DataPipeline) ActivatePipeline(input *ActivatePipelineInput) (*Activate
 const opAddTags = "AddTags"
 
 // AddTagsRequest generates a request for the AddTags operation.
-func (c *DataPipeline) AddTagsRequest(input *AddTagsInput) (req *service.Request, output *AddTagsOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) AddTagsRequest(input *AddTagsInput) (req *request.Request, output *AddTagsOutput) {
+	op := &request.Operation{
 		Name:       opAddTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -74,8 +74,8 @@ func (c *DataPipeline) AddTags(input *AddTagsInput) (*AddTagsOutput, error) {
 const opCreatePipeline = "CreatePipeline"
 
 // CreatePipelineRequest generates a request for the CreatePipeline operation.
-func (c *DataPipeline) CreatePipelineRequest(input *CreatePipelineInput) (req *service.Request, output *CreatePipelineOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) CreatePipelineRequest(input *CreatePipelineInput) (req *request.Request, output *CreatePipelineOutput) {
+	op := &request.Operation{
 		Name:       opCreatePipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -102,8 +102,8 @@ func (c *DataPipeline) CreatePipeline(input *CreatePipelineInput) (*CreatePipeli
 const opDeactivatePipeline = "DeactivatePipeline"
 
 // DeactivatePipelineRequest generates a request for the DeactivatePipeline operation.
-func (c *DataPipeline) DeactivatePipelineRequest(input *DeactivatePipelineInput) (req *service.Request, output *DeactivatePipelineOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) DeactivatePipelineRequest(input *DeactivatePipelineInput) (req *request.Request, output *DeactivatePipelineOutput) {
+	op := &request.Operation{
 		Name:       opDeactivatePipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -134,8 +134,8 @@ func (c *DataPipeline) DeactivatePipeline(input *DeactivatePipelineInput) (*Deac
 const opDeletePipeline = "DeletePipeline"
 
 // DeletePipelineRequest generates a request for the DeletePipeline operation.
-func (c *DataPipeline) DeletePipelineRequest(input *DeletePipelineInput) (req *service.Request, output *DeletePipelineOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) DeletePipelineRequest(input *DeletePipelineInput) (req *request.Request, output *DeletePipelineOutput) {
+	op := &request.Operation{
 		Name:       opDeletePipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -168,12 +168,12 @@ func (c *DataPipeline) DeletePipeline(input *DeletePipelineInput) (*DeletePipeli
 const opDescribeObjects = "DescribeObjects"
 
 // DescribeObjectsRequest generates a request for the DescribeObjects operation.
-func (c *DataPipeline) DescribeObjectsRequest(input *DescribeObjectsInput) (req *service.Request, output *DescribeObjectsOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) DescribeObjectsRequest(input *DescribeObjectsInput) (req *request.Request, output *DescribeObjectsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeObjects,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"marker"},
 			OutputTokens:    []string{"marker"},
 			LimitToken:      "",
@@ -210,8 +210,8 @@ func (c *DataPipeline) DescribeObjectsPages(input *DescribeObjectsInput, fn func
 const opDescribePipelines = "DescribePipelines"
 
 // DescribePipelinesRequest generates a request for the DescribePipelines operation.
-func (c *DataPipeline) DescribePipelinesRequest(input *DescribePipelinesInput) (req *service.Request, output *DescribePipelinesOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) DescribePipelinesRequest(input *DescribePipelinesInput) (req *request.Request, output *DescribePipelinesOutput) {
+	op := &request.Operation{
 		Name:       opDescribePipelines,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -245,8 +245,8 @@ func (c *DataPipeline) DescribePipelines(input *DescribePipelinesInput) (*Descri
 const opEvaluateExpression = "EvaluateExpression"
 
 // EvaluateExpressionRequest generates a request for the EvaluateExpression operation.
-func (c *DataPipeline) EvaluateExpressionRequest(input *EvaluateExpressionInput) (req *service.Request, output *EvaluateExpressionOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) EvaluateExpressionRequest(input *EvaluateExpressionInput) (req *request.Request, output *EvaluateExpressionOutput) {
+	op := &request.Operation{
 		Name:       opEvaluateExpression,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -274,8 +274,8 @@ func (c *DataPipeline) EvaluateExpression(input *EvaluateExpressionInput) (*Eval
 const opGetPipelineDefinition = "GetPipelineDefinition"
 
 // GetPipelineDefinitionRequest generates a request for the GetPipelineDefinition operation.
-func (c *DataPipeline) GetPipelineDefinitionRequest(input *GetPipelineDefinitionInput) (req *service.Request, output *GetPipelineDefinitionOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) GetPipelineDefinitionRequest(input *GetPipelineDefinitionInput) (req *request.Request, output *GetPipelineDefinitionOutput) {
+	op := &request.Operation{
 		Name:       opGetPipelineDefinition,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -302,12 +302,12 @@ func (c *DataPipeline) GetPipelineDefinition(input *GetPipelineDefinitionInput) 
 const opListPipelines = "ListPipelines"
 
 // ListPipelinesRequest generates a request for the ListPipelines operation.
-func (c *DataPipeline) ListPipelinesRequest(input *ListPipelinesInput) (req *service.Request, output *ListPipelinesOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) ListPipelinesRequest(input *ListPipelinesInput) (req *request.Request, output *ListPipelinesOutput) {
+	op := &request.Operation{
 		Name:       opListPipelines,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"marker"},
 			OutputTokens:    []string{"marker"},
 			LimitToken:      "",
@@ -343,8 +343,8 @@ func (c *DataPipeline) ListPipelinesPages(input *ListPipelinesInput, fn func(p *
 const opPollForTask = "PollForTask"
 
 // PollForTaskRequest generates a request for the PollForTask operation.
-func (c *DataPipeline) PollForTaskRequest(input *PollForTaskInput) (req *service.Request, output *PollForTaskOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) PollForTaskRequest(input *PollForTaskInput) (req *request.Request, output *PollForTaskOutput) {
+	op := &request.Operation{
 		Name:       opPollForTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -383,8 +383,8 @@ func (c *DataPipeline) PollForTask(input *PollForTaskInput) (*PollForTaskOutput,
 const opPutPipelineDefinition = "PutPipelineDefinition"
 
 // PutPipelineDefinitionRequest generates a request for the PutPipelineDefinition operation.
-func (c *DataPipeline) PutPipelineDefinitionRequest(input *PutPipelineDefinitionInput) (req *service.Request, output *PutPipelineDefinitionOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) PutPipelineDefinitionRequest(input *PutPipelineDefinitionInput) (req *request.Request, output *PutPipelineDefinitionOutput) {
+	op := &request.Operation{
 		Name:       opPutPipelineDefinition,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -421,12 +421,12 @@ func (c *DataPipeline) PutPipelineDefinition(input *PutPipelineDefinitionInput) 
 const opQueryObjects = "QueryObjects"
 
 // QueryObjectsRequest generates a request for the QueryObjects operation.
-func (c *DataPipeline) QueryObjectsRequest(input *QueryObjectsInput) (req *service.Request, output *QueryObjectsOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) QueryObjectsRequest(input *QueryObjectsInput) (req *request.Request, output *QueryObjectsOutput) {
+	op := &request.Operation{
 		Name:       opQueryObjects,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"marker"},
 			OutputTokens:    []string{"marker"},
 			LimitToken:      "limit",
@@ -462,8 +462,8 @@ func (c *DataPipeline) QueryObjectsPages(input *QueryObjectsInput, fn func(p *Qu
 const opRemoveTags = "RemoveTags"
 
 // RemoveTagsRequest generates a request for the RemoveTags operation.
-func (c *DataPipeline) RemoveTagsRequest(input *RemoveTagsInput) (req *service.Request, output *RemoveTagsOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) RemoveTagsRequest(input *RemoveTagsInput) (req *request.Request, output *RemoveTagsOutput) {
+	op := &request.Operation{
 		Name:       opRemoveTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -489,8 +489,8 @@ func (c *DataPipeline) RemoveTags(input *RemoveTagsInput) (*RemoveTagsOutput, er
 const opReportTaskProgress = "ReportTaskProgress"
 
 // ReportTaskProgressRequest generates a request for the ReportTaskProgress operation.
-func (c *DataPipeline) ReportTaskProgressRequest(input *ReportTaskProgressInput) (req *service.Request, output *ReportTaskProgressOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) ReportTaskProgressRequest(input *ReportTaskProgressInput) (req *request.Request, output *ReportTaskProgressOutput) {
+	op := &request.Operation{
 		Name:       opReportTaskProgress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -527,8 +527,8 @@ func (c *DataPipeline) ReportTaskProgress(input *ReportTaskProgressInput) (*Repo
 const opReportTaskRunnerHeartbeat = "ReportTaskRunnerHeartbeat"
 
 // ReportTaskRunnerHeartbeatRequest generates a request for the ReportTaskRunnerHeartbeat operation.
-func (c *DataPipeline) ReportTaskRunnerHeartbeatRequest(input *ReportTaskRunnerHeartbeatInput) (req *service.Request, output *ReportTaskRunnerHeartbeatOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) ReportTaskRunnerHeartbeatRequest(input *ReportTaskRunnerHeartbeatInput) (req *request.Request, output *ReportTaskRunnerHeartbeatOutput) {
+	op := &request.Operation{
 		Name:       opReportTaskRunnerHeartbeat,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -558,8 +558,8 @@ func (c *DataPipeline) ReportTaskRunnerHeartbeat(input *ReportTaskRunnerHeartbea
 const opSetStatus = "SetStatus"
 
 // SetStatusRequest generates a request for the SetStatus operation.
-func (c *DataPipeline) SetStatusRequest(input *SetStatusInput) (req *service.Request, output *SetStatusOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) SetStatusRequest(input *SetStatusInput) (req *request.Request, output *SetStatusOutput) {
+	op := &request.Operation{
 		Name:       opSetStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -589,8 +589,8 @@ func (c *DataPipeline) SetStatus(input *SetStatusInput) (*SetStatusOutput, error
 const opSetTaskStatus = "SetTaskStatus"
 
 // SetTaskStatusRequest generates a request for the SetTaskStatus operation.
-func (c *DataPipeline) SetTaskStatusRequest(input *SetTaskStatusInput) (req *service.Request, output *SetTaskStatusOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) SetTaskStatusRequest(input *SetTaskStatusInput) (req *request.Request, output *SetTaskStatusOutput) {
+	op := &request.Operation{
 		Name:       opSetTaskStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -620,8 +620,8 @@ func (c *DataPipeline) SetTaskStatus(input *SetTaskStatusInput) (*SetTaskStatusO
 const opValidatePipelineDefinition = "ValidatePipelineDefinition"
 
 // ValidatePipelineDefinitionRequest generates a request for the ValidatePipelineDefinition operation.
-func (c *DataPipeline) ValidatePipelineDefinitionRequest(input *ValidatePipelineDefinitionInput) (req *service.Request, output *ValidatePipelineDefinitionOutput) {
-	op := &service.Operation{
+func (c *DataPipeline) ValidatePipelineDefinitionRequest(input *ValidatePipelineDefinitionInput) (req *request.Request, output *ValidatePipelineDefinitionOutput) {
+	op := &request.Operation{
 		Name:       opValidatePipelineDefinition,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/datapipeline/datapipelineiface/interface.go
+++ b/service/datapipeline/datapipelineiface/interface.go
@@ -4,91 +4,91 @@
 package datapipelineiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/datapipeline"
 )
 
 // DataPipelineAPI is the interface type for datapipeline.DataPipeline.
 type DataPipelineAPI interface {
-	ActivatePipelineRequest(*datapipeline.ActivatePipelineInput) (*service.Request, *datapipeline.ActivatePipelineOutput)
+	ActivatePipelineRequest(*datapipeline.ActivatePipelineInput) (*request.Request, *datapipeline.ActivatePipelineOutput)
 
 	ActivatePipeline(*datapipeline.ActivatePipelineInput) (*datapipeline.ActivatePipelineOutput, error)
 
-	AddTagsRequest(*datapipeline.AddTagsInput) (*service.Request, *datapipeline.AddTagsOutput)
+	AddTagsRequest(*datapipeline.AddTagsInput) (*request.Request, *datapipeline.AddTagsOutput)
 
 	AddTags(*datapipeline.AddTagsInput) (*datapipeline.AddTagsOutput, error)
 
-	CreatePipelineRequest(*datapipeline.CreatePipelineInput) (*service.Request, *datapipeline.CreatePipelineOutput)
+	CreatePipelineRequest(*datapipeline.CreatePipelineInput) (*request.Request, *datapipeline.CreatePipelineOutput)
 
 	CreatePipeline(*datapipeline.CreatePipelineInput) (*datapipeline.CreatePipelineOutput, error)
 
-	DeactivatePipelineRequest(*datapipeline.DeactivatePipelineInput) (*service.Request, *datapipeline.DeactivatePipelineOutput)
+	DeactivatePipelineRequest(*datapipeline.DeactivatePipelineInput) (*request.Request, *datapipeline.DeactivatePipelineOutput)
 
 	DeactivatePipeline(*datapipeline.DeactivatePipelineInput) (*datapipeline.DeactivatePipelineOutput, error)
 
-	DeletePipelineRequest(*datapipeline.DeletePipelineInput) (*service.Request, *datapipeline.DeletePipelineOutput)
+	DeletePipelineRequest(*datapipeline.DeletePipelineInput) (*request.Request, *datapipeline.DeletePipelineOutput)
 
 	DeletePipeline(*datapipeline.DeletePipelineInput) (*datapipeline.DeletePipelineOutput, error)
 
-	DescribeObjectsRequest(*datapipeline.DescribeObjectsInput) (*service.Request, *datapipeline.DescribeObjectsOutput)
+	DescribeObjectsRequest(*datapipeline.DescribeObjectsInput) (*request.Request, *datapipeline.DescribeObjectsOutput)
 
 	DescribeObjects(*datapipeline.DescribeObjectsInput) (*datapipeline.DescribeObjectsOutput, error)
 
 	DescribeObjectsPages(*datapipeline.DescribeObjectsInput, func(*datapipeline.DescribeObjectsOutput, bool) bool) error
 
-	DescribePipelinesRequest(*datapipeline.DescribePipelinesInput) (*service.Request, *datapipeline.DescribePipelinesOutput)
+	DescribePipelinesRequest(*datapipeline.DescribePipelinesInput) (*request.Request, *datapipeline.DescribePipelinesOutput)
 
 	DescribePipelines(*datapipeline.DescribePipelinesInput) (*datapipeline.DescribePipelinesOutput, error)
 
-	EvaluateExpressionRequest(*datapipeline.EvaluateExpressionInput) (*service.Request, *datapipeline.EvaluateExpressionOutput)
+	EvaluateExpressionRequest(*datapipeline.EvaluateExpressionInput) (*request.Request, *datapipeline.EvaluateExpressionOutput)
 
 	EvaluateExpression(*datapipeline.EvaluateExpressionInput) (*datapipeline.EvaluateExpressionOutput, error)
 
-	GetPipelineDefinitionRequest(*datapipeline.GetPipelineDefinitionInput) (*service.Request, *datapipeline.GetPipelineDefinitionOutput)
+	GetPipelineDefinitionRequest(*datapipeline.GetPipelineDefinitionInput) (*request.Request, *datapipeline.GetPipelineDefinitionOutput)
 
 	GetPipelineDefinition(*datapipeline.GetPipelineDefinitionInput) (*datapipeline.GetPipelineDefinitionOutput, error)
 
-	ListPipelinesRequest(*datapipeline.ListPipelinesInput) (*service.Request, *datapipeline.ListPipelinesOutput)
+	ListPipelinesRequest(*datapipeline.ListPipelinesInput) (*request.Request, *datapipeline.ListPipelinesOutput)
 
 	ListPipelines(*datapipeline.ListPipelinesInput) (*datapipeline.ListPipelinesOutput, error)
 
 	ListPipelinesPages(*datapipeline.ListPipelinesInput, func(*datapipeline.ListPipelinesOutput, bool) bool) error
 
-	PollForTaskRequest(*datapipeline.PollForTaskInput) (*service.Request, *datapipeline.PollForTaskOutput)
+	PollForTaskRequest(*datapipeline.PollForTaskInput) (*request.Request, *datapipeline.PollForTaskOutput)
 
 	PollForTask(*datapipeline.PollForTaskInput) (*datapipeline.PollForTaskOutput, error)
 
-	PutPipelineDefinitionRequest(*datapipeline.PutPipelineDefinitionInput) (*service.Request, *datapipeline.PutPipelineDefinitionOutput)
+	PutPipelineDefinitionRequest(*datapipeline.PutPipelineDefinitionInput) (*request.Request, *datapipeline.PutPipelineDefinitionOutput)
 
 	PutPipelineDefinition(*datapipeline.PutPipelineDefinitionInput) (*datapipeline.PutPipelineDefinitionOutput, error)
 
-	QueryObjectsRequest(*datapipeline.QueryObjectsInput) (*service.Request, *datapipeline.QueryObjectsOutput)
+	QueryObjectsRequest(*datapipeline.QueryObjectsInput) (*request.Request, *datapipeline.QueryObjectsOutput)
 
 	QueryObjects(*datapipeline.QueryObjectsInput) (*datapipeline.QueryObjectsOutput, error)
 
 	QueryObjectsPages(*datapipeline.QueryObjectsInput, func(*datapipeline.QueryObjectsOutput, bool) bool) error
 
-	RemoveTagsRequest(*datapipeline.RemoveTagsInput) (*service.Request, *datapipeline.RemoveTagsOutput)
+	RemoveTagsRequest(*datapipeline.RemoveTagsInput) (*request.Request, *datapipeline.RemoveTagsOutput)
 
 	RemoveTags(*datapipeline.RemoveTagsInput) (*datapipeline.RemoveTagsOutput, error)
 
-	ReportTaskProgressRequest(*datapipeline.ReportTaskProgressInput) (*service.Request, *datapipeline.ReportTaskProgressOutput)
+	ReportTaskProgressRequest(*datapipeline.ReportTaskProgressInput) (*request.Request, *datapipeline.ReportTaskProgressOutput)
 
 	ReportTaskProgress(*datapipeline.ReportTaskProgressInput) (*datapipeline.ReportTaskProgressOutput, error)
 
-	ReportTaskRunnerHeartbeatRequest(*datapipeline.ReportTaskRunnerHeartbeatInput) (*service.Request, *datapipeline.ReportTaskRunnerHeartbeatOutput)
+	ReportTaskRunnerHeartbeatRequest(*datapipeline.ReportTaskRunnerHeartbeatInput) (*request.Request, *datapipeline.ReportTaskRunnerHeartbeatOutput)
 
 	ReportTaskRunnerHeartbeat(*datapipeline.ReportTaskRunnerHeartbeatInput) (*datapipeline.ReportTaskRunnerHeartbeatOutput, error)
 
-	SetStatusRequest(*datapipeline.SetStatusInput) (*service.Request, *datapipeline.SetStatusOutput)
+	SetStatusRequest(*datapipeline.SetStatusInput) (*request.Request, *datapipeline.SetStatusOutput)
 
 	SetStatus(*datapipeline.SetStatusInput) (*datapipeline.SetStatusOutput, error)
 
-	SetTaskStatusRequest(*datapipeline.SetTaskStatusInput) (*service.Request, *datapipeline.SetTaskStatusOutput)
+	SetTaskStatusRequest(*datapipeline.SetTaskStatusInput) (*request.Request, *datapipeline.SetTaskStatusOutput)
 
 	SetTaskStatus(*datapipeline.SetTaskStatusInput) (*datapipeline.SetTaskStatusOutput, error)
 
-	ValidatePipelineDefinitionRequest(*datapipeline.ValidatePipelineDefinitionInput) (*service.Request, *datapipeline.ValidatePipelineDefinitionOutput)
+	ValidatePipelineDefinitionRequest(*datapipeline.ValidatePipelineDefinitionInput) (*request.Request, *datapipeline.ValidatePipelineDefinitionOutput)
 
 	ValidatePipelineDefinition(*datapipeline.ValidatePipelineDefinitionInput) (*datapipeline.ValidatePipelineDefinitionOutput, error)
 }

--- a/service/datapipeline/service.go
+++ b/service/datapipeline/service.go
@@ -5,7 +5,9 @@ package datapipeline
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -40,16 +42,18 @@ type DataPipeline struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new DataPipeline client.
 func New(config *aws.Config) *DataPipeline {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "datapipeline",
-		APIVersion:   "2012-10-29",
-		JSONVersion:  "1.1",
-		TargetPrefix: "DataPipeline",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "datapipeline",
+			APIVersion:   "2012-10-29",
+			JSONVersion:  "1.1",
+			TargetPrefix: "DataPipeline",
+		},
 	}
 	service.Initialize()
 
@@ -70,8 +74,8 @@ func New(config *aws.Config) *DataPipeline {
 
 // newRequest creates a new request for a DataPipeline operation and runs any
 // custom request initialization.
-func (c *DataPipeline) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *DataPipeline) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/devicefarm/api.go
+++ b/service/devicefarm/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateDevicePool = "CreateDevicePool"
 
 // CreateDevicePoolRequest generates a request for the CreateDevicePool operation.
-func (c *DeviceFarm) CreateDevicePoolRequest(input *CreateDevicePoolInput) (req *service.Request, output *CreateDevicePoolOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) CreateDevicePoolRequest(input *CreateDevicePoolInput) (req *request.Request, output *CreateDevicePoolOutput) {
+	op := &request.Operation{
 		Name:       opCreateDevicePool,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -40,8 +40,8 @@ func (c *DeviceFarm) CreateDevicePool(input *CreateDevicePoolInput) (*CreateDevi
 const opCreateProject = "CreateProject"
 
 // CreateProjectRequest generates a request for the CreateProject operation.
-func (c *DeviceFarm) CreateProjectRequest(input *CreateProjectInput) (req *service.Request, output *CreateProjectOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) CreateProjectRequest(input *CreateProjectInput) (req *request.Request, output *CreateProjectOutput) {
+	op := &request.Operation{
 		Name:       opCreateProject,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -67,8 +67,8 @@ func (c *DeviceFarm) CreateProject(input *CreateProjectInput) (*CreateProjectOut
 const opCreateUpload = "CreateUpload"
 
 // CreateUploadRequest generates a request for the CreateUpload operation.
-func (c *DeviceFarm) CreateUploadRequest(input *CreateUploadInput) (req *service.Request, output *CreateUploadOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) CreateUploadRequest(input *CreateUploadInput) (req *request.Request, output *CreateUploadOutput) {
+	op := &request.Operation{
 		Name:       opCreateUpload,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -94,8 +94,8 @@ func (c *DeviceFarm) CreateUpload(input *CreateUploadInput) (*CreateUploadOutput
 const opGetAccountSettings = "GetAccountSettings"
 
 // GetAccountSettingsRequest generates a request for the GetAccountSettings operation.
-func (c *DeviceFarm) GetAccountSettingsRequest(input *GetAccountSettingsInput) (req *service.Request, output *GetAccountSettingsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetAccountSettingsRequest(input *GetAccountSettingsInput) (req *request.Request, output *GetAccountSettingsOutput) {
+	op := &request.Operation{
 		Name:       opGetAccountSettings,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -122,8 +122,8 @@ func (c *DeviceFarm) GetAccountSettings(input *GetAccountSettingsInput) (*GetAcc
 const opGetDevice = "GetDevice"
 
 // GetDeviceRequest generates a request for the GetDevice operation.
-func (c *DeviceFarm) GetDeviceRequest(input *GetDeviceInput) (req *service.Request, output *GetDeviceOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetDeviceRequest(input *GetDeviceInput) (req *request.Request, output *GetDeviceOutput) {
+	op := &request.Operation{
 		Name:       opGetDevice,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -149,8 +149,8 @@ func (c *DeviceFarm) GetDevice(input *GetDeviceInput) (*GetDeviceOutput, error) 
 const opGetDevicePool = "GetDevicePool"
 
 // GetDevicePoolRequest generates a request for the GetDevicePool operation.
-func (c *DeviceFarm) GetDevicePoolRequest(input *GetDevicePoolInput) (req *service.Request, output *GetDevicePoolOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetDevicePoolRequest(input *GetDevicePoolInput) (req *request.Request, output *GetDevicePoolOutput) {
+	op := &request.Operation{
 		Name:       opGetDevicePool,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -176,8 +176,8 @@ func (c *DeviceFarm) GetDevicePool(input *GetDevicePoolInput) (*GetDevicePoolOut
 const opGetDevicePoolCompatibility = "GetDevicePoolCompatibility"
 
 // GetDevicePoolCompatibilityRequest generates a request for the GetDevicePoolCompatibility operation.
-func (c *DeviceFarm) GetDevicePoolCompatibilityRequest(input *GetDevicePoolCompatibilityInput) (req *service.Request, output *GetDevicePoolCompatibilityOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetDevicePoolCompatibilityRequest(input *GetDevicePoolCompatibilityInput) (req *request.Request, output *GetDevicePoolCompatibilityOutput) {
+	op := &request.Operation{
 		Name:       opGetDevicePoolCompatibility,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -203,8 +203,8 @@ func (c *DeviceFarm) GetDevicePoolCompatibility(input *GetDevicePoolCompatibilit
 const opGetJob = "GetJob"
 
 // GetJobRequest generates a request for the GetJob operation.
-func (c *DeviceFarm) GetJobRequest(input *GetJobInput) (req *service.Request, output *GetJobOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetJobRequest(input *GetJobInput) (req *request.Request, output *GetJobOutput) {
+	op := &request.Operation{
 		Name:       opGetJob,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -230,8 +230,8 @@ func (c *DeviceFarm) GetJob(input *GetJobInput) (*GetJobOutput, error) {
 const opGetProject = "GetProject"
 
 // GetProjectRequest generates a request for the GetProject operation.
-func (c *DeviceFarm) GetProjectRequest(input *GetProjectInput) (req *service.Request, output *GetProjectOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetProjectRequest(input *GetProjectInput) (req *request.Request, output *GetProjectOutput) {
+	op := &request.Operation{
 		Name:       opGetProject,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -257,8 +257,8 @@ func (c *DeviceFarm) GetProject(input *GetProjectInput) (*GetProjectOutput, erro
 const opGetRun = "GetRun"
 
 // GetRunRequest generates a request for the GetRun operation.
-func (c *DeviceFarm) GetRunRequest(input *GetRunInput) (req *service.Request, output *GetRunOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetRunRequest(input *GetRunInput) (req *request.Request, output *GetRunOutput) {
+	op := &request.Operation{
 		Name:       opGetRun,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -284,8 +284,8 @@ func (c *DeviceFarm) GetRun(input *GetRunInput) (*GetRunOutput, error) {
 const opGetSuite = "GetSuite"
 
 // GetSuiteRequest generates a request for the GetSuite operation.
-func (c *DeviceFarm) GetSuiteRequest(input *GetSuiteInput) (req *service.Request, output *GetSuiteOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetSuiteRequest(input *GetSuiteInput) (req *request.Request, output *GetSuiteOutput) {
+	op := &request.Operation{
 		Name:       opGetSuite,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -311,8 +311,8 @@ func (c *DeviceFarm) GetSuite(input *GetSuiteInput) (*GetSuiteOutput, error) {
 const opGetTest = "GetTest"
 
 // GetTestRequest generates a request for the GetTest operation.
-func (c *DeviceFarm) GetTestRequest(input *GetTestInput) (req *service.Request, output *GetTestOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetTestRequest(input *GetTestInput) (req *request.Request, output *GetTestOutput) {
+	op := &request.Operation{
 		Name:       opGetTest,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -338,8 +338,8 @@ func (c *DeviceFarm) GetTest(input *GetTestInput) (*GetTestOutput, error) {
 const opGetUpload = "GetUpload"
 
 // GetUploadRequest generates a request for the GetUpload operation.
-func (c *DeviceFarm) GetUploadRequest(input *GetUploadInput) (req *service.Request, output *GetUploadOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) GetUploadRequest(input *GetUploadInput) (req *request.Request, output *GetUploadOutput) {
+	op := &request.Operation{
 		Name:       opGetUpload,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -365,12 +365,12 @@ func (c *DeviceFarm) GetUpload(input *GetUploadInput) (*GetUploadOutput, error) 
 const opListArtifacts = "ListArtifacts"
 
 // ListArtifactsRequest generates a request for the ListArtifacts operation.
-func (c *DeviceFarm) ListArtifactsRequest(input *ListArtifactsInput) (req *service.Request, output *ListArtifactsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListArtifactsRequest(input *ListArtifactsInput) (req *request.Request, output *ListArtifactsOutput) {
+	op := &request.Operation{
 		Name:       opListArtifacts,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -405,12 +405,12 @@ func (c *DeviceFarm) ListArtifactsPages(input *ListArtifactsInput, fn func(p *Li
 const opListDevicePools = "ListDevicePools"
 
 // ListDevicePoolsRequest generates a request for the ListDevicePools operation.
-func (c *DeviceFarm) ListDevicePoolsRequest(input *ListDevicePoolsInput) (req *service.Request, output *ListDevicePoolsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListDevicePoolsRequest(input *ListDevicePoolsInput) (req *request.Request, output *ListDevicePoolsOutput) {
+	op := &request.Operation{
 		Name:       opListDevicePools,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -445,12 +445,12 @@ func (c *DeviceFarm) ListDevicePoolsPages(input *ListDevicePoolsInput, fn func(p
 const opListDevices = "ListDevices"
 
 // ListDevicesRequest generates a request for the ListDevices operation.
-func (c *DeviceFarm) ListDevicesRequest(input *ListDevicesInput) (req *service.Request, output *ListDevicesOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListDevicesRequest(input *ListDevicesInput) (req *request.Request, output *ListDevicesOutput) {
+	op := &request.Operation{
 		Name:       opListDevices,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -485,12 +485,12 @@ func (c *DeviceFarm) ListDevicesPages(input *ListDevicesInput, fn func(p *ListDe
 const opListJobs = "ListJobs"
 
 // ListJobsRequest generates a request for the ListJobs operation.
-func (c *DeviceFarm) ListJobsRequest(input *ListJobsInput) (req *service.Request, output *ListJobsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListJobsRequest(input *ListJobsInput) (req *request.Request, output *ListJobsOutput) {
+	op := &request.Operation{
 		Name:       opListJobs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -525,12 +525,12 @@ func (c *DeviceFarm) ListJobsPages(input *ListJobsInput, fn func(p *ListJobsOutp
 const opListProjects = "ListProjects"
 
 // ListProjectsRequest generates a request for the ListProjects operation.
-func (c *DeviceFarm) ListProjectsRequest(input *ListProjectsInput) (req *service.Request, output *ListProjectsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListProjectsRequest(input *ListProjectsInput) (req *request.Request, output *ListProjectsOutput) {
+	op := &request.Operation{
 		Name:       opListProjects,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -565,12 +565,12 @@ func (c *DeviceFarm) ListProjectsPages(input *ListProjectsInput, fn func(p *List
 const opListRuns = "ListRuns"
 
 // ListRunsRequest generates a request for the ListRuns operation.
-func (c *DeviceFarm) ListRunsRequest(input *ListRunsInput) (req *service.Request, output *ListRunsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListRunsRequest(input *ListRunsInput) (req *request.Request, output *ListRunsOutput) {
+	op := &request.Operation{
 		Name:       opListRuns,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -605,12 +605,12 @@ func (c *DeviceFarm) ListRunsPages(input *ListRunsInput, fn func(p *ListRunsOutp
 const opListSamples = "ListSamples"
 
 // ListSamplesRequest generates a request for the ListSamples operation.
-func (c *DeviceFarm) ListSamplesRequest(input *ListSamplesInput) (req *service.Request, output *ListSamplesOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListSamplesRequest(input *ListSamplesInput) (req *request.Request, output *ListSamplesOutput) {
+	op := &request.Operation{
 		Name:       opListSamples,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -645,12 +645,12 @@ func (c *DeviceFarm) ListSamplesPages(input *ListSamplesInput, fn func(p *ListSa
 const opListSuites = "ListSuites"
 
 // ListSuitesRequest generates a request for the ListSuites operation.
-func (c *DeviceFarm) ListSuitesRequest(input *ListSuitesInput) (req *service.Request, output *ListSuitesOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListSuitesRequest(input *ListSuitesInput) (req *request.Request, output *ListSuitesOutput) {
+	op := &request.Operation{
 		Name:       opListSuites,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -685,12 +685,12 @@ func (c *DeviceFarm) ListSuitesPages(input *ListSuitesInput, fn func(p *ListSuit
 const opListTests = "ListTests"
 
 // ListTestsRequest generates a request for the ListTests operation.
-func (c *DeviceFarm) ListTestsRequest(input *ListTestsInput) (req *service.Request, output *ListTestsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListTestsRequest(input *ListTestsInput) (req *request.Request, output *ListTestsOutput) {
+	op := &request.Operation{
 		Name:       opListTests,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -725,12 +725,12 @@ func (c *DeviceFarm) ListTestsPages(input *ListTestsInput, fn func(p *ListTestsO
 const opListUniqueProblems = "ListUniqueProblems"
 
 // ListUniqueProblemsRequest generates a request for the ListUniqueProblems operation.
-func (c *DeviceFarm) ListUniqueProblemsRequest(input *ListUniqueProblemsInput) (req *service.Request, output *ListUniqueProblemsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListUniqueProblemsRequest(input *ListUniqueProblemsInput) (req *request.Request, output *ListUniqueProblemsOutput) {
+	op := &request.Operation{
 		Name:       opListUniqueProblems,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -765,12 +765,12 @@ func (c *DeviceFarm) ListUniqueProblemsPages(input *ListUniqueProblemsInput, fn 
 const opListUploads = "ListUploads"
 
 // ListUploadsRequest generates a request for the ListUploads operation.
-func (c *DeviceFarm) ListUploadsRequest(input *ListUploadsInput) (req *service.Request, output *ListUploadsOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ListUploadsRequest(input *ListUploadsInput) (req *request.Request, output *ListUploadsOutput) {
+	op := &request.Operation{
 		Name:       opListUploads,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "",
@@ -805,8 +805,8 @@ func (c *DeviceFarm) ListUploadsPages(input *ListUploadsInput, fn func(p *ListUp
 const opScheduleRun = "ScheduleRun"
 
 // ScheduleRunRequest generates a request for the ScheduleRun operation.
-func (c *DeviceFarm) ScheduleRunRequest(input *ScheduleRunInput) (req *service.Request, output *ScheduleRunOutput) {
-	op := &service.Operation{
+func (c *DeviceFarm) ScheduleRunRequest(input *ScheduleRunInput) (req *request.Request, output *ScheduleRunOutput) {
+	op := &request.Operation{
 		Name:       opScheduleRun,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/devicefarm/devicefarmiface/interface.go
+++ b/service/devicefarm/devicefarmiface/interface.go
@@ -4,131 +4,131 @@
 package devicefarmiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/devicefarm"
 )
 
 // DeviceFarmAPI is the interface type for devicefarm.DeviceFarm.
 type DeviceFarmAPI interface {
-	CreateDevicePoolRequest(*devicefarm.CreateDevicePoolInput) (*service.Request, *devicefarm.CreateDevicePoolOutput)
+	CreateDevicePoolRequest(*devicefarm.CreateDevicePoolInput) (*request.Request, *devicefarm.CreateDevicePoolOutput)
 
 	CreateDevicePool(*devicefarm.CreateDevicePoolInput) (*devicefarm.CreateDevicePoolOutput, error)
 
-	CreateProjectRequest(*devicefarm.CreateProjectInput) (*service.Request, *devicefarm.CreateProjectOutput)
+	CreateProjectRequest(*devicefarm.CreateProjectInput) (*request.Request, *devicefarm.CreateProjectOutput)
 
 	CreateProject(*devicefarm.CreateProjectInput) (*devicefarm.CreateProjectOutput, error)
 
-	CreateUploadRequest(*devicefarm.CreateUploadInput) (*service.Request, *devicefarm.CreateUploadOutput)
+	CreateUploadRequest(*devicefarm.CreateUploadInput) (*request.Request, *devicefarm.CreateUploadOutput)
 
 	CreateUpload(*devicefarm.CreateUploadInput) (*devicefarm.CreateUploadOutput, error)
 
-	GetAccountSettingsRequest(*devicefarm.GetAccountSettingsInput) (*service.Request, *devicefarm.GetAccountSettingsOutput)
+	GetAccountSettingsRequest(*devicefarm.GetAccountSettingsInput) (*request.Request, *devicefarm.GetAccountSettingsOutput)
 
 	GetAccountSettings(*devicefarm.GetAccountSettingsInput) (*devicefarm.GetAccountSettingsOutput, error)
 
-	GetDeviceRequest(*devicefarm.GetDeviceInput) (*service.Request, *devicefarm.GetDeviceOutput)
+	GetDeviceRequest(*devicefarm.GetDeviceInput) (*request.Request, *devicefarm.GetDeviceOutput)
 
 	GetDevice(*devicefarm.GetDeviceInput) (*devicefarm.GetDeviceOutput, error)
 
-	GetDevicePoolRequest(*devicefarm.GetDevicePoolInput) (*service.Request, *devicefarm.GetDevicePoolOutput)
+	GetDevicePoolRequest(*devicefarm.GetDevicePoolInput) (*request.Request, *devicefarm.GetDevicePoolOutput)
 
 	GetDevicePool(*devicefarm.GetDevicePoolInput) (*devicefarm.GetDevicePoolOutput, error)
 
-	GetDevicePoolCompatibilityRequest(*devicefarm.GetDevicePoolCompatibilityInput) (*service.Request, *devicefarm.GetDevicePoolCompatibilityOutput)
+	GetDevicePoolCompatibilityRequest(*devicefarm.GetDevicePoolCompatibilityInput) (*request.Request, *devicefarm.GetDevicePoolCompatibilityOutput)
 
 	GetDevicePoolCompatibility(*devicefarm.GetDevicePoolCompatibilityInput) (*devicefarm.GetDevicePoolCompatibilityOutput, error)
 
-	GetJobRequest(*devicefarm.GetJobInput) (*service.Request, *devicefarm.GetJobOutput)
+	GetJobRequest(*devicefarm.GetJobInput) (*request.Request, *devicefarm.GetJobOutput)
 
 	GetJob(*devicefarm.GetJobInput) (*devicefarm.GetJobOutput, error)
 
-	GetProjectRequest(*devicefarm.GetProjectInput) (*service.Request, *devicefarm.GetProjectOutput)
+	GetProjectRequest(*devicefarm.GetProjectInput) (*request.Request, *devicefarm.GetProjectOutput)
 
 	GetProject(*devicefarm.GetProjectInput) (*devicefarm.GetProjectOutput, error)
 
-	GetRunRequest(*devicefarm.GetRunInput) (*service.Request, *devicefarm.GetRunOutput)
+	GetRunRequest(*devicefarm.GetRunInput) (*request.Request, *devicefarm.GetRunOutput)
 
 	GetRun(*devicefarm.GetRunInput) (*devicefarm.GetRunOutput, error)
 
-	GetSuiteRequest(*devicefarm.GetSuiteInput) (*service.Request, *devicefarm.GetSuiteOutput)
+	GetSuiteRequest(*devicefarm.GetSuiteInput) (*request.Request, *devicefarm.GetSuiteOutput)
 
 	GetSuite(*devicefarm.GetSuiteInput) (*devicefarm.GetSuiteOutput, error)
 
-	GetTestRequest(*devicefarm.GetTestInput) (*service.Request, *devicefarm.GetTestOutput)
+	GetTestRequest(*devicefarm.GetTestInput) (*request.Request, *devicefarm.GetTestOutput)
 
 	GetTest(*devicefarm.GetTestInput) (*devicefarm.GetTestOutput, error)
 
-	GetUploadRequest(*devicefarm.GetUploadInput) (*service.Request, *devicefarm.GetUploadOutput)
+	GetUploadRequest(*devicefarm.GetUploadInput) (*request.Request, *devicefarm.GetUploadOutput)
 
 	GetUpload(*devicefarm.GetUploadInput) (*devicefarm.GetUploadOutput, error)
 
-	ListArtifactsRequest(*devicefarm.ListArtifactsInput) (*service.Request, *devicefarm.ListArtifactsOutput)
+	ListArtifactsRequest(*devicefarm.ListArtifactsInput) (*request.Request, *devicefarm.ListArtifactsOutput)
 
 	ListArtifacts(*devicefarm.ListArtifactsInput) (*devicefarm.ListArtifactsOutput, error)
 
 	ListArtifactsPages(*devicefarm.ListArtifactsInput, func(*devicefarm.ListArtifactsOutput, bool) bool) error
 
-	ListDevicePoolsRequest(*devicefarm.ListDevicePoolsInput) (*service.Request, *devicefarm.ListDevicePoolsOutput)
+	ListDevicePoolsRequest(*devicefarm.ListDevicePoolsInput) (*request.Request, *devicefarm.ListDevicePoolsOutput)
 
 	ListDevicePools(*devicefarm.ListDevicePoolsInput) (*devicefarm.ListDevicePoolsOutput, error)
 
 	ListDevicePoolsPages(*devicefarm.ListDevicePoolsInput, func(*devicefarm.ListDevicePoolsOutput, bool) bool) error
 
-	ListDevicesRequest(*devicefarm.ListDevicesInput) (*service.Request, *devicefarm.ListDevicesOutput)
+	ListDevicesRequest(*devicefarm.ListDevicesInput) (*request.Request, *devicefarm.ListDevicesOutput)
 
 	ListDevices(*devicefarm.ListDevicesInput) (*devicefarm.ListDevicesOutput, error)
 
 	ListDevicesPages(*devicefarm.ListDevicesInput, func(*devicefarm.ListDevicesOutput, bool) bool) error
 
-	ListJobsRequest(*devicefarm.ListJobsInput) (*service.Request, *devicefarm.ListJobsOutput)
+	ListJobsRequest(*devicefarm.ListJobsInput) (*request.Request, *devicefarm.ListJobsOutput)
 
 	ListJobs(*devicefarm.ListJobsInput) (*devicefarm.ListJobsOutput, error)
 
 	ListJobsPages(*devicefarm.ListJobsInput, func(*devicefarm.ListJobsOutput, bool) bool) error
 
-	ListProjectsRequest(*devicefarm.ListProjectsInput) (*service.Request, *devicefarm.ListProjectsOutput)
+	ListProjectsRequest(*devicefarm.ListProjectsInput) (*request.Request, *devicefarm.ListProjectsOutput)
 
 	ListProjects(*devicefarm.ListProjectsInput) (*devicefarm.ListProjectsOutput, error)
 
 	ListProjectsPages(*devicefarm.ListProjectsInput, func(*devicefarm.ListProjectsOutput, bool) bool) error
 
-	ListRunsRequest(*devicefarm.ListRunsInput) (*service.Request, *devicefarm.ListRunsOutput)
+	ListRunsRequest(*devicefarm.ListRunsInput) (*request.Request, *devicefarm.ListRunsOutput)
 
 	ListRuns(*devicefarm.ListRunsInput) (*devicefarm.ListRunsOutput, error)
 
 	ListRunsPages(*devicefarm.ListRunsInput, func(*devicefarm.ListRunsOutput, bool) bool) error
 
-	ListSamplesRequest(*devicefarm.ListSamplesInput) (*service.Request, *devicefarm.ListSamplesOutput)
+	ListSamplesRequest(*devicefarm.ListSamplesInput) (*request.Request, *devicefarm.ListSamplesOutput)
 
 	ListSamples(*devicefarm.ListSamplesInput) (*devicefarm.ListSamplesOutput, error)
 
 	ListSamplesPages(*devicefarm.ListSamplesInput, func(*devicefarm.ListSamplesOutput, bool) bool) error
 
-	ListSuitesRequest(*devicefarm.ListSuitesInput) (*service.Request, *devicefarm.ListSuitesOutput)
+	ListSuitesRequest(*devicefarm.ListSuitesInput) (*request.Request, *devicefarm.ListSuitesOutput)
 
 	ListSuites(*devicefarm.ListSuitesInput) (*devicefarm.ListSuitesOutput, error)
 
 	ListSuitesPages(*devicefarm.ListSuitesInput, func(*devicefarm.ListSuitesOutput, bool) bool) error
 
-	ListTestsRequest(*devicefarm.ListTestsInput) (*service.Request, *devicefarm.ListTestsOutput)
+	ListTestsRequest(*devicefarm.ListTestsInput) (*request.Request, *devicefarm.ListTestsOutput)
 
 	ListTests(*devicefarm.ListTestsInput) (*devicefarm.ListTestsOutput, error)
 
 	ListTestsPages(*devicefarm.ListTestsInput, func(*devicefarm.ListTestsOutput, bool) bool) error
 
-	ListUniqueProblemsRequest(*devicefarm.ListUniqueProblemsInput) (*service.Request, *devicefarm.ListUniqueProblemsOutput)
+	ListUniqueProblemsRequest(*devicefarm.ListUniqueProblemsInput) (*request.Request, *devicefarm.ListUniqueProblemsOutput)
 
 	ListUniqueProblems(*devicefarm.ListUniqueProblemsInput) (*devicefarm.ListUniqueProblemsOutput, error)
 
 	ListUniqueProblemsPages(*devicefarm.ListUniqueProblemsInput, func(*devicefarm.ListUniqueProblemsOutput, bool) bool) error
 
-	ListUploadsRequest(*devicefarm.ListUploadsInput) (*service.Request, *devicefarm.ListUploadsOutput)
+	ListUploadsRequest(*devicefarm.ListUploadsInput) (*request.Request, *devicefarm.ListUploadsOutput)
 
 	ListUploads(*devicefarm.ListUploadsInput) (*devicefarm.ListUploadsOutput, error)
 
 	ListUploadsPages(*devicefarm.ListUploadsInput, func(*devicefarm.ListUploadsOutput, bool) bool) error
 
-	ScheduleRunRequest(*devicefarm.ScheduleRunInput) (*service.Request, *devicefarm.ScheduleRunOutput)
+	ScheduleRunRequest(*devicefarm.ScheduleRunInput) (*request.Request, *devicefarm.ScheduleRunOutput)
 
 	ScheduleRun(*devicefarm.ScheduleRunInput) (*devicefarm.ScheduleRunOutput, error)
 }

--- a/service/devicefarm/service.go
+++ b/service/devicefarm/service.go
@@ -5,7 +5,9 @@ package devicefarm
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -21,16 +23,18 @@ type DeviceFarm struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new DeviceFarm client.
 func New(config *aws.Config) *DeviceFarm {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "devicefarm",
-		APIVersion:   "2015-06-23",
-		JSONVersion:  "1.1",
-		TargetPrefix: "DeviceFarm_20150623",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "devicefarm",
+			APIVersion:   "2015-06-23",
+			JSONVersion:  "1.1",
+			TargetPrefix: "DeviceFarm_20150623",
+		},
 	}
 	service.Initialize()
 
@@ -51,8 +55,8 @@ func New(config *aws.Config) *DeviceFarm {
 
 // newRequest creates a new request for a DeviceFarm operation and runs any
 // custom request initialization.
-func (c *DeviceFarm) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *DeviceFarm) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/directconnect/api.go
+++ b/service/directconnect/api.go
@@ -5,14 +5,14 @@ package directconnect
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAllocateConnectionOnInterconnect = "AllocateConnectionOnInterconnect"
 
 // AllocateConnectionOnInterconnectRequest generates a request for the AllocateConnectionOnInterconnect operation.
-func (c *DirectConnect) AllocateConnectionOnInterconnectRequest(input *AllocateConnectionOnInterconnectInput) (req *service.Request, output *Connection) {
-	op := &service.Operation{
+func (c *DirectConnect) AllocateConnectionOnInterconnectRequest(input *AllocateConnectionOnInterconnectInput) (req *request.Request, output *Connection) {
+	op := &request.Operation{
 		Name:       opAllocateConnectionOnInterconnect,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -41,8 +41,8 @@ func (c *DirectConnect) AllocateConnectionOnInterconnect(input *AllocateConnecti
 const opAllocatePrivateVirtualInterface = "AllocatePrivateVirtualInterface"
 
 // AllocatePrivateVirtualInterfaceRequest generates a request for the AllocatePrivateVirtualInterface operation.
-func (c *DirectConnect) AllocatePrivateVirtualInterfaceRequest(input *AllocatePrivateVirtualInterfaceInput) (req *service.Request, output *VirtualInterface) {
-	op := &service.Operation{
+func (c *DirectConnect) AllocatePrivateVirtualInterfaceRequest(input *AllocatePrivateVirtualInterfaceInput) (req *request.Request, output *VirtualInterface) {
+	op := &request.Operation{
 		Name:       opAllocatePrivateVirtualInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -76,8 +76,8 @@ func (c *DirectConnect) AllocatePrivateVirtualInterface(input *AllocatePrivateVi
 const opAllocatePublicVirtualInterface = "AllocatePublicVirtualInterface"
 
 // AllocatePublicVirtualInterfaceRequest generates a request for the AllocatePublicVirtualInterface operation.
-func (c *DirectConnect) AllocatePublicVirtualInterfaceRequest(input *AllocatePublicVirtualInterfaceInput) (req *service.Request, output *VirtualInterface) {
-	op := &service.Operation{
+func (c *DirectConnect) AllocatePublicVirtualInterfaceRequest(input *AllocatePublicVirtualInterfaceInput) (req *request.Request, output *VirtualInterface) {
+	op := &request.Operation{
 		Name:       opAllocatePublicVirtualInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -111,8 +111,8 @@ func (c *DirectConnect) AllocatePublicVirtualInterface(input *AllocatePublicVirt
 const opConfirmConnection = "ConfirmConnection"
 
 // ConfirmConnectionRequest generates a request for the ConfirmConnection operation.
-func (c *DirectConnect) ConfirmConnectionRequest(input *ConfirmConnectionInput) (req *service.Request, output *ConfirmConnectionOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) ConfirmConnectionRequest(input *ConfirmConnectionInput) (req *request.Request, output *ConfirmConnectionOutput) {
+	op := &request.Operation{
 		Name:       opConfirmConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -142,8 +142,8 @@ func (c *DirectConnect) ConfirmConnection(input *ConfirmConnectionInput) (*Confi
 const opConfirmPrivateVirtualInterface = "ConfirmPrivateVirtualInterface"
 
 // ConfirmPrivateVirtualInterfaceRequest generates a request for the ConfirmPrivateVirtualInterface operation.
-func (c *DirectConnect) ConfirmPrivateVirtualInterfaceRequest(input *ConfirmPrivateVirtualInterfaceInput) (req *service.Request, output *ConfirmPrivateVirtualInterfaceOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) ConfirmPrivateVirtualInterfaceRequest(input *ConfirmPrivateVirtualInterfaceInput) (req *request.Request, output *ConfirmPrivateVirtualInterfaceOutput) {
+	op := &request.Operation{
 		Name:       opConfirmPrivateVirtualInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -173,8 +173,8 @@ func (c *DirectConnect) ConfirmPrivateVirtualInterface(input *ConfirmPrivateVirt
 const opConfirmPublicVirtualInterface = "ConfirmPublicVirtualInterface"
 
 // ConfirmPublicVirtualInterfaceRequest generates a request for the ConfirmPublicVirtualInterface operation.
-func (c *DirectConnect) ConfirmPublicVirtualInterfaceRequest(input *ConfirmPublicVirtualInterfaceInput) (req *service.Request, output *ConfirmPublicVirtualInterfaceOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) ConfirmPublicVirtualInterfaceRequest(input *ConfirmPublicVirtualInterfaceInput) (req *request.Request, output *ConfirmPublicVirtualInterfaceOutput) {
+	op := &request.Operation{
 		Name:       opConfirmPublicVirtualInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -203,8 +203,8 @@ func (c *DirectConnect) ConfirmPublicVirtualInterface(input *ConfirmPublicVirtua
 const opCreateConnection = "CreateConnection"
 
 // CreateConnectionRequest generates a request for the CreateConnection operation.
-func (c *DirectConnect) CreateConnectionRequest(input *CreateConnectionInput) (req *service.Request, output *Connection) {
-	op := &service.Operation{
+func (c *DirectConnect) CreateConnectionRequest(input *CreateConnectionInput) (req *request.Request, output *Connection) {
+	op := &request.Operation{
 		Name:       opCreateConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -239,8 +239,8 @@ func (c *DirectConnect) CreateConnection(input *CreateConnectionInput) (*Connect
 const opCreateInterconnect = "CreateInterconnect"
 
 // CreateInterconnectRequest generates a request for the CreateInterconnect operation.
-func (c *DirectConnect) CreateInterconnectRequest(input *CreateInterconnectInput) (req *service.Request, output *Interconnect) {
-	op := &service.Operation{
+func (c *DirectConnect) CreateInterconnectRequest(input *CreateInterconnectInput) (req *request.Request, output *Interconnect) {
+	op := &request.Operation{
 		Name:       opCreateInterconnect,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -281,8 +281,8 @@ func (c *DirectConnect) CreateInterconnect(input *CreateInterconnectInput) (*Int
 const opCreatePrivateVirtualInterface = "CreatePrivateVirtualInterface"
 
 // CreatePrivateVirtualInterfaceRequest generates a request for the CreatePrivateVirtualInterface operation.
-func (c *DirectConnect) CreatePrivateVirtualInterfaceRequest(input *CreatePrivateVirtualInterfaceInput) (req *service.Request, output *VirtualInterface) {
-	op := &service.Operation{
+func (c *DirectConnect) CreatePrivateVirtualInterfaceRequest(input *CreatePrivateVirtualInterfaceInput) (req *request.Request, output *VirtualInterface) {
+	op := &request.Operation{
 		Name:       opCreatePrivateVirtualInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -310,8 +310,8 @@ func (c *DirectConnect) CreatePrivateVirtualInterface(input *CreatePrivateVirtua
 const opCreatePublicVirtualInterface = "CreatePublicVirtualInterface"
 
 // CreatePublicVirtualInterfaceRequest generates a request for the CreatePublicVirtualInterface operation.
-func (c *DirectConnect) CreatePublicVirtualInterfaceRequest(input *CreatePublicVirtualInterfaceInput) (req *service.Request, output *VirtualInterface) {
-	op := &service.Operation{
+func (c *DirectConnect) CreatePublicVirtualInterfaceRequest(input *CreatePublicVirtualInterfaceInput) (req *request.Request, output *VirtualInterface) {
+	op := &request.Operation{
 		Name:       opCreatePublicVirtualInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -340,8 +340,8 @@ func (c *DirectConnect) CreatePublicVirtualInterface(input *CreatePublicVirtualI
 const opDeleteConnection = "DeleteConnection"
 
 // DeleteConnectionRequest generates a request for the DeleteConnection operation.
-func (c *DirectConnect) DeleteConnectionRequest(input *DeleteConnectionInput) (req *service.Request, output *Connection) {
-	op := &service.Operation{
+func (c *DirectConnect) DeleteConnectionRequest(input *DeleteConnectionInput) (req *request.Request, output *Connection) {
+	op := &request.Operation{
 		Name:       opDeleteConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -372,8 +372,8 @@ func (c *DirectConnect) DeleteConnection(input *DeleteConnectionInput) (*Connect
 const opDeleteInterconnect = "DeleteInterconnect"
 
 // DeleteInterconnectRequest generates a request for the DeleteInterconnect operation.
-func (c *DirectConnect) DeleteInterconnectRequest(input *DeleteInterconnectInput) (req *service.Request, output *DeleteInterconnectOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) DeleteInterconnectRequest(input *DeleteInterconnectInput) (req *request.Request, output *DeleteInterconnectOutput) {
+	op := &request.Operation{
 		Name:       opDeleteInterconnect,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -399,8 +399,8 @@ func (c *DirectConnect) DeleteInterconnect(input *DeleteInterconnectInput) (*Del
 const opDeleteVirtualInterface = "DeleteVirtualInterface"
 
 // DeleteVirtualInterfaceRequest generates a request for the DeleteVirtualInterface operation.
-func (c *DirectConnect) DeleteVirtualInterfaceRequest(input *DeleteVirtualInterfaceInput) (req *service.Request, output *DeleteVirtualInterfaceOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) DeleteVirtualInterfaceRequest(input *DeleteVirtualInterfaceInput) (req *request.Request, output *DeleteVirtualInterfaceOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVirtualInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -426,8 +426,8 @@ func (c *DirectConnect) DeleteVirtualInterface(input *DeleteVirtualInterfaceInpu
 const opDescribeConnections = "DescribeConnections"
 
 // DescribeConnectionsRequest generates a request for the DescribeConnections operation.
-func (c *DirectConnect) DescribeConnectionsRequest(input *DescribeConnectionsInput) (req *service.Request, output *Connections) {
-	op := &service.Operation{
+func (c *DirectConnect) DescribeConnectionsRequest(input *DescribeConnectionsInput) (req *request.Request, output *Connections) {
+	op := &request.Operation{
 		Name:       opDescribeConnections,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -455,8 +455,8 @@ func (c *DirectConnect) DescribeConnections(input *DescribeConnectionsInput) (*C
 const opDescribeConnectionsOnInterconnect = "DescribeConnectionsOnInterconnect"
 
 // DescribeConnectionsOnInterconnectRequest generates a request for the DescribeConnectionsOnInterconnect operation.
-func (c *DirectConnect) DescribeConnectionsOnInterconnectRequest(input *DescribeConnectionsOnInterconnectInput) (req *service.Request, output *Connections) {
-	op := &service.Operation{
+func (c *DirectConnect) DescribeConnectionsOnInterconnectRequest(input *DescribeConnectionsOnInterconnectInput) (req *request.Request, output *Connections) {
+	op := &request.Operation{
 		Name:       opDescribeConnectionsOnInterconnect,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -482,8 +482,8 @@ func (c *DirectConnect) DescribeConnectionsOnInterconnect(input *DescribeConnect
 const opDescribeInterconnects = "DescribeInterconnects"
 
 // DescribeInterconnectsRequest generates a request for the DescribeInterconnects operation.
-func (c *DirectConnect) DescribeInterconnectsRequest(input *DescribeInterconnectsInput) (req *service.Request, output *DescribeInterconnectsOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) DescribeInterconnectsRequest(input *DescribeInterconnectsInput) (req *request.Request, output *DescribeInterconnectsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeInterconnects,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -511,8 +511,8 @@ func (c *DirectConnect) DescribeInterconnects(input *DescribeInterconnectsInput)
 const opDescribeLocations = "DescribeLocations"
 
 // DescribeLocationsRequest generates a request for the DescribeLocations operation.
-func (c *DirectConnect) DescribeLocationsRequest(input *DescribeLocationsInput) (req *service.Request, output *DescribeLocationsOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) DescribeLocationsRequest(input *DescribeLocationsInput) (req *request.Request, output *DescribeLocationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLocations,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -540,8 +540,8 @@ func (c *DirectConnect) DescribeLocations(input *DescribeLocationsInput) (*Descr
 const opDescribeVirtualGateways = "DescribeVirtualGateways"
 
 // DescribeVirtualGatewaysRequest generates a request for the DescribeVirtualGateways operation.
-func (c *DirectConnect) DescribeVirtualGatewaysRequest(input *DescribeVirtualGatewaysInput) (req *service.Request, output *DescribeVirtualGatewaysOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) DescribeVirtualGatewaysRequest(input *DescribeVirtualGatewaysInput) (req *request.Request, output *DescribeVirtualGatewaysOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVirtualGateways,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -573,8 +573,8 @@ func (c *DirectConnect) DescribeVirtualGateways(input *DescribeVirtualGatewaysIn
 const opDescribeVirtualInterfaces = "DescribeVirtualInterfaces"
 
 // DescribeVirtualInterfacesRequest generates a request for the DescribeVirtualInterfaces operation.
-func (c *DirectConnect) DescribeVirtualInterfacesRequest(input *DescribeVirtualInterfacesInput) (req *service.Request, output *DescribeVirtualInterfacesOutput) {
-	op := &service.Operation{
+func (c *DirectConnect) DescribeVirtualInterfacesRequest(input *DescribeVirtualInterfacesInput) (req *request.Request, output *DescribeVirtualInterfacesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVirtualInterfaces,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/directconnect/directconnectiface/interface.go
+++ b/service/directconnect/directconnectiface/interface.go
@@ -4,85 +4,85 @@
 package directconnectiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/directconnect"
 )
 
 // DirectConnectAPI is the interface type for directconnect.DirectConnect.
 type DirectConnectAPI interface {
-	AllocateConnectionOnInterconnectRequest(*directconnect.AllocateConnectionOnInterconnectInput) (*service.Request, *directconnect.Connection)
+	AllocateConnectionOnInterconnectRequest(*directconnect.AllocateConnectionOnInterconnectInput) (*request.Request, *directconnect.Connection)
 
 	AllocateConnectionOnInterconnect(*directconnect.AllocateConnectionOnInterconnectInput) (*directconnect.Connection, error)
 
-	AllocatePrivateVirtualInterfaceRequest(*directconnect.AllocatePrivateVirtualInterfaceInput) (*service.Request, *directconnect.VirtualInterface)
+	AllocatePrivateVirtualInterfaceRequest(*directconnect.AllocatePrivateVirtualInterfaceInput) (*request.Request, *directconnect.VirtualInterface)
 
 	AllocatePrivateVirtualInterface(*directconnect.AllocatePrivateVirtualInterfaceInput) (*directconnect.VirtualInterface, error)
 
-	AllocatePublicVirtualInterfaceRequest(*directconnect.AllocatePublicVirtualInterfaceInput) (*service.Request, *directconnect.VirtualInterface)
+	AllocatePublicVirtualInterfaceRequest(*directconnect.AllocatePublicVirtualInterfaceInput) (*request.Request, *directconnect.VirtualInterface)
 
 	AllocatePublicVirtualInterface(*directconnect.AllocatePublicVirtualInterfaceInput) (*directconnect.VirtualInterface, error)
 
-	ConfirmConnectionRequest(*directconnect.ConfirmConnectionInput) (*service.Request, *directconnect.ConfirmConnectionOutput)
+	ConfirmConnectionRequest(*directconnect.ConfirmConnectionInput) (*request.Request, *directconnect.ConfirmConnectionOutput)
 
 	ConfirmConnection(*directconnect.ConfirmConnectionInput) (*directconnect.ConfirmConnectionOutput, error)
 
-	ConfirmPrivateVirtualInterfaceRequest(*directconnect.ConfirmPrivateVirtualInterfaceInput) (*service.Request, *directconnect.ConfirmPrivateVirtualInterfaceOutput)
+	ConfirmPrivateVirtualInterfaceRequest(*directconnect.ConfirmPrivateVirtualInterfaceInput) (*request.Request, *directconnect.ConfirmPrivateVirtualInterfaceOutput)
 
 	ConfirmPrivateVirtualInterface(*directconnect.ConfirmPrivateVirtualInterfaceInput) (*directconnect.ConfirmPrivateVirtualInterfaceOutput, error)
 
-	ConfirmPublicVirtualInterfaceRequest(*directconnect.ConfirmPublicVirtualInterfaceInput) (*service.Request, *directconnect.ConfirmPublicVirtualInterfaceOutput)
+	ConfirmPublicVirtualInterfaceRequest(*directconnect.ConfirmPublicVirtualInterfaceInput) (*request.Request, *directconnect.ConfirmPublicVirtualInterfaceOutput)
 
 	ConfirmPublicVirtualInterface(*directconnect.ConfirmPublicVirtualInterfaceInput) (*directconnect.ConfirmPublicVirtualInterfaceOutput, error)
 
-	CreateConnectionRequest(*directconnect.CreateConnectionInput) (*service.Request, *directconnect.Connection)
+	CreateConnectionRequest(*directconnect.CreateConnectionInput) (*request.Request, *directconnect.Connection)
 
 	CreateConnection(*directconnect.CreateConnectionInput) (*directconnect.Connection, error)
 
-	CreateInterconnectRequest(*directconnect.CreateInterconnectInput) (*service.Request, *directconnect.Interconnect)
+	CreateInterconnectRequest(*directconnect.CreateInterconnectInput) (*request.Request, *directconnect.Interconnect)
 
 	CreateInterconnect(*directconnect.CreateInterconnectInput) (*directconnect.Interconnect, error)
 
-	CreatePrivateVirtualInterfaceRequest(*directconnect.CreatePrivateVirtualInterfaceInput) (*service.Request, *directconnect.VirtualInterface)
+	CreatePrivateVirtualInterfaceRequest(*directconnect.CreatePrivateVirtualInterfaceInput) (*request.Request, *directconnect.VirtualInterface)
 
 	CreatePrivateVirtualInterface(*directconnect.CreatePrivateVirtualInterfaceInput) (*directconnect.VirtualInterface, error)
 
-	CreatePublicVirtualInterfaceRequest(*directconnect.CreatePublicVirtualInterfaceInput) (*service.Request, *directconnect.VirtualInterface)
+	CreatePublicVirtualInterfaceRequest(*directconnect.CreatePublicVirtualInterfaceInput) (*request.Request, *directconnect.VirtualInterface)
 
 	CreatePublicVirtualInterface(*directconnect.CreatePublicVirtualInterfaceInput) (*directconnect.VirtualInterface, error)
 
-	DeleteConnectionRequest(*directconnect.DeleteConnectionInput) (*service.Request, *directconnect.Connection)
+	DeleteConnectionRequest(*directconnect.DeleteConnectionInput) (*request.Request, *directconnect.Connection)
 
 	DeleteConnection(*directconnect.DeleteConnectionInput) (*directconnect.Connection, error)
 
-	DeleteInterconnectRequest(*directconnect.DeleteInterconnectInput) (*service.Request, *directconnect.DeleteInterconnectOutput)
+	DeleteInterconnectRequest(*directconnect.DeleteInterconnectInput) (*request.Request, *directconnect.DeleteInterconnectOutput)
 
 	DeleteInterconnect(*directconnect.DeleteInterconnectInput) (*directconnect.DeleteInterconnectOutput, error)
 
-	DeleteVirtualInterfaceRequest(*directconnect.DeleteVirtualInterfaceInput) (*service.Request, *directconnect.DeleteVirtualInterfaceOutput)
+	DeleteVirtualInterfaceRequest(*directconnect.DeleteVirtualInterfaceInput) (*request.Request, *directconnect.DeleteVirtualInterfaceOutput)
 
 	DeleteVirtualInterface(*directconnect.DeleteVirtualInterfaceInput) (*directconnect.DeleteVirtualInterfaceOutput, error)
 
-	DescribeConnectionsRequest(*directconnect.DescribeConnectionsInput) (*service.Request, *directconnect.Connections)
+	DescribeConnectionsRequest(*directconnect.DescribeConnectionsInput) (*request.Request, *directconnect.Connections)
 
 	DescribeConnections(*directconnect.DescribeConnectionsInput) (*directconnect.Connections, error)
 
-	DescribeConnectionsOnInterconnectRequest(*directconnect.DescribeConnectionsOnInterconnectInput) (*service.Request, *directconnect.Connections)
+	DescribeConnectionsOnInterconnectRequest(*directconnect.DescribeConnectionsOnInterconnectInput) (*request.Request, *directconnect.Connections)
 
 	DescribeConnectionsOnInterconnect(*directconnect.DescribeConnectionsOnInterconnectInput) (*directconnect.Connections, error)
 
-	DescribeInterconnectsRequest(*directconnect.DescribeInterconnectsInput) (*service.Request, *directconnect.DescribeInterconnectsOutput)
+	DescribeInterconnectsRequest(*directconnect.DescribeInterconnectsInput) (*request.Request, *directconnect.DescribeInterconnectsOutput)
 
 	DescribeInterconnects(*directconnect.DescribeInterconnectsInput) (*directconnect.DescribeInterconnectsOutput, error)
 
-	DescribeLocationsRequest(*directconnect.DescribeLocationsInput) (*service.Request, *directconnect.DescribeLocationsOutput)
+	DescribeLocationsRequest(*directconnect.DescribeLocationsInput) (*request.Request, *directconnect.DescribeLocationsOutput)
 
 	DescribeLocations(*directconnect.DescribeLocationsInput) (*directconnect.DescribeLocationsOutput, error)
 
-	DescribeVirtualGatewaysRequest(*directconnect.DescribeVirtualGatewaysInput) (*service.Request, *directconnect.DescribeVirtualGatewaysOutput)
+	DescribeVirtualGatewaysRequest(*directconnect.DescribeVirtualGatewaysInput) (*request.Request, *directconnect.DescribeVirtualGatewaysOutput)
 
 	DescribeVirtualGateways(*directconnect.DescribeVirtualGatewaysInput) (*directconnect.DescribeVirtualGatewaysOutput, error)
 
-	DescribeVirtualInterfacesRequest(*directconnect.DescribeVirtualInterfacesInput) (*service.Request, *directconnect.DescribeVirtualInterfacesOutput)
+	DescribeVirtualInterfacesRequest(*directconnect.DescribeVirtualInterfacesInput) (*request.Request, *directconnect.DescribeVirtualInterfacesOutput)
 
 	DescribeVirtualInterfaces(*directconnect.DescribeVirtualInterfacesInput) (*directconnect.DescribeVirtualInterfacesOutput, error)
 }

--- a/service/directconnect/service.go
+++ b/service/directconnect/service.go
@@ -5,7 +5,9 @@ package directconnect
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -35,16 +37,18 @@ type DirectConnect struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new DirectConnect client.
 func New(config *aws.Config) *DirectConnect {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "directconnect",
-		APIVersion:   "2012-10-25",
-		JSONVersion:  "1.1",
-		TargetPrefix: "OvertureService",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "directconnect",
+			APIVersion:   "2012-10-25",
+			JSONVersion:  "1.1",
+			TargetPrefix: "OvertureService",
+		},
 	}
 	service.Initialize()
 
@@ -65,8 +69,8 @@ func New(config *aws.Config) *DirectConnect {
 
 // newRequest creates a new request for a DirectConnect operation and runs any
 // custom request initialization.
-func (c *DirectConnect) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *DirectConnect) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/directoryservice/api.go
+++ b/service/directoryservice/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opConnectDirectory = "ConnectDirectory"
 
 // ConnectDirectoryRequest generates a request for the ConnectDirectory operation.
-func (c *DirectoryService) ConnectDirectoryRequest(input *ConnectDirectoryInput) (req *service.Request, output *ConnectDirectoryOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) ConnectDirectoryRequest(input *ConnectDirectoryInput) (req *request.Request, output *ConnectDirectoryOutput) {
+	op := &request.Operation{
 		Name:       opConnectDirectory,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -40,8 +40,8 @@ func (c *DirectoryService) ConnectDirectory(input *ConnectDirectoryInput) (*Conn
 const opCreateAlias = "CreateAlias"
 
 // CreateAliasRequest generates a request for the CreateAlias operation.
-func (c *DirectoryService) CreateAliasRequest(input *CreateAliasInput) (req *service.Request, output *CreateAliasOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) CreateAliasRequest(input *CreateAliasInput) (req *request.Request, output *CreateAliasOutput) {
+	op := &request.Operation{
 		Name:       opCreateAlias,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -72,8 +72,8 @@ func (c *DirectoryService) CreateAlias(input *CreateAliasInput) (*CreateAliasOut
 const opCreateComputer = "CreateComputer"
 
 // CreateComputerRequest generates a request for the CreateComputer operation.
-func (c *DirectoryService) CreateComputerRequest(input *CreateComputerInput) (req *service.Request, output *CreateComputerOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) CreateComputerRequest(input *CreateComputerInput) (req *request.Request, output *CreateComputerOutput) {
+	op := &request.Operation{
 		Name:       opCreateComputer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -100,8 +100,8 @@ func (c *DirectoryService) CreateComputer(input *CreateComputerInput) (*CreateCo
 const opCreateDirectory = "CreateDirectory"
 
 // CreateDirectoryRequest generates a request for the CreateDirectory operation.
-func (c *DirectoryService) CreateDirectoryRequest(input *CreateDirectoryInput) (req *service.Request, output *CreateDirectoryOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) CreateDirectoryRequest(input *CreateDirectoryInput) (req *request.Request, output *CreateDirectoryOutput) {
+	op := &request.Operation{
 		Name:       opCreateDirectory,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -127,8 +127,8 @@ func (c *DirectoryService) CreateDirectory(input *CreateDirectoryInput) (*Create
 const opCreateSnapshot = "CreateSnapshot"
 
 // CreateSnapshotRequest generates a request for the CreateSnapshot operation.
-func (c *DirectoryService) CreateSnapshotRequest(input *CreateSnapshotInput) (req *service.Request, output *CreateSnapshotOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) CreateSnapshotRequest(input *CreateSnapshotInput) (req *request.Request, output *CreateSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCreateSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -156,8 +156,8 @@ func (c *DirectoryService) CreateSnapshot(input *CreateSnapshotInput) (*CreateSn
 const opDeleteDirectory = "DeleteDirectory"
 
 // DeleteDirectoryRequest generates a request for the DeleteDirectory operation.
-func (c *DirectoryService) DeleteDirectoryRequest(input *DeleteDirectoryInput) (req *service.Request, output *DeleteDirectoryOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) DeleteDirectoryRequest(input *DeleteDirectoryInput) (req *request.Request, output *DeleteDirectoryOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDirectory,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -183,8 +183,8 @@ func (c *DirectoryService) DeleteDirectory(input *DeleteDirectoryInput) (*Delete
 const opDeleteSnapshot = "DeleteSnapshot"
 
 // DeleteSnapshotRequest generates a request for the DeleteSnapshot operation.
-func (c *DirectoryService) DeleteSnapshotRequest(input *DeleteSnapshotInput) (req *service.Request, output *DeleteSnapshotOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) DeleteSnapshotRequest(input *DeleteSnapshotInput) (req *request.Request, output *DeleteSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -210,8 +210,8 @@ func (c *DirectoryService) DeleteSnapshot(input *DeleteSnapshotInput) (*DeleteSn
 const opDescribeDirectories = "DescribeDirectories"
 
 // DescribeDirectoriesRequest generates a request for the DescribeDirectories operation.
-func (c *DirectoryService) DescribeDirectoriesRequest(input *DescribeDirectoriesInput) (req *service.Request, output *DescribeDirectoriesOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) DescribeDirectoriesRequest(input *DescribeDirectoriesInput) (req *request.Request, output *DescribeDirectoriesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDirectories,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -248,8 +248,8 @@ func (c *DirectoryService) DescribeDirectories(input *DescribeDirectoriesInput) 
 const opDescribeSnapshots = "DescribeSnapshots"
 
 // DescribeSnapshotsRequest generates a request for the DescribeSnapshots operation.
-func (c *DirectoryService) DescribeSnapshotsRequest(input *DescribeSnapshotsInput) (req *service.Request, output *DescribeSnapshotsOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) DescribeSnapshotsRequest(input *DescribeSnapshotsInput) (req *request.Request, output *DescribeSnapshotsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSnapshots,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -282,8 +282,8 @@ func (c *DirectoryService) DescribeSnapshots(input *DescribeSnapshotsInput) (*De
 const opDisableRadius = "DisableRadius"
 
 // DisableRadiusRequest generates a request for the DisableRadius operation.
-func (c *DirectoryService) DisableRadiusRequest(input *DisableRadiusInput) (req *service.Request, output *DisableRadiusOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) DisableRadiusRequest(input *DisableRadiusInput) (req *request.Request, output *DisableRadiusOutput) {
+	op := &request.Operation{
 		Name:       opDisableRadius,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -310,8 +310,8 @@ func (c *DirectoryService) DisableRadius(input *DisableRadiusInput) (*DisableRad
 const opDisableSso = "DisableSso"
 
 // DisableSsoRequest generates a request for the DisableSso operation.
-func (c *DirectoryService) DisableSsoRequest(input *DisableSsoInput) (req *service.Request, output *DisableSsoOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) DisableSsoRequest(input *DisableSsoInput) (req *request.Request, output *DisableSsoOutput) {
+	op := &request.Operation{
 		Name:       opDisableSso,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -337,8 +337,8 @@ func (c *DirectoryService) DisableSso(input *DisableSsoInput) (*DisableSsoOutput
 const opEnableRadius = "EnableRadius"
 
 // EnableRadiusRequest generates a request for the EnableRadius operation.
-func (c *DirectoryService) EnableRadiusRequest(input *EnableRadiusInput) (req *service.Request, output *EnableRadiusOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) EnableRadiusRequest(input *EnableRadiusInput) (req *request.Request, output *EnableRadiusOutput) {
+	op := &request.Operation{
 		Name:       opEnableRadius,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -365,8 +365,8 @@ func (c *DirectoryService) EnableRadius(input *EnableRadiusInput) (*EnableRadius
 const opEnableSso = "EnableSso"
 
 // EnableSsoRequest generates a request for the EnableSso operation.
-func (c *DirectoryService) EnableSsoRequest(input *EnableSsoInput) (req *service.Request, output *EnableSsoOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) EnableSsoRequest(input *EnableSsoInput) (req *request.Request, output *EnableSsoOutput) {
+	op := &request.Operation{
 		Name:       opEnableSso,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -392,8 +392,8 @@ func (c *DirectoryService) EnableSso(input *EnableSsoInput) (*EnableSsoOutput, e
 const opGetDirectoryLimits = "GetDirectoryLimits"
 
 // GetDirectoryLimitsRequest generates a request for the GetDirectoryLimits operation.
-func (c *DirectoryService) GetDirectoryLimitsRequest(input *GetDirectoryLimitsInput) (req *service.Request, output *GetDirectoryLimitsOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) GetDirectoryLimitsRequest(input *GetDirectoryLimitsInput) (req *request.Request, output *GetDirectoryLimitsOutput) {
+	op := &request.Operation{
 		Name:       opGetDirectoryLimits,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -419,8 +419,8 @@ func (c *DirectoryService) GetDirectoryLimits(input *GetDirectoryLimitsInput) (*
 const opGetSnapshotLimits = "GetSnapshotLimits"
 
 // GetSnapshotLimitsRequest generates a request for the GetSnapshotLimits operation.
-func (c *DirectoryService) GetSnapshotLimitsRequest(input *GetSnapshotLimitsInput) (req *service.Request, output *GetSnapshotLimitsOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) GetSnapshotLimitsRequest(input *GetSnapshotLimitsInput) (req *request.Request, output *GetSnapshotLimitsOutput) {
+	op := &request.Operation{
 		Name:       opGetSnapshotLimits,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -446,8 +446,8 @@ func (c *DirectoryService) GetSnapshotLimits(input *GetSnapshotLimitsInput) (*Ge
 const opRestoreFromSnapshot = "RestoreFromSnapshot"
 
 // RestoreFromSnapshotRequest generates a request for the RestoreFromSnapshot operation.
-func (c *DirectoryService) RestoreFromSnapshotRequest(input *RestoreFromSnapshotInput) (req *service.Request, output *RestoreFromSnapshotOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) RestoreFromSnapshotRequest(input *RestoreFromSnapshotInput) (req *request.Request, output *RestoreFromSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opRestoreFromSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -481,8 +481,8 @@ func (c *DirectoryService) RestoreFromSnapshot(input *RestoreFromSnapshotInput) 
 const opUpdateRadius = "UpdateRadius"
 
 // UpdateRadiusRequest generates a request for the UpdateRadius operation.
-func (c *DirectoryService) UpdateRadiusRequest(input *UpdateRadiusInput) (req *service.Request, output *UpdateRadiusOutput) {
-	op := &service.Operation{
+func (c *DirectoryService) UpdateRadiusRequest(input *UpdateRadiusInput) (req *request.Request, output *UpdateRadiusOutput) {
+	op := &request.Operation{
 		Name:       opUpdateRadius,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/directoryservice/directoryserviceiface/interface.go
+++ b/service/directoryservice/directoryserviceiface/interface.go
@@ -4,77 +4,77 @@
 package directoryserviceiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/directoryservice"
 )
 
 // DirectoryServiceAPI is the interface type for directoryservice.DirectoryService.
 type DirectoryServiceAPI interface {
-	ConnectDirectoryRequest(*directoryservice.ConnectDirectoryInput) (*service.Request, *directoryservice.ConnectDirectoryOutput)
+	ConnectDirectoryRequest(*directoryservice.ConnectDirectoryInput) (*request.Request, *directoryservice.ConnectDirectoryOutput)
 
 	ConnectDirectory(*directoryservice.ConnectDirectoryInput) (*directoryservice.ConnectDirectoryOutput, error)
 
-	CreateAliasRequest(*directoryservice.CreateAliasInput) (*service.Request, *directoryservice.CreateAliasOutput)
+	CreateAliasRequest(*directoryservice.CreateAliasInput) (*request.Request, *directoryservice.CreateAliasOutput)
 
 	CreateAlias(*directoryservice.CreateAliasInput) (*directoryservice.CreateAliasOutput, error)
 
-	CreateComputerRequest(*directoryservice.CreateComputerInput) (*service.Request, *directoryservice.CreateComputerOutput)
+	CreateComputerRequest(*directoryservice.CreateComputerInput) (*request.Request, *directoryservice.CreateComputerOutput)
 
 	CreateComputer(*directoryservice.CreateComputerInput) (*directoryservice.CreateComputerOutput, error)
 
-	CreateDirectoryRequest(*directoryservice.CreateDirectoryInput) (*service.Request, *directoryservice.CreateDirectoryOutput)
+	CreateDirectoryRequest(*directoryservice.CreateDirectoryInput) (*request.Request, *directoryservice.CreateDirectoryOutput)
 
 	CreateDirectory(*directoryservice.CreateDirectoryInput) (*directoryservice.CreateDirectoryOutput, error)
 
-	CreateSnapshotRequest(*directoryservice.CreateSnapshotInput) (*service.Request, *directoryservice.CreateSnapshotOutput)
+	CreateSnapshotRequest(*directoryservice.CreateSnapshotInput) (*request.Request, *directoryservice.CreateSnapshotOutput)
 
 	CreateSnapshot(*directoryservice.CreateSnapshotInput) (*directoryservice.CreateSnapshotOutput, error)
 
-	DeleteDirectoryRequest(*directoryservice.DeleteDirectoryInput) (*service.Request, *directoryservice.DeleteDirectoryOutput)
+	DeleteDirectoryRequest(*directoryservice.DeleteDirectoryInput) (*request.Request, *directoryservice.DeleteDirectoryOutput)
 
 	DeleteDirectory(*directoryservice.DeleteDirectoryInput) (*directoryservice.DeleteDirectoryOutput, error)
 
-	DeleteSnapshotRequest(*directoryservice.DeleteSnapshotInput) (*service.Request, *directoryservice.DeleteSnapshotOutput)
+	DeleteSnapshotRequest(*directoryservice.DeleteSnapshotInput) (*request.Request, *directoryservice.DeleteSnapshotOutput)
 
 	DeleteSnapshot(*directoryservice.DeleteSnapshotInput) (*directoryservice.DeleteSnapshotOutput, error)
 
-	DescribeDirectoriesRequest(*directoryservice.DescribeDirectoriesInput) (*service.Request, *directoryservice.DescribeDirectoriesOutput)
+	DescribeDirectoriesRequest(*directoryservice.DescribeDirectoriesInput) (*request.Request, *directoryservice.DescribeDirectoriesOutput)
 
 	DescribeDirectories(*directoryservice.DescribeDirectoriesInput) (*directoryservice.DescribeDirectoriesOutput, error)
 
-	DescribeSnapshotsRequest(*directoryservice.DescribeSnapshotsInput) (*service.Request, *directoryservice.DescribeSnapshotsOutput)
+	DescribeSnapshotsRequest(*directoryservice.DescribeSnapshotsInput) (*request.Request, *directoryservice.DescribeSnapshotsOutput)
 
 	DescribeSnapshots(*directoryservice.DescribeSnapshotsInput) (*directoryservice.DescribeSnapshotsOutput, error)
 
-	DisableRadiusRequest(*directoryservice.DisableRadiusInput) (*service.Request, *directoryservice.DisableRadiusOutput)
+	DisableRadiusRequest(*directoryservice.DisableRadiusInput) (*request.Request, *directoryservice.DisableRadiusOutput)
 
 	DisableRadius(*directoryservice.DisableRadiusInput) (*directoryservice.DisableRadiusOutput, error)
 
-	DisableSsoRequest(*directoryservice.DisableSsoInput) (*service.Request, *directoryservice.DisableSsoOutput)
+	DisableSsoRequest(*directoryservice.DisableSsoInput) (*request.Request, *directoryservice.DisableSsoOutput)
 
 	DisableSso(*directoryservice.DisableSsoInput) (*directoryservice.DisableSsoOutput, error)
 
-	EnableRadiusRequest(*directoryservice.EnableRadiusInput) (*service.Request, *directoryservice.EnableRadiusOutput)
+	EnableRadiusRequest(*directoryservice.EnableRadiusInput) (*request.Request, *directoryservice.EnableRadiusOutput)
 
 	EnableRadius(*directoryservice.EnableRadiusInput) (*directoryservice.EnableRadiusOutput, error)
 
-	EnableSsoRequest(*directoryservice.EnableSsoInput) (*service.Request, *directoryservice.EnableSsoOutput)
+	EnableSsoRequest(*directoryservice.EnableSsoInput) (*request.Request, *directoryservice.EnableSsoOutput)
 
 	EnableSso(*directoryservice.EnableSsoInput) (*directoryservice.EnableSsoOutput, error)
 
-	GetDirectoryLimitsRequest(*directoryservice.GetDirectoryLimitsInput) (*service.Request, *directoryservice.GetDirectoryLimitsOutput)
+	GetDirectoryLimitsRequest(*directoryservice.GetDirectoryLimitsInput) (*request.Request, *directoryservice.GetDirectoryLimitsOutput)
 
 	GetDirectoryLimits(*directoryservice.GetDirectoryLimitsInput) (*directoryservice.GetDirectoryLimitsOutput, error)
 
-	GetSnapshotLimitsRequest(*directoryservice.GetSnapshotLimitsInput) (*service.Request, *directoryservice.GetSnapshotLimitsOutput)
+	GetSnapshotLimitsRequest(*directoryservice.GetSnapshotLimitsInput) (*request.Request, *directoryservice.GetSnapshotLimitsOutput)
 
 	GetSnapshotLimits(*directoryservice.GetSnapshotLimitsInput) (*directoryservice.GetSnapshotLimitsOutput, error)
 
-	RestoreFromSnapshotRequest(*directoryservice.RestoreFromSnapshotInput) (*service.Request, *directoryservice.RestoreFromSnapshotOutput)
+	RestoreFromSnapshotRequest(*directoryservice.RestoreFromSnapshotInput) (*request.Request, *directoryservice.RestoreFromSnapshotOutput)
 
 	RestoreFromSnapshot(*directoryservice.RestoreFromSnapshotInput) (*directoryservice.RestoreFromSnapshotOutput, error)
 
-	UpdateRadiusRequest(*directoryservice.UpdateRadiusInput) (*service.Request, *directoryservice.UpdateRadiusOutput)
+	UpdateRadiusRequest(*directoryservice.UpdateRadiusInput) (*request.Request, *directoryservice.UpdateRadiusOutput)
 
 	UpdateRadius(*directoryservice.UpdateRadiusInput) (*directoryservice.UpdateRadiusOutput, error)
 }

--- a/service/directoryservice/service.go
+++ b/service/directoryservice/service.go
@@ -5,7 +5,9 @@ package directoryservice
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -21,16 +23,18 @@ type DirectoryService struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new DirectoryService client.
 func New(config *aws.Config) *DirectoryService {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "ds",
-		APIVersion:   "2015-04-16",
-		JSONVersion:  "1.1",
-		TargetPrefix: "DirectoryService_20150416",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "ds",
+			APIVersion:   "2015-04-16",
+			JSONVersion:  "1.1",
+			TargetPrefix: "DirectoryService_20150416",
+		},
 	}
 	service.Initialize()
 
@@ -51,8 +55,8 @@ func New(config *aws.Config) *DirectoryService {
 
 // newRequest creates a new request for a DirectoryService operation and runs any
 // custom request initialization.
-func (c *DirectoryService) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *DirectoryService) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/dynamodb/api.go
+++ b/service/dynamodb/api.go
@@ -7,18 +7,18 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opBatchGetItem = "BatchGetItem"
 
 // BatchGetItemRequest generates a request for the BatchGetItem operation.
-func (c *DynamoDB) BatchGetItemRequest(input *BatchGetItemInput) (req *service.Request, output *BatchGetItemOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) BatchGetItemRequest(input *BatchGetItemInput) (req *request.Request, output *BatchGetItemOutput) {
+	op := &request.Operation{
 		Name:       opBatchGetItem,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"RequestItems"},
 			OutputTokens:    []string{"UnprocessedKeys"},
 			LimitToken:      "",
@@ -101,8 +101,8 @@ func (c *DynamoDB) BatchGetItemPages(input *BatchGetItemInput, fn func(p *BatchG
 const opBatchWriteItem = "BatchWriteItem"
 
 // BatchWriteItemRequest generates a request for the BatchWriteItem operation.
-func (c *DynamoDB) BatchWriteItemRequest(input *BatchWriteItemInput) (req *service.Request, output *BatchWriteItemOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) BatchWriteItemRequest(input *BatchWriteItemInput) (req *request.Request, output *BatchWriteItemOutput) {
+	op := &request.Operation{
 		Name:       opBatchWriteItem,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -196,8 +196,8 @@ func (c *DynamoDB) BatchWriteItem(input *BatchWriteItemInput) (*BatchWriteItemOu
 const opCreateTable = "CreateTable"
 
 // CreateTableRequest generates a request for the CreateTable operation.
-func (c *DynamoDB) CreateTableRequest(input *CreateTableInput) (req *service.Request, output *CreateTableOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) CreateTableRequest(input *CreateTableInput) (req *request.Request, output *CreateTableOutput) {
+	op := &request.Operation{
 		Name:       opCreateTable,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -237,8 +237,8 @@ func (c *DynamoDB) CreateTable(input *CreateTableInput) (*CreateTableOutput, err
 const opDeleteItem = "DeleteItem"
 
 // DeleteItemRequest generates a request for the DeleteItem operation.
-func (c *DynamoDB) DeleteItemRequest(input *DeleteItemInput) (req *service.Request, output *DeleteItemOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) DeleteItemRequest(input *DeleteItemInput) (req *request.Request, output *DeleteItemOutput) {
+	op := &request.Operation{
 		Name:       opDeleteItem,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -277,8 +277,8 @@ func (c *DynamoDB) DeleteItem(input *DeleteItemInput) (*DeleteItemOutput, error)
 const opDeleteTable = "DeleteTable"
 
 // DeleteTableRequest generates a request for the DeleteTable operation.
-func (c *DynamoDB) DeleteTableRequest(input *DeleteTableInput) (req *service.Request, output *DeleteTableOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) DeleteTableRequest(input *DeleteTableInput) (req *request.Request, output *DeleteTableOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTable,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -321,8 +321,8 @@ func (c *DynamoDB) DeleteTable(input *DeleteTableInput) (*DeleteTableOutput, err
 const opDescribeTable = "DescribeTable"
 
 // DescribeTableRequest generates a request for the DescribeTable operation.
-func (c *DynamoDB) DescribeTableRequest(input *DescribeTableInput) (req *service.Request, output *DescribeTableOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) DescribeTableRequest(input *DescribeTableInput) (req *request.Request, output *DescribeTableOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTable,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -356,8 +356,8 @@ func (c *DynamoDB) DescribeTable(input *DescribeTableInput) (*DescribeTableOutpu
 const opGetItem = "GetItem"
 
 // GetItemRequest generates a request for the GetItem operation.
-func (c *DynamoDB) GetItemRequest(input *GetItemInput) (req *service.Request, output *GetItemOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) GetItemRequest(input *GetItemInput) (req *request.Request, output *GetItemOutput) {
+	op := &request.Operation{
 		Name:       opGetItem,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -389,12 +389,12 @@ func (c *DynamoDB) GetItem(input *GetItemInput) (*GetItemOutput, error) {
 const opListTables = "ListTables"
 
 // ListTablesRequest generates a request for the ListTables operation.
-func (c *DynamoDB) ListTablesRequest(input *ListTablesInput) (req *service.Request, output *ListTablesOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) ListTablesRequest(input *ListTablesInput) (req *request.Request, output *ListTablesOutput) {
+	op := &request.Operation{
 		Name:       opListTables,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"ExclusiveStartTableName"},
 			OutputTokens:    []string{"LastEvaluatedTableName"},
 			LimitToken:      "Limit",
@@ -431,8 +431,8 @@ func (c *DynamoDB) ListTablesPages(input *ListTablesInput, fn func(p *ListTables
 const opPutItem = "PutItem"
 
 // PutItemRequest generates a request for the PutItem operation.
-func (c *DynamoDB) PutItemRequest(input *PutItemInput) (req *service.Request, output *PutItemOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) PutItemRequest(input *PutItemInput) (req *request.Request, output *PutItemOutput) {
+	op := &request.Operation{
 		Name:       opPutItem,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -482,12 +482,12 @@ func (c *DynamoDB) PutItem(input *PutItemInput) (*PutItemOutput, error) {
 const opQuery = "Query"
 
 // QueryRequest generates a request for the Query operation.
-func (c *DynamoDB) QueryRequest(input *QueryInput) (req *service.Request, output *QueryOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) QueryRequest(input *QueryInput) (req *request.Request, output *QueryOutput) {
+	op := &request.Operation{
 		Name:       opQuery,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"ExclusiveStartKey"},
 			OutputTokens:    []string{"LastEvaluatedKey"},
 			LimitToken:      "Limit",
@@ -546,12 +546,12 @@ func (c *DynamoDB) QueryPages(input *QueryInput, fn func(p *QueryOutput, lastPag
 const opScan = "Scan"
 
 // ScanRequest generates a request for the Scan operation.
-func (c *DynamoDB) ScanRequest(input *ScanInput) (req *service.Request, output *ScanOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) ScanRequest(input *ScanInput) (req *request.Request, output *ScanOutput) {
+	op := &request.Operation{
 		Name:       opScan,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"ExclusiveStartKey"},
 			OutputTokens:    []string{"LastEvaluatedKey"},
 			LimitToken:      "Limit",
@@ -604,8 +604,8 @@ func (c *DynamoDB) ScanPages(input *ScanInput, fn func(p *ScanOutput, lastPage b
 const opUpdateItem = "UpdateItem"
 
 // UpdateItemRequest generates a request for the UpdateItem operation.
-func (c *DynamoDB) UpdateItemRequest(input *UpdateItemInput) (req *service.Request, output *UpdateItemOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) UpdateItemRequest(input *UpdateItemInput) (req *request.Request, output *UpdateItemOutput) {
+	op := &request.Operation{
 		Name:       opUpdateItem,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -640,8 +640,8 @@ func (c *DynamoDB) UpdateItem(input *UpdateItemInput) (*UpdateItemOutput, error)
 const opUpdateTable = "UpdateTable"
 
 // UpdateTableRequest generates a request for the UpdateTable operation.
-func (c *DynamoDB) UpdateTableRequest(input *UpdateTableInput) (req *service.Request, output *UpdateTableOutput) {
-	op := &service.Operation{
+func (c *DynamoDB) UpdateTableRequest(input *UpdateTableInput) (req *request.Request, output *UpdateTableOutput) {
+	op := &request.Operation{
 		Name:       opUpdateTable,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/dynamodb/customizations_test.go
+++ b/service/dynamodb/customizations_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/stretchr/testify/assert"
@@ -27,12 +27,12 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func mockCRCResponse(svc *dynamodb.DynamoDB, status int, body, crc string) (req *service.Request) {
+func mockCRCResponse(svc *dynamodb.DynamoDB, status int, body, crc string) (req *request.Request) {
 	header := http.Header{}
 	header.Set("x-amz-crc32", crc)
 
 	req, _ = svc.ListTablesRequest(nil)
-	req.Handlers.Send.PushBack(func(*service.Request) {
+	req.Handlers.Send.PushBack(func(*request.Request) {
 		req.HTTPResponse = &http.Response{
 			StatusCode: status,
 			Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),

--- a/service/dynamodb/dynamodbiface/interface.go
+++ b/service/dynamodb/dynamodbiface/interface.go
@@ -4,69 +4,69 @@
 package dynamodbiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // DynamoDBAPI is the interface type for dynamodb.DynamoDB.
 type DynamoDBAPI interface {
-	BatchGetItemRequest(*dynamodb.BatchGetItemInput) (*service.Request, *dynamodb.BatchGetItemOutput)
+	BatchGetItemRequest(*dynamodb.BatchGetItemInput) (*request.Request, *dynamodb.BatchGetItemOutput)
 
 	BatchGetItem(*dynamodb.BatchGetItemInput) (*dynamodb.BatchGetItemOutput, error)
 
 	BatchGetItemPages(*dynamodb.BatchGetItemInput, func(*dynamodb.BatchGetItemOutput, bool) bool) error
 
-	BatchWriteItemRequest(*dynamodb.BatchWriteItemInput) (*service.Request, *dynamodb.BatchWriteItemOutput)
+	BatchWriteItemRequest(*dynamodb.BatchWriteItemInput) (*request.Request, *dynamodb.BatchWriteItemOutput)
 
 	BatchWriteItem(*dynamodb.BatchWriteItemInput) (*dynamodb.BatchWriteItemOutput, error)
 
-	CreateTableRequest(*dynamodb.CreateTableInput) (*service.Request, *dynamodb.CreateTableOutput)
+	CreateTableRequest(*dynamodb.CreateTableInput) (*request.Request, *dynamodb.CreateTableOutput)
 
 	CreateTable(*dynamodb.CreateTableInput) (*dynamodb.CreateTableOutput, error)
 
-	DeleteItemRequest(*dynamodb.DeleteItemInput) (*service.Request, *dynamodb.DeleteItemOutput)
+	DeleteItemRequest(*dynamodb.DeleteItemInput) (*request.Request, *dynamodb.DeleteItemOutput)
 
 	DeleteItem(*dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error)
 
-	DeleteTableRequest(*dynamodb.DeleteTableInput) (*service.Request, *dynamodb.DeleteTableOutput)
+	DeleteTableRequest(*dynamodb.DeleteTableInput) (*request.Request, *dynamodb.DeleteTableOutput)
 
 	DeleteTable(*dynamodb.DeleteTableInput) (*dynamodb.DeleteTableOutput, error)
 
-	DescribeTableRequest(*dynamodb.DescribeTableInput) (*service.Request, *dynamodb.DescribeTableOutput)
+	DescribeTableRequest(*dynamodb.DescribeTableInput) (*request.Request, *dynamodb.DescribeTableOutput)
 
 	DescribeTable(*dynamodb.DescribeTableInput) (*dynamodb.DescribeTableOutput, error)
 
-	GetItemRequest(*dynamodb.GetItemInput) (*service.Request, *dynamodb.GetItemOutput)
+	GetItemRequest(*dynamodb.GetItemInput) (*request.Request, *dynamodb.GetItemOutput)
 
 	GetItem(*dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error)
 
-	ListTablesRequest(*dynamodb.ListTablesInput) (*service.Request, *dynamodb.ListTablesOutput)
+	ListTablesRequest(*dynamodb.ListTablesInput) (*request.Request, *dynamodb.ListTablesOutput)
 
 	ListTables(*dynamodb.ListTablesInput) (*dynamodb.ListTablesOutput, error)
 
 	ListTablesPages(*dynamodb.ListTablesInput, func(*dynamodb.ListTablesOutput, bool) bool) error
 
-	PutItemRequest(*dynamodb.PutItemInput) (*service.Request, *dynamodb.PutItemOutput)
+	PutItemRequest(*dynamodb.PutItemInput) (*request.Request, *dynamodb.PutItemOutput)
 
 	PutItem(*dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error)
 
-	QueryRequest(*dynamodb.QueryInput) (*service.Request, *dynamodb.QueryOutput)
+	QueryRequest(*dynamodb.QueryInput) (*request.Request, *dynamodb.QueryOutput)
 
 	Query(*dynamodb.QueryInput) (*dynamodb.QueryOutput, error)
 
 	QueryPages(*dynamodb.QueryInput, func(*dynamodb.QueryOutput, bool) bool) error
 
-	ScanRequest(*dynamodb.ScanInput) (*service.Request, *dynamodb.ScanOutput)
+	ScanRequest(*dynamodb.ScanInput) (*request.Request, *dynamodb.ScanOutput)
 
 	Scan(*dynamodb.ScanInput) (*dynamodb.ScanOutput, error)
 
 	ScanPages(*dynamodb.ScanInput, func(*dynamodb.ScanOutput, bool) bool) error
 
-	UpdateItemRequest(*dynamodb.UpdateItemInput) (*service.Request, *dynamodb.UpdateItemOutput)
+	UpdateItemRequest(*dynamodb.UpdateItemInput) (*request.Request, *dynamodb.UpdateItemOutput)
 
 	UpdateItem(*dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error)
 
-	UpdateTableRequest(*dynamodb.UpdateTableInput) (*service.Request, *dynamodb.UpdateTableOutput)
+	UpdateTableRequest(*dynamodb.UpdateTableInput) (*request.Request, *dynamodb.UpdateTableOutput)
 
 	UpdateTable(*dynamodb.UpdateTableInput) (*dynamodb.UpdateTableOutput, error)
 }

--- a/service/dynamodb/service.go
+++ b/service/dynamodb/service.go
@@ -5,7 +5,9 @@ package dynamodb
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -121,16 +123,18 @@ type DynamoDB struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new DynamoDB client.
 func New(config *aws.Config) *DynamoDB {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "dynamodb",
-		APIVersion:   "2012-08-10",
-		JSONVersion:  "1.0",
-		TargetPrefix: "DynamoDB_20120810",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "dynamodb",
+			APIVersion:   "2012-08-10",
+			JSONVersion:  "1.0",
+			TargetPrefix: "DynamoDB_20120810",
+		},
 	}
 	service.Initialize()
 
@@ -151,8 +155,8 @@ func New(config *aws.Config) *DynamoDB {
 
 // newRequest creates a new request for a DynamoDB operation and runs any
 // custom request initialization.
-func (c *DynamoDB) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *DynamoDB) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/dynamodbstreams/api.go
+++ b/service/dynamodbstreams/api.go
@@ -7,15 +7,15 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 const opDescribeStream = "DescribeStream"
 
 // DescribeStreamRequest generates a request for the DescribeStream operation.
-func (c *DynamoDBStreams) DescribeStreamRequest(input *DescribeStreamInput) (req *service.Request, output *DescribeStreamOutput) {
-	op := &service.Operation{
+func (c *DynamoDBStreams) DescribeStreamRequest(input *DescribeStreamInput) (req *request.Request, output *DescribeStreamOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -51,8 +51,8 @@ func (c *DynamoDBStreams) DescribeStream(input *DescribeStreamInput) (*DescribeS
 const opGetRecords = "GetRecords"
 
 // GetRecordsRequest generates a request for the GetRecords operation.
-func (c *DynamoDBStreams) GetRecordsRequest(input *GetRecordsInput) (req *service.Request, output *GetRecordsOutput) {
-	op := &service.Operation{
+func (c *DynamoDBStreams) GetRecordsRequest(input *GetRecordsInput) (req *request.Request, output *GetRecordsOutput) {
+	op := &request.Operation{
 		Name:       opGetRecords,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -88,8 +88,8 @@ func (c *DynamoDBStreams) GetRecords(input *GetRecordsInput) (*GetRecordsOutput,
 const opGetShardIterator = "GetShardIterator"
 
 // GetShardIteratorRequest generates a request for the GetShardIterator operation.
-func (c *DynamoDBStreams) GetShardIteratorRequest(input *GetShardIteratorInput) (req *service.Request, output *GetShardIteratorOutput) {
-	op := &service.Operation{
+func (c *DynamoDBStreams) GetShardIteratorRequest(input *GetShardIteratorInput) (req *request.Request, output *GetShardIteratorOutput) {
+	op := &request.Operation{
 		Name:       opGetShardIterator,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -119,8 +119,8 @@ func (c *DynamoDBStreams) GetShardIterator(input *GetShardIteratorInput) (*GetSh
 const opListStreams = "ListStreams"
 
 // ListStreamsRequest generates a request for the ListStreams operation.
-func (c *DynamoDBStreams) ListStreamsRequest(input *ListStreamsInput) (req *service.Request, output *ListStreamsOutput) {
-	op := &service.Operation{
+func (c *DynamoDBStreams) ListStreamsRequest(input *ListStreamsInput) (req *request.Request, output *ListStreamsOutput) {
+	op := &request.Operation{
 		Name:       opListStreams,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/dynamodbstreams/dynamodbstreamsiface/interface.go
+++ b/service/dynamodbstreams/dynamodbstreamsiface/interface.go
@@ -4,25 +4,25 @@
 package dynamodbstreamsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 )
 
 // DynamoDBStreamsAPI is the interface type for dynamodbstreams.DynamoDBStreams.
 type DynamoDBStreamsAPI interface {
-	DescribeStreamRequest(*dynamodbstreams.DescribeStreamInput) (*service.Request, *dynamodbstreams.DescribeStreamOutput)
+	DescribeStreamRequest(*dynamodbstreams.DescribeStreamInput) (*request.Request, *dynamodbstreams.DescribeStreamOutput)
 
 	DescribeStream(*dynamodbstreams.DescribeStreamInput) (*dynamodbstreams.DescribeStreamOutput, error)
 
-	GetRecordsRequest(*dynamodbstreams.GetRecordsInput) (*service.Request, *dynamodbstreams.GetRecordsOutput)
+	GetRecordsRequest(*dynamodbstreams.GetRecordsInput) (*request.Request, *dynamodbstreams.GetRecordsOutput)
 
 	GetRecords(*dynamodbstreams.GetRecordsInput) (*dynamodbstreams.GetRecordsOutput, error)
 
-	GetShardIteratorRequest(*dynamodbstreams.GetShardIteratorInput) (*service.Request, *dynamodbstreams.GetShardIteratorOutput)
+	GetShardIteratorRequest(*dynamodbstreams.GetShardIteratorInput) (*request.Request, *dynamodbstreams.GetShardIteratorOutput)
 
 	GetShardIterator(*dynamodbstreams.GetShardIteratorInput) (*dynamodbstreams.GetShardIteratorOutput, error)
 
-	ListStreamsRequest(*dynamodbstreams.ListStreamsInput) (*service.Request, *dynamodbstreams.ListStreamsOutput)
+	ListStreamsRequest(*dynamodbstreams.ListStreamsInput) (*request.Request, *dynamodbstreams.ListStreamsOutput)
 
 	ListStreams(*dynamodbstreams.ListStreamsInput) (*dynamodbstreams.ListStreamsOutput, error)
 }

--- a/service/dynamodbstreams/service.go
+++ b/service/dynamodbstreams/service.go
@@ -5,7 +5,9 @@ package dynamodbstreams
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -42,17 +44,19 @@ type DynamoDBStreams struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new DynamoDBStreams client.
 func New(config *aws.Config) *DynamoDBStreams {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "streams.dynamodb",
-		SigningName:  "dynamodb",
-		APIVersion:   "2012-08-10",
-		JSONVersion:  "1.0",
-		TargetPrefix: "DynamoDBStreams_20120810",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "streams.dynamodb",
+			SigningName:  "dynamodb",
+			APIVersion:   "2012-08-10",
+			JSONVersion:  "1.0",
+			TargetPrefix: "DynamoDBStreams_20120810",
+		},
 	}
 	service.Initialize()
 
@@ -73,8 +77,8 @@ func New(config *aws.Config) *DynamoDBStreams {
 
 // newRequest creates a new request for a DynamoDBStreams operation and runs any
 // custom request initialization.
-func (c *DynamoDBStreams) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *DynamoDBStreams) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/ec2/api.go
+++ b/service/ec2/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAcceptVpcPeeringConnection = "AcceptVpcPeeringConnection"
 
 // AcceptVpcPeeringConnectionRequest generates a request for the AcceptVpcPeeringConnection operation.
-func (c *EC2) AcceptVpcPeeringConnectionRequest(input *AcceptVpcPeeringConnectionInput) (req *service.Request, output *AcceptVpcPeeringConnectionOutput) {
-	op := &service.Operation{
+func (c *EC2) AcceptVpcPeeringConnectionRequest(input *AcceptVpcPeeringConnectionInput) (req *request.Request, output *AcceptVpcPeeringConnectionOutput) {
+	op := &request.Operation{
 		Name:       opAcceptVpcPeeringConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -43,8 +43,8 @@ func (c *EC2) AcceptVpcPeeringConnection(input *AcceptVpcPeeringConnectionInput)
 const opAllocateAddress = "AllocateAddress"
 
 // AllocateAddressRequest generates a request for the AllocateAddress operation.
-func (c *EC2) AllocateAddressRequest(input *AllocateAddressInput) (req *service.Request, output *AllocateAddressOutput) {
-	op := &service.Operation{
+func (c *EC2) AllocateAddressRequest(input *AllocateAddressInput) (req *request.Request, output *AllocateAddressOutput) {
+	op := &request.Operation{
 		Name:       opAllocateAddress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -74,8 +74,8 @@ func (c *EC2) AllocateAddress(input *AllocateAddressInput) (*AllocateAddressOutp
 const opAssignPrivateIpAddresses = "AssignPrivateIpAddresses"
 
 // AssignPrivateIpAddressesRequest generates a request for the AssignPrivateIpAddresses operation.
-func (c *EC2) AssignPrivateIpAddressesRequest(input *AssignPrivateIpAddressesInput) (req *service.Request, output *AssignPrivateIpAddressesOutput) {
-	op := &service.Operation{
+func (c *EC2) AssignPrivateIpAddressesRequest(input *AssignPrivateIpAddressesInput) (req *request.Request, output *AssignPrivateIpAddressesOutput) {
+	op := &request.Operation{
 		Name:       opAssignPrivateIpAddresses,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -111,8 +111,8 @@ func (c *EC2) AssignPrivateIpAddresses(input *AssignPrivateIpAddressesInput) (*A
 const opAssociateAddress = "AssociateAddress"
 
 // AssociateAddressRequest generates a request for the AssociateAddress operation.
-func (c *EC2) AssociateAddressRequest(input *AssociateAddressInput) (req *service.Request, output *AssociateAddressOutput) {
-	op := &service.Operation{
+func (c *EC2) AssociateAddressRequest(input *AssociateAddressInput) (req *request.Request, output *AssociateAddressOutput) {
+	op := &request.Operation{
 		Name:       opAssociateAddress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -154,8 +154,8 @@ func (c *EC2) AssociateAddress(input *AssociateAddressInput) (*AssociateAddressO
 const opAssociateDhcpOptions = "AssociateDhcpOptions"
 
 // AssociateDhcpOptionsRequest generates a request for the AssociateDhcpOptions operation.
-func (c *EC2) AssociateDhcpOptionsRequest(input *AssociateDhcpOptionsInput) (req *service.Request, output *AssociateDhcpOptionsOutput) {
-	op := &service.Operation{
+func (c *EC2) AssociateDhcpOptionsRequest(input *AssociateDhcpOptionsInput) (req *request.Request, output *AssociateDhcpOptionsOutput) {
+	op := &request.Operation{
 		Name:       opAssociateDhcpOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -192,8 +192,8 @@ func (c *EC2) AssociateDhcpOptions(input *AssociateDhcpOptionsInput) (*Associate
 const opAssociateRouteTable = "AssociateRouteTable"
 
 // AssociateRouteTableRequest generates a request for the AssociateRouteTable operation.
-func (c *EC2) AssociateRouteTableRequest(input *AssociateRouteTableInput) (req *service.Request, output *AssociateRouteTableOutput) {
-	op := &service.Operation{
+func (c *EC2) AssociateRouteTableRequest(input *AssociateRouteTableInput) (req *request.Request, output *AssociateRouteTableOutput) {
+	op := &request.Operation{
 		Name:       opAssociateRouteTable,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -226,8 +226,8 @@ func (c *EC2) AssociateRouteTable(input *AssociateRouteTableInput) (*AssociateRo
 const opAttachClassicLinkVpc = "AttachClassicLinkVpc"
 
 // AttachClassicLinkVpcRequest generates a request for the AttachClassicLinkVpc operation.
-func (c *EC2) AttachClassicLinkVpcRequest(input *AttachClassicLinkVpcInput) (req *service.Request, output *AttachClassicLinkVpcOutput) {
-	op := &service.Operation{
+func (c *EC2) AttachClassicLinkVpcRequest(input *AttachClassicLinkVpcInput) (req *request.Request, output *AttachClassicLinkVpcOutput) {
+	op := &request.Operation{
 		Name:       opAttachClassicLinkVpc,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -264,8 +264,8 @@ func (c *EC2) AttachClassicLinkVpc(input *AttachClassicLinkVpcInput) (*AttachCla
 const opAttachInternetGateway = "AttachInternetGateway"
 
 // AttachInternetGatewayRequest generates a request for the AttachInternetGateway operation.
-func (c *EC2) AttachInternetGatewayRequest(input *AttachInternetGatewayInput) (req *service.Request, output *AttachInternetGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) AttachInternetGatewayRequest(input *AttachInternetGatewayInput) (req *request.Request, output *AttachInternetGatewayOutput) {
+	op := &request.Operation{
 		Name:       opAttachInternetGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -293,8 +293,8 @@ func (c *EC2) AttachInternetGateway(input *AttachInternetGatewayInput) (*AttachI
 const opAttachNetworkInterface = "AttachNetworkInterface"
 
 // AttachNetworkInterfaceRequest generates a request for the AttachNetworkInterface operation.
-func (c *EC2) AttachNetworkInterfaceRequest(input *AttachNetworkInterfaceInput) (req *service.Request, output *AttachNetworkInterfaceOutput) {
-	op := &service.Operation{
+func (c *EC2) AttachNetworkInterfaceRequest(input *AttachNetworkInterfaceInput) (req *request.Request, output *AttachNetworkInterfaceOutput) {
+	op := &request.Operation{
 		Name:       opAttachNetworkInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -320,8 +320,8 @@ func (c *EC2) AttachNetworkInterface(input *AttachNetworkInterfaceInput) (*Attac
 const opAttachVolume = "AttachVolume"
 
 // AttachVolumeRequest generates a request for the AttachVolume operation.
-func (c *EC2) AttachVolumeRequest(input *AttachVolumeInput) (req *service.Request, output *VolumeAttachment) {
-	op := &service.Operation{
+func (c *EC2) AttachVolumeRequest(input *AttachVolumeInput) (req *request.Request, output *VolumeAttachment) {
+	op := &request.Operation{
 		Name:       opAttachVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -371,8 +371,8 @@ func (c *EC2) AttachVolume(input *AttachVolumeInput) (*VolumeAttachment, error) 
 const opAttachVpnGateway = "AttachVpnGateway"
 
 // AttachVpnGatewayRequest generates a request for the AttachVpnGateway operation.
-func (c *EC2) AttachVpnGatewayRequest(input *AttachVpnGatewayInput) (req *service.Request, output *AttachVpnGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) AttachVpnGatewayRequest(input *AttachVpnGatewayInput) (req *request.Request, output *AttachVpnGatewayOutput) {
+	op := &request.Operation{
 		Name:       opAttachVpnGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -400,8 +400,8 @@ func (c *EC2) AttachVpnGateway(input *AttachVpnGatewayInput) (*AttachVpnGatewayO
 const opAuthorizeSecurityGroupEgress = "AuthorizeSecurityGroupEgress"
 
 // AuthorizeSecurityGroupEgressRequest generates a request for the AuthorizeSecurityGroupEgress operation.
-func (c *EC2) AuthorizeSecurityGroupEgressRequest(input *AuthorizeSecurityGroupEgressInput) (req *service.Request, output *AuthorizeSecurityGroupEgressOutput) {
-	op := &service.Operation{
+func (c *EC2) AuthorizeSecurityGroupEgressRequest(input *AuthorizeSecurityGroupEgressInput) (req *request.Request, output *AuthorizeSecurityGroupEgressOutput) {
+	op := &request.Operation{
 		Name:       opAuthorizeSecurityGroupEgress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -447,8 +447,8 @@ func (c *EC2) AuthorizeSecurityGroupEgress(input *AuthorizeSecurityGroupEgressIn
 const opAuthorizeSecurityGroupIngress = "AuthorizeSecurityGroupIngress"
 
 // AuthorizeSecurityGroupIngressRequest generates a request for the AuthorizeSecurityGroupIngress operation.
-func (c *EC2) AuthorizeSecurityGroupIngressRequest(input *AuthorizeSecurityGroupIngressInput) (req *service.Request, output *AuthorizeSecurityGroupIngressOutput) {
-	op := &service.Operation{
+func (c *EC2) AuthorizeSecurityGroupIngressRequest(input *AuthorizeSecurityGroupIngressInput) (req *request.Request, output *AuthorizeSecurityGroupIngressOutput) {
+	op := &request.Operation{
 		Name:       opAuthorizeSecurityGroupIngress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -492,8 +492,8 @@ func (c *EC2) AuthorizeSecurityGroupIngress(input *AuthorizeSecurityGroupIngress
 const opBundleInstance = "BundleInstance"
 
 // BundleInstanceRequest generates a request for the BundleInstance operation.
-func (c *EC2) BundleInstanceRequest(input *BundleInstanceInput) (req *service.Request, output *BundleInstanceOutput) {
-	op := &service.Operation{
+func (c *EC2) BundleInstanceRequest(input *BundleInstanceInput) (req *request.Request, output *BundleInstanceOutput) {
+	op := &request.Operation{
 		Name:       opBundleInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -528,8 +528,8 @@ func (c *EC2) BundleInstance(input *BundleInstanceInput) (*BundleInstanceOutput,
 const opCancelBundleTask = "CancelBundleTask"
 
 // CancelBundleTaskRequest generates a request for the CancelBundleTask operation.
-func (c *EC2) CancelBundleTaskRequest(input *CancelBundleTaskInput) (req *service.Request, output *CancelBundleTaskOutput) {
-	op := &service.Operation{
+func (c *EC2) CancelBundleTaskRequest(input *CancelBundleTaskInput) (req *request.Request, output *CancelBundleTaskOutput) {
+	op := &request.Operation{
 		Name:       opCancelBundleTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -555,8 +555,8 @@ func (c *EC2) CancelBundleTask(input *CancelBundleTaskInput) (*CancelBundleTaskO
 const opCancelConversionTask = "CancelConversionTask"
 
 // CancelConversionTaskRequest generates a request for the CancelConversionTask operation.
-func (c *EC2) CancelConversionTaskRequest(input *CancelConversionTaskInput) (req *service.Request, output *CancelConversionTaskOutput) {
-	op := &service.Operation{
+func (c *EC2) CancelConversionTaskRequest(input *CancelConversionTaskInput) (req *request.Request, output *CancelConversionTaskOutput) {
+	op := &request.Operation{
 		Name:       opCancelConversionTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -590,8 +590,8 @@ func (c *EC2) CancelConversionTask(input *CancelConversionTaskInput) (*CancelCon
 const opCancelExportTask = "CancelExportTask"
 
 // CancelExportTaskRequest generates a request for the CancelExportTask operation.
-func (c *EC2) CancelExportTaskRequest(input *CancelExportTaskInput) (req *service.Request, output *CancelExportTaskOutput) {
-	op := &service.Operation{
+func (c *EC2) CancelExportTaskRequest(input *CancelExportTaskInput) (req *request.Request, output *CancelExportTaskOutput) {
+	op := &request.Operation{
 		Name:       opCancelExportTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -620,8 +620,8 @@ func (c *EC2) CancelExportTask(input *CancelExportTaskInput) (*CancelExportTaskO
 const opCancelImportTask = "CancelImportTask"
 
 // CancelImportTaskRequest generates a request for the CancelImportTask operation.
-func (c *EC2) CancelImportTaskRequest(input *CancelImportTaskInput) (req *service.Request, output *CancelImportTaskOutput) {
-	op := &service.Operation{
+func (c *EC2) CancelImportTaskRequest(input *CancelImportTaskInput) (req *request.Request, output *CancelImportTaskOutput) {
+	op := &request.Operation{
 		Name:       opCancelImportTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -647,8 +647,8 @@ func (c *EC2) CancelImportTask(input *CancelImportTaskInput) (*CancelImportTaskO
 const opCancelReservedInstancesListing = "CancelReservedInstancesListing"
 
 // CancelReservedInstancesListingRequest generates a request for the CancelReservedInstancesListing operation.
-func (c *EC2) CancelReservedInstancesListingRequest(input *CancelReservedInstancesListingInput) (req *service.Request, output *CancelReservedInstancesListingOutput) {
-	op := &service.Operation{
+func (c *EC2) CancelReservedInstancesListingRequest(input *CancelReservedInstancesListingInput) (req *request.Request, output *CancelReservedInstancesListingOutput) {
+	op := &request.Operation{
 		Name:       opCancelReservedInstancesListing,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -678,8 +678,8 @@ func (c *EC2) CancelReservedInstancesListing(input *CancelReservedInstancesListi
 const opCancelSpotFleetRequests = "CancelSpotFleetRequests"
 
 // CancelSpotFleetRequestsRequest generates a request for the CancelSpotFleetRequests operation.
-func (c *EC2) CancelSpotFleetRequestsRequest(input *CancelSpotFleetRequestsInput) (req *service.Request, output *CancelSpotFleetRequestsOutput) {
-	op := &service.Operation{
+func (c *EC2) CancelSpotFleetRequestsRequest(input *CancelSpotFleetRequestsInput) (req *request.Request, output *CancelSpotFleetRequestsOutput) {
+	op := &request.Operation{
 		Name:       opCancelSpotFleetRequests,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -705,8 +705,8 @@ func (c *EC2) CancelSpotFleetRequests(input *CancelSpotFleetRequestsInput) (*Can
 const opCancelSpotInstanceRequests = "CancelSpotInstanceRequests"
 
 // CancelSpotInstanceRequestsRequest generates a request for the CancelSpotInstanceRequests operation.
-func (c *EC2) CancelSpotInstanceRequestsRequest(input *CancelSpotInstanceRequestsInput) (req *service.Request, output *CancelSpotInstanceRequestsOutput) {
-	op := &service.Operation{
+func (c *EC2) CancelSpotInstanceRequestsRequest(input *CancelSpotInstanceRequestsInput) (req *request.Request, output *CancelSpotInstanceRequestsOutput) {
+	op := &request.Operation{
 		Name:       opCancelSpotInstanceRequests,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -740,8 +740,8 @@ func (c *EC2) CancelSpotInstanceRequests(input *CancelSpotInstanceRequestsInput)
 const opConfirmProductInstance = "ConfirmProductInstance"
 
 // ConfirmProductInstanceRequest generates a request for the ConfirmProductInstance operation.
-func (c *EC2) ConfirmProductInstanceRequest(input *ConfirmProductInstanceInput) (req *service.Request, output *ConfirmProductInstanceOutput) {
-	op := &service.Operation{
+func (c *EC2) ConfirmProductInstanceRequest(input *ConfirmProductInstanceInput) (req *request.Request, output *ConfirmProductInstanceOutput) {
+	op := &request.Operation{
 		Name:       opConfirmProductInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -770,8 +770,8 @@ func (c *EC2) ConfirmProductInstance(input *ConfirmProductInstanceInput) (*Confi
 const opCopyImage = "CopyImage"
 
 // CopyImageRequest generates a request for the CopyImage operation.
-func (c *EC2) CopyImageRequest(input *CopyImageInput) (req *service.Request, output *CopyImageOutput) {
-	op := &service.Operation{
+func (c *EC2) CopyImageRequest(input *CopyImageInput) (req *request.Request, output *CopyImageOutput) {
+	op := &request.Operation{
 		Name:       opCopyImage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -803,8 +803,8 @@ func (c *EC2) CopyImage(input *CopyImageInput) (*CopyImageOutput, error) {
 const opCopySnapshot = "CopySnapshot"
 
 // CopySnapshotRequest generates a request for the CopySnapshot operation.
-func (c *EC2) CopySnapshotRequest(input *CopySnapshotInput) (req *service.Request, output *CopySnapshotOutput) {
-	op := &service.Operation{
+func (c *EC2) CopySnapshotRequest(input *CopySnapshotInput) (req *request.Request, output *CopySnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCopySnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -843,8 +843,8 @@ func (c *EC2) CopySnapshot(input *CopySnapshotInput) (*CopySnapshotOutput, error
 const opCreateCustomerGateway = "CreateCustomerGateway"
 
 // CreateCustomerGatewayRequest generates a request for the CreateCustomerGateway operation.
-func (c *EC2) CreateCustomerGatewayRequest(input *CreateCustomerGatewayInput) (req *service.Request, output *CreateCustomerGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateCustomerGatewayRequest(input *CreateCustomerGatewayInput) (req *request.Request, output *CreateCustomerGatewayOutput) {
+	op := &request.Operation{
 		Name:       opCreateCustomerGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -894,8 +894,8 @@ func (c *EC2) CreateCustomerGateway(input *CreateCustomerGatewayInput) (*CreateC
 const opCreateDhcpOptions = "CreateDhcpOptions"
 
 // CreateDhcpOptionsRequest generates a request for the CreateDhcpOptions operation.
-func (c *EC2) CreateDhcpOptionsRequest(input *CreateDhcpOptionsInput) (req *service.Request, output *CreateDhcpOptionsOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateDhcpOptionsRequest(input *CreateDhcpOptionsInput) (req *request.Request, output *CreateDhcpOptionsOutput) {
+	op := &request.Operation{
 		Name:       opCreateDhcpOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -949,8 +949,8 @@ func (c *EC2) CreateDhcpOptions(input *CreateDhcpOptionsInput) (*CreateDhcpOptio
 const opCreateFlowLogs = "CreateFlowLogs"
 
 // CreateFlowLogsRequest generates a request for the CreateFlowLogs operation.
-func (c *EC2) CreateFlowLogsRequest(input *CreateFlowLogsInput) (req *service.Request, output *CreateFlowLogsOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateFlowLogsRequest(input *CreateFlowLogsInput) (req *request.Request, output *CreateFlowLogsOutput) {
+	op := &request.Operation{
 		Name:       opCreateFlowLogs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -985,8 +985,8 @@ func (c *EC2) CreateFlowLogs(input *CreateFlowLogsInput) (*CreateFlowLogsOutput,
 const opCreateImage = "CreateImage"
 
 // CreateImageRequest generates a request for the CreateImage operation.
-func (c *EC2) CreateImageRequest(input *CreateImageInput) (req *service.Request, output *CreateImageOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateImageRequest(input *CreateImageInput) (req *request.Request, output *CreateImageOutput) {
+	op := &request.Operation{
 		Name:       opCreateImage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1021,8 +1021,8 @@ func (c *EC2) CreateImage(input *CreateImageInput) (*CreateImageOutput, error) {
 const opCreateInstanceExportTask = "CreateInstanceExportTask"
 
 // CreateInstanceExportTaskRequest generates a request for the CreateInstanceExportTask operation.
-func (c *EC2) CreateInstanceExportTaskRequest(input *CreateInstanceExportTaskInput) (req *service.Request, output *CreateInstanceExportTaskOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateInstanceExportTaskRequest(input *CreateInstanceExportTaskInput) (req *request.Request, output *CreateInstanceExportTaskOutput) {
+	op := &request.Operation{
 		Name:       opCreateInstanceExportTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1053,8 +1053,8 @@ func (c *EC2) CreateInstanceExportTask(input *CreateInstanceExportTaskInput) (*C
 const opCreateInternetGateway = "CreateInternetGateway"
 
 // CreateInternetGatewayRequest generates a request for the CreateInternetGateway operation.
-func (c *EC2) CreateInternetGatewayRequest(input *CreateInternetGatewayInput) (req *service.Request, output *CreateInternetGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateInternetGatewayRequest(input *CreateInternetGatewayInput) (req *request.Request, output *CreateInternetGatewayOutput) {
+	op := &request.Operation{
 		Name:       opCreateInternetGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1084,8 +1084,8 @@ func (c *EC2) CreateInternetGateway(input *CreateInternetGatewayInput) (*CreateI
 const opCreateKeyPair = "CreateKeyPair"
 
 // CreateKeyPairRequest generates a request for the CreateKeyPair operation.
-func (c *EC2) CreateKeyPairRequest(input *CreateKeyPairInput) (req *service.Request, output *CreateKeyPairOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateKeyPairRequest(input *CreateKeyPairInput) (req *request.Request, output *CreateKeyPairOutput) {
+	op := &request.Operation{
 		Name:       opCreateKeyPair,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1122,8 +1122,8 @@ func (c *EC2) CreateKeyPair(input *CreateKeyPairInput) (*CreateKeyPairOutput, er
 const opCreateNetworkAcl = "CreateNetworkAcl"
 
 // CreateNetworkAclRequest generates a request for the CreateNetworkAcl operation.
-func (c *EC2) CreateNetworkAclRequest(input *CreateNetworkAclInput) (req *service.Request, output *CreateNetworkAclOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateNetworkAclRequest(input *CreateNetworkAclInput) (req *request.Request, output *CreateNetworkAclOutput) {
+	op := &request.Operation{
 		Name:       opCreateNetworkAcl,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1153,8 +1153,8 @@ func (c *EC2) CreateNetworkAcl(input *CreateNetworkAclInput) (*CreateNetworkAclO
 const opCreateNetworkAclEntry = "CreateNetworkAclEntry"
 
 // CreateNetworkAclEntryRequest generates a request for the CreateNetworkAclEntry operation.
-func (c *EC2) CreateNetworkAclEntryRequest(input *CreateNetworkAclEntryInput) (req *service.Request, output *CreateNetworkAclEntryOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateNetworkAclEntryRequest(input *CreateNetworkAclEntryInput) (req *request.Request, output *CreateNetworkAclEntryOutput) {
+	op := &request.Operation{
 		Name:       opCreateNetworkAclEntry,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1196,8 +1196,8 @@ func (c *EC2) CreateNetworkAclEntry(input *CreateNetworkAclEntryInput) (*CreateN
 const opCreateNetworkInterface = "CreateNetworkInterface"
 
 // CreateNetworkInterfaceRequest generates a request for the CreateNetworkInterface operation.
-func (c *EC2) CreateNetworkInterfaceRequest(input *CreateNetworkInterfaceInput) (req *service.Request, output *CreateNetworkInterfaceOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateNetworkInterfaceRequest(input *CreateNetworkInterfaceInput) (req *request.Request, output *CreateNetworkInterfaceOutput) {
+	op := &request.Operation{
 		Name:       opCreateNetworkInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1227,8 +1227,8 @@ func (c *EC2) CreateNetworkInterface(input *CreateNetworkInterfaceInput) (*Creat
 const opCreatePlacementGroup = "CreatePlacementGroup"
 
 // CreatePlacementGroupRequest generates a request for the CreatePlacementGroup operation.
-func (c *EC2) CreatePlacementGroupRequest(input *CreatePlacementGroupInput) (req *service.Request, output *CreatePlacementGroupOutput) {
-	op := &service.Operation{
+func (c *EC2) CreatePlacementGroupRequest(input *CreatePlacementGroupInput) (req *request.Request, output *CreatePlacementGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreatePlacementGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1259,8 +1259,8 @@ func (c *EC2) CreatePlacementGroup(input *CreatePlacementGroupInput) (*CreatePla
 const opCreateReservedInstancesListing = "CreateReservedInstancesListing"
 
 // CreateReservedInstancesListingRequest generates a request for the CreateReservedInstancesListing operation.
-func (c *EC2) CreateReservedInstancesListingRequest(input *CreateReservedInstancesListingInput) (req *service.Request, output *CreateReservedInstancesListingOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateReservedInstancesListingRequest(input *CreateReservedInstancesListingInput) (req *request.Request, output *CreateReservedInstancesListingOutput) {
+	op := &request.Operation{
 		Name:       opCreateReservedInstancesListing,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1305,8 +1305,8 @@ func (c *EC2) CreateReservedInstancesListing(input *CreateReservedInstancesListi
 const opCreateRoute = "CreateRoute"
 
 // CreateRouteRequest generates a request for the CreateRoute operation.
-func (c *EC2) CreateRouteRequest(input *CreateRouteInput) (req *service.Request, output *CreateRouteOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateRouteRequest(input *CreateRouteInput) (req *request.Request, output *CreateRouteOutput) {
+	op := &request.Operation{
 		Name:       opCreateRoute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1350,8 +1350,8 @@ func (c *EC2) CreateRoute(input *CreateRouteInput) (*CreateRouteOutput, error) {
 const opCreateRouteTable = "CreateRouteTable"
 
 // CreateRouteTableRequest generates a request for the CreateRouteTable operation.
-func (c *EC2) CreateRouteTableRequest(input *CreateRouteTableInput) (req *service.Request, output *CreateRouteTableOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateRouteTableRequest(input *CreateRouteTableInput) (req *request.Request, output *CreateRouteTableOutput) {
+	op := &request.Operation{
 		Name:       opCreateRouteTable,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1381,8 +1381,8 @@ func (c *EC2) CreateRouteTable(input *CreateRouteTableInput) (*CreateRouteTableO
 const opCreateSecurityGroup = "CreateSecurityGroup"
 
 // CreateSecurityGroupRequest generates a request for the CreateSecurityGroup operation.
-func (c *EC2) CreateSecurityGroupRequest(input *CreateSecurityGroupInput) (req *service.Request, output *CreateSecurityGroupOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateSecurityGroupRequest(input *CreateSecurityGroupInput) (req *request.Request, output *CreateSecurityGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1434,8 +1434,8 @@ func (c *EC2) CreateSecurityGroup(input *CreateSecurityGroupInput) (*CreateSecur
 const opCreateSnapshot = "CreateSnapshot"
 
 // CreateSnapshotRequest generates a request for the CreateSnapshot operation.
-func (c *EC2) CreateSnapshotRequest(input *CreateSnapshotInput) (req *service.Request, output *Snapshot) {
-	op := &service.Operation{
+func (c *EC2) CreateSnapshotRequest(input *CreateSnapshotInput) (req *request.Request, output *Snapshot) {
+	op := &request.Operation{
 		Name:       opCreateSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1488,8 +1488,8 @@ func (c *EC2) CreateSnapshot(input *CreateSnapshotInput) (*Snapshot, error) {
 const opCreateSpotDatafeedSubscription = "CreateSpotDatafeedSubscription"
 
 // CreateSpotDatafeedSubscriptionRequest generates a request for the CreateSpotDatafeedSubscription operation.
-func (c *EC2) CreateSpotDatafeedSubscriptionRequest(input *CreateSpotDatafeedSubscriptionInput) (req *service.Request, output *CreateSpotDatafeedSubscriptionOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateSpotDatafeedSubscriptionRequest(input *CreateSpotDatafeedSubscriptionInput) (req *request.Request, output *CreateSpotDatafeedSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opCreateSpotDatafeedSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1518,8 +1518,8 @@ func (c *EC2) CreateSpotDatafeedSubscription(input *CreateSpotDatafeedSubscripti
 const opCreateSubnet = "CreateSubnet"
 
 // CreateSubnetRequest generates a request for the CreateSubnet operation.
-func (c *EC2) CreateSubnetRequest(input *CreateSubnetInput) (req *service.Request, output *CreateSubnetOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateSubnetRequest(input *CreateSubnetInput) (req *request.Request, output *CreateSubnetOutput) {
+	op := &request.Operation{
 		Name:       opCreateSubnet,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1569,8 +1569,8 @@ func (c *EC2) CreateSubnet(input *CreateSubnetInput) (*CreateSubnetOutput, error
 const opCreateTags = "CreateTags"
 
 // CreateTagsRequest generates a request for the CreateTags operation.
-func (c *EC2) CreateTagsRequest(input *CreateTagsInput) (req *service.Request, output *CreateTagsOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateTagsRequest(input *CreateTagsInput) (req *request.Request, output *CreateTagsOutput) {
+	op := &request.Operation{
 		Name:       opCreateTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1601,8 +1601,8 @@ func (c *EC2) CreateTags(input *CreateTagsInput) (*CreateTagsOutput, error) {
 const opCreateVolume = "CreateVolume"
 
 // CreateVolumeRequest generates a request for the CreateVolume operation.
-func (c *EC2) CreateVolumeRequest(input *CreateVolumeInput) (req *service.Request, output *Volume) {
-	op := &service.Operation{
+func (c *EC2) CreateVolumeRequest(input *CreateVolumeInput) (req *request.Request, output *Volume) {
+	op := &request.Operation{
 		Name:       opCreateVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1643,8 +1643,8 @@ func (c *EC2) CreateVolume(input *CreateVolumeInput) (*Volume, error) {
 const opCreateVpc = "CreateVpc"
 
 // CreateVpcRequest generates a request for the CreateVpc operation.
-func (c *EC2) CreateVpcRequest(input *CreateVpcInput) (req *service.Request, output *CreateVpcOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateVpcRequest(input *CreateVpcInput) (req *request.Request, output *CreateVpcOutput) {
+	op := &request.Operation{
 		Name:       opCreateVpc,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1680,8 +1680,8 @@ func (c *EC2) CreateVpc(input *CreateVpcInput) (*CreateVpcOutput, error) {
 const opCreateVpcEndpoint = "CreateVpcEndpoint"
 
 // CreateVpcEndpointRequest generates a request for the CreateVpcEndpoint operation.
-func (c *EC2) CreateVpcEndpointRequest(input *CreateVpcEndpointInput) (req *service.Request, output *CreateVpcEndpointOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateVpcEndpointRequest(input *CreateVpcEndpointInput) (req *request.Request, output *CreateVpcEndpointOutput) {
+	op := &request.Operation{
 		Name:       opCreateVpcEndpoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1713,8 +1713,8 @@ func (c *EC2) CreateVpcEndpoint(input *CreateVpcEndpointInput) (*CreateVpcEndpoi
 const opCreateVpcPeeringConnection = "CreateVpcPeeringConnection"
 
 // CreateVpcPeeringConnectionRequest generates a request for the CreateVpcPeeringConnection operation.
-func (c *EC2) CreateVpcPeeringConnectionRequest(input *CreateVpcPeeringConnectionInput) (req *service.Request, output *CreateVpcPeeringConnectionOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateVpcPeeringConnectionRequest(input *CreateVpcPeeringConnectionInput) (req *request.Request, output *CreateVpcPeeringConnectionOutput) {
+	op := &request.Operation{
 		Name:       opCreateVpcPeeringConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1750,8 +1750,8 @@ func (c *EC2) CreateVpcPeeringConnection(input *CreateVpcPeeringConnectionInput)
 const opCreateVpnConnection = "CreateVpnConnection"
 
 // CreateVpnConnectionRequest generates a request for the CreateVpnConnection operation.
-func (c *EC2) CreateVpnConnectionRequest(input *CreateVpnConnectionInput) (req *service.Request, output *CreateVpnConnectionOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateVpnConnectionRequest(input *CreateVpnConnectionInput) (req *request.Request, output *CreateVpnConnectionOutput) {
+	op := &request.Operation{
 		Name:       opCreateVpnConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1793,8 +1793,8 @@ func (c *EC2) CreateVpnConnection(input *CreateVpnConnectionInput) (*CreateVpnCo
 const opCreateVpnConnectionRoute = "CreateVpnConnectionRoute"
 
 // CreateVpnConnectionRouteRequest generates a request for the CreateVpnConnectionRoute operation.
-func (c *EC2) CreateVpnConnectionRouteRequest(input *CreateVpnConnectionRouteInput) (req *service.Request, output *CreateVpnConnectionRouteOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateVpnConnectionRouteRequest(input *CreateVpnConnectionRouteInput) (req *request.Request, output *CreateVpnConnectionRouteOutput) {
+	op := &request.Operation{
 		Name:       opCreateVpnConnectionRoute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1827,8 +1827,8 @@ func (c *EC2) CreateVpnConnectionRoute(input *CreateVpnConnectionRouteInput) (*C
 const opCreateVpnGateway = "CreateVpnGateway"
 
 // CreateVpnGatewayRequest generates a request for the CreateVpnGateway operation.
-func (c *EC2) CreateVpnGatewayRequest(input *CreateVpnGatewayInput) (req *service.Request, output *CreateVpnGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) CreateVpnGatewayRequest(input *CreateVpnGatewayInput) (req *request.Request, output *CreateVpnGatewayOutput) {
+	op := &request.Operation{
 		Name:       opCreateVpnGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1860,8 +1860,8 @@ func (c *EC2) CreateVpnGateway(input *CreateVpnGatewayInput) (*CreateVpnGatewayO
 const opDeleteCustomerGateway = "DeleteCustomerGateway"
 
 // DeleteCustomerGatewayRequest generates a request for the DeleteCustomerGateway operation.
-func (c *EC2) DeleteCustomerGatewayRequest(input *DeleteCustomerGatewayInput) (req *service.Request, output *DeleteCustomerGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteCustomerGatewayRequest(input *DeleteCustomerGatewayInput) (req *request.Request, output *DeleteCustomerGatewayOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCustomerGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1888,8 +1888,8 @@ func (c *EC2) DeleteCustomerGateway(input *DeleteCustomerGatewayInput) (*DeleteC
 const opDeleteDhcpOptions = "DeleteDhcpOptions"
 
 // DeleteDhcpOptionsRequest generates a request for the DeleteDhcpOptions operation.
-func (c *EC2) DeleteDhcpOptionsRequest(input *DeleteDhcpOptionsInput) (req *service.Request, output *DeleteDhcpOptionsOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteDhcpOptionsRequest(input *DeleteDhcpOptionsInput) (req *request.Request, output *DeleteDhcpOptionsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDhcpOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1918,8 +1918,8 @@ func (c *EC2) DeleteDhcpOptions(input *DeleteDhcpOptionsInput) (*DeleteDhcpOptio
 const opDeleteFlowLogs = "DeleteFlowLogs"
 
 // DeleteFlowLogsRequest generates a request for the DeleteFlowLogs operation.
-func (c *EC2) DeleteFlowLogsRequest(input *DeleteFlowLogsInput) (req *service.Request, output *DeleteFlowLogsOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteFlowLogsRequest(input *DeleteFlowLogsInput) (req *request.Request, output *DeleteFlowLogsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteFlowLogs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1945,8 +1945,8 @@ func (c *EC2) DeleteFlowLogs(input *DeleteFlowLogsInput) (*DeleteFlowLogsOutput,
 const opDeleteInternetGateway = "DeleteInternetGateway"
 
 // DeleteInternetGatewayRequest generates a request for the DeleteInternetGateway operation.
-func (c *EC2) DeleteInternetGatewayRequest(input *DeleteInternetGatewayInput) (req *service.Request, output *DeleteInternetGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteInternetGatewayRequest(input *DeleteInternetGatewayInput) (req *request.Request, output *DeleteInternetGatewayOutput) {
+	op := &request.Operation{
 		Name:       opDeleteInternetGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1973,8 +1973,8 @@ func (c *EC2) DeleteInternetGateway(input *DeleteInternetGatewayInput) (*DeleteI
 const opDeleteKeyPair = "DeleteKeyPair"
 
 // DeleteKeyPairRequest generates a request for the DeleteKeyPair operation.
-func (c *EC2) DeleteKeyPairRequest(input *DeleteKeyPairInput) (req *service.Request, output *DeleteKeyPairOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteKeyPairRequest(input *DeleteKeyPairInput) (req *request.Request, output *DeleteKeyPairOutput) {
+	op := &request.Operation{
 		Name:       opDeleteKeyPair,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2000,8 +2000,8 @@ func (c *EC2) DeleteKeyPair(input *DeleteKeyPairInput) (*DeleteKeyPairOutput, er
 const opDeleteNetworkAcl = "DeleteNetworkAcl"
 
 // DeleteNetworkAclRequest generates a request for the DeleteNetworkAcl operation.
-func (c *EC2) DeleteNetworkAclRequest(input *DeleteNetworkAclInput) (req *service.Request, output *DeleteNetworkAclOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteNetworkAclRequest(input *DeleteNetworkAclInput) (req *request.Request, output *DeleteNetworkAclOutput) {
+	op := &request.Operation{
 		Name:       opDeleteNetworkAcl,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2028,8 +2028,8 @@ func (c *EC2) DeleteNetworkAcl(input *DeleteNetworkAclInput) (*DeleteNetworkAclO
 const opDeleteNetworkAclEntry = "DeleteNetworkAclEntry"
 
 // DeleteNetworkAclEntryRequest generates a request for the DeleteNetworkAclEntry operation.
-func (c *EC2) DeleteNetworkAclEntryRequest(input *DeleteNetworkAclEntryInput) (req *service.Request, output *DeleteNetworkAclEntryOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteNetworkAclEntryRequest(input *DeleteNetworkAclEntryInput) (req *request.Request, output *DeleteNetworkAclEntryOutput) {
+	op := &request.Operation{
 		Name:       opDeleteNetworkAclEntry,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2056,8 +2056,8 @@ func (c *EC2) DeleteNetworkAclEntry(input *DeleteNetworkAclEntryInput) (*DeleteN
 const opDeleteNetworkInterface = "DeleteNetworkInterface"
 
 // DeleteNetworkInterfaceRequest generates a request for the DeleteNetworkInterface operation.
-func (c *EC2) DeleteNetworkInterfaceRequest(input *DeleteNetworkInterfaceInput) (req *service.Request, output *DeleteNetworkInterfaceOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteNetworkInterfaceRequest(input *DeleteNetworkInterfaceInput) (req *request.Request, output *DeleteNetworkInterfaceOutput) {
+	op := &request.Operation{
 		Name:       opDeleteNetworkInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2084,8 +2084,8 @@ func (c *EC2) DeleteNetworkInterface(input *DeleteNetworkInterfaceInput) (*Delet
 const opDeletePlacementGroup = "DeletePlacementGroup"
 
 // DeletePlacementGroupRequest generates a request for the DeletePlacementGroup operation.
-func (c *EC2) DeletePlacementGroupRequest(input *DeletePlacementGroupInput) (req *service.Request, output *DeletePlacementGroupOutput) {
-	op := &service.Operation{
+func (c *EC2) DeletePlacementGroupRequest(input *DeletePlacementGroupInput) (req *request.Request, output *DeletePlacementGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeletePlacementGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2114,8 +2114,8 @@ func (c *EC2) DeletePlacementGroup(input *DeletePlacementGroupInput) (*DeletePla
 const opDeleteRoute = "DeleteRoute"
 
 // DeleteRouteRequest generates a request for the DeleteRoute operation.
-func (c *EC2) DeleteRouteRequest(input *DeleteRouteInput) (req *service.Request, output *DeleteRouteOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteRouteRequest(input *DeleteRouteInput) (req *request.Request, output *DeleteRouteOutput) {
+	op := &request.Operation{
 		Name:       opDeleteRoute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2141,8 +2141,8 @@ func (c *EC2) DeleteRoute(input *DeleteRouteInput) (*DeleteRouteOutput, error) {
 const opDeleteRouteTable = "DeleteRouteTable"
 
 // DeleteRouteTableRequest generates a request for the DeleteRouteTable operation.
-func (c *EC2) DeleteRouteTableRequest(input *DeleteRouteTableInput) (req *service.Request, output *DeleteRouteTableOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteRouteTableRequest(input *DeleteRouteTableInput) (req *request.Request, output *DeleteRouteTableOutput) {
+	op := &request.Operation{
 		Name:       opDeleteRouteTable,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2170,8 +2170,8 @@ func (c *EC2) DeleteRouteTable(input *DeleteRouteTableInput) (*DeleteRouteTableO
 const opDeleteSecurityGroup = "DeleteSecurityGroup"
 
 // DeleteSecurityGroupRequest generates a request for the DeleteSecurityGroup operation.
-func (c *EC2) DeleteSecurityGroupRequest(input *DeleteSecurityGroupInput) (req *service.Request, output *DeleteSecurityGroupOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteSecurityGroupRequest(input *DeleteSecurityGroupInput) (req *request.Request, output *DeleteSecurityGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2201,8 +2201,8 @@ func (c *EC2) DeleteSecurityGroup(input *DeleteSecurityGroupInput) (*DeleteSecur
 const opDeleteSnapshot = "DeleteSnapshot"
 
 // DeleteSnapshotRequest generates a request for the DeleteSnapshot operation.
-func (c *EC2) DeleteSnapshotRequest(input *DeleteSnapshotInput) (req *service.Request, output *DeleteSnapshotOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteSnapshotRequest(input *DeleteSnapshotInput) (req *request.Request, output *DeleteSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2242,8 +2242,8 @@ func (c *EC2) DeleteSnapshot(input *DeleteSnapshotInput) (*DeleteSnapshotOutput,
 const opDeleteSpotDatafeedSubscription = "DeleteSpotDatafeedSubscription"
 
 // DeleteSpotDatafeedSubscriptionRequest generates a request for the DeleteSpotDatafeedSubscription operation.
-func (c *EC2) DeleteSpotDatafeedSubscriptionRequest(input *DeleteSpotDatafeedSubscriptionInput) (req *service.Request, output *DeleteSpotDatafeedSubscriptionOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteSpotDatafeedSubscriptionRequest(input *DeleteSpotDatafeedSubscriptionInput) (req *request.Request, output *DeleteSpotDatafeedSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSpotDatafeedSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2271,8 +2271,8 @@ func (c *EC2) DeleteSpotDatafeedSubscription(input *DeleteSpotDatafeedSubscripti
 const opDeleteSubnet = "DeleteSubnet"
 
 // DeleteSubnetRequest generates a request for the DeleteSubnet operation.
-func (c *EC2) DeleteSubnetRequest(input *DeleteSubnetInput) (req *service.Request, output *DeleteSubnetOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteSubnetRequest(input *DeleteSubnetInput) (req *request.Request, output *DeleteSubnetOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSubnet,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2299,8 +2299,8 @@ func (c *EC2) DeleteSubnet(input *DeleteSubnetInput) (*DeleteSubnetOutput, error
 const opDeleteTags = "DeleteTags"
 
 // DeleteTagsRequest generates a request for the DeleteTags operation.
-func (c *EC2) DeleteTagsRequest(input *DeleteTagsInput) (req *service.Request, output *DeleteTagsOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteTagsRequest(input *DeleteTagsInput) (req *request.Request, output *DeleteTagsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2330,8 +2330,8 @@ func (c *EC2) DeleteTags(input *DeleteTagsInput) (*DeleteTagsOutput, error) {
 const opDeleteVolume = "DeleteVolume"
 
 // DeleteVolumeRequest generates a request for the DeleteVolume operation.
-func (c *EC2) DeleteVolumeRequest(input *DeleteVolumeInput) (req *service.Request, output *DeleteVolumeOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteVolumeRequest(input *DeleteVolumeInput) (req *request.Request, output *DeleteVolumeOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2363,8 +2363,8 @@ func (c *EC2) DeleteVolume(input *DeleteVolumeInput) (*DeleteVolumeOutput, error
 const opDeleteVpc = "DeleteVpc"
 
 // DeleteVpcRequest generates a request for the DeleteVpc operation.
-func (c *EC2) DeleteVpcRequest(input *DeleteVpcInput) (req *service.Request, output *DeleteVpcOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteVpcRequest(input *DeleteVpcInput) (req *request.Request, output *DeleteVpcOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVpc,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2394,8 +2394,8 @@ func (c *EC2) DeleteVpc(input *DeleteVpcInput) (*DeleteVpcOutput, error) {
 const opDeleteVpcEndpoints = "DeleteVpcEndpoints"
 
 // DeleteVpcEndpointsRequest generates a request for the DeleteVpcEndpoints operation.
-func (c *EC2) DeleteVpcEndpointsRequest(input *DeleteVpcEndpointsInput) (req *service.Request, output *DeleteVpcEndpointsOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteVpcEndpointsRequest(input *DeleteVpcEndpointsInput) (req *request.Request, output *DeleteVpcEndpointsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVpcEndpoints,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2422,8 +2422,8 @@ func (c *EC2) DeleteVpcEndpoints(input *DeleteVpcEndpointsInput) (*DeleteVpcEndp
 const opDeleteVpcPeeringConnection = "DeleteVpcPeeringConnection"
 
 // DeleteVpcPeeringConnectionRequest generates a request for the DeleteVpcPeeringConnection operation.
-func (c *EC2) DeleteVpcPeeringConnectionRequest(input *DeleteVpcPeeringConnectionInput) (req *service.Request, output *DeleteVpcPeeringConnectionOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteVpcPeeringConnectionRequest(input *DeleteVpcPeeringConnectionInput) (req *request.Request, output *DeleteVpcPeeringConnectionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVpcPeeringConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2452,8 +2452,8 @@ func (c *EC2) DeleteVpcPeeringConnection(input *DeleteVpcPeeringConnectionInput)
 const opDeleteVpnConnection = "DeleteVpnConnection"
 
 // DeleteVpnConnectionRequest generates a request for the DeleteVpnConnection operation.
-func (c *EC2) DeleteVpnConnectionRequest(input *DeleteVpnConnectionInput) (req *service.Request, output *DeleteVpnConnectionOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteVpnConnectionRequest(input *DeleteVpnConnectionInput) (req *request.Request, output *DeleteVpnConnectionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVpnConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2488,8 +2488,8 @@ func (c *EC2) DeleteVpnConnection(input *DeleteVpnConnectionInput) (*DeleteVpnCo
 const opDeleteVpnConnectionRoute = "DeleteVpnConnectionRoute"
 
 // DeleteVpnConnectionRouteRequest generates a request for the DeleteVpnConnectionRoute operation.
-func (c *EC2) DeleteVpnConnectionRouteRequest(input *DeleteVpnConnectionRouteInput) (req *service.Request, output *DeleteVpnConnectionRouteOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteVpnConnectionRouteRequest(input *DeleteVpnConnectionRouteInput) (req *request.Request, output *DeleteVpnConnectionRouteOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVpnConnectionRoute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2518,8 +2518,8 @@ func (c *EC2) DeleteVpnConnectionRoute(input *DeleteVpnConnectionRouteInput) (*D
 const opDeleteVpnGateway = "DeleteVpnGateway"
 
 // DeleteVpnGatewayRequest generates a request for the DeleteVpnGateway operation.
-func (c *EC2) DeleteVpnGatewayRequest(input *DeleteVpnGatewayInput) (req *service.Request, output *DeleteVpnGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) DeleteVpnGatewayRequest(input *DeleteVpnGatewayInput) (req *request.Request, output *DeleteVpnGatewayOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVpnGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2549,8 +2549,8 @@ func (c *EC2) DeleteVpnGateway(input *DeleteVpnGatewayInput) (*DeleteVpnGatewayO
 const opDeregisterImage = "DeregisterImage"
 
 // DeregisterImageRequest generates a request for the DeregisterImage operation.
-func (c *EC2) DeregisterImageRequest(input *DeregisterImageInput) (req *service.Request, output *DeregisterImageOutput) {
-	op := &service.Operation{
+func (c *EC2) DeregisterImageRequest(input *DeregisterImageInput) (req *request.Request, output *DeregisterImageOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterImage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2579,8 +2579,8 @@ func (c *EC2) DeregisterImage(input *DeregisterImageInput) (*DeregisterImageOutp
 const opDescribeAccountAttributes = "DescribeAccountAttributes"
 
 // DescribeAccountAttributesRequest generates a request for the DescribeAccountAttributes operation.
-func (c *EC2) DescribeAccountAttributesRequest(input *DescribeAccountAttributesInput) (req *service.Request, output *DescribeAccountAttributesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeAccountAttributesRequest(input *DescribeAccountAttributesInput) (req *request.Request, output *DescribeAccountAttributesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAccountAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2624,8 +2624,8 @@ func (c *EC2) DescribeAccountAttributes(input *DescribeAccountAttributesInput) (
 const opDescribeAddresses = "DescribeAddresses"
 
 // DescribeAddressesRequest generates a request for the DescribeAddresses operation.
-func (c *EC2) DescribeAddressesRequest(input *DescribeAddressesInput) (req *service.Request, output *DescribeAddressesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeAddressesRequest(input *DescribeAddressesInput) (req *request.Request, output *DescribeAddressesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAddresses,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2655,8 +2655,8 @@ func (c *EC2) DescribeAddresses(input *DescribeAddressesInput) (*DescribeAddress
 const opDescribeAvailabilityZones = "DescribeAvailabilityZones"
 
 // DescribeAvailabilityZonesRequest generates a request for the DescribeAvailabilityZones operation.
-func (c *EC2) DescribeAvailabilityZonesRequest(input *DescribeAvailabilityZonesInput) (req *service.Request, output *DescribeAvailabilityZonesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeAvailabilityZonesRequest(input *DescribeAvailabilityZonesInput) (req *request.Request, output *DescribeAvailabilityZonesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAvailabilityZones,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2688,8 +2688,8 @@ func (c *EC2) DescribeAvailabilityZones(input *DescribeAvailabilityZonesInput) (
 const opDescribeBundleTasks = "DescribeBundleTasks"
 
 // DescribeBundleTasksRequest generates a request for the DescribeBundleTasks operation.
-func (c *EC2) DescribeBundleTasksRequest(input *DescribeBundleTasksInput) (req *service.Request, output *DescribeBundleTasksOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeBundleTasksRequest(input *DescribeBundleTasksInput) (req *request.Request, output *DescribeBundleTasksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeBundleTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2720,8 +2720,8 @@ func (c *EC2) DescribeBundleTasks(input *DescribeBundleTasksInput) (*DescribeBun
 const opDescribeClassicLinkInstances = "DescribeClassicLinkInstances"
 
 // DescribeClassicLinkInstancesRequest generates a request for the DescribeClassicLinkInstances operation.
-func (c *EC2) DescribeClassicLinkInstancesRequest(input *DescribeClassicLinkInstancesInput) (req *service.Request, output *DescribeClassicLinkInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeClassicLinkInstancesRequest(input *DescribeClassicLinkInstancesInput) (req *request.Request, output *DescribeClassicLinkInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClassicLinkInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2750,8 +2750,8 @@ func (c *EC2) DescribeClassicLinkInstances(input *DescribeClassicLinkInstancesIn
 const opDescribeConversionTasks = "DescribeConversionTasks"
 
 // DescribeConversionTasksRequest generates a request for the DescribeConversionTasks operation.
-func (c *EC2) DescribeConversionTasksRequest(input *DescribeConversionTasksInput) (req *service.Request, output *DescribeConversionTasksOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeConversionTasksRequest(input *DescribeConversionTasksInput) (req *request.Request, output *DescribeConversionTasksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeConversionTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2780,8 +2780,8 @@ func (c *EC2) DescribeConversionTasks(input *DescribeConversionTasksInput) (*Des
 const opDescribeCustomerGateways = "DescribeCustomerGateways"
 
 // DescribeCustomerGatewaysRequest generates a request for the DescribeCustomerGateways operation.
-func (c *EC2) DescribeCustomerGatewaysRequest(input *DescribeCustomerGatewaysInput) (req *service.Request, output *DescribeCustomerGatewaysOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeCustomerGatewaysRequest(input *DescribeCustomerGatewaysInput) (req *request.Request, output *DescribeCustomerGatewaysOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCustomerGateways,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2811,8 +2811,8 @@ func (c *EC2) DescribeCustomerGateways(input *DescribeCustomerGatewaysInput) (*D
 const opDescribeDhcpOptions = "DescribeDhcpOptions"
 
 // DescribeDhcpOptionsRequest generates a request for the DescribeDhcpOptions operation.
-func (c *EC2) DescribeDhcpOptionsRequest(input *DescribeDhcpOptionsInput) (req *service.Request, output *DescribeDhcpOptionsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeDhcpOptionsRequest(input *DescribeDhcpOptionsInput) (req *request.Request, output *DescribeDhcpOptionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDhcpOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2841,8 +2841,8 @@ func (c *EC2) DescribeDhcpOptions(input *DescribeDhcpOptionsInput) (*DescribeDhc
 const opDescribeExportTasks = "DescribeExportTasks"
 
 // DescribeExportTasksRequest generates a request for the DescribeExportTasks operation.
-func (c *EC2) DescribeExportTasksRequest(input *DescribeExportTasksInput) (req *service.Request, output *DescribeExportTasksOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeExportTasksRequest(input *DescribeExportTasksInput) (req *request.Request, output *DescribeExportTasksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeExportTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2868,8 +2868,8 @@ func (c *EC2) DescribeExportTasks(input *DescribeExportTasksInput) (*DescribeExp
 const opDescribeFlowLogs = "DescribeFlowLogs"
 
 // DescribeFlowLogsRequest generates a request for the DescribeFlowLogs operation.
-func (c *EC2) DescribeFlowLogsRequest(input *DescribeFlowLogsInput) (req *service.Request, output *DescribeFlowLogsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeFlowLogsRequest(input *DescribeFlowLogsInput) (req *request.Request, output *DescribeFlowLogsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeFlowLogs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2897,8 +2897,8 @@ func (c *EC2) DescribeFlowLogs(input *DescribeFlowLogsInput) (*DescribeFlowLogsO
 const opDescribeImageAttribute = "DescribeImageAttribute"
 
 // DescribeImageAttributeRequest generates a request for the DescribeImageAttribute operation.
-func (c *EC2) DescribeImageAttributeRequest(input *DescribeImageAttributeInput) (req *service.Request, output *DescribeImageAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeImageAttributeRequest(input *DescribeImageAttributeInput) (req *request.Request, output *DescribeImageAttributeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeImageAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2925,8 +2925,8 @@ func (c *EC2) DescribeImageAttribute(input *DescribeImageAttributeInput) (*Descr
 const opDescribeImages = "DescribeImages"
 
 // DescribeImagesRequest generates a request for the DescribeImages operation.
-func (c *EC2) DescribeImagesRequest(input *DescribeImagesInput) (req *service.Request, output *DescribeImagesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeImagesRequest(input *DescribeImagesInput) (req *request.Request, output *DescribeImagesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeImages,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2958,8 +2958,8 @@ func (c *EC2) DescribeImages(input *DescribeImagesInput) (*DescribeImagesOutput,
 const opDescribeImportImageTasks = "DescribeImportImageTasks"
 
 // DescribeImportImageTasksRequest generates a request for the DescribeImportImageTasks operation.
-func (c *EC2) DescribeImportImageTasksRequest(input *DescribeImportImageTasksInput) (req *service.Request, output *DescribeImportImageTasksOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeImportImageTasksRequest(input *DescribeImportImageTasksInput) (req *request.Request, output *DescribeImportImageTasksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeImportImageTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2986,8 +2986,8 @@ func (c *EC2) DescribeImportImageTasks(input *DescribeImportImageTasksInput) (*D
 const opDescribeImportSnapshotTasks = "DescribeImportSnapshotTasks"
 
 // DescribeImportSnapshotTasksRequest generates a request for the DescribeImportSnapshotTasks operation.
-func (c *EC2) DescribeImportSnapshotTasksRequest(input *DescribeImportSnapshotTasksInput) (req *service.Request, output *DescribeImportSnapshotTasksOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeImportSnapshotTasksRequest(input *DescribeImportSnapshotTasksInput) (req *request.Request, output *DescribeImportSnapshotTasksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeImportSnapshotTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3013,8 +3013,8 @@ func (c *EC2) DescribeImportSnapshotTasks(input *DescribeImportSnapshotTasksInpu
 const opDescribeInstanceAttribute = "DescribeInstanceAttribute"
 
 // DescribeInstanceAttributeRequest generates a request for the DescribeInstanceAttribute operation.
-func (c *EC2) DescribeInstanceAttributeRequest(input *DescribeInstanceAttributeInput) (req *service.Request, output *DescribeInstanceAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeInstanceAttributeRequest(input *DescribeInstanceAttributeInput) (req *request.Request, output *DescribeInstanceAttributeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeInstanceAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3044,12 +3044,12 @@ func (c *EC2) DescribeInstanceAttribute(input *DescribeInstanceAttributeInput) (
 const opDescribeInstanceStatus = "DescribeInstanceStatus"
 
 // DescribeInstanceStatusRequest generates a request for the DescribeInstanceStatus operation.
-func (c *EC2) DescribeInstanceStatusRequest(input *DescribeInstanceStatusInput) (req *service.Request, output *DescribeInstanceStatusOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeInstanceStatusRequest(input *DescribeInstanceStatusInput) (req *request.Request, output *DescribeInstanceStatusOutput) {
+	op := &request.Operation{
 		Name:       opDescribeInstanceStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxResults",
@@ -3103,12 +3103,12 @@ func (c *EC2) DescribeInstanceStatusPages(input *DescribeInstanceStatusInput, fn
 const opDescribeInstances = "DescribeInstances"
 
 // DescribeInstancesRequest generates a request for the DescribeInstances operation.
-func (c *EC2) DescribeInstancesRequest(input *DescribeInstancesInput) (req *service.Request, output *DescribeInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeInstancesRequest(input *DescribeInstancesInput) (req *request.Request, output *DescribeInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxResults",
@@ -3152,8 +3152,8 @@ func (c *EC2) DescribeInstancesPages(input *DescribeInstancesInput, fn func(p *D
 const opDescribeInternetGateways = "DescribeInternetGateways"
 
 // DescribeInternetGatewaysRequest generates a request for the DescribeInternetGateways operation.
-func (c *EC2) DescribeInternetGatewaysRequest(input *DescribeInternetGatewaysInput) (req *service.Request, output *DescribeInternetGatewaysOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeInternetGatewaysRequest(input *DescribeInternetGatewaysInput) (req *request.Request, output *DescribeInternetGatewaysOutput) {
+	op := &request.Operation{
 		Name:       opDescribeInternetGateways,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3179,8 +3179,8 @@ func (c *EC2) DescribeInternetGateways(input *DescribeInternetGatewaysInput) (*D
 const opDescribeKeyPairs = "DescribeKeyPairs"
 
 // DescribeKeyPairsRequest generates a request for the DescribeKeyPairs operation.
-func (c *EC2) DescribeKeyPairsRequest(input *DescribeKeyPairsInput) (req *service.Request, output *DescribeKeyPairsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeKeyPairsRequest(input *DescribeKeyPairsInput) (req *request.Request, output *DescribeKeyPairsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeKeyPairs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3209,8 +3209,8 @@ func (c *EC2) DescribeKeyPairs(input *DescribeKeyPairsInput) (*DescribeKeyPairsO
 const opDescribeMovingAddresses = "DescribeMovingAddresses"
 
 // DescribeMovingAddressesRequest generates a request for the DescribeMovingAddresses operation.
-func (c *EC2) DescribeMovingAddressesRequest(input *DescribeMovingAddressesInput) (req *service.Request, output *DescribeMovingAddressesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeMovingAddressesRequest(input *DescribeMovingAddressesInput) (req *request.Request, output *DescribeMovingAddressesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeMovingAddresses,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3238,8 +3238,8 @@ func (c *EC2) DescribeMovingAddresses(input *DescribeMovingAddressesInput) (*Des
 const opDescribeNetworkAcls = "DescribeNetworkAcls"
 
 // DescribeNetworkAclsRequest generates a request for the DescribeNetworkAcls operation.
-func (c *EC2) DescribeNetworkAclsRequest(input *DescribeNetworkAclsInput) (req *service.Request, output *DescribeNetworkAclsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeNetworkAclsRequest(input *DescribeNetworkAclsInput) (req *request.Request, output *DescribeNetworkAclsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeNetworkAcls,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3268,8 +3268,8 @@ func (c *EC2) DescribeNetworkAcls(input *DescribeNetworkAclsInput) (*DescribeNet
 const opDescribeNetworkInterfaceAttribute = "DescribeNetworkInterfaceAttribute"
 
 // DescribeNetworkInterfaceAttributeRequest generates a request for the DescribeNetworkInterfaceAttribute operation.
-func (c *EC2) DescribeNetworkInterfaceAttributeRequest(input *DescribeNetworkInterfaceAttributeInput) (req *service.Request, output *DescribeNetworkInterfaceAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeNetworkInterfaceAttributeRequest(input *DescribeNetworkInterfaceAttributeInput) (req *request.Request, output *DescribeNetworkInterfaceAttributeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeNetworkInterfaceAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3296,8 +3296,8 @@ func (c *EC2) DescribeNetworkInterfaceAttribute(input *DescribeNetworkInterfaceA
 const opDescribeNetworkInterfaces = "DescribeNetworkInterfaces"
 
 // DescribeNetworkInterfacesRequest generates a request for the DescribeNetworkInterfaces operation.
-func (c *EC2) DescribeNetworkInterfacesRequest(input *DescribeNetworkInterfacesInput) (req *service.Request, output *DescribeNetworkInterfacesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeNetworkInterfacesRequest(input *DescribeNetworkInterfacesInput) (req *request.Request, output *DescribeNetworkInterfacesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeNetworkInterfaces,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3323,8 +3323,8 @@ func (c *EC2) DescribeNetworkInterfaces(input *DescribeNetworkInterfacesInput) (
 const opDescribePlacementGroups = "DescribePlacementGroups"
 
 // DescribePlacementGroupsRequest generates a request for the DescribePlacementGroups operation.
-func (c *EC2) DescribePlacementGroupsRequest(input *DescribePlacementGroupsInput) (req *service.Request, output *DescribePlacementGroupsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribePlacementGroupsRequest(input *DescribePlacementGroupsInput) (req *request.Request, output *DescribePlacementGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribePlacementGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3352,8 +3352,8 @@ func (c *EC2) DescribePlacementGroups(input *DescribePlacementGroupsInput) (*Des
 const opDescribePrefixLists = "DescribePrefixLists"
 
 // DescribePrefixListsRequest generates a request for the DescribePrefixLists operation.
-func (c *EC2) DescribePrefixListsRequest(input *DescribePrefixListsInput) (req *service.Request, output *DescribePrefixListsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribePrefixListsRequest(input *DescribePrefixListsInput) (req *request.Request, output *DescribePrefixListsOutput) {
+	op := &request.Operation{
 		Name:       opDescribePrefixLists,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3383,8 +3383,8 @@ func (c *EC2) DescribePrefixLists(input *DescribePrefixListsInput) (*DescribePre
 const opDescribeRegions = "DescribeRegions"
 
 // DescribeRegionsRequest generates a request for the DescribeRegions operation.
-func (c *EC2) DescribeRegionsRequest(input *DescribeRegionsInput) (req *service.Request, output *DescribeRegionsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeRegionsRequest(input *DescribeRegionsInput) (req *request.Request, output *DescribeRegionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeRegions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3413,8 +3413,8 @@ func (c *EC2) DescribeRegions(input *DescribeRegionsInput) (*DescribeRegionsOutp
 const opDescribeReservedInstances = "DescribeReservedInstances"
 
 // DescribeReservedInstancesRequest generates a request for the DescribeReservedInstances operation.
-func (c *EC2) DescribeReservedInstancesRequest(input *DescribeReservedInstancesInput) (req *service.Request, output *DescribeReservedInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeReservedInstancesRequest(input *DescribeReservedInstancesInput) (req *request.Request, output *DescribeReservedInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3443,8 +3443,8 @@ func (c *EC2) DescribeReservedInstances(input *DescribeReservedInstancesInput) (
 const opDescribeReservedInstancesListings = "DescribeReservedInstancesListings"
 
 // DescribeReservedInstancesListingsRequest generates a request for the DescribeReservedInstancesListings operation.
-func (c *EC2) DescribeReservedInstancesListingsRequest(input *DescribeReservedInstancesListingsInput) (req *service.Request, output *DescribeReservedInstancesListingsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeReservedInstancesListingsRequest(input *DescribeReservedInstancesListingsInput) (req *request.Request, output *DescribeReservedInstancesListingsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedInstancesListings,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3491,12 +3491,12 @@ func (c *EC2) DescribeReservedInstancesListings(input *DescribeReservedInstances
 const opDescribeReservedInstancesModifications = "DescribeReservedInstancesModifications"
 
 // DescribeReservedInstancesModificationsRequest generates a request for the DescribeReservedInstancesModifications operation.
-func (c *EC2) DescribeReservedInstancesModificationsRequest(input *DescribeReservedInstancesModificationsInput) (req *service.Request, output *DescribeReservedInstancesModificationsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeReservedInstancesModificationsRequest(input *DescribeReservedInstancesModificationsInput) (req *request.Request, output *DescribeReservedInstancesModificationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedInstancesModifications,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -3537,12 +3537,12 @@ func (c *EC2) DescribeReservedInstancesModificationsPages(input *DescribeReserve
 const opDescribeReservedInstancesOfferings = "DescribeReservedInstancesOfferings"
 
 // DescribeReservedInstancesOfferingsRequest generates a request for the DescribeReservedInstancesOfferings operation.
-func (c *EC2) DescribeReservedInstancesOfferingsRequest(input *DescribeReservedInstancesOfferingsInput) (req *service.Request, output *DescribeReservedInstancesOfferingsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeReservedInstancesOfferingsRequest(input *DescribeReservedInstancesOfferingsInput) (req *request.Request, output *DescribeReservedInstancesOfferingsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedInstancesOfferings,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxResults",
@@ -3584,8 +3584,8 @@ func (c *EC2) DescribeReservedInstancesOfferingsPages(input *DescribeReservedIns
 const opDescribeRouteTables = "DescribeRouteTables"
 
 // DescribeRouteTablesRequest generates a request for the DescribeRouteTables operation.
-func (c *EC2) DescribeRouteTablesRequest(input *DescribeRouteTablesInput) (req *service.Request, output *DescribeRouteTablesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeRouteTablesRequest(input *DescribeRouteTablesInput) (req *request.Request, output *DescribeRouteTablesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeRouteTables,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3619,8 +3619,8 @@ func (c *EC2) DescribeRouteTables(input *DescribeRouteTablesInput) (*DescribeRou
 const opDescribeSecurityGroups = "DescribeSecurityGroups"
 
 // DescribeSecurityGroupsRequest generates a request for the DescribeSecurityGroups operation.
-func (c *EC2) DescribeSecurityGroupsRequest(input *DescribeSecurityGroupsInput) (req *service.Request, output *DescribeSecurityGroupsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSecurityGroupsRequest(input *DescribeSecurityGroupsInput) (req *request.Request, output *DescribeSecurityGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSecurityGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3653,8 +3653,8 @@ func (c *EC2) DescribeSecurityGroups(input *DescribeSecurityGroupsInput) (*Descr
 const opDescribeSnapshotAttribute = "DescribeSnapshotAttribute"
 
 // DescribeSnapshotAttributeRequest generates a request for the DescribeSnapshotAttribute operation.
-func (c *EC2) DescribeSnapshotAttributeRequest(input *DescribeSnapshotAttributeInput) (req *service.Request, output *DescribeSnapshotAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSnapshotAttributeRequest(input *DescribeSnapshotAttributeInput) (req *request.Request, output *DescribeSnapshotAttributeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSnapshotAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3684,12 +3684,12 @@ func (c *EC2) DescribeSnapshotAttribute(input *DescribeSnapshotAttributeInput) (
 const opDescribeSnapshots = "DescribeSnapshots"
 
 // DescribeSnapshotsRequest generates a request for the DescribeSnapshots operation.
-func (c *EC2) DescribeSnapshotsRequest(input *DescribeSnapshotsInput) (req *service.Request, output *DescribeSnapshotsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSnapshotsRequest(input *DescribeSnapshotsInput) (req *request.Request, output *DescribeSnapshotsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSnapshots,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -3763,8 +3763,8 @@ func (c *EC2) DescribeSnapshotsPages(input *DescribeSnapshotsInput, fn func(p *D
 const opDescribeSpotDatafeedSubscription = "DescribeSpotDatafeedSubscription"
 
 // DescribeSpotDatafeedSubscriptionRequest generates a request for the DescribeSpotDatafeedSubscription operation.
-func (c *EC2) DescribeSpotDatafeedSubscriptionRequest(input *DescribeSpotDatafeedSubscriptionInput) (req *service.Request, output *DescribeSpotDatafeedSubscriptionOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSpotDatafeedSubscriptionRequest(input *DescribeSpotDatafeedSubscriptionInput) (req *request.Request, output *DescribeSpotDatafeedSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSpotDatafeedSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3792,8 +3792,8 @@ func (c *EC2) DescribeSpotDatafeedSubscription(input *DescribeSpotDatafeedSubscr
 const opDescribeSpotFleetInstances = "DescribeSpotFleetInstances"
 
 // DescribeSpotFleetInstancesRequest generates a request for the DescribeSpotFleetInstances operation.
-func (c *EC2) DescribeSpotFleetInstancesRequest(input *DescribeSpotFleetInstancesInput) (req *service.Request, output *DescribeSpotFleetInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSpotFleetInstancesRequest(input *DescribeSpotFleetInstancesInput) (req *request.Request, output *DescribeSpotFleetInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSpotFleetInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3819,8 +3819,8 @@ func (c *EC2) DescribeSpotFleetInstances(input *DescribeSpotFleetInstancesInput)
 const opDescribeSpotFleetRequestHistory = "DescribeSpotFleetRequestHistory"
 
 // DescribeSpotFleetRequestHistoryRequest generates a request for the DescribeSpotFleetRequestHistory operation.
-func (c *EC2) DescribeSpotFleetRequestHistoryRequest(input *DescribeSpotFleetRequestHistoryInput) (req *service.Request, output *DescribeSpotFleetRequestHistoryOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSpotFleetRequestHistoryRequest(input *DescribeSpotFleetRequestHistoryInput) (req *request.Request, output *DescribeSpotFleetRequestHistoryOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSpotFleetRequestHistory,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3851,8 +3851,8 @@ func (c *EC2) DescribeSpotFleetRequestHistory(input *DescribeSpotFleetRequestHis
 const opDescribeSpotFleetRequests = "DescribeSpotFleetRequests"
 
 // DescribeSpotFleetRequestsRequest generates a request for the DescribeSpotFleetRequests operation.
-func (c *EC2) DescribeSpotFleetRequestsRequest(input *DescribeSpotFleetRequestsInput) (req *service.Request, output *DescribeSpotFleetRequestsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSpotFleetRequestsRequest(input *DescribeSpotFleetRequestsInput) (req *request.Request, output *DescribeSpotFleetRequestsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSpotFleetRequests,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3878,8 +3878,8 @@ func (c *EC2) DescribeSpotFleetRequests(input *DescribeSpotFleetRequestsInput) (
 const opDescribeSpotInstanceRequests = "DescribeSpotInstanceRequests"
 
 // DescribeSpotInstanceRequestsRequest generates a request for the DescribeSpotInstanceRequests operation.
-func (c *EC2) DescribeSpotInstanceRequestsRequest(input *DescribeSpotInstanceRequestsInput) (req *service.Request, output *DescribeSpotInstanceRequestsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSpotInstanceRequestsRequest(input *DescribeSpotInstanceRequestsInput) (req *request.Request, output *DescribeSpotInstanceRequestsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSpotInstanceRequests,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3916,12 +3916,12 @@ func (c *EC2) DescribeSpotInstanceRequests(input *DescribeSpotInstanceRequestsIn
 const opDescribeSpotPriceHistory = "DescribeSpotPriceHistory"
 
 // DescribeSpotPriceHistoryRequest generates a request for the DescribeSpotPriceHistory operation.
-func (c *EC2) DescribeSpotPriceHistoryRequest(input *DescribeSpotPriceHistoryInput) (req *service.Request, output *DescribeSpotPriceHistoryOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSpotPriceHistoryRequest(input *DescribeSpotPriceHistoryInput) (req *request.Request, output *DescribeSpotPriceHistoryOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSpotPriceHistory,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxResults",
@@ -3964,8 +3964,8 @@ func (c *EC2) DescribeSpotPriceHistoryPages(input *DescribeSpotPriceHistoryInput
 const opDescribeSubnets = "DescribeSubnets"
 
 // DescribeSubnetsRequest generates a request for the DescribeSubnets operation.
-func (c *EC2) DescribeSubnetsRequest(input *DescribeSubnetsInput) (req *service.Request, output *DescribeSubnetsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeSubnetsRequest(input *DescribeSubnetsInput) (req *request.Request, output *DescribeSubnetsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSubnets,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3994,8 +3994,8 @@ func (c *EC2) DescribeSubnets(input *DescribeSubnetsInput) (*DescribeSubnetsOutp
 const opDescribeTags = "DescribeTags"
 
 // DescribeTagsRequest generates a request for the DescribeTags operation.
-func (c *EC2) DescribeTagsRequest(input *DescribeTagsInput) (req *service.Request, output *DescribeTagsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeTagsRequest(input *DescribeTagsInput) (req *request.Request, output *DescribeTagsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4024,8 +4024,8 @@ func (c *EC2) DescribeTags(input *DescribeTagsInput) (*DescribeTagsOutput, error
 const opDescribeVolumeAttribute = "DescribeVolumeAttribute"
 
 // DescribeVolumeAttributeRequest generates a request for the DescribeVolumeAttribute operation.
-func (c *EC2) DescribeVolumeAttributeRequest(input *DescribeVolumeAttributeInput) (req *service.Request, output *DescribeVolumeAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVolumeAttributeRequest(input *DescribeVolumeAttributeInput) (req *request.Request, output *DescribeVolumeAttributeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVolumeAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4055,12 +4055,12 @@ func (c *EC2) DescribeVolumeAttribute(input *DescribeVolumeAttributeInput) (*Des
 const opDescribeVolumeStatus = "DescribeVolumeStatus"
 
 // DescribeVolumeStatusRequest generates a request for the DescribeVolumeStatus operation.
-func (c *EC2) DescribeVolumeStatusRequest(input *DescribeVolumeStatusInput) (req *service.Request, output *DescribeVolumeStatusOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVolumeStatusRequest(input *DescribeVolumeStatusInput) (req *request.Request, output *DescribeVolumeStatusOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVolumeStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxResults",
@@ -4129,12 +4129,12 @@ func (c *EC2) DescribeVolumeStatusPages(input *DescribeVolumeStatusInput, fn fun
 const opDescribeVolumes = "DescribeVolumes"
 
 // DescribeVolumesRequest generates a request for the DescribeVolumes operation.
-func (c *EC2) DescribeVolumesRequest(input *DescribeVolumesInput) (req *service.Request, output *DescribeVolumesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVolumesRequest(input *DescribeVolumesInput) (req *request.Request, output *DescribeVolumesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVolumes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxResults",
@@ -4179,8 +4179,8 @@ func (c *EC2) DescribeVolumesPages(input *DescribeVolumesInput, fn func(p *Descr
 const opDescribeVpcAttribute = "DescribeVpcAttribute"
 
 // DescribeVpcAttributeRequest generates a request for the DescribeVpcAttribute operation.
-func (c *EC2) DescribeVpcAttributeRequest(input *DescribeVpcAttributeInput) (req *service.Request, output *DescribeVpcAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVpcAttributeRequest(input *DescribeVpcAttributeInput) (req *request.Request, output *DescribeVpcAttributeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVpcAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4207,8 +4207,8 @@ func (c *EC2) DescribeVpcAttribute(input *DescribeVpcAttributeInput) (*DescribeV
 const opDescribeVpcClassicLink = "DescribeVpcClassicLink"
 
 // DescribeVpcClassicLinkRequest generates a request for the DescribeVpcClassicLink operation.
-func (c *EC2) DescribeVpcClassicLinkRequest(input *DescribeVpcClassicLinkInput) (req *service.Request, output *DescribeVpcClassicLinkOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVpcClassicLinkRequest(input *DescribeVpcClassicLinkInput) (req *request.Request, output *DescribeVpcClassicLinkOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVpcClassicLink,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4234,8 +4234,8 @@ func (c *EC2) DescribeVpcClassicLink(input *DescribeVpcClassicLinkInput) (*Descr
 const opDescribeVpcEndpointServices = "DescribeVpcEndpointServices"
 
 // DescribeVpcEndpointServicesRequest generates a request for the DescribeVpcEndpointServices operation.
-func (c *EC2) DescribeVpcEndpointServicesRequest(input *DescribeVpcEndpointServicesInput) (req *service.Request, output *DescribeVpcEndpointServicesOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVpcEndpointServicesRequest(input *DescribeVpcEndpointServicesInput) (req *request.Request, output *DescribeVpcEndpointServicesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVpcEndpointServices,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4262,8 +4262,8 @@ func (c *EC2) DescribeVpcEndpointServices(input *DescribeVpcEndpointServicesInpu
 const opDescribeVpcEndpoints = "DescribeVpcEndpoints"
 
 // DescribeVpcEndpointsRequest generates a request for the DescribeVpcEndpoints operation.
-func (c *EC2) DescribeVpcEndpointsRequest(input *DescribeVpcEndpointsInput) (req *service.Request, output *DescribeVpcEndpointsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVpcEndpointsRequest(input *DescribeVpcEndpointsInput) (req *request.Request, output *DescribeVpcEndpointsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVpcEndpoints,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4289,8 +4289,8 @@ func (c *EC2) DescribeVpcEndpoints(input *DescribeVpcEndpointsInput) (*DescribeV
 const opDescribeVpcPeeringConnections = "DescribeVpcPeeringConnections"
 
 // DescribeVpcPeeringConnectionsRequest generates a request for the DescribeVpcPeeringConnections operation.
-func (c *EC2) DescribeVpcPeeringConnectionsRequest(input *DescribeVpcPeeringConnectionsInput) (req *service.Request, output *DescribeVpcPeeringConnectionsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVpcPeeringConnectionsRequest(input *DescribeVpcPeeringConnectionsInput) (req *request.Request, output *DescribeVpcPeeringConnectionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVpcPeeringConnections,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4316,8 +4316,8 @@ func (c *EC2) DescribeVpcPeeringConnections(input *DescribeVpcPeeringConnections
 const opDescribeVpcs = "DescribeVpcs"
 
 // DescribeVpcsRequest generates a request for the DescribeVpcs operation.
-func (c *EC2) DescribeVpcsRequest(input *DescribeVpcsInput) (req *service.Request, output *DescribeVpcsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVpcsRequest(input *DescribeVpcsInput) (req *request.Request, output *DescribeVpcsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVpcs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4343,8 +4343,8 @@ func (c *EC2) DescribeVpcs(input *DescribeVpcsInput) (*DescribeVpcsOutput, error
 const opDescribeVpnConnections = "DescribeVpnConnections"
 
 // DescribeVpnConnectionsRequest generates a request for the DescribeVpnConnections operation.
-func (c *EC2) DescribeVpnConnectionsRequest(input *DescribeVpnConnectionsInput) (req *service.Request, output *DescribeVpnConnectionsOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVpnConnectionsRequest(input *DescribeVpnConnectionsInput) (req *request.Request, output *DescribeVpnConnectionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVpnConnections,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4374,8 +4374,8 @@ func (c *EC2) DescribeVpnConnections(input *DescribeVpnConnectionsInput) (*Descr
 const opDescribeVpnGateways = "DescribeVpnGateways"
 
 // DescribeVpnGatewaysRequest generates a request for the DescribeVpnGateways operation.
-func (c *EC2) DescribeVpnGatewaysRequest(input *DescribeVpnGatewaysInput) (req *service.Request, output *DescribeVpnGatewaysOutput) {
-	op := &service.Operation{
+func (c *EC2) DescribeVpnGatewaysRequest(input *DescribeVpnGatewaysInput) (req *request.Request, output *DescribeVpnGatewaysOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVpnGateways,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4405,8 +4405,8 @@ func (c *EC2) DescribeVpnGateways(input *DescribeVpnGatewaysInput) (*DescribeVpn
 const opDetachClassicLinkVpc = "DetachClassicLinkVpc"
 
 // DetachClassicLinkVpcRequest generates a request for the DetachClassicLinkVpc operation.
-func (c *EC2) DetachClassicLinkVpcRequest(input *DetachClassicLinkVpcInput) (req *service.Request, output *DetachClassicLinkVpcOutput) {
-	op := &service.Operation{
+func (c *EC2) DetachClassicLinkVpcRequest(input *DetachClassicLinkVpcInput) (req *request.Request, output *DetachClassicLinkVpcOutput) {
+	op := &request.Operation{
 		Name:       opDetachClassicLinkVpc,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4434,8 +4434,8 @@ func (c *EC2) DetachClassicLinkVpc(input *DetachClassicLinkVpcInput) (*DetachCla
 const opDetachInternetGateway = "DetachInternetGateway"
 
 // DetachInternetGatewayRequest generates a request for the DetachInternetGateway operation.
-func (c *EC2) DetachInternetGatewayRequest(input *DetachInternetGatewayInput) (req *service.Request, output *DetachInternetGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) DetachInternetGatewayRequest(input *DetachInternetGatewayInput) (req *request.Request, output *DetachInternetGatewayOutput) {
+	op := &request.Operation{
 		Name:       opDetachInternetGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4463,8 +4463,8 @@ func (c *EC2) DetachInternetGateway(input *DetachInternetGatewayInput) (*DetachI
 const opDetachNetworkInterface = "DetachNetworkInterface"
 
 // DetachNetworkInterfaceRequest generates a request for the DetachNetworkInterface operation.
-func (c *EC2) DetachNetworkInterfaceRequest(input *DetachNetworkInterfaceInput) (req *service.Request, output *DetachNetworkInterfaceOutput) {
-	op := &service.Operation{
+func (c *EC2) DetachNetworkInterfaceRequest(input *DetachNetworkInterfaceInput) (req *request.Request, output *DetachNetworkInterfaceOutput) {
+	op := &request.Operation{
 		Name:       opDetachNetworkInterface,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4490,8 +4490,8 @@ func (c *EC2) DetachNetworkInterface(input *DetachNetworkInterfaceInput) (*Detac
 const opDetachVolume = "DetachVolume"
 
 // DetachVolumeRequest generates a request for the DetachVolume operation.
-func (c *EC2) DetachVolumeRequest(input *DetachVolumeInput) (req *service.Request, output *VolumeAttachment) {
-	op := &service.Operation{
+func (c *EC2) DetachVolumeRequest(input *DetachVolumeInput) (req *request.Request, output *VolumeAttachment) {
+	op := &request.Operation{
 		Name:       opDetachVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4529,8 +4529,8 @@ func (c *EC2) DetachVolume(input *DetachVolumeInput) (*VolumeAttachment, error) 
 const opDetachVpnGateway = "DetachVpnGateway"
 
 // DetachVpnGatewayRequest generates a request for the DetachVpnGateway operation.
-func (c *EC2) DetachVpnGatewayRequest(input *DetachVpnGatewayInput) (req *service.Request, output *DetachVpnGatewayOutput) {
-	op := &service.Operation{
+func (c *EC2) DetachVpnGatewayRequest(input *DetachVpnGatewayInput) (req *request.Request, output *DetachVpnGatewayOutput) {
+	op := &request.Operation{
 		Name:       opDetachVpnGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4563,8 +4563,8 @@ func (c *EC2) DetachVpnGateway(input *DetachVpnGatewayInput) (*DetachVpnGatewayO
 const opDisableVgwRoutePropagation = "DisableVgwRoutePropagation"
 
 // DisableVgwRoutePropagationRequest generates a request for the DisableVgwRoutePropagation operation.
-func (c *EC2) DisableVgwRoutePropagationRequest(input *DisableVgwRoutePropagationInput) (req *service.Request, output *DisableVgwRoutePropagationOutput) {
-	op := &service.Operation{
+func (c *EC2) DisableVgwRoutePropagationRequest(input *DisableVgwRoutePropagationInput) (req *request.Request, output *DisableVgwRoutePropagationOutput) {
+	op := &request.Operation{
 		Name:       opDisableVgwRoutePropagation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4591,8 +4591,8 @@ func (c *EC2) DisableVgwRoutePropagation(input *DisableVgwRoutePropagationInput)
 const opDisableVpcClassicLink = "DisableVpcClassicLink"
 
 // DisableVpcClassicLinkRequest generates a request for the DisableVpcClassicLink operation.
-func (c *EC2) DisableVpcClassicLinkRequest(input *DisableVpcClassicLinkInput) (req *service.Request, output *DisableVpcClassicLinkOutput) {
-	op := &service.Operation{
+func (c *EC2) DisableVpcClassicLinkRequest(input *DisableVpcClassicLinkInput) (req *request.Request, output *DisableVpcClassicLinkOutput) {
+	op := &request.Operation{
 		Name:       opDisableVpcClassicLink,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4619,8 +4619,8 @@ func (c *EC2) DisableVpcClassicLink(input *DisableVpcClassicLinkInput) (*Disable
 const opDisassociateAddress = "DisassociateAddress"
 
 // DisassociateAddressRequest generates a request for the DisassociateAddress operation.
-func (c *EC2) DisassociateAddressRequest(input *DisassociateAddressInput) (req *service.Request, output *DisassociateAddressOutput) {
-	op := &service.Operation{
+func (c *EC2) DisassociateAddressRequest(input *DisassociateAddressInput) (req *request.Request, output *DisassociateAddressOutput) {
+	op := &request.Operation{
 		Name:       opDisassociateAddress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4654,8 +4654,8 @@ func (c *EC2) DisassociateAddress(input *DisassociateAddressInput) (*Disassociat
 const opDisassociateRouteTable = "DisassociateRouteTable"
 
 // DisassociateRouteTableRequest generates a request for the DisassociateRouteTable operation.
-func (c *EC2) DisassociateRouteTableRequest(input *DisassociateRouteTableInput) (req *service.Request, output *DisassociateRouteTableOutput) {
-	op := &service.Operation{
+func (c *EC2) DisassociateRouteTableRequest(input *DisassociateRouteTableInput) (req *request.Request, output *DisassociateRouteTableOutput) {
+	op := &request.Operation{
 		Name:       opDisassociateRouteTable,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4686,8 +4686,8 @@ func (c *EC2) DisassociateRouteTable(input *DisassociateRouteTableInput) (*Disas
 const opEnableVgwRoutePropagation = "EnableVgwRoutePropagation"
 
 // EnableVgwRoutePropagationRequest generates a request for the EnableVgwRoutePropagation operation.
-func (c *EC2) EnableVgwRoutePropagationRequest(input *EnableVgwRoutePropagationInput) (req *service.Request, output *EnableVgwRoutePropagationOutput) {
-	op := &service.Operation{
+func (c *EC2) EnableVgwRoutePropagationRequest(input *EnableVgwRoutePropagationInput) (req *request.Request, output *EnableVgwRoutePropagationOutput) {
+	op := &request.Operation{
 		Name:       opEnableVgwRoutePropagation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4714,8 +4714,8 @@ func (c *EC2) EnableVgwRoutePropagation(input *EnableVgwRoutePropagationInput) (
 const opEnableVolumeIO = "EnableVolumeIO"
 
 // EnableVolumeIORequest generates a request for the EnableVolumeIO operation.
-func (c *EC2) EnableVolumeIORequest(input *EnableVolumeIOInput) (req *service.Request, output *EnableVolumeIOOutput) {
-	op := &service.Operation{
+func (c *EC2) EnableVolumeIORequest(input *EnableVolumeIOInput) (req *request.Request, output *EnableVolumeIOOutput) {
+	op := &request.Operation{
 		Name:       opEnableVolumeIO,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4742,8 +4742,8 @@ func (c *EC2) EnableVolumeIO(input *EnableVolumeIOInput) (*EnableVolumeIOOutput,
 const opEnableVpcClassicLink = "EnableVpcClassicLink"
 
 // EnableVpcClassicLinkRequest generates a request for the EnableVpcClassicLink operation.
-func (c *EC2) EnableVpcClassicLinkRequest(input *EnableVpcClassicLinkInput) (req *service.Request, output *EnableVpcClassicLinkOutput) {
-	op := &service.Operation{
+func (c *EC2) EnableVpcClassicLinkRequest(input *EnableVpcClassicLinkInput) (req *request.Request, output *EnableVpcClassicLinkOutput) {
+	op := &request.Operation{
 		Name:       opEnableVpcClassicLink,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4775,8 +4775,8 @@ func (c *EC2) EnableVpcClassicLink(input *EnableVpcClassicLinkInput) (*EnableVpc
 const opGetConsoleOutput = "GetConsoleOutput"
 
 // GetConsoleOutputRequest generates a request for the GetConsoleOutput operation.
-func (c *EC2) GetConsoleOutputRequest(input *GetConsoleOutputInput) (req *service.Request, output *GetConsoleOutputOutput) {
-	op := &service.Operation{
+func (c *EC2) GetConsoleOutputRequest(input *GetConsoleOutputInput) (req *request.Request, output *GetConsoleOutputOutput) {
+	op := &request.Operation{
 		Name:       opGetConsoleOutput,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4819,8 +4819,8 @@ func (c *EC2) GetConsoleOutput(input *GetConsoleOutputInput) (*GetConsoleOutputO
 const opGetPasswordData = "GetPasswordData"
 
 // GetPasswordDataRequest generates a request for the GetPasswordData operation.
-func (c *EC2) GetPasswordDataRequest(input *GetPasswordDataInput) (req *service.Request, output *GetPasswordDataOutput) {
-	op := &service.Operation{
+func (c *EC2) GetPasswordDataRequest(input *GetPasswordDataInput) (req *request.Request, output *GetPasswordDataOutput) {
+	op := &request.Operation{
 		Name:       opGetPasswordData,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4859,8 +4859,8 @@ func (c *EC2) GetPasswordData(input *GetPasswordDataInput) (*GetPasswordDataOutp
 const opImportImage = "ImportImage"
 
 // ImportImageRequest generates a request for the ImportImage operation.
-func (c *EC2) ImportImageRequest(input *ImportImageInput) (req *service.Request, output *ImportImageOutput) {
-	op := &service.Operation{
+func (c *EC2) ImportImageRequest(input *ImportImageInput) (req *request.Request, output *ImportImageOutput) {
+	op := &request.Operation{
 		Name:       opImportImage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4887,8 +4887,8 @@ func (c *EC2) ImportImage(input *ImportImageInput) (*ImportImageOutput, error) {
 const opImportInstance = "ImportInstance"
 
 // ImportInstanceRequest generates a request for the ImportInstance operation.
-func (c *EC2) ImportInstanceRequest(input *ImportInstanceInput) (req *service.Request, output *ImportInstanceOutput) {
-	op := &service.Operation{
+func (c *EC2) ImportInstanceRequest(input *ImportInstanceInput) (req *request.Request, output *ImportInstanceOutput) {
+	op := &request.Operation{
 		Name:       opImportInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4920,8 +4920,8 @@ func (c *EC2) ImportInstance(input *ImportInstanceInput) (*ImportInstanceOutput,
 const opImportKeyPair = "ImportKeyPair"
 
 // ImportKeyPairRequest generates a request for the ImportKeyPair operation.
-func (c *EC2) ImportKeyPairRequest(input *ImportKeyPairInput) (req *service.Request, output *ImportKeyPairOutput) {
-	op := &service.Operation{
+func (c *EC2) ImportKeyPairRequest(input *ImportKeyPairInput) (req *request.Request, output *ImportKeyPairOutput) {
+	op := &request.Operation{
 		Name:       opImportKeyPair,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4954,8 +4954,8 @@ func (c *EC2) ImportKeyPair(input *ImportKeyPairInput) (*ImportKeyPairOutput, er
 const opImportSnapshot = "ImportSnapshot"
 
 // ImportSnapshotRequest generates a request for the ImportSnapshot operation.
-func (c *EC2) ImportSnapshotRequest(input *ImportSnapshotInput) (req *service.Request, output *ImportSnapshotOutput) {
-	op := &service.Operation{
+func (c *EC2) ImportSnapshotRequest(input *ImportSnapshotInput) (req *request.Request, output *ImportSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opImportSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -4981,8 +4981,8 @@ func (c *EC2) ImportSnapshot(input *ImportSnapshotInput) (*ImportSnapshotOutput,
 const opImportVolume = "ImportVolume"
 
 // ImportVolumeRequest generates a request for the ImportVolume operation.
-func (c *EC2) ImportVolumeRequest(input *ImportVolumeInput) (req *service.Request, output *ImportVolumeOutput) {
-	op := &service.Operation{
+func (c *EC2) ImportVolumeRequest(input *ImportVolumeInput) (req *request.Request, output *ImportVolumeOutput) {
+	op := &request.Operation{
 		Name:       opImportVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5013,8 +5013,8 @@ func (c *EC2) ImportVolume(input *ImportVolumeInput) (*ImportVolumeOutput, error
 const opModifyImageAttribute = "ModifyImageAttribute"
 
 // ModifyImageAttributeRequest generates a request for the ModifyImageAttribute operation.
-func (c *EC2) ModifyImageAttributeRequest(input *ModifyImageAttributeInput) (req *service.Request, output *ModifyImageAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifyImageAttributeRequest(input *ModifyImageAttributeInput) (req *request.Request, output *ModifyImageAttributeOutput) {
+	op := &request.Operation{
 		Name:       opModifyImageAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5044,8 +5044,8 @@ func (c *EC2) ModifyImageAttribute(input *ModifyImageAttributeInput) (*ModifyIma
 const opModifyInstanceAttribute = "ModifyInstanceAttribute"
 
 // ModifyInstanceAttributeRequest generates a request for the ModifyInstanceAttribute operation.
-func (c *EC2) ModifyInstanceAttributeRequest(input *ModifyInstanceAttributeInput) (req *service.Request, output *ModifyInstanceAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifyInstanceAttributeRequest(input *ModifyInstanceAttributeInput) (req *request.Request, output *ModifyInstanceAttributeOutput) {
+	op := &request.Operation{
 		Name:       opModifyInstanceAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5076,8 +5076,8 @@ func (c *EC2) ModifyInstanceAttribute(input *ModifyInstanceAttributeInput) (*Mod
 const opModifyNetworkInterfaceAttribute = "ModifyNetworkInterfaceAttribute"
 
 // ModifyNetworkInterfaceAttributeRequest generates a request for the ModifyNetworkInterfaceAttribute operation.
-func (c *EC2) ModifyNetworkInterfaceAttributeRequest(input *ModifyNetworkInterfaceAttributeInput) (req *service.Request, output *ModifyNetworkInterfaceAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifyNetworkInterfaceAttributeRequest(input *ModifyNetworkInterfaceAttributeInput) (req *request.Request, output *ModifyNetworkInterfaceAttributeOutput) {
+	op := &request.Operation{
 		Name:       opModifyNetworkInterfaceAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5104,8 +5104,8 @@ func (c *EC2) ModifyNetworkInterfaceAttribute(input *ModifyNetworkInterfaceAttri
 const opModifyReservedInstances = "ModifyReservedInstances"
 
 // ModifyReservedInstancesRequest generates a request for the ModifyReservedInstances operation.
-func (c *EC2) ModifyReservedInstancesRequest(input *ModifyReservedInstancesInput) (req *service.Request, output *ModifyReservedInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifyReservedInstancesRequest(input *ModifyReservedInstancesInput) (req *request.Request, output *ModifyReservedInstancesOutput) {
+	op := &request.Operation{
 		Name:       opModifyReservedInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5137,8 +5137,8 @@ func (c *EC2) ModifyReservedInstances(input *ModifyReservedInstancesInput) (*Mod
 const opModifySnapshotAttribute = "ModifySnapshotAttribute"
 
 // ModifySnapshotAttributeRequest generates a request for the ModifySnapshotAttribute operation.
-func (c *EC2) ModifySnapshotAttributeRequest(input *ModifySnapshotAttributeInput) (req *service.Request, output *ModifySnapshotAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifySnapshotAttributeRequest(input *ModifySnapshotAttributeInput) (req *request.Request, output *ModifySnapshotAttributeOutput) {
+	op := &request.Operation{
 		Name:       opModifySnapshotAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5174,8 +5174,8 @@ func (c *EC2) ModifySnapshotAttribute(input *ModifySnapshotAttributeInput) (*Mod
 const opModifySubnetAttribute = "ModifySubnetAttribute"
 
 // ModifySubnetAttributeRequest generates a request for the ModifySubnetAttribute operation.
-func (c *EC2) ModifySubnetAttributeRequest(input *ModifySubnetAttributeInput) (req *service.Request, output *ModifySubnetAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifySubnetAttributeRequest(input *ModifySubnetAttributeInput) (req *request.Request, output *ModifySubnetAttributeOutput) {
+	op := &request.Operation{
 		Name:       opModifySubnetAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5201,8 +5201,8 @@ func (c *EC2) ModifySubnetAttribute(input *ModifySubnetAttributeInput) (*ModifyS
 const opModifyVolumeAttribute = "ModifyVolumeAttribute"
 
 // ModifyVolumeAttributeRequest generates a request for the ModifyVolumeAttribute operation.
-func (c *EC2) ModifyVolumeAttributeRequest(input *ModifyVolumeAttributeInput) (req *service.Request, output *ModifyVolumeAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifyVolumeAttributeRequest(input *ModifyVolumeAttributeInput) (req *request.Request, output *ModifyVolumeAttributeOutput) {
+	op := &request.Operation{
 		Name:       opModifyVolumeAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5237,8 +5237,8 @@ func (c *EC2) ModifyVolumeAttribute(input *ModifyVolumeAttributeInput) (*ModifyV
 const opModifyVpcAttribute = "ModifyVpcAttribute"
 
 // ModifyVpcAttributeRequest generates a request for the ModifyVpcAttribute operation.
-func (c *EC2) ModifyVpcAttributeRequest(input *ModifyVpcAttributeInput) (req *service.Request, output *ModifyVpcAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifyVpcAttributeRequest(input *ModifyVpcAttributeInput) (req *request.Request, output *ModifyVpcAttributeOutput) {
+	op := &request.Operation{
 		Name:       opModifyVpcAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5264,8 +5264,8 @@ func (c *EC2) ModifyVpcAttribute(input *ModifyVpcAttributeInput) (*ModifyVpcAttr
 const opModifyVpcEndpoint = "ModifyVpcEndpoint"
 
 // ModifyVpcEndpointRequest generates a request for the ModifyVpcEndpoint operation.
-func (c *EC2) ModifyVpcEndpointRequest(input *ModifyVpcEndpointInput) (req *service.Request, output *ModifyVpcEndpointOutput) {
-	op := &service.Operation{
+func (c *EC2) ModifyVpcEndpointRequest(input *ModifyVpcEndpointInput) (req *request.Request, output *ModifyVpcEndpointOutput) {
+	op := &request.Operation{
 		Name:       opModifyVpcEndpoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5293,8 +5293,8 @@ func (c *EC2) ModifyVpcEndpoint(input *ModifyVpcEndpointInput) (*ModifyVpcEndpoi
 const opMonitorInstances = "MonitorInstances"
 
 // MonitorInstancesRequest generates a request for the MonitorInstances operation.
-func (c *EC2) MonitorInstancesRequest(input *MonitorInstancesInput) (req *service.Request, output *MonitorInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) MonitorInstancesRequest(input *MonitorInstancesInput) (req *request.Request, output *MonitorInstancesOutput) {
+	op := &request.Operation{
 		Name:       opMonitorInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5322,8 +5322,8 @@ func (c *EC2) MonitorInstances(input *MonitorInstancesInput) (*MonitorInstancesO
 const opMoveAddressToVpc = "MoveAddressToVpc"
 
 // MoveAddressToVpcRequest generates a request for the MoveAddressToVpc operation.
-func (c *EC2) MoveAddressToVpcRequest(input *MoveAddressToVpcInput) (req *service.Request, output *MoveAddressToVpcOutput) {
-	op := &service.Operation{
+func (c *EC2) MoveAddressToVpcRequest(input *MoveAddressToVpcInput) (req *request.Request, output *MoveAddressToVpcOutput) {
+	op := &request.Operation{
 		Name:       opMoveAddressToVpc,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5355,8 +5355,8 @@ func (c *EC2) MoveAddressToVpc(input *MoveAddressToVpcInput) (*MoveAddressToVpcO
 const opPurchaseReservedInstancesOffering = "PurchaseReservedInstancesOffering"
 
 // PurchaseReservedInstancesOfferingRequest generates a request for the PurchaseReservedInstancesOffering operation.
-func (c *EC2) PurchaseReservedInstancesOfferingRequest(input *PurchaseReservedInstancesOfferingInput) (req *service.Request, output *PurchaseReservedInstancesOfferingOutput) {
-	op := &service.Operation{
+func (c *EC2) PurchaseReservedInstancesOfferingRequest(input *PurchaseReservedInstancesOfferingInput) (req *request.Request, output *PurchaseReservedInstancesOfferingOutput) {
+	op := &request.Operation{
 		Name:       opPurchaseReservedInstancesOffering,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5393,8 +5393,8 @@ func (c *EC2) PurchaseReservedInstancesOffering(input *PurchaseReservedInstances
 const opRebootInstances = "RebootInstances"
 
 // RebootInstancesRequest generates a request for the RebootInstances operation.
-func (c *EC2) RebootInstancesRequest(input *RebootInstancesInput) (req *service.Request, output *RebootInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) RebootInstancesRequest(input *RebootInstancesInput) (req *request.Request, output *RebootInstancesOutput) {
+	op := &request.Operation{
 		Name:       opRebootInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5430,8 +5430,8 @@ func (c *EC2) RebootInstances(input *RebootInstancesInput) (*RebootInstancesOutp
 const opRegisterImage = "RegisterImage"
 
 // RegisterImageRequest generates a request for the RegisterImage operation.
-func (c *EC2) RegisterImageRequest(input *RegisterImageInput) (req *service.Request, output *RegisterImageOutput) {
-	op := &service.Operation{
+func (c *EC2) RegisterImageRequest(input *RegisterImageInput) (req *request.Request, output *RegisterImageOutput) {
+	op := &request.Operation{
 		Name:       opRegisterImage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5480,8 +5480,8 @@ func (c *EC2) RegisterImage(input *RegisterImageInput) (*RegisterImageOutput, er
 const opRejectVpcPeeringConnection = "RejectVpcPeeringConnection"
 
 // RejectVpcPeeringConnectionRequest generates a request for the RejectVpcPeeringConnection operation.
-func (c *EC2) RejectVpcPeeringConnectionRequest(input *RejectVpcPeeringConnectionInput) (req *service.Request, output *RejectVpcPeeringConnectionOutput) {
-	op := &service.Operation{
+func (c *EC2) RejectVpcPeeringConnectionRequest(input *RejectVpcPeeringConnectionInput) (req *request.Request, output *RejectVpcPeeringConnectionOutput) {
+	op := &request.Operation{
 		Name:       opRejectVpcPeeringConnection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5511,8 +5511,8 @@ func (c *EC2) RejectVpcPeeringConnection(input *RejectVpcPeeringConnectionInput)
 const opReleaseAddress = "ReleaseAddress"
 
 // ReleaseAddressRequest generates a request for the ReleaseAddress operation.
-func (c *EC2) ReleaseAddressRequest(input *ReleaseAddressInput) (req *service.Request, output *ReleaseAddressOutput) {
-	op := &service.Operation{
+func (c *EC2) ReleaseAddressRequest(input *ReleaseAddressInput) (req *request.Request, output *ReleaseAddressOutput) {
+	op := &request.Operation{
 		Name:       opReleaseAddress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5552,8 +5552,8 @@ func (c *EC2) ReleaseAddress(input *ReleaseAddressInput) (*ReleaseAddressOutput,
 const opReplaceNetworkAclAssociation = "ReplaceNetworkAclAssociation"
 
 // ReplaceNetworkAclAssociationRequest generates a request for the ReplaceNetworkAclAssociation operation.
-func (c *EC2) ReplaceNetworkAclAssociationRequest(input *ReplaceNetworkAclAssociationInput) (req *service.Request, output *ReplaceNetworkAclAssociationOutput) {
-	op := &service.Operation{
+func (c *EC2) ReplaceNetworkAclAssociationRequest(input *ReplaceNetworkAclAssociationInput) (req *request.Request, output *ReplaceNetworkAclAssociationOutput) {
+	op := &request.Operation{
 		Name:       opReplaceNetworkAclAssociation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5582,8 +5582,8 @@ func (c *EC2) ReplaceNetworkAclAssociation(input *ReplaceNetworkAclAssociationIn
 const opReplaceNetworkAclEntry = "ReplaceNetworkAclEntry"
 
 // ReplaceNetworkAclEntryRequest generates a request for the ReplaceNetworkAclEntry operation.
-func (c *EC2) ReplaceNetworkAclEntryRequest(input *ReplaceNetworkAclEntryInput) (req *service.Request, output *ReplaceNetworkAclEntryOutput) {
-	op := &service.Operation{
+func (c *EC2) ReplaceNetworkAclEntryRequest(input *ReplaceNetworkAclEntryInput) (req *request.Request, output *ReplaceNetworkAclEntryOutput) {
+	op := &request.Operation{
 		Name:       opReplaceNetworkAclEntry,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5611,8 +5611,8 @@ func (c *EC2) ReplaceNetworkAclEntry(input *ReplaceNetworkAclEntryInput) (*Repla
 const opReplaceRoute = "ReplaceRoute"
 
 // ReplaceRouteRequest generates a request for the ReplaceRoute operation.
-func (c *EC2) ReplaceRouteRequest(input *ReplaceRouteInput) (req *service.Request, output *ReplaceRouteOutput) {
-	op := &service.Operation{
+func (c *EC2) ReplaceRouteRequest(input *ReplaceRouteInput) (req *request.Request, output *ReplaceRouteOutput) {
+	op := &request.Operation{
 		Name:       opReplaceRoute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5643,8 +5643,8 @@ func (c *EC2) ReplaceRoute(input *ReplaceRouteInput) (*ReplaceRouteOutput, error
 const opReplaceRouteTableAssociation = "ReplaceRouteTableAssociation"
 
 // ReplaceRouteTableAssociationRequest generates a request for the ReplaceRouteTableAssociation operation.
-func (c *EC2) ReplaceRouteTableAssociationRequest(input *ReplaceRouteTableAssociationInput) (req *service.Request, output *ReplaceRouteTableAssociationOutput) {
-	op := &service.Operation{
+func (c *EC2) ReplaceRouteTableAssociationRequest(input *ReplaceRouteTableAssociationInput) (req *request.Request, output *ReplaceRouteTableAssociationOutput) {
+	op := &request.Operation{
 		Name:       opReplaceRouteTableAssociation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5678,8 +5678,8 @@ func (c *EC2) ReplaceRouteTableAssociation(input *ReplaceRouteTableAssociationIn
 const opReportInstanceStatus = "ReportInstanceStatus"
 
 // ReportInstanceStatusRequest generates a request for the ReportInstanceStatus operation.
-func (c *EC2) ReportInstanceStatusRequest(input *ReportInstanceStatusInput) (req *service.Request, output *ReportInstanceStatusOutput) {
-	op := &service.Operation{
+func (c *EC2) ReportInstanceStatusRequest(input *ReportInstanceStatusInput) (req *request.Request, output *ReportInstanceStatusOutput) {
+	op := &request.Operation{
 		Name:       opReportInstanceStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5711,8 +5711,8 @@ func (c *EC2) ReportInstanceStatus(input *ReportInstanceStatusInput) (*ReportIns
 const opRequestSpotFleet = "RequestSpotFleet"
 
 // RequestSpotFleetRequest generates a request for the RequestSpotFleet operation.
-func (c *EC2) RequestSpotFleetRequest(input *RequestSpotFleetInput) (req *service.Request, output *RequestSpotFleetOutput) {
-	op := &service.Operation{
+func (c *EC2) RequestSpotFleetRequest(input *RequestSpotFleetInput) (req *request.Request, output *RequestSpotFleetOutput) {
+	op := &request.Operation{
 		Name:       opRequestSpotFleet,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5741,8 +5741,8 @@ func (c *EC2) RequestSpotFleet(input *RequestSpotFleetInput) (*RequestSpotFleetO
 const opRequestSpotInstances = "RequestSpotInstances"
 
 // RequestSpotInstancesRequest generates a request for the RequestSpotInstances operation.
-func (c *EC2) RequestSpotInstancesRequest(input *RequestSpotInstancesInput) (req *service.Request, output *RequestSpotInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) RequestSpotInstancesRequest(input *RequestSpotInstancesInput) (req *request.Request, output *RequestSpotInstancesOutput) {
+	op := &request.Operation{
 		Name:       opRequestSpotInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5773,8 +5773,8 @@ func (c *EC2) RequestSpotInstances(input *RequestSpotInstancesInput) (*RequestSp
 const opResetImageAttribute = "ResetImageAttribute"
 
 // ResetImageAttributeRequest generates a request for the ResetImageAttribute operation.
-func (c *EC2) ResetImageAttributeRequest(input *ResetImageAttributeInput) (req *service.Request, output *ResetImageAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ResetImageAttributeRequest(input *ResetImageAttributeInput) (req *request.Request, output *ResetImageAttributeOutput) {
+	op := &request.Operation{
 		Name:       opResetImageAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5802,8 +5802,8 @@ func (c *EC2) ResetImageAttribute(input *ResetImageAttributeInput) (*ResetImageA
 const opResetInstanceAttribute = "ResetInstanceAttribute"
 
 // ResetInstanceAttributeRequest generates a request for the ResetInstanceAttribute operation.
-func (c *EC2) ResetInstanceAttributeRequest(input *ResetInstanceAttributeInput) (req *service.Request, output *ResetInstanceAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ResetInstanceAttributeRequest(input *ResetInstanceAttributeInput) (req *request.Request, output *ResetInstanceAttributeOutput) {
+	op := &request.Operation{
 		Name:       opResetInstanceAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5837,8 +5837,8 @@ func (c *EC2) ResetInstanceAttribute(input *ResetInstanceAttributeInput) (*Reset
 const opResetNetworkInterfaceAttribute = "ResetNetworkInterfaceAttribute"
 
 // ResetNetworkInterfaceAttributeRequest generates a request for the ResetNetworkInterfaceAttribute operation.
-func (c *EC2) ResetNetworkInterfaceAttributeRequest(input *ResetNetworkInterfaceAttributeInput) (req *service.Request, output *ResetNetworkInterfaceAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ResetNetworkInterfaceAttributeRequest(input *ResetNetworkInterfaceAttributeInput) (req *request.Request, output *ResetNetworkInterfaceAttributeOutput) {
+	op := &request.Operation{
 		Name:       opResetNetworkInterfaceAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5865,8 +5865,8 @@ func (c *EC2) ResetNetworkInterfaceAttribute(input *ResetNetworkInterfaceAttribu
 const opResetSnapshotAttribute = "ResetSnapshotAttribute"
 
 // ResetSnapshotAttributeRequest generates a request for the ResetSnapshotAttribute operation.
-func (c *EC2) ResetSnapshotAttributeRequest(input *ResetSnapshotAttributeInput) (req *service.Request, output *ResetSnapshotAttributeOutput) {
-	op := &service.Operation{
+func (c *EC2) ResetSnapshotAttributeRequest(input *ResetSnapshotAttributeInput) (req *request.Request, output *ResetSnapshotAttributeOutput) {
+	op := &request.Operation{
 		Name:       opResetSnapshotAttribute,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5896,8 +5896,8 @@ func (c *EC2) ResetSnapshotAttribute(input *ResetSnapshotAttributeInput) (*Reset
 const opRestoreAddressToClassic = "RestoreAddressToClassic"
 
 // RestoreAddressToClassicRequest generates a request for the RestoreAddressToClassic operation.
-func (c *EC2) RestoreAddressToClassicRequest(input *RestoreAddressToClassicInput) (req *service.Request, output *RestoreAddressToClassicOutput) {
-	op := &service.Operation{
+func (c *EC2) RestoreAddressToClassicRequest(input *RestoreAddressToClassicInput) (req *request.Request, output *RestoreAddressToClassicOutput) {
+	op := &request.Operation{
 		Name:       opRestoreAddressToClassic,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5926,8 +5926,8 @@ func (c *EC2) RestoreAddressToClassic(input *RestoreAddressToClassicInput) (*Res
 const opRevokeSecurityGroupEgress = "RevokeSecurityGroupEgress"
 
 // RevokeSecurityGroupEgressRequest generates a request for the RevokeSecurityGroupEgress operation.
-func (c *EC2) RevokeSecurityGroupEgressRequest(input *RevokeSecurityGroupEgressInput) (req *service.Request, output *RevokeSecurityGroupEgressOutput) {
-	op := &service.Operation{
+func (c *EC2) RevokeSecurityGroupEgressRequest(input *RevokeSecurityGroupEgressInput) (req *request.Request, output *RevokeSecurityGroupEgressOutput) {
+	op := &request.Operation{
 		Name:       opRevokeSecurityGroupEgress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -5963,8 +5963,8 @@ func (c *EC2) RevokeSecurityGroupEgress(input *RevokeSecurityGroupEgressInput) (
 const opRevokeSecurityGroupIngress = "RevokeSecurityGroupIngress"
 
 // RevokeSecurityGroupIngressRequest generates a request for the RevokeSecurityGroupIngress operation.
-func (c *EC2) RevokeSecurityGroupIngressRequest(input *RevokeSecurityGroupIngressInput) (req *service.Request, output *RevokeSecurityGroupIngressOutput) {
-	op := &service.Operation{
+func (c *EC2) RevokeSecurityGroupIngressRequest(input *RevokeSecurityGroupIngressInput) (req *request.Request, output *RevokeSecurityGroupIngressOutput) {
+	op := &request.Operation{
 		Name:       opRevokeSecurityGroupIngress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -6000,8 +6000,8 @@ func (c *EC2) RevokeSecurityGroupIngress(input *RevokeSecurityGroupIngressInput)
 const opRunInstances = "RunInstances"
 
 // RunInstancesRequest generates a request for the RunInstances operation.
-func (c *EC2) RunInstancesRequest(input *RunInstancesInput) (req *service.Request, output *Reservation) {
-	op := &service.Operation{
+func (c *EC2) RunInstancesRequest(input *RunInstancesInput) (req *request.Request, output *Reservation) {
+	op := &request.Operation{
 		Name:       opRunInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -6059,8 +6059,8 @@ func (c *EC2) RunInstances(input *RunInstancesInput) (*Reservation, error) {
 const opStartInstances = "StartInstances"
 
 // StartInstancesRequest generates a request for the StartInstances operation.
-func (c *EC2) StartInstancesRequest(input *StartInstancesInput) (req *service.Request, output *StartInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) StartInstancesRequest(input *StartInstancesInput) (req *request.Request, output *StartInstancesOutput) {
+	op := &request.Operation{
 		Name:       opStartInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -6104,8 +6104,8 @@ func (c *EC2) StartInstances(input *StartInstancesInput) (*StartInstancesOutput,
 const opStopInstances = "StopInstances"
 
 // StopInstancesRequest generates a request for the StopInstances operation.
-func (c *EC2) StopInstancesRequest(input *StopInstancesInput) (req *service.Request, output *StopInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) StopInstancesRequest(input *StopInstancesInput) (req *request.Request, output *StopInstancesOutput) {
+	op := &request.Operation{
 		Name:       opStopInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -6161,8 +6161,8 @@ func (c *EC2) StopInstances(input *StopInstancesInput) (*StopInstancesOutput, er
 const opTerminateInstances = "TerminateInstances"
 
 // TerminateInstancesRequest generates a request for the TerminateInstances operation.
-func (c *EC2) TerminateInstancesRequest(input *TerminateInstancesInput) (req *service.Request, output *TerminateInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) TerminateInstancesRequest(input *TerminateInstancesInput) (req *request.Request, output *TerminateInstancesOutput) {
+	op := &request.Operation{
 		Name:       opTerminateInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -6208,8 +6208,8 @@ func (c *EC2) TerminateInstances(input *TerminateInstancesInput) (*TerminateInst
 const opUnassignPrivateIpAddresses = "UnassignPrivateIpAddresses"
 
 // UnassignPrivateIpAddressesRequest generates a request for the UnassignPrivateIpAddresses operation.
-func (c *EC2) UnassignPrivateIpAddressesRequest(input *UnassignPrivateIpAddressesInput) (req *service.Request, output *UnassignPrivateIpAddressesOutput) {
-	op := &service.Operation{
+func (c *EC2) UnassignPrivateIpAddressesRequest(input *UnassignPrivateIpAddressesInput) (req *request.Request, output *UnassignPrivateIpAddressesOutput) {
+	op := &request.Operation{
 		Name:       opUnassignPrivateIpAddresses,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -6235,8 +6235,8 @@ func (c *EC2) UnassignPrivateIpAddresses(input *UnassignPrivateIpAddressesInput)
 const opUnmonitorInstances = "UnmonitorInstances"
 
 // UnmonitorInstancesRequest generates a request for the UnmonitorInstances operation.
-func (c *EC2) UnmonitorInstancesRequest(input *UnmonitorInstancesInput) (req *service.Request, output *UnmonitorInstancesOutput) {
-	op := &service.Operation{
+func (c *EC2) UnmonitorInstancesRequest(input *UnmonitorInstancesInput) (req *request.Request, output *UnmonitorInstancesOutput) {
+	op := &request.Operation{
 		Name:       opUnmonitorInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/ec2/customizations.go
+++ b/service/ec2/customizations.go
@@ -4,18 +4,18 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 func init() {
-	initRequest = func(r *service.Request) {
+	initRequest = func(r *request.Request) {
 		if r.Operation.Name == opCopySnapshot { // fill the PresignedURL parameter
 			r.Handlers.Build.PushFront(fillPresignedURL)
 		}
 	}
 }
 
-func fillPresignedURL(r *service.Request) {
+func fillPresignedURL(r *request.Request) {
 	if !r.ParamsFilled() {
 		return
 	}

--- a/service/ec2/ec2iface/interface.go
+++ b/service/ec2/ec2iface/interface.go
@@ -4,753 +4,753 @@
 package ec2iface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 // EC2API is the interface type for ec2.EC2.
 type EC2API interface {
-	AcceptVpcPeeringConnectionRequest(*ec2.AcceptVpcPeeringConnectionInput) (*service.Request, *ec2.AcceptVpcPeeringConnectionOutput)
+	AcceptVpcPeeringConnectionRequest(*ec2.AcceptVpcPeeringConnectionInput) (*request.Request, *ec2.AcceptVpcPeeringConnectionOutput)
 
 	AcceptVpcPeeringConnection(*ec2.AcceptVpcPeeringConnectionInput) (*ec2.AcceptVpcPeeringConnectionOutput, error)
 
-	AllocateAddressRequest(*ec2.AllocateAddressInput) (*service.Request, *ec2.AllocateAddressOutput)
+	AllocateAddressRequest(*ec2.AllocateAddressInput) (*request.Request, *ec2.AllocateAddressOutput)
 
 	AllocateAddress(*ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error)
 
-	AssignPrivateIpAddressesRequest(*ec2.AssignPrivateIpAddressesInput) (*service.Request, *ec2.AssignPrivateIpAddressesOutput)
+	AssignPrivateIpAddressesRequest(*ec2.AssignPrivateIpAddressesInput) (*request.Request, *ec2.AssignPrivateIpAddressesOutput)
 
 	AssignPrivateIpAddresses(*ec2.AssignPrivateIpAddressesInput) (*ec2.AssignPrivateIpAddressesOutput, error)
 
-	AssociateAddressRequest(*ec2.AssociateAddressInput) (*service.Request, *ec2.AssociateAddressOutput)
+	AssociateAddressRequest(*ec2.AssociateAddressInput) (*request.Request, *ec2.AssociateAddressOutput)
 
 	AssociateAddress(*ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error)
 
-	AssociateDhcpOptionsRequest(*ec2.AssociateDhcpOptionsInput) (*service.Request, *ec2.AssociateDhcpOptionsOutput)
+	AssociateDhcpOptionsRequest(*ec2.AssociateDhcpOptionsInput) (*request.Request, *ec2.AssociateDhcpOptionsOutput)
 
 	AssociateDhcpOptions(*ec2.AssociateDhcpOptionsInput) (*ec2.AssociateDhcpOptionsOutput, error)
 
-	AssociateRouteTableRequest(*ec2.AssociateRouteTableInput) (*service.Request, *ec2.AssociateRouteTableOutput)
+	AssociateRouteTableRequest(*ec2.AssociateRouteTableInput) (*request.Request, *ec2.AssociateRouteTableOutput)
 
 	AssociateRouteTable(*ec2.AssociateRouteTableInput) (*ec2.AssociateRouteTableOutput, error)
 
-	AttachClassicLinkVpcRequest(*ec2.AttachClassicLinkVpcInput) (*service.Request, *ec2.AttachClassicLinkVpcOutput)
+	AttachClassicLinkVpcRequest(*ec2.AttachClassicLinkVpcInput) (*request.Request, *ec2.AttachClassicLinkVpcOutput)
 
 	AttachClassicLinkVpc(*ec2.AttachClassicLinkVpcInput) (*ec2.AttachClassicLinkVpcOutput, error)
 
-	AttachInternetGatewayRequest(*ec2.AttachInternetGatewayInput) (*service.Request, *ec2.AttachInternetGatewayOutput)
+	AttachInternetGatewayRequest(*ec2.AttachInternetGatewayInput) (*request.Request, *ec2.AttachInternetGatewayOutput)
 
 	AttachInternetGateway(*ec2.AttachInternetGatewayInput) (*ec2.AttachInternetGatewayOutput, error)
 
-	AttachNetworkInterfaceRequest(*ec2.AttachNetworkInterfaceInput) (*service.Request, *ec2.AttachNetworkInterfaceOutput)
+	AttachNetworkInterfaceRequest(*ec2.AttachNetworkInterfaceInput) (*request.Request, *ec2.AttachNetworkInterfaceOutput)
 
 	AttachNetworkInterface(*ec2.AttachNetworkInterfaceInput) (*ec2.AttachNetworkInterfaceOutput, error)
 
-	AttachVolumeRequest(*ec2.AttachVolumeInput) (*service.Request, *ec2.VolumeAttachment)
+	AttachVolumeRequest(*ec2.AttachVolumeInput) (*request.Request, *ec2.VolumeAttachment)
 
 	AttachVolume(*ec2.AttachVolumeInput) (*ec2.VolumeAttachment, error)
 
-	AttachVpnGatewayRequest(*ec2.AttachVpnGatewayInput) (*service.Request, *ec2.AttachVpnGatewayOutput)
+	AttachVpnGatewayRequest(*ec2.AttachVpnGatewayInput) (*request.Request, *ec2.AttachVpnGatewayOutput)
 
 	AttachVpnGateway(*ec2.AttachVpnGatewayInput) (*ec2.AttachVpnGatewayOutput, error)
 
-	AuthorizeSecurityGroupEgressRequest(*ec2.AuthorizeSecurityGroupEgressInput) (*service.Request, *ec2.AuthorizeSecurityGroupEgressOutput)
+	AuthorizeSecurityGroupEgressRequest(*ec2.AuthorizeSecurityGroupEgressInput) (*request.Request, *ec2.AuthorizeSecurityGroupEgressOutput)
 
 	AuthorizeSecurityGroupEgress(*ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error)
 
-	AuthorizeSecurityGroupIngressRequest(*ec2.AuthorizeSecurityGroupIngressInput) (*service.Request, *ec2.AuthorizeSecurityGroupIngressOutput)
+	AuthorizeSecurityGroupIngressRequest(*ec2.AuthorizeSecurityGroupIngressInput) (*request.Request, *ec2.AuthorizeSecurityGroupIngressOutput)
 
 	AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error)
 
-	BundleInstanceRequest(*ec2.BundleInstanceInput) (*service.Request, *ec2.BundleInstanceOutput)
+	BundleInstanceRequest(*ec2.BundleInstanceInput) (*request.Request, *ec2.BundleInstanceOutput)
 
 	BundleInstance(*ec2.BundleInstanceInput) (*ec2.BundleInstanceOutput, error)
 
-	CancelBundleTaskRequest(*ec2.CancelBundleTaskInput) (*service.Request, *ec2.CancelBundleTaskOutput)
+	CancelBundleTaskRequest(*ec2.CancelBundleTaskInput) (*request.Request, *ec2.CancelBundleTaskOutput)
 
 	CancelBundleTask(*ec2.CancelBundleTaskInput) (*ec2.CancelBundleTaskOutput, error)
 
-	CancelConversionTaskRequest(*ec2.CancelConversionTaskInput) (*service.Request, *ec2.CancelConversionTaskOutput)
+	CancelConversionTaskRequest(*ec2.CancelConversionTaskInput) (*request.Request, *ec2.CancelConversionTaskOutput)
 
 	CancelConversionTask(*ec2.CancelConversionTaskInput) (*ec2.CancelConversionTaskOutput, error)
 
-	CancelExportTaskRequest(*ec2.CancelExportTaskInput) (*service.Request, *ec2.CancelExportTaskOutput)
+	CancelExportTaskRequest(*ec2.CancelExportTaskInput) (*request.Request, *ec2.CancelExportTaskOutput)
 
 	CancelExportTask(*ec2.CancelExportTaskInput) (*ec2.CancelExportTaskOutput, error)
 
-	CancelImportTaskRequest(*ec2.CancelImportTaskInput) (*service.Request, *ec2.CancelImportTaskOutput)
+	CancelImportTaskRequest(*ec2.CancelImportTaskInput) (*request.Request, *ec2.CancelImportTaskOutput)
 
 	CancelImportTask(*ec2.CancelImportTaskInput) (*ec2.CancelImportTaskOutput, error)
 
-	CancelReservedInstancesListingRequest(*ec2.CancelReservedInstancesListingInput) (*service.Request, *ec2.CancelReservedInstancesListingOutput)
+	CancelReservedInstancesListingRequest(*ec2.CancelReservedInstancesListingInput) (*request.Request, *ec2.CancelReservedInstancesListingOutput)
 
 	CancelReservedInstancesListing(*ec2.CancelReservedInstancesListingInput) (*ec2.CancelReservedInstancesListingOutput, error)
 
-	CancelSpotFleetRequestsRequest(*ec2.CancelSpotFleetRequestsInput) (*service.Request, *ec2.CancelSpotFleetRequestsOutput)
+	CancelSpotFleetRequestsRequest(*ec2.CancelSpotFleetRequestsInput) (*request.Request, *ec2.CancelSpotFleetRequestsOutput)
 
 	CancelSpotFleetRequests(*ec2.CancelSpotFleetRequestsInput) (*ec2.CancelSpotFleetRequestsOutput, error)
 
-	CancelSpotInstanceRequestsRequest(*ec2.CancelSpotInstanceRequestsInput) (*service.Request, *ec2.CancelSpotInstanceRequestsOutput)
+	CancelSpotInstanceRequestsRequest(*ec2.CancelSpotInstanceRequestsInput) (*request.Request, *ec2.CancelSpotInstanceRequestsOutput)
 
 	CancelSpotInstanceRequests(*ec2.CancelSpotInstanceRequestsInput) (*ec2.CancelSpotInstanceRequestsOutput, error)
 
-	ConfirmProductInstanceRequest(*ec2.ConfirmProductInstanceInput) (*service.Request, *ec2.ConfirmProductInstanceOutput)
+	ConfirmProductInstanceRequest(*ec2.ConfirmProductInstanceInput) (*request.Request, *ec2.ConfirmProductInstanceOutput)
 
 	ConfirmProductInstance(*ec2.ConfirmProductInstanceInput) (*ec2.ConfirmProductInstanceOutput, error)
 
-	CopyImageRequest(*ec2.CopyImageInput) (*service.Request, *ec2.CopyImageOutput)
+	CopyImageRequest(*ec2.CopyImageInput) (*request.Request, *ec2.CopyImageOutput)
 
 	CopyImage(*ec2.CopyImageInput) (*ec2.CopyImageOutput, error)
 
-	CopySnapshotRequest(*ec2.CopySnapshotInput) (*service.Request, *ec2.CopySnapshotOutput)
+	CopySnapshotRequest(*ec2.CopySnapshotInput) (*request.Request, *ec2.CopySnapshotOutput)
 
 	CopySnapshot(*ec2.CopySnapshotInput) (*ec2.CopySnapshotOutput, error)
 
-	CreateCustomerGatewayRequest(*ec2.CreateCustomerGatewayInput) (*service.Request, *ec2.CreateCustomerGatewayOutput)
+	CreateCustomerGatewayRequest(*ec2.CreateCustomerGatewayInput) (*request.Request, *ec2.CreateCustomerGatewayOutput)
 
 	CreateCustomerGateway(*ec2.CreateCustomerGatewayInput) (*ec2.CreateCustomerGatewayOutput, error)
 
-	CreateDhcpOptionsRequest(*ec2.CreateDhcpOptionsInput) (*service.Request, *ec2.CreateDhcpOptionsOutput)
+	CreateDhcpOptionsRequest(*ec2.CreateDhcpOptionsInput) (*request.Request, *ec2.CreateDhcpOptionsOutput)
 
 	CreateDhcpOptions(*ec2.CreateDhcpOptionsInput) (*ec2.CreateDhcpOptionsOutput, error)
 
-	CreateFlowLogsRequest(*ec2.CreateFlowLogsInput) (*service.Request, *ec2.CreateFlowLogsOutput)
+	CreateFlowLogsRequest(*ec2.CreateFlowLogsInput) (*request.Request, *ec2.CreateFlowLogsOutput)
 
 	CreateFlowLogs(*ec2.CreateFlowLogsInput) (*ec2.CreateFlowLogsOutput, error)
 
-	CreateImageRequest(*ec2.CreateImageInput) (*service.Request, *ec2.CreateImageOutput)
+	CreateImageRequest(*ec2.CreateImageInput) (*request.Request, *ec2.CreateImageOutput)
 
 	CreateImage(*ec2.CreateImageInput) (*ec2.CreateImageOutput, error)
 
-	CreateInstanceExportTaskRequest(*ec2.CreateInstanceExportTaskInput) (*service.Request, *ec2.CreateInstanceExportTaskOutput)
+	CreateInstanceExportTaskRequest(*ec2.CreateInstanceExportTaskInput) (*request.Request, *ec2.CreateInstanceExportTaskOutput)
 
 	CreateInstanceExportTask(*ec2.CreateInstanceExportTaskInput) (*ec2.CreateInstanceExportTaskOutput, error)
 
-	CreateInternetGatewayRequest(*ec2.CreateInternetGatewayInput) (*service.Request, *ec2.CreateInternetGatewayOutput)
+	CreateInternetGatewayRequest(*ec2.CreateInternetGatewayInput) (*request.Request, *ec2.CreateInternetGatewayOutput)
 
 	CreateInternetGateway(*ec2.CreateInternetGatewayInput) (*ec2.CreateInternetGatewayOutput, error)
 
-	CreateKeyPairRequest(*ec2.CreateKeyPairInput) (*service.Request, *ec2.CreateKeyPairOutput)
+	CreateKeyPairRequest(*ec2.CreateKeyPairInput) (*request.Request, *ec2.CreateKeyPairOutput)
 
 	CreateKeyPair(*ec2.CreateKeyPairInput) (*ec2.CreateKeyPairOutput, error)
 
-	CreateNetworkAclRequest(*ec2.CreateNetworkAclInput) (*service.Request, *ec2.CreateNetworkAclOutput)
+	CreateNetworkAclRequest(*ec2.CreateNetworkAclInput) (*request.Request, *ec2.CreateNetworkAclOutput)
 
 	CreateNetworkAcl(*ec2.CreateNetworkAclInput) (*ec2.CreateNetworkAclOutput, error)
 
-	CreateNetworkAclEntryRequest(*ec2.CreateNetworkAclEntryInput) (*service.Request, *ec2.CreateNetworkAclEntryOutput)
+	CreateNetworkAclEntryRequest(*ec2.CreateNetworkAclEntryInput) (*request.Request, *ec2.CreateNetworkAclEntryOutput)
 
 	CreateNetworkAclEntry(*ec2.CreateNetworkAclEntryInput) (*ec2.CreateNetworkAclEntryOutput, error)
 
-	CreateNetworkInterfaceRequest(*ec2.CreateNetworkInterfaceInput) (*service.Request, *ec2.CreateNetworkInterfaceOutput)
+	CreateNetworkInterfaceRequest(*ec2.CreateNetworkInterfaceInput) (*request.Request, *ec2.CreateNetworkInterfaceOutput)
 
 	CreateNetworkInterface(*ec2.CreateNetworkInterfaceInput) (*ec2.CreateNetworkInterfaceOutput, error)
 
-	CreatePlacementGroupRequest(*ec2.CreatePlacementGroupInput) (*service.Request, *ec2.CreatePlacementGroupOutput)
+	CreatePlacementGroupRequest(*ec2.CreatePlacementGroupInput) (*request.Request, *ec2.CreatePlacementGroupOutput)
 
 	CreatePlacementGroup(*ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error)
 
-	CreateReservedInstancesListingRequest(*ec2.CreateReservedInstancesListingInput) (*service.Request, *ec2.CreateReservedInstancesListingOutput)
+	CreateReservedInstancesListingRequest(*ec2.CreateReservedInstancesListingInput) (*request.Request, *ec2.CreateReservedInstancesListingOutput)
 
 	CreateReservedInstancesListing(*ec2.CreateReservedInstancesListingInput) (*ec2.CreateReservedInstancesListingOutput, error)
 
-	CreateRouteRequest(*ec2.CreateRouteInput) (*service.Request, *ec2.CreateRouteOutput)
+	CreateRouteRequest(*ec2.CreateRouteInput) (*request.Request, *ec2.CreateRouteOutput)
 
 	CreateRoute(*ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error)
 
-	CreateRouteTableRequest(*ec2.CreateRouteTableInput) (*service.Request, *ec2.CreateRouteTableOutput)
+	CreateRouteTableRequest(*ec2.CreateRouteTableInput) (*request.Request, *ec2.CreateRouteTableOutput)
 
 	CreateRouteTable(*ec2.CreateRouteTableInput) (*ec2.CreateRouteTableOutput, error)
 
-	CreateSecurityGroupRequest(*ec2.CreateSecurityGroupInput) (*service.Request, *ec2.CreateSecurityGroupOutput)
+	CreateSecurityGroupRequest(*ec2.CreateSecurityGroupInput) (*request.Request, *ec2.CreateSecurityGroupOutput)
 
 	CreateSecurityGroup(*ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error)
 
-	CreateSnapshotRequest(*ec2.CreateSnapshotInput) (*service.Request, *ec2.Snapshot)
+	CreateSnapshotRequest(*ec2.CreateSnapshotInput) (*request.Request, *ec2.Snapshot)
 
 	CreateSnapshot(*ec2.CreateSnapshotInput) (*ec2.Snapshot, error)
 
-	CreateSpotDatafeedSubscriptionRequest(*ec2.CreateSpotDatafeedSubscriptionInput) (*service.Request, *ec2.CreateSpotDatafeedSubscriptionOutput)
+	CreateSpotDatafeedSubscriptionRequest(*ec2.CreateSpotDatafeedSubscriptionInput) (*request.Request, *ec2.CreateSpotDatafeedSubscriptionOutput)
 
 	CreateSpotDatafeedSubscription(*ec2.CreateSpotDatafeedSubscriptionInput) (*ec2.CreateSpotDatafeedSubscriptionOutput, error)
 
-	CreateSubnetRequest(*ec2.CreateSubnetInput) (*service.Request, *ec2.CreateSubnetOutput)
+	CreateSubnetRequest(*ec2.CreateSubnetInput) (*request.Request, *ec2.CreateSubnetOutput)
 
 	CreateSubnet(*ec2.CreateSubnetInput) (*ec2.CreateSubnetOutput, error)
 
-	CreateTagsRequest(*ec2.CreateTagsInput) (*service.Request, *ec2.CreateTagsOutput)
+	CreateTagsRequest(*ec2.CreateTagsInput) (*request.Request, *ec2.CreateTagsOutput)
 
 	CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
 
-	CreateVolumeRequest(*ec2.CreateVolumeInput) (*service.Request, *ec2.Volume)
+	CreateVolumeRequest(*ec2.CreateVolumeInput) (*request.Request, *ec2.Volume)
 
 	CreateVolume(*ec2.CreateVolumeInput) (*ec2.Volume, error)
 
-	CreateVpcRequest(*ec2.CreateVpcInput) (*service.Request, *ec2.CreateVpcOutput)
+	CreateVpcRequest(*ec2.CreateVpcInput) (*request.Request, *ec2.CreateVpcOutput)
 
 	CreateVpc(*ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error)
 
-	CreateVpcEndpointRequest(*ec2.CreateVpcEndpointInput) (*service.Request, *ec2.CreateVpcEndpointOutput)
+	CreateVpcEndpointRequest(*ec2.CreateVpcEndpointInput) (*request.Request, *ec2.CreateVpcEndpointOutput)
 
 	CreateVpcEndpoint(*ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error)
 
-	CreateVpcPeeringConnectionRequest(*ec2.CreateVpcPeeringConnectionInput) (*service.Request, *ec2.CreateVpcPeeringConnectionOutput)
+	CreateVpcPeeringConnectionRequest(*ec2.CreateVpcPeeringConnectionInput) (*request.Request, *ec2.CreateVpcPeeringConnectionOutput)
 
 	CreateVpcPeeringConnection(*ec2.CreateVpcPeeringConnectionInput) (*ec2.CreateVpcPeeringConnectionOutput, error)
 
-	CreateVpnConnectionRequest(*ec2.CreateVpnConnectionInput) (*service.Request, *ec2.CreateVpnConnectionOutput)
+	CreateVpnConnectionRequest(*ec2.CreateVpnConnectionInput) (*request.Request, *ec2.CreateVpnConnectionOutput)
 
 	CreateVpnConnection(*ec2.CreateVpnConnectionInput) (*ec2.CreateVpnConnectionOutput, error)
 
-	CreateVpnConnectionRouteRequest(*ec2.CreateVpnConnectionRouteInput) (*service.Request, *ec2.CreateVpnConnectionRouteOutput)
+	CreateVpnConnectionRouteRequest(*ec2.CreateVpnConnectionRouteInput) (*request.Request, *ec2.CreateVpnConnectionRouteOutput)
 
 	CreateVpnConnectionRoute(*ec2.CreateVpnConnectionRouteInput) (*ec2.CreateVpnConnectionRouteOutput, error)
 
-	CreateVpnGatewayRequest(*ec2.CreateVpnGatewayInput) (*service.Request, *ec2.CreateVpnGatewayOutput)
+	CreateVpnGatewayRequest(*ec2.CreateVpnGatewayInput) (*request.Request, *ec2.CreateVpnGatewayOutput)
 
 	CreateVpnGateway(*ec2.CreateVpnGatewayInput) (*ec2.CreateVpnGatewayOutput, error)
 
-	DeleteCustomerGatewayRequest(*ec2.DeleteCustomerGatewayInput) (*service.Request, *ec2.DeleteCustomerGatewayOutput)
+	DeleteCustomerGatewayRequest(*ec2.DeleteCustomerGatewayInput) (*request.Request, *ec2.DeleteCustomerGatewayOutput)
 
 	DeleteCustomerGateway(*ec2.DeleteCustomerGatewayInput) (*ec2.DeleteCustomerGatewayOutput, error)
 
-	DeleteDhcpOptionsRequest(*ec2.DeleteDhcpOptionsInput) (*service.Request, *ec2.DeleteDhcpOptionsOutput)
+	DeleteDhcpOptionsRequest(*ec2.DeleteDhcpOptionsInput) (*request.Request, *ec2.DeleteDhcpOptionsOutput)
 
 	DeleteDhcpOptions(*ec2.DeleteDhcpOptionsInput) (*ec2.DeleteDhcpOptionsOutput, error)
 
-	DeleteFlowLogsRequest(*ec2.DeleteFlowLogsInput) (*service.Request, *ec2.DeleteFlowLogsOutput)
+	DeleteFlowLogsRequest(*ec2.DeleteFlowLogsInput) (*request.Request, *ec2.DeleteFlowLogsOutput)
 
 	DeleteFlowLogs(*ec2.DeleteFlowLogsInput) (*ec2.DeleteFlowLogsOutput, error)
 
-	DeleteInternetGatewayRequest(*ec2.DeleteInternetGatewayInput) (*service.Request, *ec2.DeleteInternetGatewayOutput)
+	DeleteInternetGatewayRequest(*ec2.DeleteInternetGatewayInput) (*request.Request, *ec2.DeleteInternetGatewayOutput)
 
 	DeleteInternetGateway(*ec2.DeleteInternetGatewayInput) (*ec2.DeleteInternetGatewayOutput, error)
 
-	DeleteKeyPairRequest(*ec2.DeleteKeyPairInput) (*service.Request, *ec2.DeleteKeyPairOutput)
+	DeleteKeyPairRequest(*ec2.DeleteKeyPairInput) (*request.Request, *ec2.DeleteKeyPairOutput)
 
 	DeleteKeyPair(*ec2.DeleteKeyPairInput) (*ec2.DeleteKeyPairOutput, error)
 
-	DeleteNetworkAclRequest(*ec2.DeleteNetworkAclInput) (*service.Request, *ec2.DeleteNetworkAclOutput)
+	DeleteNetworkAclRequest(*ec2.DeleteNetworkAclInput) (*request.Request, *ec2.DeleteNetworkAclOutput)
 
 	DeleteNetworkAcl(*ec2.DeleteNetworkAclInput) (*ec2.DeleteNetworkAclOutput, error)
 
-	DeleteNetworkAclEntryRequest(*ec2.DeleteNetworkAclEntryInput) (*service.Request, *ec2.DeleteNetworkAclEntryOutput)
+	DeleteNetworkAclEntryRequest(*ec2.DeleteNetworkAclEntryInput) (*request.Request, *ec2.DeleteNetworkAclEntryOutput)
 
 	DeleteNetworkAclEntry(*ec2.DeleteNetworkAclEntryInput) (*ec2.DeleteNetworkAclEntryOutput, error)
 
-	DeleteNetworkInterfaceRequest(*ec2.DeleteNetworkInterfaceInput) (*service.Request, *ec2.DeleteNetworkInterfaceOutput)
+	DeleteNetworkInterfaceRequest(*ec2.DeleteNetworkInterfaceInput) (*request.Request, *ec2.DeleteNetworkInterfaceOutput)
 
 	DeleteNetworkInterface(*ec2.DeleteNetworkInterfaceInput) (*ec2.DeleteNetworkInterfaceOutput, error)
 
-	DeletePlacementGroupRequest(*ec2.DeletePlacementGroupInput) (*service.Request, *ec2.DeletePlacementGroupOutput)
+	DeletePlacementGroupRequest(*ec2.DeletePlacementGroupInput) (*request.Request, *ec2.DeletePlacementGroupOutput)
 
 	DeletePlacementGroup(*ec2.DeletePlacementGroupInput) (*ec2.DeletePlacementGroupOutput, error)
 
-	DeleteRouteRequest(*ec2.DeleteRouteInput) (*service.Request, *ec2.DeleteRouteOutput)
+	DeleteRouteRequest(*ec2.DeleteRouteInput) (*request.Request, *ec2.DeleteRouteOutput)
 
 	DeleteRoute(*ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error)
 
-	DeleteRouteTableRequest(*ec2.DeleteRouteTableInput) (*service.Request, *ec2.DeleteRouteTableOutput)
+	DeleteRouteTableRequest(*ec2.DeleteRouteTableInput) (*request.Request, *ec2.DeleteRouteTableOutput)
 
 	DeleteRouteTable(*ec2.DeleteRouteTableInput) (*ec2.DeleteRouteTableOutput, error)
 
-	DeleteSecurityGroupRequest(*ec2.DeleteSecurityGroupInput) (*service.Request, *ec2.DeleteSecurityGroupOutput)
+	DeleteSecurityGroupRequest(*ec2.DeleteSecurityGroupInput) (*request.Request, *ec2.DeleteSecurityGroupOutput)
 
 	DeleteSecurityGroup(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error)
 
-	DeleteSnapshotRequest(*ec2.DeleteSnapshotInput) (*service.Request, *ec2.DeleteSnapshotOutput)
+	DeleteSnapshotRequest(*ec2.DeleteSnapshotInput) (*request.Request, *ec2.DeleteSnapshotOutput)
 
 	DeleteSnapshot(*ec2.DeleteSnapshotInput) (*ec2.DeleteSnapshotOutput, error)
 
-	DeleteSpotDatafeedSubscriptionRequest(*ec2.DeleteSpotDatafeedSubscriptionInput) (*service.Request, *ec2.DeleteSpotDatafeedSubscriptionOutput)
+	DeleteSpotDatafeedSubscriptionRequest(*ec2.DeleteSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DeleteSpotDatafeedSubscriptionOutput)
 
 	DeleteSpotDatafeedSubscription(*ec2.DeleteSpotDatafeedSubscriptionInput) (*ec2.DeleteSpotDatafeedSubscriptionOutput, error)
 
-	DeleteSubnetRequest(*ec2.DeleteSubnetInput) (*service.Request, *ec2.DeleteSubnetOutput)
+	DeleteSubnetRequest(*ec2.DeleteSubnetInput) (*request.Request, *ec2.DeleteSubnetOutput)
 
 	DeleteSubnet(*ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error)
 
-	DeleteTagsRequest(*ec2.DeleteTagsInput) (*service.Request, *ec2.DeleteTagsOutput)
+	DeleteTagsRequest(*ec2.DeleteTagsInput) (*request.Request, *ec2.DeleteTagsOutput)
 
 	DeleteTags(*ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error)
 
-	DeleteVolumeRequest(*ec2.DeleteVolumeInput) (*service.Request, *ec2.DeleteVolumeOutput)
+	DeleteVolumeRequest(*ec2.DeleteVolumeInput) (*request.Request, *ec2.DeleteVolumeOutput)
 
 	DeleteVolume(*ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
 
-	DeleteVpcRequest(*ec2.DeleteVpcInput) (*service.Request, *ec2.DeleteVpcOutput)
+	DeleteVpcRequest(*ec2.DeleteVpcInput) (*request.Request, *ec2.DeleteVpcOutput)
 
 	DeleteVpc(*ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error)
 
-	DeleteVpcEndpointsRequest(*ec2.DeleteVpcEndpointsInput) (*service.Request, *ec2.DeleteVpcEndpointsOutput)
+	DeleteVpcEndpointsRequest(*ec2.DeleteVpcEndpointsInput) (*request.Request, *ec2.DeleteVpcEndpointsOutput)
 
 	DeleteVpcEndpoints(*ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error)
 
-	DeleteVpcPeeringConnectionRequest(*ec2.DeleteVpcPeeringConnectionInput) (*service.Request, *ec2.DeleteVpcPeeringConnectionOutput)
+	DeleteVpcPeeringConnectionRequest(*ec2.DeleteVpcPeeringConnectionInput) (*request.Request, *ec2.DeleteVpcPeeringConnectionOutput)
 
 	DeleteVpcPeeringConnection(*ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error)
 
-	DeleteVpnConnectionRequest(*ec2.DeleteVpnConnectionInput) (*service.Request, *ec2.DeleteVpnConnectionOutput)
+	DeleteVpnConnectionRequest(*ec2.DeleteVpnConnectionInput) (*request.Request, *ec2.DeleteVpnConnectionOutput)
 
 	DeleteVpnConnection(*ec2.DeleteVpnConnectionInput) (*ec2.DeleteVpnConnectionOutput, error)
 
-	DeleteVpnConnectionRouteRequest(*ec2.DeleteVpnConnectionRouteInput) (*service.Request, *ec2.DeleteVpnConnectionRouteOutput)
+	DeleteVpnConnectionRouteRequest(*ec2.DeleteVpnConnectionRouteInput) (*request.Request, *ec2.DeleteVpnConnectionRouteOutput)
 
 	DeleteVpnConnectionRoute(*ec2.DeleteVpnConnectionRouteInput) (*ec2.DeleteVpnConnectionRouteOutput, error)
 
-	DeleteVpnGatewayRequest(*ec2.DeleteVpnGatewayInput) (*service.Request, *ec2.DeleteVpnGatewayOutput)
+	DeleteVpnGatewayRequest(*ec2.DeleteVpnGatewayInput) (*request.Request, *ec2.DeleteVpnGatewayOutput)
 
 	DeleteVpnGateway(*ec2.DeleteVpnGatewayInput) (*ec2.DeleteVpnGatewayOutput, error)
 
-	DeregisterImageRequest(*ec2.DeregisterImageInput) (*service.Request, *ec2.DeregisterImageOutput)
+	DeregisterImageRequest(*ec2.DeregisterImageInput) (*request.Request, *ec2.DeregisterImageOutput)
 
 	DeregisterImage(*ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error)
 
-	DescribeAccountAttributesRequest(*ec2.DescribeAccountAttributesInput) (*service.Request, *ec2.DescribeAccountAttributesOutput)
+	DescribeAccountAttributesRequest(*ec2.DescribeAccountAttributesInput) (*request.Request, *ec2.DescribeAccountAttributesOutput)
 
 	DescribeAccountAttributes(*ec2.DescribeAccountAttributesInput) (*ec2.DescribeAccountAttributesOutput, error)
 
-	DescribeAddressesRequest(*ec2.DescribeAddressesInput) (*service.Request, *ec2.DescribeAddressesOutput)
+	DescribeAddressesRequest(*ec2.DescribeAddressesInput) (*request.Request, *ec2.DescribeAddressesOutput)
 
 	DescribeAddresses(*ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error)
 
-	DescribeAvailabilityZonesRequest(*ec2.DescribeAvailabilityZonesInput) (*service.Request, *ec2.DescribeAvailabilityZonesOutput)
+	DescribeAvailabilityZonesRequest(*ec2.DescribeAvailabilityZonesInput) (*request.Request, *ec2.DescribeAvailabilityZonesOutput)
 
 	DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error)
 
-	DescribeBundleTasksRequest(*ec2.DescribeBundleTasksInput) (*service.Request, *ec2.DescribeBundleTasksOutput)
+	DescribeBundleTasksRequest(*ec2.DescribeBundleTasksInput) (*request.Request, *ec2.DescribeBundleTasksOutput)
 
 	DescribeBundleTasks(*ec2.DescribeBundleTasksInput) (*ec2.DescribeBundleTasksOutput, error)
 
-	DescribeClassicLinkInstancesRequest(*ec2.DescribeClassicLinkInstancesInput) (*service.Request, *ec2.DescribeClassicLinkInstancesOutput)
+	DescribeClassicLinkInstancesRequest(*ec2.DescribeClassicLinkInstancesInput) (*request.Request, *ec2.DescribeClassicLinkInstancesOutput)
 
 	DescribeClassicLinkInstances(*ec2.DescribeClassicLinkInstancesInput) (*ec2.DescribeClassicLinkInstancesOutput, error)
 
-	DescribeConversionTasksRequest(*ec2.DescribeConversionTasksInput) (*service.Request, *ec2.DescribeConversionTasksOutput)
+	DescribeConversionTasksRequest(*ec2.DescribeConversionTasksInput) (*request.Request, *ec2.DescribeConversionTasksOutput)
 
 	DescribeConversionTasks(*ec2.DescribeConversionTasksInput) (*ec2.DescribeConversionTasksOutput, error)
 
-	DescribeCustomerGatewaysRequest(*ec2.DescribeCustomerGatewaysInput) (*service.Request, *ec2.DescribeCustomerGatewaysOutput)
+	DescribeCustomerGatewaysRequest(*ec2.DescribeCustomerGatewaysInput) (*request.Request, *ec2.DescribeCustomerGatewaysOutput)
 
 	DescribeCustomerGateways(*ec2.DescribeCustomerGatewaysInput) (*ec2.DescribeCustomerGatewaysOutput, error)
 
-	DescribeDhcpOptionsRequest(*ec2.DescribeDhcpOptionsInput) (*service.Request, *ec2.DescribeDhcpOptionsOutput)
+	DescribeDhcpOptionsRequest(*ec2.DescribeDhcpOptionsInput) (*request.Request, *ec2.DescribeDhcpOptionsOutput)
 
 	DescribeDhcpOptions(*ec2.DescribeDhcpOptionsInput) (*ec2.DescribeDhcpOptionsOutput, error)
 
-	DescribeExportTasksRequest(*ec2.DescribeExportTasksInput) (*service.Request, *ec2.DescribeExportTasksOutput)
+	DescribeExportTasksRequest(*ec2.DescribeExportTasksInput) (*request.Request, *ec2.DescribeExportTasksOutput)
 
 	DescribeExportTasks(*ec2.DescribeExportTasksInput) (*ec2.DescribeExportTasksOutput, error)
 
-	DescribeFlowLogsRequest(*ec2.DescribeFlowLogsInput) (*service.Request, *ec2.DescribeFlowLogsOutput)
+	DescribeFlowLogsRequest(*ec2.DescribeFlowLogsInput) (*request.Request, *ec2.DescribeFlowLogsOutput)
 
 	DescribeFlowLogs(*ec2.DescribeFlowLogsInput) (*ec2.DescribeFlowLogsOutput, error)
 
-	DescribeImageAttributeRequest(*ec2.DescribeImageAttributeInput) (*service.Request, *ec2.DescribeImageAttributeOutput)
+	DescribeImageAttributeRequest(*ec2.DescribeImageAttributeInput) (*request.Request, *ec2.DescribeImageAttributeOutput)
 
 	DescribeImageAttribute(*ec2.DescribeImageAttributeInput) (*ec2.DescribeImageAttributeOutput, error)
 
-	DescribeImagesRequest(*ec2.DescribeImagesInput) (*service.Request, *ec2.DescribeImagesOutput)
+	DescribeImagesRequest(*ec2.DescribeImagesInput) (*request.Request, *ec2.DescribeImagesOutput)
 
 	DescribeImages(*ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error)
 
-	DescribeImportImageTasksRequest(*ec2.DescribeImportImageTasksInput) (*service.Request, *ec2.DescribeImportImageTasksOutput)
+	DescribeImportImageTasksRequest(*ec2.DescribeImportImageTasksInput) (*request.Request, *ec2.DescribeImportImageTasksOutput)
 
 	DescribeImportImageTasks(*ec2.DescribeImportImageTasksInput) (*ec2.DescribeImportImageTasksOutput, error)
 
-	DescribeImportSnapshotTasksRequest(*ec2.DescribeImportSnapshotTasksInput) (*service.Request, *ec2.DescribeImportSnapshotTasksOutput)
+	DescribeImportSnapshotTasksRequest(*ec2.DescribeImportSnapshotTasksInput) (*request.Request, *ec2.DescribeImportSnapshotTasksOutput)
 
 	DescribeImportSnapshotTasks(*ec2.DescribeImportSnapshotTasksInput) (*ec2.DescribeImportSnapshotTasksOutput, error)
 
-	DescribeInstanceAttributeRequest(*ec2.DescribeInstanceAttributeInput) (*service.Request, *ec2.DescribeInstanceAttributeOutput)
+	DescribeInstanceAttributeRequest(*ec2.DescribeInstanceAttributeInput) (*request.Request, *ec2.DescribeInstanceAttributeOutput)
 
 	DescribeInstanceAttribute(*ec2.DescribeInstanceAttributeInput) (*ec2.DescribeInstanceAttributeOutput, error)
 
-	DescribeInstanceStatusRequest(*ec2.DescribeInstanceStatusInput) (*service.Request, *ec2.DescribeInstanceStatusOutput)
+	DescribeInstanceStatusRequest(*ec2.DescribeInstanceStatusInput) (*request.Request, *ec2.DescribeInstanceStatusOutput)
 
 	DescribeInstanceStatus(*ec2.DescribeInstanceStatusInput) (*ec2.DescribeInstanceStatusOutput, error)
 
 	DescribeInstanceStatusPages(*ec2.DescribeInstanceStatusInput, func(*ec2.DescribeInstanceStatusOutput, bool) bool) error
 
-	DescribeInstancesRequest(*ec2.DescribeInstancesInput) (*service.Request, *ec2.DescribeInstancesOutput)
+	DescribeInstancesRequest(*ec2.DescribeInstancesInput) (*request.Request, *ec2.DescribeInstancesOutput)
 
 	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
 
 	DescribeInstancesPages(*ec2.DescribeInstancesInput, func(*ec2.DescribeInstancesOutput, bool) bool) error
 
-	DescribeInternetGatewaysRequest(*ec2.DescribeInternetGatewaysInput) (*service.Request, *ec2.DescribeInternetGatewaysOutput)
+	DescribeInternetGatewaysRequest(*ec2.DescribeInternetGatewaysInput) (*request.Request, *ec2.DescribeInternetGatewaysOutput)
 
 	DescribeInternetGateways(*ec2.DescribeInternetGatewaysInput) (*ec2.DescribeInternetGatewaysOutput, error)
 
-	DescribeKeyPairsRequest(*ec2.DescribeKeyPairsInput) (*service.Request, *ec2.DescribeKeyPairsOutput)
+	DescribeKeyPairsRequest(*ec2.DescribeKeyPairsInput) (*request.Request, *ec2.DescribeKeyPairsOutput)
 
 	DescribeKeyPairs(*ec2.DescribeKeyPairsInput) (*ec2.DescribeKeyPairsOutput, error)
 
-	DescribeMovingAddressesRequest(*ec2.DescribeMovingAddressesInput) (*service.Request, *ec2.DescribeMovingAddressesOutput)
+	DescribeMovingAddressesRequest(*ec2.DescribeMovingAddressesInput) (*request.Request, *ec2.DescribeMovingAddressesOutput)
 
 	DescribeMovingAddresses(*ec2.DescribeMovingAddressesInput) (*ec2.DescribeMovingAddressesOutput, error)
 
-	DescribeNetworkAclsRequest(*ec2.DescribeNetworkAclsInput) (*service.Request, *ec2.DescribeNetworkAclsOutput)
+	DescribeNetworkAclsRequest(*ec2.DescribeNetworkAclsInput) (*request.Request, *ec2.DescribeNetworkAclsOutput)
 
 	DescribeNetworkAcls(*ec2.DescribeNetworkAclsInput) (*ec2.DescribeNetworkAclsOutput, error)
 
-	DescribeNetworkInterfaceAttributeRequest(*ec2.DescribeNetworkInterfaceAttributeInput) (*service.Request, *ec2.DescribeNetworkInterfaceAttributeOutput)
+	DescribeNetworkInterfaceAttributeRequest(*ec2.DescribeNetworkInterfaceAttributeInput) (*request.Request, *ec2.DescribeNetworkInterfaceAttributeOutput)
 
 	DescribeNetworkInterfaceAttribute(*ec2.DescribeNetworkInterfaceAttributeInput) (*ec2.DescribeNetworkInterfaceAttributeOutput, error)
 
-	DescribeNetworkInterfacesRequest(*ec2.DescribeNetworkInterfacesInput) (*service.Request, *ec2.DescribeNetworkInterfacesOutput)
+	DescribeNetworkInterfacesRequest(*ec2.DescribeNetworkInterfacesInput) (*request.Request, *ec2.DescribeNetworkInterfacesOutput)
 
 	DescribeNetworkInterfaces(*ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error)
 
-	DescribePlacementGroupsRequest(*ec2.DescribePlacementGroupsInput) (*service.Request, *ec2.DescribePlacementGroupsOutput)
+	DescribePlacementGroupsRequest(*ec2.DescribePlacementGroupsInput) (*request.Request, *ec2.DescribePlacementGroupsOutput)
 
 	DescribePlacementGroups(*ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error)
 
-	DescribePrefixListsRequest(*ec2.DescribePrefixListsInput) (*service.Request, *ec2.DescribePrefixListsOutput)
+	DescribePrefixListsRequest(*ec2.DescribePrefixListsInput) (*request.Request, *ec2.DescribePrefixListsOutput)
 
 	DescribePrefixLists(*ec2.DescribePrefixListsInput) (*ec2.DescribePrefixListsOutput, error)
 
-	DescribeRegionsRequest(*ec2.DescribeRegionsInput) (*service.Request, *ec2.DescribeRegionsOutput)
+	DescribeRegionsRequest(*ec2.DescribeRegionsInput) (*request.Request, *ec2.DescribeRegionsOutput)
 
 	DescribeRegions(*ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error)
 
-	DescribeReservedInstancesRequest(*ec2.DescribeReservedInstancesInput) (*service.Request, *ec2.DescribeReservedInstancesOutput)
+	DescribeReservedInstancesRequest(*ec2.DescribeReservedInstancesInput) (*request.Request, *ec2.DescribeReservedInstancesOutput)
 
 	DescribeReservedInstances(*ec2.DescribeReservedInstancesInput) (*ec2.DescribeReservedInstancesOutput, error)
 
-	DescribeReservedInstancesListingsRequest(*ec2.DescribeReservedInstancesListingsInput) (*service.Request, *ec2.DescribeReservedInstancesListingsOutput)
+	DescribeReservedInstancesListingsRequest(*ec2.DescribeReservedInstancesListingsInput) (*request.Request, *ec2.DescribeReservedInstancesListingsOutput)
 
 	DescribeReservedInstancesListings(*ec2.DescribeReservedInstancesListingsInput) (*ec2.DescribeReservedInstancesListingsOutput, error)
 
-	DescribeReservedInstancesModificationsRequest(*ec2.DescribeReservedInstancesModificationsInput) (*service.Request, *ec2.DescribeReservedInstancesModificationsOutput)
+	DescribeReservedInstancesModificationsRequest(*ec2.DescribeReservedInstancesModificationsInput) (*request.Request, *ec2.DescribeReservedInstancesModificationsOutput)
 
 	DescribeReservedInstancesModifications(*ec2.DescribeReservedInstancesModificationsInput) (*ec2.DescribeReservedInstancesModificationsOutput, error)
 
 	DescribeReservedInstancesModificationsPages(*ec2.DescribeReservedInstancesModificationsInput, func(*ec2.DescribeReservedInstancesModificationsOutput, bool) bool) error
 
-	DescribeReservedInstancesOfferingsRequest(*ec2.DescribeReservedInstancesOfferingsInput) (*service.Request, *ec2.DescribeReservedInstancesOfferingsOutput)
+	DescribeReservedInstancesOfferingsRequest(*ec2.DescribeReservedInstancesOfferingsInput) (*request.Request, *ec2.DescribeReservedInstancesOfferingsOutput)
 
 	DescribeReservedInstancesOfferings(*ec2.DescribeReservedInstancesOfferingsInput) (*ec2.DescribeReservedInstancesOfferingsOutput, error)
 
 	DescribeReservedInstancesOfferingsPages(*ec2.DescribeReservedInstancesOfferingsInput, func(*ec2.DescribeReservedInstancesOfferingsOutput, bool) bool) error
 
-	DescribeRouteTablesRequest(*ec2.DescribeRouteTablesInput) (*service.Request, *ec2.DescribeRouteTablesOutput)
+	DescribeRouteTablesRequest(*ec2.DescribeRouteTablesInput) (*request.Request, *ec2.DescribeRouteTablesOutput)
 
 	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
 
-	DescribeSecurityGroupsRequest(*ec2.DescribeSecurityGroupsInput) (*service.Request, *ec2.DescribeSecurityGroupsOutput)
+	DescribeSecurityGroupsRequest(*ec2.DescribeSecurityGroupsInput) (*request.Request, *ec2.DescribeSecurityGroupsOutput)
 
 	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
 
-	DescribeSnapshotAttributeRequest(*ec2.DescribeSnapshotAttributeInput) (*service.Request, *ec2.DescribeSnapshotAttributeOutput)
+	DescribeSnapshotAttributeRequest(*ec2.DescribeSnapshotAttributeInput) (*request.Request, *ec2.DescribeSnapshotAttributeOutput)
 
 	DescribeSnapshotAttribute(*ec2.DescribeSnapshotAttributeInput) (*ec2.DescribeSnapshotAttributeOutput, error)
 
-	DescribeSnapshotsRequest(*ec2.DescribeSnapshotsInput) (*service.Request, *ec2.DescribeSnapshotsOutput)
+	DescribeSnapshotsRequest(*ec2.DescribeSnapshotsInput) (*request.Request, *ec2.DescribeSnapshotsOutput)
 
 	DescribeSnapshots(*ec2.DescribeSnapshotsInput) (*ec2.DescribeSnapshotsOutput, error)
 
 	DescribeSnapshotsPages(*ec2.DescribeSnapshotsInput, func(*ec2.DescribeSnapshotsOutput, bool) bool) error
 
-	DescribeSpotDatafeedSubscriptionRequest(*ec2.DescribeSpotDatafeedSubscriptionInput) (*service.Request, *ec2.DescribeSpotDatafeedSubscriptionOutput)
+	DescribeSpotDatafeedSubscriptionRequest(*ec2.DescribeSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DescribeSpotDatafeedSubscriptionOutput)
 
 	DescribeSpotDatafeedSubscription(*ec2.DescribeSpotDatafeedSubscriptionInput) (*ec2.DescribeSpotDatafeedSubscriptionOutput, error)
 
-	DescribeSpotFleetInstancesRequest(*ec2.DescribeSpotFleetInstancesInput) (*service.Request, *ec2.DescribeSpotFleetInstancesOutput)
+	DescribeSpotFleetInstancesRequest(*ec2.DescribeSpotFleetInstancesInput) (*request.Request, *ec2.DescribeSpotFleetInstancesOutput)
 
 	DescribeSpotFleetInstances(*ec2.DescribeSpotFleetInstancesInput) (*ec2.DescribeSpotFleetInstancesOutput, error)
 
-	DescribeSpotFleetRequestHistoryRequest(*ec2.DescribeSpotFleetRequestHistoryInput) (*service.Request, *ec2.DescribeSpotFleetRequestHistoryOutput)
+	DescribeSpotFleetRequestHistoryRequest(*ec2.DescribeSpotFleetRequestHistoryInput) (*request.Request, *ec2.DescribeSpotFleetRequestHistoryOutput)
 
 	DescribeSpotFleetRequestHistory(*ec2.DescribeSpotFleetRequestHistoryInput) (*ec2.DescribeSpotFleetRequestHistoryOutput, error)
 
-	DescribeSpotFleetRequestsRequest(*ec2.DescribeSpotFleetRequestsInput) (*service.Request, *ec2.DescribeSpotFleetRequestsOutput)
+	DescribeSpotFleetRequestsRequest(*ec2.DescribeSpotFleetRequestsInput) (*request.Request, *ec2.DescribeSpotFleetRequestsOutput)
 
 	DescribeSpotFleetRequests(*ec2.DescribeSpotFleetRequestsInput) (*ec2.DescribeSpotFleetRequestsOutput, error)
 
-	DescribeSpotInstanceRequestsRequest(*ec2.DescribeSpotInstanceRequestsInput) (*service.Request, *ec2.DescribeSpotInstanceRequestsOutput)
+	DescribeSpotInstanceRequestsRequest(*ec2.DescribeSpotInstanceRequestsInput) (*request.Request, *ec2.DescribeSpotInstanceRequestsOutput)
 
 	DescribeSpotInstanceRequests(*ec2.DescribeSpotInstanceRequestsInput) (*ec2.DescribeSpotInstanceRequestsOutput, error)
 
-	DescribeSpotPriceHistoryRequest(*ec2.DescribeSpotPriceHistoryInput) (*service.Request, *ec2.DescribeSpotPriceHistoryOutput)
+	DescribeSpotPriceHistoryRequest(*ec2.DescribeSpotPriceHistoryInput) (*request.Request, *ec2.DescribeSpotPriceHistoryOutput)
 
 	DescribeSpotPriceHistory(*ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error)
 
 	DescribeSpotPriceHistoryPages(*ec2.DescribeSpotPriceHistoryInput, func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool) error
 
-	DescribeSubnetsRequest(*ec2.DescribeSubnetsInput) (*service.Request, *ec2.DescribeSubnetsOutput)
+	DescribeSubnetsRequest(*ec2.DescribeSubnetsInput) (*request.Request, *ec2.DescribeSubnetsOutput)
 
 	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
 
-	DescribeTagsRequest(*ec2.DescribeTagsInput) (*service.Request, *ec2.DescribeTagsOutput)
+	DescribeTagsRequest(*ec2.DescribeTagsInput) (*request.Request, *ec2.DescribeTagsOutput)
 
 	DescribeTags(*ec2.DescribeTagsInput) (*ec2.DescribeTagsOutput, error)
 
-	DescribeVolumeAttributeRequest(*ec2.DescribeVolumeAttributeInput) (*service.Request, *ec2.DescribeVolumeAttributeOutput)
+	DescribeVolumeAttributeRequest(*ec2.DescribeVolumeAttributeInput) (*request.Request, *ec2.DescribeVolumeAttributeOutput)
 
 	DescribeVolumeAttribute(*ec2.DescribeVolumeAttributeInput) (*ec2.DescribeVolumeAttributeOutput, error)
 
-	DescribeVolumeStatusRequest(*ec2.DescribeVolumeStatusInput) (*service.Request, *ec2.DescribeVolumeStatusOutput)
+	DescribeVolumeStatusRequest(*ec2.DescribeVolumeStatusInput) (*request.Request, *ec2.DescribeVolumeStatusOutput)
 
 	DescribeVolumeStatus(*ec2.DescribeVolumeStatusInput) (*ec2.DescribeVolumeStatusOutput, error)
 
 	DescribeVolumeStatusPages(*ec2.DescribeVolumeStatusInput, func(*ec2.DescribeVolumeStatusOutput, bool) bool) error
 
-	DescribeVolumesRequest(*ec2.DescribeVolumesInput) (*service.Request, *ec2.DescribeVolumesOutput)
+	DescribeVolumesRequest(*ec2.DescribeVolumesInput) (*request.Request, *ec2.DescribeVolumesOutput)
 
 	DescribeVolumes(*ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
 
 	DescribeVolumesPages(*ec2.DescribeVolumesInput, func(*ec2.DescribeVolumesOutput, bool) bool) error
 
-	DescribeVpcAttributeRequest(*ec2.DescribeVpcAttributeInput) (*service.Request, *ec2.DescribeVpcAttributeOutput)
+	DescribeVpcAttributeRequest(*ec2.DescribeVpcAttributeInput) (*request.Request, *ec2.DescribeVpcAttributeOutput)
 
 	DescribeVpcAttribute(*ec2.DescribeVpcAttributeInput) (*ec2.DescribeVpcAttributeOutput, error)
 
-	DescribeVpcClassicLinkRequest(*ec2.DescribeVpcClassicLinkInput) (*service.Request, *ec2.DescribeVpcClassicLinkOutput)
+	DescribeVpcClassicLinkRequest(*ec2.DescribeVpcClassicLinkInput) (*request.Request, *ec2.DescribeVpcClassicLinkOutput)
 
 	DescribeVpcClassicLink(*ec2.DescribeVpcClassicLinkInput) (*ec2.DescribeVpcClassicLinkOutput, error)
 
-	DescribeVpcEndpointServicesRequest(*ec2.DescribeVpcEndpointServicesInput) (*service.Request, *ec2.DescribeVpcEndpointServicesOutput)
+	DescribeVpcEndpointServicesRequest(*ec2.DescribeVpcEndpointServicesInput) (*request.Request, *ec2.DescribeVpcEndpointServicesOutput)
 
 	DescribeVpcEndpointServices(*ec2.DescribeVpcEndpointServicesInput) (*ec2.DescribeVpcEndpointServicesOutput, error)
 
-	DescribeVpcEndpointsRequest(*ec2.DescribeVpcEndpointsInput) (*service.Request, *ec2.DescribeVpcEndpointsOutput)
+	DescribeVpcEndpointsRequest(*ec2.DescribeVpcEndpointsInput) (*request.Request, *ec2.DescribeVpcEndpointsOutput)
 
 	DescribeVpcEndpoints(*ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error)
 
-	DescribeVpcPeeringConnectionsRequest(*ec2.DescribeVpcPeeringConnectionsInput) (*service.Request, *ec2.DescribeVpcPeeringConnectionsOutput)
+	DescribeVpcPeeringConnectionsRequest(*ec2.DescribeVpcPeeringConnectionsInput) (*request.Request, *ec2.DescribeVpcPeeringConnectionsOutput)
 
 	DescribeVpcPeeringConnections(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error)
 
-	DescribeVpcsRequest(*ec2.DescribeVpcsInput) (*service.Request, *ec2.DescribeVpcsOutput)
+	DescribeVpcsRequest(*ec2.DescribeVpcsInput) (*request.Request, *ec2.DescribeVpcsOutput)
 
 	DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 
-	DescribeVpnConnectionsRequest(*ec2.DescribeVpnConnectionsInput) (*service.Request, *ec2.DescribeVpnConnectionsOutput)
+	DescribeVpnConnectionsRequest(*ec2.DescribeVpnConnectionsInput) (*request.Request, *ec2.DescribeVpnConnectionsOutput)
 
 	DescribeVpnConnections(*ec2.DescribeVpnConnectionsInput) (*ec2.DescribeVpnConnectionsOutput, error)
 
-	DescribeVpnGatewaysRequest(*ec2.DescribeVpnGatewaysInput) (*service.Request, *ec2.DescribeVpnGatewaysOutput)
+	DescribeVpnGatewaysRequest(*ec2.DescribeVpnGatewaysInput) (*request.Request, *ec2.DescribeVpnGatewaysOutput)
 
 	DescribeVpnGateways(*ec2.DescribeVpnGatewaysInput) (*ec2.DescribeVpnGatewaysOutput, error)
 
-	DetachClassicLinkVpcRequest(*ec2.DetachClassicLinkVpcInput) (*service.Request, *ec2.DetachClassicLinkVpcOutput)
+	DetachClassicLinkVpcRequest(*ec2.DetachClassicLinkVpcInput) (*request.Request, *ec2.DetachClassicLinkVpcOutput)
 
 	DetachClassicLinkVpc(*ec2.DetachClassicLinkVpcInput) (*ec2.DetachClassicLinkVpcOutput, error)
 
-	DetachInternetGatewayRequest(*ec2.DetachInternetGatewayInput) (*service.Request, *ec2.DetachInternetGatewayOutput)
+	DetachInternetGatewayRequest(*ec2.DetachInternetGatewayInput) (*request.Request, *ec2.DetachInternetGatewayOutput)
 
 	DetachInternetGateway(*ec2.DetachInternetGatewayInput) (*ec2.DetachInternetGatewayOutput, error)
 
-	DetachNetworkInterfaceRequest(*ec2.DetachNetworkInterfaceInput) (*service.Request, *ec2.DetachNetworkInterfaceOutput)
+	DetachNetworkInterfaceRequest(*ec2.DetachNetworkInterfaceInput) (*request.Request, *ec2.DetachNetworkInterfaceOutput)
 
 	DetachNetworkInterface(*ec2.DetachNetworkInterfaceInput) (*ec2.DetachNetworkInterfaceOutput, error)
 
-	DetachVolumeRequest(*ec2.DetachVolumeInput) (*service.Request, *ec2.VolumeAttachment)
+	DetachVolumeRequest(*ec2.DetachVolumeInput) (*request.Request, *ec2.VolumeAttachment)
 
 	DetachVolume(*ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error)
 
-	DetachVpnGatewayRequest(*ec2.DetachVpnGatewayInput) (*service.Request, *ec2.DetachVpnGatewayOutput)
+	DetachVpnGatewayRequest(*ec2.DetachVpnGatewayInput) (*request.Request, *ec2.DetachVpnGatewayOutput)
 
 	DetachVpnGateway(*ec2.DetachVpnGatewayInput) (*ec2.DetachVpnGatewayOutput, error)
 
-	DisableVgwRoutePropagationRequest(*ec2.DisableVgwRoutePropagationInput) (*service.Request, *ec2.DisableVgwRoutePropagationOutput)
+	DisableVgwRoutePropagationRequest(*ec2.DisableVgwRoutePropagationInput) (*request.Request, *ec2.DisableVgwRoutePropagationOutput)
 
 	DisableVgwRoutePropagation(*ec2.DisableVgwRoutePropagationInput) (*ec2.DisableVgwRoutePropagationOutput, error)
 
-	DisableVpcClassicLinkRequest(*ec2.DisableVpcClassicLinkInput) (*service.Request, *ec2.DisableVpcClassicLinkOutput)
+	DisableVpcClassicLinkRequest(*ec2.DisableVpcClassicLinkInput) (*request.Request, *ec2.DisableVpcClassicLinkOutput)
 
 	DisableVpcClassicLink(*ec2.DisableVpcClassicLinkInput) (*ec2.DisableVpcClassicLinkOutput, error)
 
-	DisassociateAddressRequest(*ec2.DisassociateAddressInput) (*service.Request, *ec2.DisassociateAddressOutput)
+	DisassociateAddressRequest(*ec2.DisassociateAddressInput) (*request.Request, *ec2.DisassociateAddressOutput)
 
 	DisassociateAddress(*ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error)
 
-	DisassociateRouteTableRequest(*ec2.DisassociateRouteTableInput) (*service.Request, *ec2.DisassociateRouteTableOutput)
+	DisassociateRouteTableRequest(*ec2.DisassociateRouteTableInput) (*request.Request, *ec2.DisassociateRouteTableOutput)
 
 	DisassociateRouteTable(*ec2.DisassociateRouteTableInput) (*ec2.DisassociateRouteTableOutput, error)
 
-	EnableVgwRoutePropagationRequest(*ec2.EnableVgwRoutePropagationInput) (*service.Request, *ec2.EnableVgwRoutePropagationOutput)
+	EnableVgwRoutePropagationRequest(*ec2.EnableVgwRoutePropagationInput) (*request.Request, *ec2.EnableVgwRoutePropagationOutput)
 
 	EnableVgwRoutePropagation(*ec2.EnableVgwRoutePropagationInput) (*ec2.EnableVgwRoutePropagationOutput, error)
 
-	EnableVolumeIORequest(*ec2.EnableVolumeIOInput) (*service.Request, *ec2.EnableVolumeIOOutput)
+	EnableVolumeIORequest(*ec2.EnableVolumeIOInput) (*request.Request, *ec2.EnableVolumeIOOutput)
 
 	EnableVolumeIO(*ec2.EnableVolumeIOInput) (*ec2.EnableVolumeIOOutput, error)
 
-	EnableVpcClassicLinkRequest(*ec2.EnableVpcClassicLinkInput) (*service.Request, *ec2.EnableVpcClassicLinkOutput)
+	EnableVpcClassicLinkRequest(*ec2.EnableVpcClassicLinkInput) (*request.Request, *ec2.EnableVpcClassicLinkOutput)
 
 	EnableVpcClassicLink(*ec2.EnableVpcClassicLinkInput) (*ec2.EnableVpcClassicLinkOutput, error)
 
-	GetConsoleOutputRequest(*ec2.GetConsoleOutputInput) (*service.Request, *ec2.GetConsoleOutputOutput)
+	GetConsoleOutputRequest(*ec2.GetConsoleOutputInput) (*request.Request, *ec2.GetConsoleOutputOutput)
 
 	GetConsoleOutput(*ec2.GetConsoleOutputInput) (*ec2.GetConsoleOutputOutput, error)
 
-	GetPasswordDataRequest(*ec2.GetPasswordDataInput) (*service.Request, *ec2.GetPasswordDataOutput)
+	GetPasswordDataRequest(*ec2.GetPasswordDataInput) (*request.Request, *ec2.GetPasswordDataOutput)
 
 	GetPasswordData(*ec2.GetPasswordDataInput) (*ec2.GetPasswordDataOutput, error)
 
-	ImportImageRequest(*ec2.ImportImageInput) (*service.Request, *ec2.ImportImageOutput)
+	ImportImageRequest(*ec2.ImportImageInput) (*request.Request, *ec2.ImportImageOutput)
 
 	ImportImage(*ec2.ImportImageInput) (*ec2.ImportImageOutput, error)
 
-	ImportInstanceRequest(*ec2.ImportInstanceInput) (*service.Request, *ec2.ImportInstanceOutput)
+	ImportInstanceRequest(*ec2.ImportInstanceInput) (*request.Request, *ec2.ImportInstanceOutput)
 
 	ImportInstance(*ec2.ImportInstanceInput) (*ec2.ImportInstanceOutput, error)
 
-	ImportKeyPairRequest(*ec2.ImportKeyPairInput) (*service.Request, *ec2.ImportKeyPairOutput)
+	ImportKeyPairRequest(*ec2.ImportKeyPairInput) (*request.Request, *ec2.ImportKeyPairOutput)
 
 	ImportKeyPair(*ec2.ImportKeyPairInput) (*ec2.ImportKeyPairOutput, error)
 
-	ImportSnapshotRequest(*ec2.ImportSnapshotInput) (*service.Request, *ec2.ImportSnapshotOutput)
+	ImportSnapshotRequest(*ec2.ImportSnapshotInput) (*request.Request, *ec2.ImportSnapshotOutput)
 
 	ImportSnapshot(*ec2.ImportSnapshotInput) (*ec2.ImportSnapshotOutput, error)
 
-	ImportVolumeRequest(*ec2.ImportVolumeInput) (*service.Request, *ec2.ImportVolumeOutput)
+	ImportVolumeRequest(*ec2.ImportVolumeInput) (*request.Request, *ec2.ImportVolumeOutput)
 
 	ImportVolume(*ec2.ImportVolumeInput) (*ec2.ImportVolumeOutput, error)
 
-	ModifyImageAttributeRequest(*ec2.ModifyImageAttributeInput) (*service.Request, *ec2.ModifyImageAttributeOutput)
+	ModifyImageAttributeRequest(*ec2.ModifyImageAttributeInput) (*request.Request, *ec2.ModifyImageAttributeOutput)
 
 	ModifyImageAttribute(*ec2.ModifyImageAttributeInput) (*ec2.ModifyImageAttributeOutput, error)
 
-	ModifyInstanceAttributeRequest(*ec2.ModifyInstanceAttributeInput) (*service.Request, *ec2.ModifyInstanceAttributeOutput)
+	ModifyInstanceAttributeRequest(*ec2.ModifyInstanceAttributeInput) (*request.Request, *ec2.ModifyInstanceAttributeOutput)
 
 	ModifyInstanceAttribute(*ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error)
 
-	ModifyNetworkInterfaceAttributeRequest(*ec2.ModifyNetworkInterfaceAttributeInput) (*service.Request, *ec2.ModifyNetworkInterfaceAttributeOutput)
+	ModifyNetworkInterfaceAttributeRequest(*ec2.ModifyNetworkInterfaceAttributeInput) (*request.Request, *ec2.ModifyNetworkInterfaceAttributeOutput)
 
 	ModifyNetworkInterfaceAttribute(*ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error)
 
-	ModifyReservedInstancesRequest(*ec2.ModifyReservedInstancesInput) (*service.Request, *ec2.ModifyReservedInstancesOutput)
+	ModifyReservedInstancesRequest(*ec2.ModifyReservedInstancesInput) (*request.Request, *ec2.ModifyReservedInstancesOutput)
 
 	ModifyReservedInstances(*ec2.ModifyReservedInstancesInput) (*ec2.ModifyReservedInstancesOutput, error)
 
-	ModifySnapshotAttributeRequest(*ec2.ModifySnapshotAttributeInput) (*service.Request, *ec2.ModifySnapshotAttributeOutput)
+	ModifySnapshotAttributeRequest(*ec2.ModifySnapshotAttributeInput) (*request.Request, *ec2.ModifySnapshotAttributeOutput)
 
 	ModifySnapshotAttribute(*ec2.ModifySnapshotAttributeInput) (*ec2.ModifySnapshotAttributeOutput, error)
 
-	ModifySubnetAttributeRequest(*ec2.ModifySubnetAttributeInput) (*service.Request, *ec2.ModifySubnetAttributeOutput)
+	ModifySubnetAttributeRequest(*ec2.ModifySubnetAttributeInput) (*request.Request, *ec2.ModifySubnetAttributeOutput)
 
 	ModifySubnetAttribute(*ec2.ModifySubnetAttributeInput) (*ec2.ModifySubnetAttributeOutput, error)
 
-	ModifyVolumeAttributeRequest(*ec2.ModifyVolumeAttributeInput) (*service.Request, *ec2.ModifyVolumeAttributeOutput)
+	ModifyVolumeAttributeRequest(*ec2.ModifyVolumeAttributeInput) (*request.Request, *ec2.ModifyVolumeAttributeOutput)
 
 	ModifyVolumeAttribute(*ec2.ModifyVolumeAttributeInput) (*ec2.ModifyVolumeAttributeOutput, error)
 
-	ModifyVpcAttributeRequest(*ec2.ModifyVpcAttributeInput) (*service.Request, *ec2.ModifyVpcAttributeOutput)
+	ModifyVpcAttributeRequest(*ec2.ModifyVpcAttributeInput) (*request.Request, *ec2.ModifyVpcAttributeOutput)
 
 	ModifyVpcAttribute(*ec2.ModifyVpcAttributeInput) (*ec2.ModifyVpcAttributeOutput, error)
 
-	ModifyVpcEndpointRequest(*ec2.ModifyVpcEndpointInput) (*service.Request, *ec2.ModifyVpcEndpointOutput)
+	ModifyVpcEndpointRequest(*ec2.ModifyVpcEndpointInput) (*request.Request, *ec2.ModifyVpcEndpointOutput)
 
 	ModifyVpcEndpoint(*ec2.ModifyVpcEndpointInput) (*ec2.ModifyVpcEndpointOutput, error)
 
-	MonitorInstancesRequest(*ec2.MonitorInstancesInput) (*service.Request, *ec2.MonitorInstancesOutput)
+	MonitorInstancesRequest(*ec2.MonitorInstancesInput) (*request.Request, *ec2.MonitorInstancesOutput)
 
 	MonitorInstances(*ec2.MonitorInstancesInput) (*ec2.MonitorInstancesOutput, error)
 
-	MoveAddressToVpcRequest(*ec2.MoveAddressToVpcInput) (*service.Request, *ec2.MoveAddressToVpcOutput)
+	MoveAddressToVpcRequest(*ec2.MoveAddressToVpcInput) (*request.Request, *ec2.MoveAddressToVpcOutput)
 
 	MoveAddressToVpc(*ec2.MoveAddressToVpcInput) (*ec2.MoveAddressToVpcOutput, error)
 
-	PurchaseReservedInstancesOfferingRequest(*ec2.PurchaseReservedInstancesOfferingInput) (*service.Request, *ec2.PurchaseReservedInstancesOfferingOutput)
+	PurchaseReservedInstancesOfferingRequest(*ec2.PurchaseReservedInstancesOfferingInput) (*request.Request, *ec2.PurchaseReservedInstancesOfferingOutput)
 
 	PurchaseReservedInstancesOffering(*ec2.PurchaseReservedInstancesOfferingInput) (*ec2.PurchaseReservedInstancesOfferingOutput, error)
 
-	RebootInstancesRequest(*ec2.RebootInstancesInput) (*service.Request, *ec2.RebootInstancesOutput)
+	RebootInstancesRequest(*ec2.RebootInstancesInput) (*request.Request, *ec2.RebootInstancesOutput)
 
 	RebootInstances(*ec2.RebootInstancesInput) (*ec2.RebootInstancesOutput, error)
 
-	RegisterImageRequest(*ec2.RegisterImageInput) (*service.Request, *ec2.RegisterImageOutput)
+	RegisterImageRequest(*ec2.RegisterImageInput) (*request.Request, *ec2.RegisterImageOutput)
 
 	RegisterImage(*ec2.RegisterImageInput) (*ec2.RegisterImageOutput, error)
 
-	RejectVpcPeeringConnectionRequest(*ec2.RejectVpcPeeringConnectionInput) (*service.Request, *ec2.RejectVpcPeeringConnectionOutput)
+	RejectVpcPeeringConnectionRequest(*ec2.RejectVpcPeeringConnectionInput) (*request.Request, *ec2.RejectVpcPeeringConnectionOutput)
 
 	RejectVpcPeeringConnection(*ec2.RejectVpcPeeringConnectionInput) (*ec2.RejectVpcPeeringConnectionOutput, error)
 
-	ReleaseAddressRequest(*ec2.ReleaseAddressInput) (*service.Request, *ec2.ReleaseAddressOutput)
+	ReleaseAddressRequest(*ec2.ReleaseAddressInput) (*request.Request, *ec2.ReleaseAddressOutput)
 
 	ReleaseAddress(*ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error)
 
-	ReplaceNetworkAclAssociationRequest(*ec2.ReplaceNetworkAclAssociationInput) (*service.Request, *ec2.ReplaceNetworkAclAssociationOutput)
+	ReplaceNetworkAclAssociationRequest(*ec2.ReplaceNetworkAclAssociationInput) (*request.Request, *ec2.ReplaceNetworkAclAssociationOutput)
 
 	ReplaceNetworkAclAssociation(*ec2.ReplaceNetworkAclAssociationInput) (*ec2.ReplaceNetworkAclAssociationOutput, error)
 
-	ReplaceNetworkAclEntryRequest(*ec2.ReplaceNetworkAclEntryInput) (*service.Request, *ec2.ReplaceNetworkAclEntryOutput)
+	ReplaceNetworkAclEntryRequest(*ec2.ReplaceNetworkAclEntryInput) (*request.Request, *ec2.ReplaceNetworkAclEntryOutput)
 
 	ReplaceNetworkAclEntry(*ec2.ReplaceNetworkAclEntryInput) (*ec2.ReplaceNetworkAclEntryOutput, error)
 
-	ReplaceRouteRequest(*ec2.ReplaceRouteInput) (*service.Request, *ec2.ReplaceRouteOutput)
+	ReplaceRouteRequest(*ec2.ReplaceRouteInput) (*request.Request, *ec2.ReplaceRouteOutput)
 
 	ReplaceRoute(*ec2.ReplaceRouteInput) (*ec2.ReplaceRouteOutput, error)
 
-	ReplaceRouteTableAssociationRequest(*ec2.ReplaceRouteTableAssociationInput) (*service.Request, *ec2.ReplaceRouteTableAssociationOutput)
+	ReplaceRouteTableAssociationRequest(*ec2.ReplaceRouteTableAssociationInput) (*request.Request, *ec2.ReplaceRouteTableAssociationOutput)
 
 	ReplaceRouteTableAssociation(*ec2.ReplaceRouteTableAssociationInput) (*ec2.ReplaceRouteTableAssociationOutput, error)
 
-	ReportInstanceStatusRequest(*ec2.ReportInstanceStatusInput) (*service.Request, *ec2.ReportInstanceStatusOutput)
+	ReportInstanceStatusRequest(*ec2.ReportInstanceStatusInput) (*request.Request, *ec2.ReportInstanceStatusOutput)
 
 	ReportInstanceStatus(*ec2.ReportInstanceStatusInput) (*ec2.ReportInstanceStatusOutput, error)
 
-	RequestSpotFleetRequest(*ec2.RequestSpotFleetInput) (*service.Request, *ec2.RequestSpotFleetOutput)
+	RequestSpotFleetRequest(*ec2.RequestSpotFleetInput) (*request.Request, *ec2.RequestSpotFleetOutput)
 
 	RequestSpotFleet(*ec2.RequestSpotFleetInput) (*ec2.RequestSpotFleetOutput, error)
 
-	RequestSpotInstancesRequest(*ec2.RequestSpotInstancesInput) (*service.Request, *ec2.RequestSpotInstancesOutput)
+	RequestSpotInstancesRequest(*ec2.RequestSpotInstancesInput) (*request.Request, *ec2.RequestSpotInstancesOutput)
 
 	RequestSpotInstances(*ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error)
 
-	ResetImageAttributeRequest(*ec2.ResetImageAttributeInput) (*service.Request, *ec2.ResetImageAttributeOutput)
+	ResetImageAttributeRequest(*ec2.ResetImageAttributeInput) (*request.Request, *ec2.ResetImageAttributeOutput)
 
 	ResetImageAttribute(*ec2.ResetImageAttributeInput) (*ec2.ResetImageAttributeOutput, error)
 
-	ResetInstanceAttributeRequest(*ec2.ResetInstanceAttributeInput) (*service.Request, *ec2.ResetInstanceAttributeOutput)
+	ResetInstanceAttributeRequest(*ec2.ResetInstanceAttributeInput) (*request.Request, *ec2.ResetInstanceAttributeOutput)
 
 	ResetInstanceAttribute(*ec2.ResetInstanceAttributeInput) (*ec2.ResetInstanceAttributeOutput, error)
 
-	ResetNetworkInterfaceAttributeRequest(*ec2.ResetNetworkInterfaceAttributeInput) (*service.Request, *ec2.ResetNetworkInterfaceAttributeOutput)
+	ResetNetworkInterfaceAttributeRequest(*ec2.ResetNetworkInterfaceAttributeInput) (*request.Request, *ec2.ResetNetworkInterfaceAttributeOutput)
 
 	ResetNetworkInterfaceAttribute(*ec2.ResetNetworkInterfaceAttributeInput) (*ec2.ResetNetworkInterfaceAttributeOutput, error)
 
-	ResetSnapshotAttributeRequest(*ec2.ResetSnapshotAttributeInput) (*service.Request, *ec2.ResetSnapshotAttributeOutput)
+	ResetSnapshotAttributeRequest(*ec2.ResetSnapshotAttributeInput) (*request.Request, *ec2.ResetSnapshotAttributeOutput)
 
 	ResetSnapshotAttribute(*ec2.ResetSnapshotAttributeInput) (*ec2.ResetSnapshotAttributeOutput, error)
 
-	RestoreAddressToClassicRequest(*ec2.RestoreAddressToClassicInput) (*service.Request, *ec2.RestoreAddressToClassicOutput)
+	RestoreAddressToClassicRequest(*ec2.RestoreAddressToClassicInput) (*request.Request, *ec2.RestoreAddressToClassicOutput)
 
 	RestoreAddressToClassic(*ec2.RestoreAddressToClassicInput) (*ec2.RestoreAddressToClassicOutput, error)
 
-	RevokeSecurityGroupEgressRequest(*ec2.RevokeSecurityGroupEgressInput) (*service.Request, *ec2.RevokeSecurityGroupEgressOutput)
+	RevokeSecurityGroupEgressRequest(*ec2.RevokeSecurityGroupEgressInput) (*request.Request, *ec2.RevokeSecurityGroupEgressOutput)
 
 	RevokeSecurityGroupEgress(*ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error)
 
-	RevokeSecurityGroupIngressRequest(*ec2.RevokeSecurityGroupIngressInput) (*service.Request, *ec2.RevokeSecurityGroupIngressOutput)
+	RevokeSecurityGroupIngressRequest(*ec2.RevokeSecurityGroupIngressInput) (*request.Request, *ec2.RevokeSecurityGroupIngressOutput)
 
 	RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error)
 
-	RunInstancesRequest(*ec2.RunInstancesInput) (*service.Request, *ec2.Reservation)
+	RunInstancesRequest(*ec2.RunInstancesInput) (*request.Request, *ec2.Reservation)
 
 	RunInstances(*ec2.RunInstancesInput) (*ec2.Reservation, error)
 
-	StartInstancesRequest(*ec2.StartInstancesInput) (*service.Request, *ec2.StartInstancesOutput)
+	StartInstancesRequest(*ec2.StartInstancesInput) (*request.Request, *ec2.StartInstancesOutput)
 
 	StartInstances(*ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error)
 
-	StopInstancesRequest(*ec2.StopInstancesInput) (*service.Request, *ec2.StopInstancesOutput)
+	StopInstancesRequest(*ec2.StopInstancesInput) (*request.Request, *ec2.StopInstancesOutput)
 
 	StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error)
 
-	TerminateInstancesRequest(*ec2.TerminateInstancesInput) (*service.Request, *ec2.TerminateInstancesOutput)
+	TerminateInstancesRequest(*ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput)
 
 	TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
 
-	UnassignPrivateIpAddressesRequest(*ec2.UnassignPrivateIpAddressesInput) (*service.Request, *ec2.UnassignPrivateIpAddressesOutput)
+	UnassignPrivateIpAddressesRequest(*ec2.UnassignPrivateIpAddressesInput) (*request.Request, *ec2.UnassignPrivateIpAddressesOutput)
 
 	UnassignPrivateIpAddresses(*ec2.UnassignPrivateIpAddressesInput) (*ec2.UnassignPrivateIpAddressesOutput, error)
 
-	UnmonitorInstancesRequest(*ec2.UnmonitorInstancesInput) (*service.Request, *ec2.UnmonitorInstancesOutput)
+	UnmonitorInstancesRequest(*ec2.UnmonitorInstancesInput) (*request.Request, *ec2.UnmonitorInstancesOutput)
 
 	UnmonitorInstances(*ec2.UnmonitorInstancesInput) (*ec2.UnmonitorInstancesOutput, error)
 }

--- a/service/ec2/service.go
+++ b/service/ec2/service.go
@@ -5,7 +5,9 @@ package ec2
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/ec2query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -22,14 +24,16 @@ type EC2 struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new EC2 client.
 func New(config *aws.Config) *EC2 {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "ec2",
-		APIVersion:  "2015-04-15",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "ec2",
+			APIVersion:  "2015-04-15",
+		},
 	}
 	service.Initialize()
 
@@ -50,8 +54,8 @@ func New(config *aws.Config) *EC2 {
 
 // newRequest creates a new request for a EC2 operation and runs any
 // custom request initialization.
-func (c *EC2) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *EC2) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/ecs/api.go
+++ b/service/ecs/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateCluster = "CreateCluster"
 
 // CreateClusterRequest generates a request for the CreateCluster operation.
-func (c *ECS) CreateClusterRequest(input *CreateClusterInput) (req *service.Request, output *CreateClusterOutput) {
-	op := &service.Operation{
+func (c *ECS) CreateClusterRequest(input *CreateClusterInput) (req *request.Request, output *CreateClusterOutput) {
+	op := &request.Operation{
 		Name:       opCreateCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -42,8 +42,8 @@ func (c *ECS) CreateCluster(input *CreateClusterInput) (*CreateClusterOutput, er
 const opCreateService = "CreateService"
 
 // CreateServiceRequest generates a request for the CreateService operation.
-func (c *ECS) CreateServiceRequest(input *CreateServiceInput) (req *service.Request, output *CreateServiceOutput) {
-	op := &service.Operation{
+func (c *ECS) CreateServiceRequest(input *CreateServiceInput) (req *request.Request, output *CreateServiceOutput) {
+	op := &request.Operation{
 		Name:       opCreateService,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -71,8 +71,8 @@ func (c *ECS) CreateService(input *CreateServiceInput) (*CreateServiceOutput, er
 const opDeleteCluster = "DeleteCluster"
 
 // DeleteClusterRequest generates a request for the DeleteCluster operation.
-func (c *ECS) DeleteClusterRequest(input *DeleteClusterInput) (req *service.Request, output *DeleteClusterOutput) {
-	op := &service.Operation{
+func (c *ECS) DeleteClusterRequest(input *DeleteClusterInput) (req *request.Request, output *DeleteClusterOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -100,8 +100,8 @@ func (c *ECS) DeleteCluster(input *DeleteClusterInput) (*DeleteClusterOutput, er
 const opDeleteService = "DeleteService"
 
 // DeleteServiceRequest generates a request for the DeleteService operation.
-func (c *ECS) DeleteServiceRequest(input *DeleteServiceInput) (req *service.Request, output *DeleteServiceOutput) {
-	op := &service.Operation{
+func (c *ECS) DeleteServiceRequest(input *DeleteServiceInput) (req *request.Request, output *DeleteServiceOutput) {
+	op := &request.Operation{
 		Name:       opDeleteService,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -127,8 +127,8 @@ func (c *ECS) DeleteService(input *DeleteServiceInput) (*DeleteServiceOutput, er
 const opDeregisterContainerInstance = "DeregisterContainerInstance"
 
 // DeregisterContainerInstanceRequest generates a request for the DeregisterContainerInstance operation.
-func (c *ECS) DeregisterContainerInstanceRequest(input *DeregisterContainerInstanceInput) (req *service.Request, output *DeregisterContainerInstanceOutput) {
-	op := &service.Operation{
+func (c *ECS) DeregisterContainerInstanceRequest(input *DeregisterContainerInstanceInput) (req *request.Request, output *DeregisterContainerInstanceOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterContainerInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -167,8 +167,8 @@ func (c *ECS) DeregisterContainerInstance(input *DeregisterContainerInstanceInpu
 const opDeregisterTaskDefinition = "DeregisterTaskDefinition"
 
 // DeregisterTaskDefinitionRequest generates a request for the DeregisterTaskDefinition operation.
-func (c *ECS) DeregisterTaskDefinitionRequest(input *DeregisterTaskDefinitionInput) (req *service.Request, output *DeregisterTaskDefinitionOutput) {
-	op := &service.Operation{
+func (c *ECS) DeregisterTaskDefinitionRequest(input *DeregisterTaskDefinitionInput) (req *request.Request, output *DeregisterTaskDefinitionOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterTaskDefinition,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -203,8 +203,8 @@ func (c *ECS) DeregisterTaskDefinition(input *DeregisterTaskDefinitionInput) (*D
 const opDescribeClusters = "DescribeClusters"
 
 // DescribeClustersRequest generates a request for the DescribeClusters operation.
-func (c *ECS) DescribeClustersRequest(input *DescribeClustersInput) (req *service.Request, output *DescribeClustersOutput) {
-	op := &service.Operation{
+func (c *ECS) DescribeClustersRequest(input *DescribeClustersInput) (req *request.Request, output *DescribeClustersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClusters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -230,8 +230,8 @@ func (c *ECS) DescribeClusters(input *DescribeClustersInput) (*DescribeClustersO
 const opDescribeContainerInstances = "DescribeContainerInstances"
 
 // DescribeContainerInstancesRequest generates a request for the DescribeContainerInstances operation.
-func (c *ECS) DescribeContainerInstancesRequest(input *DescribeContainerInstancesInput) (req *service.Request, output *DescribeContainerInstancesOutput) {
-	op := &service.Operation{
+func (c *ECS) DescribeContainerInstancesRequest(input *DescribeContainerInstancesInput) (req *request.Request, output *DescribeContainerInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeContainerInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -258,8 +258,8 @@ func (c *ECS) DescribeContainerInstances(input *DescribeContainerInstancesInput)
 const opDescribeServices = "DescribeServices"
 
 // DescribeServicesRequest generates a request for the DescribeServices operation.
-func (c *ECS) DescribeServicesRequest(input *DescribeServicesInput) (req *service.Request, output *DescribeServicesOutput) {
-	op := &service.Operation{
+func (c *ECS) DescribeServicesRequest(input *DescribeServicesInput) (req *request.Request, output *DescribeServicesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeServices,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -285,8 +285,8 @@ func (c *ECS) DescribeServices(input *DescribeServicesInput) (*DescribeServicesO
 const opDescribeTaskDefinition = "DescribeTaskDefinition"
 
 // DescribeTaskDefinitionRequest generates a request for the DescribeTaskDefinition operation.
-func (c *ECS) DescribeTaskDefinitionRequest(input *DescribeTaskDefinitionInput) (req *service.Request, output *DescribeTaskDefinitionOutput) {
-	op := &service.Operation{
+func (c *ECS) DescribeTaskDefinitionRequest(input *DescribeTaskDefinitionInput) (req *request.Request, output *DescribeTaskDefinitionOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTaskDefinition,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -317,8 +317,8 @@ func (c *ECS) DescribeTaskDefinition(input *DescribeTaskDefinitionInput) (*Descr
 const opDescribeTasks = "DescribeTasks"
 
 // DescribeTasksRequest generates a request for the DescribeTasks operation.
-func (c *ECS) DescribeTasksRequest(input *DescribeTasksInput) (req *service.Request, output *DescribeTasksOutput) {
-	op := &service.Operation{
+func (c *ECS) DescribeTasksRequest(input *DescribeTasksInput) (req *request.Request, output *DescribeTasksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -344,8 +344,8 @@ func (c *ECS) DescribeTasks(input *DescribeTasksInput) (*DescribeTasksOutput, er
 const opDiscoverPollEndpoint = "DiscoverPollEndpoint"
 
 // DiscoverPollEndpointRequest generates a request for the DiscoverPollEndpoint operation.
-func (c *ECS) DiscoverPollEndpointRequest(input *DiscoverPollEndpointInput) (req *service.Request, output *DiscoverPollEndpointOutput) {
-	op := &service.Operation{
+func (c *ECS) DiscoverPollEndpointRequest(input *DiscoverPollEndpointInput) (req *request.Request, output *DiscoverPollEndpointOutput) {
+	op := &request.Operation{
 		Name:       opDiscoverPollEndpoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -375,12 +375,12 @@ func (c *ECS) DiscoverPollEndpoint(input *DiscoverPollEndpointInput) (*DiscoverP
 const opListClusters = "ListClusters"
 
 // ListClustersRequest generates a request for the ListClusters operation.
-func (c *ECS) ListClustersRequest(input *ListClustersInput) (req *service.Request, output *ListClustersOutput) {
-	op := &service.Operation{
+func (c *ECS) ListClustersRequest(input *ListClustersInput) (req *request.Request, output *ListClustersOutput) {
+	op := &request.Operation{
 		Name:       opListClusters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "maxResults",
@@ -415,12 +415,12 @@ func (c *ECS) ListClustersPages(input *ListClustersInput, fn func(p *ListCluster
 const opListContainerInstances = "ListContainerInstances"
 
 // ListContainerInstancesRequest generates a request for the ListContainerInstances operation.
-func (c *ECS) ListContainerInstancesRequest(input *ListContainerInstancesInput) (req *service.Request, output *ListContainerInstancesOutput) {
-	op := &service.Operation{
+func (c *ECS) ListContainerInstancesRequest(input *ListContainerInstancesInput) (req *request.Request, output *ListContainerInstancesOutput) {
+	op := &request.Operation{
 		Name:       opListContainerInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "maxResults",
@@ -455,12 +455,12 @@ func (c *ECS) ListContainerInstancesPages(input *ListContainerInstancesInput, fn
 const opListServices = "ListServices"
 
 // ListServicesRequest generates a request for the ListServices operation.
-func (c *ECS) ListServicesRequest(input *ListServicesInput) (req *service.Request, output *ListServicesOutput) {
-	op := &service.Operation{
+func (c *ECS) ListServicesRequest(input *ListServicesInput) (req *request.Request, output *ListServicesOutput) {
+	op := &request.Operation{
 		Name:       opListServices,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "maxResults",
@@ -495,12 +495,12 @@ func (c *ECS) ListServicesPages(input *ListServicesInput, fn func(p *ListService
 const opListTaskDefinitionFamilies = "ListTaskDefinitionFamilies"
 
 // ListTaskDefinitionFamiliesRequest generates a request for the ListTaskDefinitionFamilies operation.
-func (c *ECS) ListTaskDefinitionFamiliesRequest(input *ListTaskDefinitionFamiliesInput) (req *service.Request, output *ListTaskDefinitionFamiliesOutput) {
-	op := &service.Operation{
+func (c *ECS) ListTaskDefinitionFamiliesRequest(input *ListTaskDefinitionFamiliesInput) (req *request.Request, output *ListTaskDefinitionFamiliesOutput) {
+	op := &request.Operation{
 		Name:       opListTaskDefinitionFamilies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "maxResults",
@@ -537,12 +537,12 @@ func (c *ECS) ListTaskDefinitionFamiliesPages(input *ListTaskDefinitionFamiliesI
 const opListTaskDefinitions = "ListTaskDefinitions"
 
 // ListTaskDefinitionsRequest generates a request for the ListTaskDefinitions operation.
-func (c *ECS) ListTaskDefinitionsRequest(input *ListTaskDefinitionsInput) (req *service.Request, output *ListTaskDefinitionsOutput) {
-	op := &service.Operation{
+func (c *ECS) ListTaskDefinitionsRequest(input *ListTaskDefinitionsInput) (req *request.Request, output *ListTaskDefinitionsOutput) {
+	op := &request.Operation{
 		Name:       opListTaskDefinitions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "maxResults",
@@ -579,12 +579,12 @@ func (c *ECS) ListTaskDefinitionsPages(input *ListTaskDefinitionsInput, fn func(
 const opListTasks = "ListTasks"
 
 // ListTasksRequest generates a request for the ListTasks operation.
-func (c *ECS) ListTasksRequest(input *ListTasksInput) (req *service.Request, output *ListTasksOutput) {
-	op := &service.Operation{
+func (c *ECS) ListTasksRequest(input *ListTasksInput) (req *request.Request, output *ListTasksOutput) {
+	op := &request.Operation{
 		Name:       opListTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "maxResults",
@@ -621,8 +621,8 @@ func (c *ECS) ListTasksPages(input *ListTasksInput, fn func(p *ListTasksOutput, 
 const opRegisterContainerInstance = "RegisterContainerInstance"
 
 // RegisterContainerInstanceRequest generates a request for the RegisterContainerInstance operation.
-func (c *ECS) RegisterContainerInstanceRequest(input *RegisterContainerInstanceInput) (req *service.Request, output *RegisterContainerInstanceOutput) {
-	op := &service.Operation{
+func (c *ECS) RegisterContainerInstanceRequest(input *RegisterContainerInstanceInput) (req *request.Request, output *RegisterContainerInstanceOutput) {
+	op := &request.Operation{
 		Name:       opRegisterContainerInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -652,8 +652,8 @@ func (c *ECS) RegisterContainerInstance(input *RegisterContainerInstanceInput) (
 const opRegisterTaskDefinition = "RegisterTaskDefinition"
 
 // RegisterTaskDefinitionRequest generates a request for the RegisterTaskDefinition operation.
-func (c *ECS) RegisterTaskDefinitionRequest(input *RegisterTaskDefinitionInput) (req *service.Request, output *RegisterTaskDefinitionOutput) {
-	op := &service.Operation{
+func (c *ECS) RegisterTaskDefinitionRequest(input *RegisterTaskDefinitionInput) (req *request.Request, output *RegisterTaskDefinitionOutput) {
+	op := &request.Operation{
 		Name:       opRegisterTaskDefinition,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -683,8 +683,8 @@ func (c *ECS) RegisterTaskDefinition(input *RegisterTaskDefinitionInput) (*Regis
 const opRunTask = "RunTask"
 
 // RunTaskRequest generates a request for the RunTask operation.
-func (c *ECS) RunTaskRequest(input *RunTaskInput) (req *service.Request, output *RunTaskOutput) {
-	op := &service.Operation{
+func (c *ECS) RunTaskRequest(input *RunTaskInput) (req *request.Request, output *RunTaskOutput) {
+	op := &request.Operation{
 		Name:       opRunTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -714,8 +714,8 @@ func (c *ECS) RunTask(input *RunTaskInput) (*RunTaskOutput, error) {
 const opStartTask = "StartTask"
 
 // StartTaskRequest generates a request for the StartTask operation.
-func (c *ECS) StartTaskRequest(input *StartTaskInput) (req *service.Request, output *StartTaskOutput) {
-	op := &service.Operation{
+func (c *ECS) StartTaskRequest(input *StartTaskInput) (req *request.Request, output *StartTaskOutput) {
+	op := &request.Operation{
 		Name:       opStartTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -745,8 +745,8 @@ func (c *ECS) StartTask(input *StartTaskInput) (*StartTaskOutput, error) {
 const opStopTask = "StopTask"
 
 // StopTaskRequest generates a request for the StopTask operation.
-func (c *ECS) StopTaskRequest(input *StopTaskInput) (req *service.Request, output *StopTaskOutput) {
-	op := &service.Operation{
+func (c *ECS) StopTaskRequest(input *StopTaskInput) (req *request.Request, output *StopTaskOutput) {
+	op := &request.Operation{
 		Name:       opStopTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -772,8 +772,8 @@ func (c *ECS) StopTask(input *StopTaskInput) (*StopTaskOutput, error) {
 const opSubmitContainerStateChange = "SubmitContainerStateChange"
 
 // SubmitContainerStateChangeRequest generates a request for the SubmitContainerStateChange operation.
-func (c *ECS) SubmitContainerStateChangeRequest(input *SubmitContainerStateChangeInput) (req *service.Request, output *SubmitContainerStateChangeOutput) {
-	op := &service.Operation{
+func (c *ECS) SubmitContainerStateChangeRequest(input *SubmitContainerStateChangeInput) (req *request.Request, output *SubmitContainerStateChangeOutput) {
+	op := &request.Operation{
 		Name:       opSubmitContainerStateChange,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -802,8 +802,8 @@ func (c *ECS) SubmitContainerStateChange(input *SubmitContainerStateChangeInput)
 const opSubmitTaskStateChange = "SubmitTaskStateChange"
 
 // SubmitTaskStateChangeRequest generates a request for the SubmitTaskStateChange operation.
-func (c *ECS) SubmitTaskStateChangeRequest(input *SubmitTaskStateChangeInput) (req *service.Request, output *SubmitTaskStateChangeOutput) {
-	op := &service.Operation{
+func (c *ECS) SubmitTaskStateChangeRequest(input *SubmitTaskStateChangeInput) (req *request.Request, output *SubmitTaskStateChangeOutput) {
+	op := &request.Operation{
 		Name:       opSubmitTaskStateChange,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -832,8 +832,8 @@ func (c *ECS) SubmitTaskStateChange(input *SubmitTaskStateChangeInput) (*SubmitT
 const opUpdateContainerAgent = "UpdateContainerAgent"
 
 // UpdateContainerAgentRequest generates a request for the UpdateContainerAgent operation.
-func (c *ECS) UpdateContainerAgentRequest(input *UpdateContainerAgentInput) (req *service.Request, output *UpdateContainerAgentOutput) {
-	op := &service.Operation{
+func (c *ECS) UpdateContainerAgentRequest(input *UpdateContainerAgentInput) (req *request.Request, output *UpdateContainerAgentOutput) {
+	op := &request.Operation{
 		Name:       opUpdateContainerAgent,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -869,8 +869,8 @@ func (c *ECS) UpdateContainerAgent(input *UpdateContainerAgentInput) (*UpdateCon
 const opUpdateService = "UpdateService"
 
 // UpdateServiceRequest generates a request for the UpdateService operation.
-func (c *ECS) UpdateServiceRequest(input *UpdateServiceInput) (req *service.Request, output *UpdateServiceOutput) {
-	op := &service.Operation{
+func (c *ECS) UpdateServiceRequest(input *UpdateServiceInput) (req *request.Request, output *UpdateServiceOutput) {
+	op := &request.Operation{
 		Name:       opUpdateService,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/ecs/ecsiface/interface.go
+++ b/service/ecs/ecsiface/interface.go
@@ -4,129 +4,129 @@
 package ecsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
 // ECSAPI is the interface type for ecs.ECS.
 type ECSAPI interface {
-	CreateClusterRequest(*ecs.CreateClusterInput) (*service.Request, *ecs.CreateClusterOutput)
+	CreateClusterRequest(*ecs.CreateClusterInput) (*request.Request, *ecs.CreateClusterOutput)
 
 	CreateCluster(*ecs.CreateClusterInput) (*ecs.CreateClusterOutput, error)
 
-	CreateServiceRequest(*ecs.CreateServiceInput) (*service.Request, *ecs.CreateServiceOutput)
+	CreateServiceRequest(*ecs.CreateServiceInput) (*request.Request, *ecs.CreateServiceOutput)
 
 	CreateService(*ecs.CreateServiceInput) (*ecs.CreateServiceOutput, error)
 
-	DeleteClusterRequest(*ecs.DeleteClusterInput) (*service.Request, *ecs.DeleteClusterOutput)
+	DeleteClusterRequest(*ecs.DeleteClusterInput) (*request.Request, *ecs.DeleteClusterOutput)
 
 	DeleteCluster(*ecs.DeleteClusterInput) (*ecs.DeleteClusterOutput, error)
 
-	DeleteServiceRequest(*ecs.DeleteServiceInput) (*service.Request, *ecs.DeleteServiceOutput)
+	DeleteServiceRequest(*ecs.DeleteServiceInput) (*request.Request, *ecs.DeleteServiceOutput)
 
 	DeleteService(*ecs.DeleteServiceInput) (*ecs.DeleteServiceOutput, error)
 
-	DeregisterContainerInstanceRequest(*ecs.DeregisterContainerInstanceInput) (*service.Request, *ecs.DeregisterContainerInstanceOutput)
+	DeregisterContainerInstanceRequest(*ecs.DeregisterContainerInstanceInput) (*request.Request, *ecs.DeregisterContainerInstanceOutput)
 
 	DeregisterContainerInstance(*ecs.DeregisterContainerInstanceInput) (*ecs.DeregisterContainerInstanceOutput, error)
 
-	DeregisterTaskDefinitionRequest(*ecs.DeregisterTaskDefinitionInput) (*service.Request, *ecs.DeregisterTaskDefinitionOutput)
+	DeregisterTaskDefinitionRequest(*ecs.DeregisterTaskDefinitionInput) (*request.Request, *ecs.DeregisterTaskDefinitionOutput)
 
 	DeregisterTaskDefinition(*ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error)
 
-	DescribeClustersRequest(*ecs.DescribeClustersInput) (*service.Request, *ecs.DescribeClustersOutput)
+	DescribeClustersRequest(*ecs.DescribeClustersInput) (*request.Request, *ecs.DescribeClustersOutput)
 
 	DescribeClusters(*ecs.DescribeClustersInput) (*ecs.DescribeClustersOutput, error)
 
-	DescribeContainerInstancesRequest(*ecs.DescribeContainerInstancesInput) (*service.Request, *ecs.DescribeContainerInstancesOutput)
+	DescribeContainerInstancesRequest(*ecs.DescribeContainerInstancesInput) (*request.Request, *ecs.DescribeContainerInstancesOutput)
 
 	DescribeContainerInstances(*ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error)
 
-	DescribeServicesRequest(*ecs.DescribeServicesInput) (*service.Request, *ecs.DescribeServicesOutput)
+	DescribeServicesRequest(*ecs.DescribeServicesInput) (*request.Request, *ecs.DescribeServicesOutput)
 
 	DescribeServices(*ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error)
 
-	DescribeTaskDefinitionRequest(*ecs.DescribeTaskDefinitionInput) (*service.Request, *ecs.DescribeTaskDefinitionOutput)
+	DescribeTaskDefinitionRequest(*ecs.DescribeTaskDefinitionInput) (*request.Request, *ecs.DescribeTaskDefinitionOutput)
 
 	DescribeTaskDefinition(*ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error)
 
-	DescribeTasksRequest(*ecs.DescribeTasksInput) (*service.Request, *ecs.DescribeTasksOutput)
+	DescribeTasksRequest(*ecs.DescribeTasksInput) (*request.Request, *ecs.DescribeTasksOutput)
 
 	DescribeTasks(*ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
 
-	DiscoverPollEndpointRequest(*ecs.DiscoverPollEndpointInput) (*service.Request, *ecs.DiscoverPollEndpointOutput)
+	DiscoverPollEndpointRequest(*ecs.DiscoverPollEndpointInput) (*request.Request, *ecs.DiscoverPollEndpointOutput)
 
 	DiscoverPollEndpoint(*ecs.DiscoverPollEndpointInput) (*ecs.DiscoverPollEndpointOutput, error)
 
-	ListClustersRequest(*ecs.ListClustersInput) (*service.Request, *ecs.ListClustersOutput)
+	ListClustersRequest(*ecs.ListClustersInput) (*request.Request, *ecs.ListClustersOutput)
 
 	ListClusters(*ecs.ListClustersInput) (*ecs.ListClustersOutput, error)
 
 	ListClustersPages(*ecs.ListClustersInput, func(*ecs.ListClustersOutput, bool) bool) error
 
-	ListContainerInstancesRequest(*ecs.ListContainerInstancesInput) (*service.Request, *ecs.ListContainerInstancesOutput)
+	ListContainerInstancesRequest(*ecs.ListContainerInstancesInput) (*request.Request, *ecs.ListContainerInstancesOutput)
 
 	ListContainerInstances(*ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error)
 
 	ListContainerInstancesPages(*ecs.ListContainerInstancesInput, func(*ecs.ListContainerInstancesOutput, bool) bool) error
 
-	ListServicesRequest(*ecs.ListServicesInput) (*service.Request, *ecs.ListServicesOutput)
+	ListServicesRequest(*ecs.ListServicesInput) (*request.Request, *ecs.ListServicesOutput)
 
 	ListServices(*ecs.ListServicesInput) (*ecs.ListServicesOutput, error)
 
 	ListServicesPages(*ecs.ListServicesInput, func(*ecs.ListServicesOutput, bool) bool) error
 
-	ListTaskDefinitionFamiliesRequest(*ecs.ListTaskDefinitionFamiliesInput) (*service.Request, *ecs.ListTaskDefinitionFamiliesOutput)
+	ListTaskDefinitionFamiliesRequest(*ecs.ListTaskDefinitionFamiliesInput) (*request.Request, *ecs.ListTaskDefinitionFamiliesOutput)
 
 	ListTaskDefinitionFamilies(*ecs.ListTaskDefinitionFamiliesInput) (*ecs.ListTaskDefinitionFamiliesOutput, error)
 
 	ListTaskDefinitionFamiliesPages(*ecs.ListTaskDefinitionFamiliesInput, func(*ecs.ListTaskDefinitionFamiliesOutput, bool) bool) error
 
-	ListTaskDefinitionsRequest(*ecs.ListTaskDefinitionsInput) (*service.Request, *ecs.ListTaskDefinitionsOutput)
+	ListTaskDefinitionsRequest(*ecs.ListTaskDefinitionsInput) (*request.Request, *ecs.ListTaskDefinitionsOutput)
 
 	ListTaskDefinitions(*ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error)
 
 	ListTaskDefinitionsPages(*ecs.ListTaskDefinitionsInput, func(*ecs.ListTaskDefinitionsOutput, bool) bool) error
 
-	ListTasksRequest(*ecs.ListTasksInput) (*service.Request, *ecs.ListTasksOutput)
+	ListTasksRequest(*ecs.ListTasksInput) (*request.Request, *ecs.ListTasksOutput)
 
 	ListTasks(*ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
 
 	ListTasksPages(*ecs.ListTasksInput, func(*ecs.ListTasksOutput, bool) bool) error
 
-	RegisterContainerInstanceRequest(*ecs.RegisterContainerInstanceInput) (*service.Request, *ecs.RegisterContainerInstanceOutput)
+	RegisterContainerInstanceRequest(*ecs.RegisterContainerInstanceInput) (*request.Request, *ecs.RegisterContainerInstanceOutput)
 
 	RegisterContainerInstance(*ecs.RegisterContainerInstanceInput) (*ecs.RegisterContainerInstanceOutput, error)
 
-	RegisterTaskDefinitionRequest(*ecs.RegisterTaskDefinitionInput) (*service.Request, *ecs.RegisterTaskDefinitionOutput)
+	RegisterTaskDefinitionRequest(*ecs.RegisterTaskDefinitionInput) (*request.Request, *ecs.RegisterTaskDefinitionOutput)
 
 	RegisterTaskDefinition(*ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
 
-	RunTaskRequest(*ecs.RunTaskInput) (*service.Request, *ecs.RunTaskOutput)
+	RunTaskRequest(*ecs.RunTaskInput) (*request.Request, *ecs.RunTaskOutput)
 
 	RunTask(*ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
 
-	StartTaskRequest(*ecs.StartTaskInput) (*service.Request, *ecs.StartTaskOutput)
+	StartTaskRequest(*ecs.StartTaskInput) (*request.Request, *ecs.StartTaskOutput)
 
 	StartTask(*ecs.StartTaskInput) (*ecs.StartTaskOutput, error)
 
-	StopTaskRequest(*ecs.StopTaskInput) (*service.Request, *ecs.StopTaskOutput)
+	StopTaskRequest(*ecs.StopTaskInput) (*request.Request, *ecs.StopTaskOutput)
 
 	StopTask(*ecs.StopTaskInput) (*ecs.StopTaskOutput, error)
 
-	SubmitContainerStateChangeRequest(*ecs.SubmitContainerStateChangeInput) (*service.Request, *ecs.SubmitContainerStateChangeOutput)
+	SubmitContainerStateChangeRequest(*ecs.SubmitContainerStateChangeInput) (*request.Request, *ecs.SubmitContainerStateChangeOutput)
 
 	SubmitContainerStateChange(*ecs.SubmitContainerStateChangeInput) (*ecs.SubmitContainerStateChangeOutput, error)
 
-	SubmitTaskStateChangeRequest(*ecs.SubmitTaskStateChangeInput) (*service.Request, *ecs.SubmitTaskStateChangeOutput)
+	SubmitTaskStateChangeRequest(*ecs.SubmitTaskStateChangeInput) (*request.Request, *ecs.SubmitTaskStateChangeOutput)
 
 	SubmitTaskStateChange(*ecs.SubmitTaskStateChangeInput) (*ecs.SubmitTaskStateChangeOutput, error)
 
-	UpdateContainerAgentRequest(*ecs.UpdateContainerAgentInput) (*service.Request, *ecs.UpdateContainerAgentOutput)
+	UpdateContainerAgentRequest(*ecs.UpdateContainerAgentInput) (*request.Request, *ecs.UpdateContainerAgentOutput)
 
 	UpdateContainerAgent(*ecs.UpdateContainerAgentInput) (*ecs.UpdateContainerAgentOutput, error)
 
-	UpdateServiceRequest(*ecs.UpdateServiceInput) (*service.Request, *ecs.UpdateServiceOutput)
+	UpdateServiceRequest(*ecs.UpdateServiceInput) (*request.Request, *ecs.UpdateServiceOutput)
 
 	UpdateService(*ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error)
 }

--- a/service/ecs/service.go
+++ b/service/ecs/service.go
@@ -5,7 +5,9 @@ package ecs
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -31,16 +33,18 @@ type ECS struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new ECS client.
 func New(config *aws.Config) *ECS {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "ecs",
-		APIVersion:   "2014-11-13",
-		JSONVersion:  "1.1",
-		TargetPrefix: "AmazonEC2ContainerServiceV20141113",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "ecs",
+			APIVersion:   "2014-11-13",
+			JSONVersion:  "1.1",
+			TargetPrefix: "AmazonEC2ContainerServiceV20141113",
+		},
 	}
 	service.Initialize()
 
@@ -61,8 +65,8 @@ func New(config *aws.Config) *ECS {
 
 // newRequest creates a new request for a ECS operation and runs any
 // custom request initialization.
-func (c *ECS) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *ECS) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/efs/api.go
+++ b/service/efs/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateFileSystem = "CreateFileSystem"
 
 // CreateFileSystemRequest generates a request for the CreateFileSystem operation.
-func (c *EFS) CreateFileSystemRequest(input *CreateFileSystemInput) (req *service.Request, output *FileSystemDescription) {
-	op := &service.Operation{
+func (c *EFS) CreateFileSystemRequest(input *CreateFileSystemInput) (req *request.Request, output *FileSystemDescription) {
+	op := &request.Operation{
 		Name:       opCreateFileSystem,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-02-01/file-systems",
@@ -70,8 +70,8 @@ func (c *EFS) CreateFileSystem(input *CreateFileSystemInput) (*FileSystemDescrip
 const opCreateMountTarget = "CreateMountTarget"
 
 // CreateMountTargetRequest generates a request for the CreateMountTarget operation.
-func (c *EFS) CreateMountTargetRequest(input *CreateMountTargetInput) (req *service.Request, output *MountTargetDescription) {
-	op := &service.Operation{
+func (c *EFS) CreateMountTargetRequest(input *CreateMountTargetInput) (req *request.Request, output *MountTargetDescription) {
+	op := &request.Operation{
 		Name:       opCreateMountTarget,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-02-01/mount-targets",
@@ -172,8 +172,8 @@ func (c *EFS) CreateMountTarget(input *CreateMountTargetInput) (*MountTargetDesc
 const opCreateTags = "CreateTags"
 
 // CreateTagsRequest generates a request for the CreateTags operation.
-func (c *EFS) CreateTagsRequest(input *CreateTagsInput) (req *service.Request, output *CreateTagsOutput) {
-	op := &service.Operation{
+func (c *EFS) CreateTagsRequest(input *CreateTagsInput) (req *request.Request, output *CreateTagsOutput) {
+	op := &request.Operation{
 		Name:       opCreateTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-02-01/create-tags/{FileSystemId}",
@@ -206,8 +206,8 @@ func (c *EFS) CreateTags(input *CreateTagsInput) (*CreateTagsOutput, error) {
 const opDeleteFileSystem = "DeleteFileSystem"
 
 // DeleteFileSystemRequest generates a request for the DeleteFileSystem operation.
-func (c *EFS) DeleteFileSystemRequest(input *DeleteFileSystemInput) (req *service.Request, output *DeleteFileSystemOutput) {
-	op := &service.Operation{
+func (c *EFS) DeleteFileSystemRequest(input *DeleteFileSystemInput) (req *request.Request, output *DeleteFileSystemOutput) {
+	op := &request.Operation{
 		Name:       opDeleteFileSystem,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-02-01/file-systems/{FileSystemId}",
@@ -246,8 +246,8 @@ func (c *EFS) DeleteFileSystem(input *DeleteFileSystemInput) (*DeleteFileSystemO
 const opDeleteMountTarget = "DeleteMountTarget"
 
 // DeleteMountTargetRequest generates a request for the DeleteMountTarget operation.
-func (c *EFS) DeleteMountTargetRequest(input *DeleteMountTargetInput) (req *service.Request, output *DeleteMountTargetOutput) {
-	op := &service.Operation{
+func (c *EFS) DeleteMountTargetRequest(input *DeleteMountTargetInput) (req *request.Request, output *DeleteMountTargetOutput) {
+	op := &request.Operation{
 		Name:       opDeleteMountTarget,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-02-01/mount-targets/{MountTargetId}",
@@ -294,8 +294,8 @@ func (c *EFS) DeleteMountTarget(input *DeleteMountTargetInput) (*DeleteMountTarg
 const opDeleteTags = "DeleteTags"
 
 // DeleteTagsRequest generates a request for the DeleteTags operation.
-func (c *EFS) DeleteTagsRequest(input *DeleteTagsInput) (req *service.Request, output *DeleteTagsOutput) {
-	op := &service.Operation{
+func (c *EFS) DeleteTagsRequest(input *DeleteTagsInput) (req *request.Request, output *DeleteTagsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-02-01/delete-tags/{FileSystemId}",
@@ -328,8 +328,8 @@ func (c *EFS) DeleteTags(input *DeleteTagsInput) (*DeleteTagsOutput, error) {
 const opDescribeFileSystems = "DescribeFileSystems"
 
 // DescribeFileSystemsRequest generates a request for the DescribeFileSystems operation.
-func (c *EFS) DescribeFileSystemsRequest(input *DescribeFileSystemsInput) (req *service.Request, output *DescribeFileSystemsOutput) {
-	op := &service.Operation{
+func (c *EFS) DescribeFileSystemsRequest(input *DescribeFileSystemsInput) (req *request.Request, output *DescribeFileSystemsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeFileSystems,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-02-01/file-systems",
@@ -380,8 +380,8 @@ func (c *EFS) DescribeFileSystems(input *DescribeFileSystemsInput) (*DescribeFil
 const opDescribeMountTargetSecurityGroups = "DescribeMountTargetSecurityGroups"
 
 // DescribeMountTargetSecurityGroupsRequest generates a request for the DescribeMountTargetSecurityGroups operation.
-func (c *EFS) DescribeMountTargetSecurityGroupsRequest(input *DescribeMountTargetSecurityGroupsInput) (req *service.Request, output *DescribeMountTargetSecurityGroupsOutput) {
-	op := &service.Operation{
+func (c *EFS) DescribeMountTargetSecurityGroupsRequest(input *DescribeMountTargetSecurityGroupsInput) (req *request.Request, output *DescribeMountTargetSecurityGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeMountTargetSecurityGroups,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-02-01/mount-targets/{MountTargetId}/security-groups",
@@ -415,8 +415,8 @@ func (c *EFS) DescribeMountTargetSecurityGroups(input *DescribeMountTargetSecuri
 const opDescribeMountTargets = "DescribeMountTargets"
 
 // DescribeMountTargetsRequest generates a request for the DescribeMountTargets operation.
-func (c *EFS) DescribeMountTargetsRequest(input *DescribeMountTargetsInput) (req *service.Request, output *DescribeMountTargetsOutput) {
-	op := &service.Operation{
+func (c *EFS) DescribeMountTargetsRequest(input *DescribeMountTargetsInput) (req *request.Request, output *DescribeMountTargetsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeMountTargets,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-02-01/mount-targets",
@@ -446,8 +446,8 @@ func (c *EFS) DescribeMountTargets(input *DescribeMountTargetsInput) (*DescribeM
 const opDescribeTags = "DescribeTags"
 
 // DescribeTagsRequest generates a request for the DescribeTags operation.
-func (c *EFS) DescribeTagsRequest(input *DescribeTagsInput) (req *service.Request, output *DescribeTagsOutput) {
-	op := &service.Operation{
+func (c *EFS) DescribeTagsRequest(input *DescribeTagsInput) (req *request.Request, output *DescribeTagsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTags,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-02-01/tags/{FileSystemId}/",
@@ -479,8 +479,8 @@ func (c *EFS) DescribeTags(input *DescribeTagsInput) (*DescribeTagsOutput, error
 const opModifyMountTargetSecurityGroups = "ModifyMountTargetSecurityGroups"
 
 // ModifyMountTargetSecurityGroupsRequest generates a request for the ModifyMountTargetSecurityGroups operation.
-func (c *EFS) ModifyMountTargetSecurityGroupsRequest(input *ModifyMountTargetSecurityGroupsInput) (req *service.Request, output *ModifyMountTargetSecurityGroupsOutput) {
-	op := &service.Operation{
+func (c *EFS) ModifyMountTargetSecurityGroupsRequest(input *ModifyMountTargetSecurityGroupsInput) (req *request.Request, output *ModifyMountTargetSecurityGroupsOutput) {
+	op := &request.Operation{
 		Name:       opModifyMountTargetSecurityGroups,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2015-02-01/mount-targets/{MountTargetId}/security-groups",

--- a/service/efs/efsiface/interface.go
+++ b/service/efs/efsiface/interface.go
@@ -4,53 +4,53 @@
 package efsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/efs"
 )
 
 // EFSAPI is the interface type for efs.EFS.
 type EFSAPI interface {
-	CreateFileSystemRequest(*efs.CreateFileSystemInput) (*service.Request, *efs.FileSystemDescription)
+	CreateFileSystemRequest(*efs.CreateFileSystemInput) (*request.Request, *efs.FileSystemDescription)
 
 	CreateFileSystem(*efs.CreateFileSystemInput) (*efs.FileSystemDescription, error)
 
-	CreateMountTargetRequest(*efs.CreateMountTargetInput) (*service.Request, *efs.MountTargetDescription)
+	CreateMountTargetRequest(*efs.CreateMountTargetInput) (*request.Request, *efs.MountTargetDescription)
 
 	CreateMountTarget(*efs.CreateMountTargetInput) (*efs.MountTargetDescription, error)
 
-	CreateTagsRequest(*efs.CreateTagsInput) (*service.Request, *efs.CreateTagsOutput)
+	CreateTagsRequest(*efs.CreateTagsInput) (*request.Request, *efs.CreateTagsOutput)
 
 	CreateTags(*efs.CreateTagsInput) (*efs.CreateTagsOutput, error)
 
-	DeleteFileSystemRequest(*efs.DeleteFileSystemInput) (*service.Request, *efs.DeleteFileSystemOutput)
+	DeleteFileSystemRequest(*efs.DeleteFileSystemInput) (*request.Request, *efs.DeleteFileSystemOutput)
 
 	DeleteFileSystem(*efs.DeleteFileSystemInput) (*efs.DeleteFileSystemOutput, error)
 
-	DeleteMountTargetRequest(*efs.DeleteMountTargetInput) (*service.Request, *efs.DeleteMountTargetOutput)
+	DeleteMountTargetRequest(*efs.DeleteMountTargetInput) (*request.Request, *efs.DeleteMountTargetOutput)
 
 	DeleteMountTarget(*efs.DeleteMountTargetInput) (*efs.DeleteMountTargetOutput, error)
 
-	DeleteTagsRequest(*efs.DeleteTagsInput) (*service.Request, *efs.DeleteTagsOutput)
+	DeleteTagsRequest(*efs.DeleteTagsInput) (*request.Request, *efs.DeleteTagsOutput)
 
 	DeleteTags(*efs.DeleteTagsInput) (*efs.DeleteTagsOutput, error)
 
-	DescribeFileSystemsRequest(*efs.DescribeFileSystemsInput) (*service.Request, *efs.DescribeFileSystemsOutput)
+	DescribeFileSystemsRequest(*efs.DescribeFileSystemsInput) (*request.Request, *efs.DescribeFileSystemsOutput)
 
 	DescribeFileSystems(*efs.DescribeFileSystemsInput) (*efs.DescribeFileSystemsOutput, error)
 
-	DescribeMountTargetSecurityGroupsRequest(*efs.DescribeMountTargetSecurityGroupsInput) (*service.Request, *efs.DescribeMountTargetSecurityGroupsOutput)
+	DescribeMountTargetSecurityGroupsRequest(*efs.DescribeMountTargetSecurityGroupsInput) (*request.Request, *efs.DescribeMountTargetSecurityGroupsOutput)
 
 	DescribeMountTargetSecurityGroups(*efs.DescribeMountTargetSecurityGroupsInput) (*efs.DescribeMountTargetSecurityGroupsOutput, error)
 
-	DescribeMountTargetsRequest(*efs.DescribeMountTargetsInput) (*service.Request, *efs.DescribeMountTargetsOutput)
+	DescribeMountTargetsRequest(*efs.DescribeMountTargetsInput) (*request.Request, *efs.DescribeMountTargetsOutput)
 
 	DescribeMountTargets(*efs.DescribeMountTargetsInput) (*efs.DescribeMountTargetsOutput, error)
 
-	DescribeTagsRequest(*efs.DescribeTagsInput) (*service.Request, *efs.DescribeTagsOutput)
+	DescribeTagsRequest(*efs.DescribeTagsInput) (*request.Request, *efs.DescribeTagsOutput)
 
 	DescribeTags(*efs.DescribeTagsInput) (*efs.DescribeTagsOutput, error)
 
-	ModifyMountTargetSecurityGroupsRequest(*efs.ModifyMountTargetSecurityGroupsInput) (*service.Request, *efs.ModifyMountTargetSecurityGroupsOutput)
+	ModifyMountTargetSecurityGroupsRequest(*efs.ModifyMountTargetSecurityGroupsInput) (*request.Request, *efs.ModifyMountTargetSecurityGroupsOutput)
 
 	ModifyMountTargetSecurityGroups(*efs.ModifyMountTargetSecurityGroupsInput) (*efs.ModifyMountTargetSecurityGroupsOutput, error)
 }

--- a/service/efs/service.go
+++ b/service/efs/service.go
@@ -5,7 +5,9 @@ package efs
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -18,14 +20,16 @@ type EFS struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new EFS client.
 func New(config *aws.Config) *EFS {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "elasticfilesystem",
-		APIVersion:  "2015-02-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "elasticfilesystem",
+			APIVersion:  "2015-02-01",
+		},
 	}
 	service.Initialize()
 
@@ -46,8 +50,8 @@ func New(config *aws.Config) *EFS {
 
 // newRequest creates a new request for a EFS operation and runs any
 // custom request initialization.
-func (c *EFS) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *EFS) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/elasticache/api.go
+++ b/service/elasticache/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddTagsToResource = "AddTagsToResource"
 
 // AddTagsToResourceRequest generates a request for the AddTagsToResource operation.
-func (c *ElastiCache) AddTagsToResourceRequest(input *AddTagsToResourceInput) (req *service.Request, output *TagListMessage) {
-	op := &service.Operation{
+func (c *ElastiCache) AddTagsToResourceRequest(input *AddTagsToResourceInput) (req *request.Request, output *TagListMessage) {
+	op := &request.Operation{
 		Name:       opAddTagsToResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -50,8 +50,8 @@ func (c *ElastiCache) AddTagsToResource(input *AddTagsToResourceInput) (*TagList
 const opAuthorizeCacheSecurityGroupIngress = "AuthorizeCacheSecurityGroupIngress"
 
 // AuthorizeCacheSecurityGroupIngressRequest generates a request for the AuthorizeCacheSecurityGroupIngress operation.
-func (c *ElastiCache) AuthorizeCacheSecurityGroupIngressRequest(input *AuthorizeCacheSecurityGroupIngressInput) (req *service.Request, output *AuthorizeCacheSecurityGroupIngressOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) AuthorizeCacheSecurityGroupIngressRequest(input *AuthorizeCacheSecurityGroupIngressInput) (req *request.Request, output *AuthorizeCacheSecurityGroupIngressOutput) {
+	op := &request.Operation{
 		Name:       opAuthorizeCacheSecurityGroupIngress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -82,8 +82,8 @@ func (c *ElastiCache) AuthorizeCacheSecurityGroupIngress(input *AuthorizeCacheSe
 const opCopySnapshot = "CopySnapshot"
 
 // CopySnapshotRequest generates a request for the CopySnapshot operation.
-func (c *ElastiCache) CopySnapshotRequest(input *CopySnapshotInput) (req *service.Request, output *CopySnapshotOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) CopySnapshotRequest(input *CopySnapshotInput) (req *request.Request, output *CopySnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCopySnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -109,8 +109,8 @@ func (c *ElastiCache) CopySnapshot(input *CopySnapshotInput) (*CopySnapshotOutpu
 const opCreateCacheCluster = "CreateCacheCluster"
 
 // CreateCacheClusterRequest generates a request for the CreateCacheCluster operation.
-func (c *ElastiCache) CreateCacheClusterRequest(input *CreateCacheClusterInput) (req *service.Request, output *CreateCacheClusterOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) CreateCacheClusterRequest(input *CreateCacheClusterInput) (req *request.Request, output *CreateCacheClusterOutput) {
+	op := &request.Operation{
 		Name:       opCreateCacheCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -138,8 +138,8 @@ func (c *ElastiCache) CreateCacheCluster(input *CreateCacheClusterInput) (*Creat
 const opCreateCacheParameterGroup = "CreateCacheParameterGroup"
 
 // CreateCacheParameterGroupRequest generates a request for the CreateCacheParameterGroup operation.
-func (c *ElastiCache) CreateCacheParameterGroupRequest(input *CreateCacheParameterGroupInput) (req *service.Request, output *CreateCacheParameterGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) CreateCacheParameterGroupRequest(input *CreateCacheParameterGroupInput) (req *request.Request, output *CreateCacheParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateCacheParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -167,8 +167,8 @@ func (c *ElastiCache) CreateCacheParameterGroup(input *CreateCacheParameterGroup
 const opCreateCacheSecurityGroup = "CreateCacheSecurityGroup"
 
 // CreateCacheSecurityGroupRequest generates a request for the CreateCacheSecurityGroup operation.
-func (c *ElastiCache) CreateCacheSecurityGroupRequest(input *CreateCacheSecurityGroupInput) (req *service.Request, output *CreateCacheSecurityGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) CreateCacheSecurityGroupRequest(input *CreateCacheSecurityGroupInput) (req *request.Request, output *CreateCacheSecurityGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateCacheSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -200,8 +200,8 @@ func (c *ElastiCache) CreateCacheSecurityGroup(input *CreateCacheSecurityGroupIn
 const opCreateCacheSubnetGroup = "CreateCacheSubnetGroup"
 
 // CreateCacheSubnetGroupRequest generates a request for the CreateCacheSubnetGroup operation.
-func (c *ElastiCache) CreateCacheSubnetGroupRequest(input *CreateCacheSubnetGroupInput) (req *service.Request, output *CreateCacheSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) CreateCacheSubnetGroupRequest(input *CreateCacheSubnetGroupInput) (req *request.Request, output *CreateCacheSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateCacheSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -230,8 +230,8 @@ func (c *ElastiCache) CreateCacheSubnetGroup(input *CreateCacheSubnetGroupInput)
 const opCreateReplicationGroup = "CreateReplicationGroup"
 
 // CreateReplicationGroupRequest generates a request for the CreateReplicationGroup operation.
-func (c *ElastiCache) CreateReplicationGroupRequest(input *CreateReplicationGroupInput) (req *service.Request, output *CreateReplicationGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) CreateReplicationGroupRequest(input *CreateReplicationGroupInput) (req *request.Request, output *CreateReplicationGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateReplicationGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -267,8 +267,8 @@ func (c *ElastiCache) CreateReplicationGroup(input *CreateReplicationGroupInput)
 const opCreateSnapshot = "CreateSnapshot"
 
 // CreateSnapshotRequest generates a request for the CreateSnapshot operation.
-func (c *ElastiCache) CreateSnapshotRequest(input *CreateSnapshotInput) (req *service.Request, output *CreateSnapshotOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) CreateSnapshotRequest(input *CreateSnapshotInput) (req *request.Request, output *CreateSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCreateSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -295,8 +295,8 @@ func (c *ElastiCache) CreateSnapshot(input *CreateSnapshotInput) (*CreateSnapsho
 const opDeleteCacheCluster = "DeleteCacheCluster"
 
 // DeleteCacheClusterRequest generates a request for the DeleteCacheCluster operation.
-func (c *ElastiCache) DeleteCacheClusterRequest(input *DeleteCacheClusterInput) (req *service.Request, output *DeleteCacheClusterOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DeleteCacheClusterRequest(input *DeleteCacheClusterInput) (req *request.Request, output *DeleteCacheClusterOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCacheCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -329,8 +329,8 @@ func (c *ElastiCache) DeleteCacheCluster(input *DeleteCacheClusterInput) (*Delet
 const opDeleteCacheParameterGroup = "DeleteCacheParameterGroup"
 
 // DeleteCacheParameterGroupRequest generates a request for the DeleteCacheParameterGroup operation.
-func (c *ElastiCache) DeleteCacheParameterGroupRequest(input *DeleteCacheParameterGroupInput) (req *service.Request, output *DeleteCacheParameterGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DeleteCacheParameterGroupRequest(input *DeleteCacheParameterGroupInput) (req *request.Request, output *DeleteCacheParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCacheParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -358,8 +358,8 @@ func (c *ElastiCache) DeleteCacheParameterGroup(input *DeleteCacheParameterGroup
 const opDeleteCacheSecurityGroup = "DeleteCacheSecurityGroup"
 
 // DeleteCacheSecurityGroupRequest generates a request for the DeleteCacheSecurityGroup operation.
-func (c *ElastiCache) DeleteCacheSecurityGroupRequest(input *DeleteCacheSecurityGroupInput) (req *service.Request, output *DeleteCacheSecurityGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DeleteCacheSecurityGroupRequest(input *DeleteCacheSecurityGroupInput) (req *request.Request, output *DeleteCacheSecurityGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCacheSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -388,8 +388,8 @@ func (c *ElastiCache) DeleteCacheSecurityGroup(input *DeleteCacheSecurityGroupIn
 const opDeleteCacheSubnetGroup = "DeleteCacheSubnetGroup"
 
 // DeleteCacheSubnetGroupRequest generates a request for the DeleteCacheSubnetGroup operation.
-func (c *ElastiCache) DeleteCacheSubnetGroupRequest(input *DeleteCacheSubnetGroupInput) (req *service.Request, output *DeleteCacheSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DeleteCacheSubnetGroupRequest(input *DeleteCacheSubnetGroupInput) (req *request.Request, output *DeleteCacheSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCacheSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -418,8 +418,8 @@ func (c *ElastiCache) DeleteCacheSubnetGroup(input *DeleteCacheSubnetGroupInput)
 const opDeleteReplicationGroup = "DeleteReplicationGroup"
 
 // DeleteReplicationGroupRequest generates a request for the DeleteReplicationGroup operation.
-func (c *ElastiCache) DeleteReplicationGroupRequest(input *DeleteReplicationGroupInput) (req *service.Request, output *DeleteReplicationGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DeleteReplicationGroupRequest(input *DeleteReplicationGroupInput) (req *request.Request, output *DeleteReplicationGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteReplicationGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -452,8 +452,8 @@ func (c *ElastiCache) DeleteReplicationGroup(input *DeleteReplicationGroupInput)
 const opDeleteSnapshot = "DeleteSnapshot"
 
 // DeleteSnapshotRequest generates a request for the DeleteSnapshot operation.
-func (c *ElastiCache) DeleteSnapshotRequest(input *DeleteSnapshotInput) (req *service.Request, output *DeleteSnapshotOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DeleteSnapshotRequest(input *DeleteSnapshotInput) (req *request.Request, output *DeleteSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -481,12 +481,12 @@ func (c *ElastiCache) DeleteSnapshot(input *DeleteSnapshotInput) (*DeleteSnapsho
 const opDescribeCacheClusters = "DescribeCacheClusters"
 
 // DescribeCacheClustersRequest generates a request for the DescribeCacheClusters operation.
-func (c *ElastiCache) DescribeCacheClustersRequest(input *DescribeCacheClustersInput) (req *service.Request, output *DescribeCacheClustersOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeCacheClustersRequest(input *DescribeCacheClustersInput) (req *request.Request, output *DescribeCacheClustersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCacheClusters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -542,12 +542,12 @@ func (c *ElastiCache) DescribeCacheClustersPages(input *DescribeCacheClustersInp
 const opDescribeCacheEngineVersions = "DescribeCacheEngineVersions"
 
 // DescribeCacheEngineVersionsRequest generates a request for the DescribeCacheEngineVersions operation.
-func (c *ElastiCache) DescribeCacheEngineVersionsRequest(input *DescribeCacheEngineVersionsInput) (req *service.Request, output *DescribeCacheEngineVersionsOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeCacheEngineVersionsRequest(input *DescribeCacheEngineVersionsInput) (req *request.Request, output *DescribeCacheEngineVersionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCacheEngineVersions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -583,12 +583,12 @@ func (c *ElastiCache) DescribeCacheEngineVersionsPages(input *DescribeCacheEngin
 const opDescribeCacheParameterGroups = "DescribeCacheParameterGroups"
 
 // DescribeCacheParameterGroupsRequest generates a request for the DescribeCacheParameterGroups operation.
-func (c *ElastiCache) DescribeCacheParameterGroupsRequest(input *DescribeCacheParameterGroupsInput) (req *service.Request, output *DescribeCacheParameterGroupsOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeCacheParameterGroupsRequest(input *DescribeCacheParameterGroupsInput) (req *request.Request, output *DescribeCacheParameterGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCacheParameterGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -625,12 +625,12 @@ func (c *ElastiCache) DescribeCacheParameterGroupsPages(input *DescribeCachePara
 const opDescribeCacheParameters = "DescribeCacheParameters"
 
 // DescribeCacheParametersRequest generates a request for the DescribeCacheParameters operation.
-func (c *ElastiCache) DescribeCacheParametersRequest(input *DescribeCacheParametersInput) (req *service.Request, output *DescribeCacheParametersOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeCacheParametersRequest(input *DescribeCacheParametersInput) (req *request.Request, output *DescribeCacheParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCacheParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -666,12 +666,12 @@ func (c *ElastiCache) DescribeCacheParametersPages(input *DescribeCacheParameter
 const opDescribeCacheSecurityGroups = "DescribeCacheSecurityGroups"
 
 // DescribeCacheSecurityGroupsRequest generates a request for the DescribeCacheSecurityGroups operation.
-func (c *ElastiCache) DescribeCacheSecurityGroupsRequest(input *DescribeCacheSecurityGroupsInput) (req *service.Request, output *DescribeCacheSecurityGroupsOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeCacheSecurityGroupsRequest(input *DescribeCacheSecurityGroupsInput) (req *request.Request, output *DescribeCacheSecurityGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCacheSecurityGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -708,12 +708,12 @@ func (c *ElastiCache) DescribeCacheSecurityGroupsPages(input *DescribeCacheSecur
 const opDescribeCacheSubnetGroups = "DescribeCacheSubnetGroups"
 
 // DescribeCacheSubnetGroupsRequest generates a request for the DescribeCacheSubnetGroups operation.
-func (c *ElastiCache) DescribeCacheSubnetGroupsRequest(input *DescribeCacheSubnetGroupsInput) (req *service.Request, output *DescribeCacheSubnetGroupsOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeCacheSubnetGroupsRequest(input *DescribeCacheSubnetGroupsInput) (req *request.Request, output *DescribeCacheSubnetGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCacheSubnetGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -750,12 +750,12 @@ func (c *ElastiCache) DescribeCacheSubnetGroupsPages(input *DescribeCacheSubnetG
 const opDescribeEngineDefaultParameters = "DescribeEngineDefaultParameters"
 
 // DescribeEngineDefaultParametersRequest generates a request for the DescribeEngineDefaultParameters operation.
-func (c *ElastiCache) DescribeEngineDefaultParametersRequest(input *DescribeEngineDefaultParametersInput) (req *service.Request, output *DescribeEngineDefaultParametersOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeEngineDefaultParametersRequest(input *DescribeEngineDefaultParametersInput) (req *request.Request, output *DescribeEngineDefaultParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEngineDefaultParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"EngineDefaults.Marker"},
 			LimitToken:      "MaxRecords",
@@ -791,12 +791,12 @@ func (c *ElastiCache) DescribeEngineDefaultParametersPages(input *DescribeEngine
 const opDescribeEvents = "DescribeEvents"
 
 // DescribeEventsRequest generates a request for the DescribeEvents operation.
-func (c *ElastiCache) DescribeEventsRequest(input *DescribeEventsInput) (req *service.Request, output *DescribeEventsOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeEventsRequest(input *DescribeEventsInput) (req *request.Request, output *DescribeEventsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -837,12 +837,12 @@ func (c *ElastiCache) DescribeEventsPages(input *DescribeEventsInput, fn func(p 
 const opDescribeReplicationGroups = "DescribeReplicationGroups"
 
 // DescribeReplicationGroupsRequest generates a request for the DescribeReplicationGroups operation.
-func (c *ElastiCache) DescribeReplicationGroupsRequest(input *DescribeReplicationGroupsInput) (req *service.Request, output *DescribeReplicationGroupsOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeReplicationGroupsRequest(input *DescribeReplicationGroupsInput) (req *request.Request, output *DescribeReplicationGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReplicationGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -879,12 +879,12 @@ func (c *ElastiCache) DescribeReplicationGroupsPages(input *DescribeReplicationG
 const opDescribeReservedCacheNodes = "DescribeReservedCacheNodes"
 
 // DescribeReservedCacheNodesRequest generates a request for the DescribeReservedCacheNodes operation.
-func (c *ElastiCache) DescribeReservedCacheNodesRequest(input *DescribeReservedCacheNodesInput) (req *service.Request, output *DescribeReservedCacheNodesOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeReservedCacheNodesRequest(input *DescribeReservedCacheNodesInput) (req *request.Request, output *DescribeReservedCacheNodesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedCacheNodes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -920,12 +920,12 @@ func (c *ElastiCache) DescribeReservedCacheNodesPages(input *DescribeReservedCac
 const opDescribeReservedCacheNodesOfferings = "DescribeReservedCacheNodesOfferings"
 
 // DescribeReservedCacheNodesOfferingsRequest generates a request for the DescribeReservedCacheNodesOfferings operation.
-func (c *ElastiCache) DescribeReservedCacheNodesOfferingsRequest(input *DescribeReservedCacheNodesOfferingsInput) (req *service.Request, output *DescribeReservedCacheNodesOfferingsOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeReservedCacheNodesOfferingsRequest(input *DescribeReservedCacheNodesOfferingsInput) (req *request.Request, output *DescribeReservedCacheNodesOfferingsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedCacheNodesOfferings,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -961,12 +961,12 @@ func (c *ElastiCache) DescribeReservedCacheNodesOfferingsPages(input *DescribeRe
 const opDescribeSnapshots = "DescribeSnapshots"
 
 // DescribeSnapshotsRequest generates a request for the DescribeSnapshots operation.
-func (c *ElastiCache) DescribeSnapshotsRequest(input *DescribeSnapshotsInput) (req *service.Request, output *DescribeSnapshotsOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) DescribeSnapshotsRequest(input *DescribeSnapshotsInput) (req *request.Request, output *DescribeSnapshotsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSnapshots,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1004,8 +1004,8 @@ func (c *ElastiCache) DescribeSnapshotsPages(input *DescribeSnapshotsInput, fn f
 const opListTagsForResource = "ListTagsForResource"
 
 // ListTagsForResourceRequest generates a request for the ListTagsForResource operation.
-func (c *ElastiCache) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *service.Request, output *TagListMessage) {
-	op := &service.Operation{
+func (c *ElastiCache) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *TagListMessage) {
+	op := &request.Operation{
 		Name:       opListTagsForResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1038,8 +1038,8 @@ func (c *ElastiCache) ListTagsForResource(input *ListTagsForResourceInput) (*Tag
 const opModifyCacheCluster = "ModifyCacheCluster"
 
 // ModifyCacheClusterRequest generates a request for the ModifyCacheCluster operation.
-func (c *ElastiCache) ModifyCacheClusterRequest(input *ModifyCacheClusterInput) (req *service.Request, output *ModifyCacheClusterOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) ModifyCacheClusterRequest(input *ModifyCacheClusterInput) (req *request.Request, output *ModifyCacheClusterOutput) {
+	op := &request.Operation{
 		Name:       opModifyCacheCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1067,8 +1067,8 @@ func (c *ElastiCache) ModifyCacheCluster(input *ModifyCacheClusterInput) (*Modif
 const opModifyCacheParameterGroup = "ModifyCacheParameterGroup"
 
 // ModifyCacheParameterGroupRequest generates a request for the ModifyCacheParameterGroup operation.
-func (c *ElastiCache) ModifyCacheParameterGroupRequest(input *ModifyCacheParameterGroupInput) (req *service.Request, output *CacheParameterGroupNameMessage) {
-	op := &service.Operation{
+func (c *ElastiCache) ModifyCacheParameterGroupRequest(input *ModifyCacheParameterGroupInput) (req *request.Request, output *CacheParameterGroupNameMessage) {
+	op := &request.Operation{
 		Name:       opModifyCacheParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1096,8 +1096,8 @@ func (c *ElastiCache) ModifyCacheParameterGroup(input *ModifyCacheParameterGroup
 const opModifyCacheSubnetGroup = "ModifyCacheSubnetGroup"
 
 // ModifyCacheSubnetGroupRequest generates a request for the ModifyCacheSubnetGroup operation.
-func (c *ElastiCache) ModifyCacheSubnetGroupRequest(input *ModifyCacheSubnetGroupInput) (req *service.Request, output *ModifyCacheSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) ModifyCacheSubnetGroupRequest(input *ModifyCacheSubnetGroupInput) (req *request.Request, output *ModifyCacheSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opModifyCacheSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1123,8 +1123,8 @@ func (c *ElastiCache) ModifyCacheSubnetGroup(input *ModifyCacheSubnetGroupInput)
 const opModifyReplicationGroup = "ModifyReplicationGroup"
 
 // ModifyReplicationGroupRequest generates a request for the ModifyReplicationGroup operation.
-func (c *ElastiCache) ModifyReplicationGroupRequest(input *ModifyReplicationGroupInput) (req *service.Request, output *ModifyReplicationGroupOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) ModifyReplicationGroupRequest(input *ModifyReplicationGroupInput) (req *request.Request, output *ModifyReplicationGroupOutput) {
+	op := &request.Operation{
 		Name:       opModifyReplicationGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1151,8 +1151,8 @@ func (c *ElastiCache) ModifyReplicationGroup(input *ModifyReplicationGroupInput)
 const opPurchaseReservedCacheNodesOffering = "PurchaseReservedCacheNodesOffering"
 
 // PurchaseReservedCacheNodesOfferingRequest generates a request for the PurchaseReservedCacheNodesOffering operation.
-func (c *ElastiCache) PurchaseReservedCacheNodesOfferingRequest(input *PurchaseReservedCacheNodesOfferingInput) (req *service.Request, output *PurchaseReservedCacheNodesOfferingOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) PurchaseReservedCacheNodesOfferingRequest(input *PurchaseReservedCacheNodesOfferingInput) (req *request.Request, output *PurchaseReservedCacheNodesOfferingOutput) {
+	op := &request.Operation{
 		Name:       opPurchaseReservedCacheNodesOffering,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1179,8 +1179,8 @@ func (c *ElastiCache) PurchaseReservedCacheNodesOffering(input *PurchaseReserved
 const opRebootCacheCluster = "RebootCacheCluster"
 
 // RebootCacheClusterRequest generates a request for the RebootCacheCluster operation.
-func (c *ElastiCache) RebootCacheClusterRequest(input *RebootCacheClusterInput) (req *service.Request, output *RebootCacheClusterOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) RebootCacheClusterRequest(input *RebootCacheClusterInput) (req *request.Request, output *RebootCacheClusterOutput) {
+	op := &request.Operation{
 		Name:       opRebootCacheCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1215,8 +1215,8 @@ func (c *ElastiCache) RebootCacheCluster(input *RebootCacheClusterInput) (*Reboo
 const opRemoveTagsFromResource = "RemoveTagsFromResource"
 
 // RemoveTagsFromResourceRequest generates a request for the RemoveTagsFromResource operation.
-func (c *ElastiCache) RemoveTagsFromResourceRequest(input *RemoveTagsFromResourceInput) (req *service.Request, output *TagListMessage) {
-	op := &service.Operation{
+func (c *ElastiCache) RemoveTagsFromResourceRequest(input *RemoveTagsFromResourceInput) (req *request.Request, output *TagListMessage) {
+	op := &request.Operation{
 		Name:       opRemoveTagsFromResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1243,8 +1243,8 @@ func (c *ElastiCache) RemoveTagsFromResource(input *RemoveTagsFromResourceInput)
 const opResetCacheParameterGroup = "ResetCacheParameterGroup"
 
 // ResetCacheParameterGroupRequest generates a request for the ResetCacheParameterGroup operation.
-func (c *ElastiCache) ResetCacheParameterGroupRequest(input *ResetCacheParameterGroupInput) (req *service.Request, output *CacheParameterGroupNameMessage) {
-	op := &service.Operation{
+func (c *ElastiCache) ResetCacheParameterGroupRequest(input *ResetCacheParameterGroupInput) (req *request.Request, output *CacheParameterGroupNameMessage) {
+	op := &request.Operation{
 		Name:       opResetCacheParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1273,8 +1273,8 @@ func (c *ElastiCache) ResetCacheParameterGroup(input *ResetCacheParameterGroupIn
 const opRevokeCacheSecurityGroupIngress = "RevokeCacheSecurityGroupIngress"
 
 // RevokeCacheSecurityGroupIngressRequest generates a request for the RevokeCacheSecurityGroupIngress operation.
-func (c *ElastiCache) RevokeCacheSecurityGroupIngressRequest(input *RevokeCacheSecurityGroupIngressInput) (req *service.Request, output *RevokeCacheSecurityGroupIngressOutput) {
-	op := &service.Operation{
+func (c *ElastiCache) RevokeCacheSecurityGroupIngressRequest(input *RevokeCacheSecurityGroupIngressInput) (req *request.Request, output *RevokeCacheSecurityGroupIngressOutput) {
+	op := &request.Operation{
 		Name:       opRevokeCacheSecurityGroupIngress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/elasticache/elasticacheiface/interface.go
+++ b/service/elasticache/elasticacheiface/interface.go
@@ -4,181 +4,181 @@
 package elasticacheiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 )
 
 // ElastiCacheAPI is the interface type for elasticache.ElastiCache.
 type ElastiCacheAPI interface {
-	AddTagsToResourceRequest(*elasticache.AddTagsToResourceInput) (*service.Request, *elasticache.TagListMessage)
+	AddTagsToResourceRequest(*elasticache.AddTagsToResourceInput) (*request.Request, *elasticache.TagListMessage)
 
 	AddTagsToResource(*elasticache.AddTagsToResourceInput) (*elasticache.TagListMessage, error)
 
-	AuthorizeCacheSecurityGroupIngressRequest(*elasticache.AuthorizeCacheSecurityGroupIngressInput) (*service.Request, *elasticache.AuthorizeCacheSecurityGroupIngressOutput)
+	AuthorizeCacheSecurityGroupIngressRequest(*elasticache.AuthorizeCacheSecurityGroupIngressInput) (*request.Request, *elasticache.AuthorizeCacheSecurityGroupIngressOutput)
 
 	AuthorizeCacheSecurityGroupIngress(*elasticache.AuthorizeCacheSecurityGroupIngressInput) (*elasticache.AuthorizeCacheSecurityGroupIngressOutput, error)
 
-	CopySnapshotRequest(*elasticache.CopySnapshotInput) (*service.Request, *elasticache.CopySnapshotOutput)
+	CopySnapshotRequest(*elasticache.CopySnapshotInput) (*request.Request, *elasticache.CopySnapshotOutput)
 
 	CopySnapshot(*elasticache.CopySnapshotInput) (*elasticache.CopySnapshotOutput, error)
 
-	CreateCacheClusterRequest(*elasticache.CreateCacheClusterInput) (*service.Request, *elasticache.CreateCacheClusterOutput)
+	CreateCacheClusterRequest(*elasticache.CreateCacheClusterInput) (*request.Request, *elasticache.CreateCacheClusterOutput)
 
 	CreateCacheCluster(*elasticache.CreateCacheClusterInput) (*elasticache.CreateCacheClusterOutput, error)
 
-	CreateCacheParameterGroupRequest(*elasticache.CreateCacheParameterGroupInput) (*service.Request, *elasticache.CreateCacheParameterGroupOutput)
+	CreateCacheParameterGroupRequest(*elasticache.CreateCacheParameterGroupInput) (*request.Request, *elasticache.CreateCacheParameterGroupOutput)
 
 	CreateCacheParameterGroup(*elasticache.CreateCacheParameterGroupInput) (*elasticache.CreateCacheParameterGroupOutput, error)
 
-	CreateCacheSecurityGroupRequest(*elasticache.CreateCacheSecurityGroupInput) (*service.Request, *elasticache.CreateCacheSecurityGroupOutput)
+	CreateCacheSecurityGroupRequest(*elasticache.CreateCacheSecurityGroupInput) (*request.Request, *elasticache.CreateCacheSecurityGroupOutput)
 
 	CreateCacheSecurityGroup(*elasticache.CreateCacheSecurityGroupInput) (*elasticache.CreateCacheSecurityGroupOutput, error)
 
-	CreateCacheSubnetGroupRequest(*elasticache.CreateCacheSubnetGroupInput) (*service.Request, *elasticache.CreateCacheSubnetGroupOutput)
+	CreateCacheSubnetGroupRequest(*elasticache.CreateCacheSubnetGroupInput) (*request.Request, *elasticache.CreateCacheSubnetGroupOutput)
 
 	CreateCacheSubnetGroup(*elasticache.CreateCacheSubnetGroupInput) (*elasticache.CreateCacheSubnetGroupOutput, error)
 
-	CreateReplicationGroupRequest(*elasticache.CreateReplicationGroupInput) (*service.Request, *elasticache.CreateReplicationGroupOutput)
+	CreateReplicationGroupRequest(*elasticache.CreateReplicationGroupInput) (*request.Request, *elasticache.CreateReplicationGroupOutput)
 
 	CreateReplicationGroup(*elasticache.CreateReplicationGroupInput) (*elasticache.CreateReplicationGroupOutput, error)
 
-	CreateSnapshotRequest(*elasticache.CreateSnapshotInput) (*service.Request, *elasticache.CreateSnapshotOutput)
+	CreateSnapshotRequest(*elasticache.CreateSnapshotInput) (*request.Request, *elasticache.CreateSnapshotOutput)
 
 	CreateSnapshot(*elasticache.CreateSnapshotInput) (*elasticache.CreateSnapshotOutput, error)
 
-	DeleteCacheClusterRequest(*elasticache.DeleteCacheClusterInput) (*service.Request, *elasticache.DeleteCacheClusterOutput)
+	DeleteCacheClusterRequest(*elasticache.DeleteCacheClusterInput) (*request.Request, *elasticache.DeleteCacheClusterOutput)
 
 	DeleteCacheCluster(*elasticache.DeleteCacheClusterInput) (*elasticache.DeleteCacheClusterOutput, error)
 
-	DeleteCacheParameterGroupRequest(*elasticache.DeleteCacheParameterGroupInput) (*service.Request, *elasticache.DeleteCacheParameterGroupOutput)
+	DeleteCacheParameterGroupRequest(*elasticache.DeleteCacheParameterGroupInput) (*request.Request, *elasticache.DeleteCacheParameterGroupOutput)
 
 	DeleteCacheParameterGroup(*elasticache.DeleteCacheParameterGroupInput) (*elasticache.DeleteCacheParameterGroupOutput, error)
 
-	DeleteCacheSecurityGroupRequest(*elasticache.DeleteCacheSecurityGroupInput) (*service.Request, *elasticache.DeleteCacheSecurityGroupOutput)
+	DeleteCacheSecurityGroupRequest(*elasticache.DeleteCacheSecurityGroupInput) (*request.Request, *elasticache.DeleteCacheSecurityGroupOutput)
 
 	DeleteCacheSecurityGroup(*elasticache.DeleteCacheSecurityGroupInput) (*elasticache.DeleteCacheSecurityGroupOutput, error)
 
-	DeleteCacheSubnetGroupRequest(*elasticache.DeleteCacheSubnetGroupInput) (*service.Request, *elasticache.DeleteCacheSubnetGroupOutput)
+	DeleteCacheSubnetGroupRequest(*elasticache.DeleteCacheSubnetGroupInput) (*request.Request, *elasticache.DeleteCacheSubnetGroupOutput)
 
 	DeleteCacheSubnetGroup(*elasticache.DeleteCacheSubnetGroupInput) (*elasticache.DeleteCacheSubnetGroupOutput, error)
 
-	DeleteReplicationGroupRequest(*elasticache.DeleteReplicationGroupInput) (*service.Request, *elasticache.DeleteReplicationGroupOutput)
+	DeleteReplicationGroupRequest(*elasticache.DeleteReplicationGroupInput) (*request.Request, *elasticache.DeleteReplicationGroupOutput)
 
 	DeleteReplicationGroup(*elasticache.DeleteReplicationGroupInput) (*elasticache.DeleteReplicationGroupOutput, error)
 
-	DeleteSnapshotRequest(*elasticache.DeleteSnapshotInput) (*service.Request, *elasticache.DeleteSnapshotOutput)
+	DeleteSnapshotRequest(*elasticache.DeleteSnapshotInput) (*request.Request, *elasticache.DeleteSnapshotOutput)
 
 	DeleteSnapshot(*elasticache.DeleteSnapshotInput) (*elasticache.DeleteSnapshotOutput, error)
 
-	DescribeCacheClustersRequest(*elasticache.DescribeCacheClustersInput) (*service.Request, *elasticache.DescribeCacheClustersOutput)
+	DescribeCacheClustersRequest(*elasticache.DescribeCacheClustersInput) (*request.Request, *elasticache.DescribeCacheClustersOutput)
 
 	DescribeCacheClusters(*elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error)
 
 	DescribeCacheClustersPages(*elasticache.DescribeCacheClustersInput, func(*elasticache.DescribeCacheClustersOutput, bool) bool) error
 
-	DescribeCacheEngineVersionsRequest(*elasticache.DescribeCacheEngineVersionsInput) (*service.Request, *elasticache.DescribeCacheEngineVersionsOutput)
+	DescribeCacheEngineVersionsRequest(*elasticache.DescribeCacheEngineVersionsInput) (*request.Request, *elasticache.DescribeCacheEngineVersionsOutput)
 
 	DescribeCacheEngineVersions(*elasticache.DescribeCacheEngineVersionsInput) (*elasticache.DescribeCacheEngineVersionsOutput, error)
 
 	DescribeCacheEngineVersionsPages(*elasticache.DescribeCacheEngineVersionsInput, func(*elasticache.DescribeCacheEngineVersionsOutput, bool) bool) error
 
-	DescribeCacheParameterGroupsRequest(*elasticache.DescribeCacheParameterGroupsInput) (*service.Request, *elasticache.DescribeCacheParameterGroupsOutput)
+	DescribeCacheParameterGroupsRequest(*elasticache.DescribeCacheParameterGroupsInput) (*request.Request, *elasticache.DescribeCacheParameterGroupsOutput)
 
 	DescribeCacheParameterGroups(*elasticache.DescribeCacheParameterGroupsInput) (*elasticache.DescribeCacheParameterGroupsOutput, error)
 
 	DescribeCacheParameterGroupsPages(*elasticache.DescribeCacheParameterGroupsInput, func(*elasticache.DescribeCacheParameterGroupsOutput, bool) bool) error
 
-	DescribeCacheParametersRequest(*elasticache.DescribeCacheParametersInput) (*service.Request, *elasticache.DescribeCacheParametersOutput)
+	DescribeCacheParametersRequest(*elasticache.DescribeCacheParametersInput) (*request.Request, *elasticache.DescribeCacheParametersOutput)
 
 	DescribeCacheParameters(*elasticache.DescribeCacheParametersInput) (*elasticache.DescribeCacheParametersOutput, error)
 
 	DescribeCacheParametersPages(*elasticache.DescribeCacheParametersInput, func(*elasticache.DescribeCacheParametersOutput, bool) bool) error
 
-	DescribeCacheSecurityGroupsRequest(*elasticache.DescribeCacheSecurityGroupsInput) (*service.Request, *elasticache.DescribeCacheSecurityGroupsOutput)
+	DescribeCacheSecurityGroupsRequest(*elasticache.DescribeCacheSecurityGroupsInput) (*request.Request, *elasticache.DescribeCacheSecurityGroupsOutput)
 
 	DescribeCacheSecurityGroups(*elasticache.DescribeCacheSecurityGroupsInput) (*elasticache.DescribeCacheSecurityGroupsOutput, error)
 
 	DescribeCacheSecurityGroupsPages(*elasticache.DescribeCacheSecurityGroupsInput, func(*elasticache.DescribeCacheSecurityGroupsOutput, bool) bool) error
 
-	DescribeCacheSubnetGroupsRequest(*elasticache.DescribeCacheSubnetGroupsInput) (*service.Request, *elasticache.DescribeCacheSubnetGroupsOutput)
+	DescribeCacheSubnetGroupsRequest(*elasticache.DescribeCacheSubnetGroupsInput) (*request.Request, *elasticache.DescribeCacheSubnetGroupsOutput)
 
 	DescribeCacheSubnetGroups(*elasticache.DescribeCacheSubnetGroupsInput) (*elasticache.DescribeCacheSubnetGroupsOutput, error)
 
 	DescribeCacheSubnetGroupsPages(*elasticache.DescribeCacheSubnetGroupsInput, func(*elasticache.DescribeCacheSubnetGroupsOutput, bool) bool) error
 
-	DescribeEngineDefaultParametersRequest(*elasticache.DescribeEngineDefaultParametersInput) (*service.Request, *elasticache.DescribeEngineDefaultParametersOutput)
+	DescribeEngineDefaultParametersRequest(*elasticache.DescribeEngineDefaultParametersInput) (*request.Request, *elasticache.DescribeEngineDefaultParametersOutput)
 
 	DescribeEngineDefaultParameters(*elasticache.DescribeEngineDefaultParametersInput) (*elasticache.DescribeEngineDefaultParametersOutput, error)
 
 	DescribeEngineDefaultParametersPages(*elasticache.DescribeEngineDefaultParametersInput, func(*elasticache.DescribeEngineDefaultParametersOutput, bool) bool) error
 
-	DescribeEventsRequest(*elasticache.DescribeEventsInput) (*service.Request, *elasticache.DescribeEventsOutput)
+	DescribeEventsRequest(*elasticache.DescribeEventsInput) (*request.Request, *elasticache.DescribeEventsOutput)
 
 	DescribeEvents(*elasticache.DescribeEventsInput) (*elasticache.DescribeEventsOutput, error)
 
 	DescribeEventsPages(*elasticache.DescribeEventsInput, func(*elasticache.DescribeEventsOutput, bool) bool) error
 
-	DescribeReplicationGroupsRequest(*elasticache.DescribeReplicationGroupsInput) (*service.Request, *elasticache.DescribeReplicationGroupsOutput)
+	DescribeReplicationGroupsRequest(*elasticache.DescribeReplicationGroupsInput) (*request.Request, *elasticache.DescribeReplicationGroupsOutput)
 
 	DescribeReplicationGroups(*elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error)
 
 	DescribeReplicationGroupsPages(*elasticache.DescribeReplicationGroupsInput, func(*elasticache.DescribeReplicationGroupsOutput, bool) bool) error
 
-	DescribeReservedCacheNodesRequest(*elasticache.DescribeReservedCacheNodesInput) (*service.Request, *elasticache.DescribeReservedCacheNodesOutput)
+	DescribeReservedCacheNodesRequest(*elasticache.DescribeReservedCacheNodesInput) (*request.Request, *elasticache.DescribeReservedCacheNodesOutput)
 
 	DescribeReservedCacheNodes(*elasticache.DescribeReservedCacheNodesInput) (*elasticache.DescribeReservedCacheNodesOutput, error)
 
 	DescribeReservedCacheNodesPages(*elasticache.DescribeReservedCacheNodesInput, func(*elasticache.DescribeReservedCacheNodesOutput, bool) bool) error
 
-	DescribeReservedCacheNodesOfferingsRequest(*elasticache.DescribeReservedCacheNodesOfferingsInput) (*service.Request, *elasticache.DescribeReservedCacheNodesOfferingsOutput)
+	DescribeReservedCacheNodesOfferingsRequest(*elasticache.DescribeReservedCacheNodesOfferingsInput) (*request.Request, *elasticache.DescribeReservedCacheNodesOfferingsOutput)
 
 	DescribeReservedCacheNodesOfferings(*elasticache.DescribeReservedCacheNodesOfferingsInput) (*elasticache.DescribeReservedCacheNodesOfferingsOutput, error)
 
 	DescribeReservedCacheNodesOfferingsPages(*elasticache.DescribeReservedCacheNodesOfferingsInput, func(*elasticache.DescribeReservedCacheNodesOfferingsOutput, bool) bool) error
 
-	DescribeSnapshotsRequest(*elasticache.DescribeSnapshotsInput) (*service.Request, *elasticache.DescribeSnapshotsOutput)
+	DescribeSnapshotsRequest(*elasticache.DescribeSnapshotsInput) (*request.Request, *elasticache.DescribeSnapshotsOutput)
 
 	DescribeSnapshots(*elasticache.DescribeSnapshotsInput) (*elasticache.DescribeSnapshotsOutput, error)
 
 	DescribeSnapshotsPages(*elasticache.DescribeSnapshotsInput, func(*elasticache.DescribeSnapshotsOutput, bool) bool) error
 
-	ListTagsForResourceRequest(*elasticache.ListTagsForResourceInput) (*service.Request, *elasticache.TagListMessage)
+	ListTagsForResourceRequest(*elasticache.ListTagsForResourceInput) (*request.Request, *elasticache.TagListMessage)
 
 	ListTagsForResource(*elasticache.ListTagsForResourceInput) (*elasticache.TagListMessage, error)
 
-	ModifyCacheClusterRequest(*elasticache.ModifyCacheClusterInput) (*service.Request, *elasticache.ModifyCacheClusterOutput)
+	ModifyCacheClusterRequest(*elasticache.ModifyCacheClusterInput) (*request.Request, *elasticache.ModifyCacheClusterOutput)
 
 	ModifyCacheCluster(*elasticache.ModifyCacheClusterInput) (*elasticache.ModifyCacheClusterOutput, error)
 
-	ModifyCacheParameterGroupRequest(*elasticache.ModifyCacheParameterGroupInput) (*service.Request, *elasticache.CacheParameterGroupNameMessage)
+	ModifyCacheParameterGroupRequest(*elasticache.ModifyCacheParameterGroupInput) (*request.Request, *elasticache.CacheParameterGroupNameMessage)
 
 	ModifyCacheParameterGroup(*elasticache.ModifyCacheParameterGroupInput) (*elasticache.CacheParameterGroupNameMessage, error)
 
-	ModifyCacheSubnetGroupRequest(*elasticache.ModifyCacheSubnetGroupInput) (*service.Request, *elasticache.ModifyCacheSubnetGroupOutput)
+	ModifyCacheSubnetGroupRequest(*elasticache.ModifyCacheSubnetGroupInput) (*request.Request, *elasticache.ModifyCacheSubnetGroupOutput)
 
 	ModifyCacheSubnetGroup(*elasticache.ModifyCacheSubnetGroupInput) (*elasticache.ModifyCacheSubnetGroupOutput, error)
 
-	ModifyReplicationGroupRequest(*elasticache.ModifyReplicationGroupInput) (*service.Request, *elasticache.ModifyReplicationGroupOutput)
+	ModifyReplicationGroupRequest(*elasticache.ModifyReplicationGroupInput) (*request.Request, *elasticache.ModifyReplicationGroupOutput)
 
 	ModifyReplicationGroup(*elasticache.ModifyReplicationGroupInput) (*elasticache.ModifyReplicationGroupOutput, error)
 
-	PurchaseReservedCacheNodesOfferingRequest(*elasticache.PurchaseReservedCacheNodesOfferingInput) (*service.Request, *elasticache.PurchaseReservedCacheNodesOfferingOutput)
+	PurchaseReservedCacheNodesOfferingRequest(*elasticache.PurchaseReservedCacheNodesOfferingInput) (*request.Request, *elasticache.PurchaseReservedCacheNodesOfferingOutput)
 
 	PurchaseReservedCacheNodesOffering(*elasticache.PurchaseReservedCacheNodesOfferingInput) (*elasticache.PurchaseReservedCacheNodesOfferingOutput, error)
 
-	RebootCacheClusterRequest(*elasticache.RebootCacheClusterInput) (*service.Request, *elasticache.RebootCacheClusterOutput)
+	RebootCacheClusterRequest(*elasticache.RebootCacheClusterInput) (*request.Request, *elasticache.RebootCacheClusterOutput)
 
 	RebootCacheCluster(*elasticache.RebootCacheClusterInput) (*elasticache.RebootCacheClusterOutput, error)
 
-	RemoveTagsFromResourceRequest(*elasticache.RemoveTagsFromResourceInput) (*service.Request, *elasticache.TagListMessage)
+	RemoveTagsFromResourceRequest(*elasticache.RemoveTagsFromResourceInput) (*request.Request, *elasticache.TagListMessage)
 
 	RemoveTagsFromResource(*elasticache.RemoveTagsFromResourceInput) (*elasticache.TagListMessage, error)
 
-	ResetCacheParameterGroupRequest(*elasticache.ResetCacheParameterGroupInput) (*service.Request, *elasticache.CacheParameterGroupNameMessage)
+	ResetCacheParameterGroupRequest(*elasticache.ResetCacheParameterGroupInput) (*request.Request, *elasticache.CacheParameterGroupNameMessage)
 
 	ResetCacheParameterGroup(*elasticache.ResetCacheParameterGroupInput) (*elasticache.CacheParameterGroupNameMessage, error)
 
-	RevokeCacheSecurityGroupIngressRequest(*elasticache.RevokeCacheSecurityGroupIngressInput) (*service.Request, *elasticache.RevokeCacheSecurityGroupIngressOutput)
+	RevokeCacheSecurityGroupIngressRequest(*elasticache.RevokeCacheSecurityGroupIngressInput) (*request.Request, *elasticache.RevokeCacheSecurityGroupIngressOutput)
 
 	RevokeCacheSecurityGroupIngress(*elasticache.RevokeCacheSecurityGroupIngressInput) (*elasticache.RevokeCacheSecurityGroupIngressOutput, error)
 }

--- a/service/elasticache/service.go
+++ b/service/elasticache/service.go
@@ -5,7 +5,9 @@ package elasticache
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -29,14 +31,16 @@ type ElastiCache struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new ElastiCache client.
 func New(config *aws.Config) *ElastiCache {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "elasticache",
-		APIVersion:  "2015-02-02",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "elasticache",
+			APIVersion:  "2015-02-02",
+		},
 	}
 	service.Initialize()
 
@@ -57,8 +61,8 @@ func New(config *aws.Config) *ElastiCache {
 
 // newRequest creates a new request for a ElastiCache operation and runs any
 // custom request initialization.
-func (c *ElastiCache) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *ElastiCache) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/elasticbeanstalk/api.go
+++ b/service/elasticbeanstalk/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAbortEnvironmentUpdate = "AbortEnvironmentUpdate"
 
 // AbortEnvironmentUpdateRequest generates a request for the AbortEnvironmentUpdate operation.
-func (c *ElasticBeanstalk) AbortEnvironmentUpdateRequest(input *AbortEnvironmentUpdateInput) (req *service.Request, output *AbortEnvironmentUpdateOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) AbortEnvironmentUpdateRequest(input *AbortEnvironmentUpdateInput) (req *request.Request, output *AbortEnvironmentUpdateOutput) {
+	op := &request.Operation{
 		Name:       opAbortEnvironmentUpdate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -41,8 +41,8 @@ func (c *ElasticBeanstalk) AbortEnvironmentUpdate(input *AbortEnvironmentUpdateI
 const opCheckDNSAvailability = "CheckDNSAvailability"
 
 // CheckDNSAvailabilityRequest generates a request for the CheckDNSAvailability operation.
-func (c *ElasticBeanstalk) CheckDNSAvailabilityRequest(input *CheckDNSAvailabilityInput) (req *service.Request, output *CheckDNSAvailabilityOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) CheckDNSAvailabilityRequest(input *CheckDNSAvailabilityInput) (req *request.Request, output *CheckDNSAvailabilityOutput) {
+	op := &request.Operation{
 		Name:       opCheckDNSAvailability,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -68,8 +68,8 @@ func (c *ElasticBeanstalk) CheckDNSAvailability(input *CheckDNSAvailabilityInput
 const opCreateApplication = "CreateApplication"
 
 // CreateApplicationRequest generates a request for the CreateApplication operation.
-func (c *ElasticBeanstalk) CreateApplicationRequest(input *CreateApplicationInput) (req *service.Request, output *ApplicationDescriptionMessage) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) CreateApplicationRequest(input *CreateApplicationInput) (req *request.Request, output *ApplicationDescriptionMessage) {
+	op := &request.Operation{
 		Name:       opCreateApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -96,8 +96,8 @@ func (c *ElasticBeanstalk) CreateApplication(input *CreateApplicationInput) (*Ap
 const opCreateApplicationVersion = "CreateApplicationVersion"
 
 // CreateApplicationVersionRequest generates a request for the CreateApplicationVersion operation.
-func (c *ElasticBeanstalk) CreateApplicationVersionRequest(input *CreateApplicationVersionInput) (req *service.Request, output *ApplicationVersionDescriptionMessage) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) CreateApplicationVersionRequest(input *CreateApplicationVersionInput) (req *request.Request, output *ApplicationVersionDescriptionMessage) {
+	op := &request.Operation{
 		Name:       opCreateApplicationVersion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -128,8 +128,8 @@ func (c *ElasticBeanstalk) CreateApplicationVersion(input *CreateApplicationVers
 const opCreateConfigurationTemplate = "CreateConfigurationTemplate"
 
 // CreateConfigurationTemplateRequest generates a request for the CreateConfigurationTemplate operation.
-func (c *ElasticBeanstalk) CreateConfigurationTemplateRequest(input *CreateConfigurationTemplateInput) (req *service.Request, output *ConfigurationSettingsDescription) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) CreateConfigurationTemplateRequest(input *CreateConfigurationTemplateInput) (req *request.Request, output *ConfigurationSettingsDescription) {
+	op := &request.Operation{
 		Name:       opCreateConfigurationTemplate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -161,8 +161,8 @@ func (c *ElasticBeanstalk) CreateConfigurationTemplate(input *CreateConfiguratio
 const opCreateEnvironment = "CreateEnvironment"
 
 // CreateEnvironmentRequest generates a request for the CreateEnvironment operation.
-func (c *ElasticBeanstalk) CreateEnvironmentRequest(input *CreateEnvironmentInput) (req *service.Request, output *EnvironmentDescription) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) CreateEnvironmentRequest(input *CreateEnvironmentInput) (req *request.Request, output *EnvironmentDescription) {
+	op := &request.Operation{
 		Name:       opCreateEnvironment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -189,8 +189,8 @@ func (c *ElasticBeanstalk) CreateEnvironment(input *CreateEnvironmentInput) (*En
 const opCreateStorageLocation = "CreateStorageLocation"
 
 // CreateStorageLocationRequest generates a request for the CreateStorageLocation operation.
-func (c *ElasticBeanstalk) CreateStorageLocationRequest(input *CreateStorageLocationInput) (req *service.Request, output *CreateStorageLocationOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) CreateStorageLocationRequest(input *CreateStorageLocationInput) (req *request.Request, output *CreateStorageLocationOutput) {
+	op := &request.Operation{
 		Name:       opCreateStorageLocation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -218,8 +218,8 @@ func (c *ElasticBeanstalk) CreateStorageLocation(input *CreateStorageLocationInp
 const opDeleteApplication = "DeleteApplication"
 
 // DeleteApplicationRequest generates a request for the DeleteApplication operation.
-func (c *ElasticBeanstalk) DeleteApplicationRequest(input *DeleteApplicationInput) (req *service.Request, output *DeleteApplicationOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DeleteApplicationRequest(input *DeleteApplicationInput) (req *request.Request, output *DeleteApplicationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -249,8 +249,8 @@ func (c *ElasticBeanstalk) DeleteApplication(input *DeleteApplicationInput) (*De
 const opDeleteApplicationVersion = "DeleteApplicationVersion"
 
 // DeleteApplicationVersionRequest generates a request for the DeleteApplicationVersion operation.
-func (c *ElasticBeanstalk) DeleteApplicationVersionRequest(input *DeleteApplicationVersionInput) (req *service.Request, output *DeleteApplicationVersionOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DeleteApplicationVersionRequest(input *DeleteApplicationVersionInput) (req *request.Request, output *DeleteApplicationVersionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteApplicationVersion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -279,8 +279,8 @@ func (c *ElasticBeanstalk) DeleteApplicationVersion(input *DeleteApplicationVers
 const opDeleteConfigurationTemplate = "DeleteConfigurationTemplate"
 
 // DeleteConfigurationTemplateRequest generates a request for the DeleteConfigurationTemplate operation.
-func (c *ElasticBeanstalk) DeleteConfigurationTemplateRequest(input *DeleteConfigurationTemplateInput) (req *service.Request, output *DeleteConfigurationTemplateOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DeleteConfigurationTemplateRequest(input *DeleteConfigurationTemplateInput) (req *request.Request, output *DeleteConfigurationTemplateOutput) {
+	op := &request.Operation{
 		Name:       opDeleteConfigurationTemplate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -310,8 +310,8 @@ func (c *ElasticBeanstalk) DeleteConfigurationTemplate(input *DeleteConfiguratio
 const opDeleteEnvironmentConfiguration = "DeleteEnvironmentConfiguration"
 
 // DeleteEnvironmentConfigurationRequest generates a request for the DeleteEnvironmentConfiguration operation.
-func (c *ElasticBeanstalk) DeleteEnvironmentConfigurationRequest(input *DeleteEnvironmentConfigurationInput) (req *service.Request, output *DeleteEnvironmentConfigurationOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DeleteEnvironmentConfigurationRequest(input *DeleteEnvironmentConfigurationInput) (req *request.Request, output *DeleteEnvironmentConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteEnvironmentConfiguration,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -344,8 +344,8 @@ func (c *ElasticBeanstalk) DeleteEnvironmentConfiguration(input *DeleteEnvironme
 const opDescribeApplicationVersions = "DescribeApplicationVersions"
 
 // DescribeApplicationVersionsRequest generates a request for the DescribeApplicationVersions operation.
-func (c *ElasticBeanstalk) DescribeApplicationVersionsRequest(input *DescribeApplicationVersionsInput) (req *service.Request, output *DescribeApplicationVersionsOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeApplicationVersionsRequest(input *DescribeApplicationVersionsInput) (req *request.Request, output *DescribeApplicationVersionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeApplicationVersions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -371,8 +371,8 @@ func (c *ElasticBeanstalk) DescribeApplicationVersions(input *DescribeApplicatio
 const opDescribeApplications = "DescribeApplications"
 
 // DescribeApplicationsRequest generates a request for the DescribeApplications operation.
-func (c *ElasticBeanstalk) DescribeApplicationsRequest(input *DescribeApplicationsInput) (req *service.Request, output *DescribeApplicationsOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeApplicationsRequest(input *DescribeApplicationsInput) (req *request.Request, output *DescribeApplicationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeApplications,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -398,8 +398,8 @@ func (c *ElasticBeanstalk) DescribeApplications(input *DescribeApplicationsInput
 const opDescribeConfigurationOptions = "DescribeConfigurationOptions"
 
 // DescribeConfigurationOptionsRequest generates a request for the DescribeConfigurationOptions operation.
-func (c *ElasticBeanstalk) DescribeConfigurationOptionsRequest(input *DescribeConfigurationOptionsInput) (req *service.Request, output *DescribeConfigurationOptionsOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeConfigurationOptionsRequest(input *DescribeConfigurationOptionsInput) (req *request.Request, output *DescribeConfigurationOptionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeConfigurationOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -429,8 +429,8 @@ func (c *ElasticBeanstalk) DescribeConfigurationOptions(input *DescribeConfigura
 const opDescribeConfigurationSettings = "DescribeConfigurationSettings"
 
 // DescribeConfigurationSettingsRequest generates a request for the DescribeConfigurationSettings operation.
-func (c *ElasticBeanstalk) DescribeConfigurationSettingsRequest(input *DescribeConfigurationSettingsInput) (req *service.Request, output *DescribeConfigurationSettingsOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeConfigurationSettingsRequest(input *DescribeConfigurationSettingsInput) (req *request.Request, output *DescribeConfigurationSettingsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeConfigurationSettings,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -468,8 +468,8 @@ func (c *ElasticBeanstalk) DescribeConfigurationSettings(input *DescribeConfigur
 const opDescribeEnvironmentHealth = "DescribeEnvironmentHealth"
 
 // DescribeEnvironmentHealthRequest generates a request for the DescribeEnvironmentHealth operation.
-func (c *ElasticBeanstalk) DescribeEnvironmentHealthRequest(input *DescribeEnvironmentHealthInput) (req *service.Request, output *DescribeEnvironmentHealthOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeEnvironmentHealthRequest(input *DescribeEnvironmentHealthInput) (req *request.Request, output *DescribeEnvironmentHealthOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEnvironmentHealth,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -497,8 +497,8 @@ func (c *ElasticBeanstalk) DescribeEnvironmentHealth(input *DescribeEnvironmentH
 const opDescribeEnvironmentResources = "DescribeEnvironmentResources"
 
 // DescribeEnvironmentResourcesRequest generates a request for the DescribeEnvironmentResources operation.
-func (c *ElasticBeanstalk) DescribeEnvironmentResourcesRequest(input *DescribeEnvironmentResourcesInput) (req *service.Request, output *DescribeEnvironmentResourcesOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeEnvironmentResourcesRequest(input *DescribeEnvironmentResourcesInput) (req *request.Request, output *DescribeEnvironmentResourcesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEnvironmentResources,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -524,8 +524,8 @@ func (c *ElasticBeanstalk) DescribeEnvironmentResources(input *DescribeEnvironme
 const opDescribeEnvironments = "DescribeEnvironments"
 
 // DescribeEnvironmentsRequest generates a request for the DescribeEnvironments operation.
-func (c *ElasticBeanstalk) DescribeEnvironmentsRequest(input *DescribeEnvironmentsInput) (req *service.Request, output *DescribeEnvironmentsOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeEnvironmentsRequest(input *DescribeEnvironmentsInput) (req *request.Request, output *DescribeEnvironmentsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEnvironments,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -551,12 +551,12 @@ func (c *ElasticBeanstalk) DescribeEnvironments(input *DescribeEnvironmentsInput
 const opDescribeEvents = "DescribeEvents"
 
 // DescribeEventsRequest generates a request for the DescribeEvents operation.
-func (c *ElasticBeanstalk) DescribeEventsRequest(input *DescribeEventsInput) (req *service.Request, output *DescribeEventsOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeEventsRequest(input *DescribeEventsInput) (req *request.Request, output *DescribeEventsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxRecords",
@@ -593,8 +593,8 @@ func (c *ElasticBeanstalk) DescribeEventsPages(input *DescribeEventsInput, fn fu
 const opDescribeInstancesHealth = "DescribeInstancesHealth"
 
 // DescribeInstancesHealthRequest generates a request for the DescribeInstancesHealth operation.
-func (c *ElasticBeanstalk) DescribeInstancesHealthRequest(input *DescribeInstancesHealthInput) (req *service.Request, output *DescribeInstancesHealthOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) DescribeInstancesHealthRequest(input *DescribeInstancesHealthInput) (req *request.Request, output *DescribeInstancesHealthOutput) {
+	op := &request.Operation{
 		Name:       opDescribeInstancesHealth,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -622,8 +622,8 @@ func (c *ElasticBeanstalk) DescribeInstancesHealth(input *DescribeInstancesHealt
 const opListAvailableSolutionStacks = "ListAvailableSolutionStacks"
 
 // ListAvailableSolutionStacksRequest generates a request for the ListAvailableSolutionStacks operation.
-func (c *ElasticBeanstalk) ListAvailableSolutionStacksRequest(input *ListAvailableSolutionStacksInput) (req *service.Request, output *ListAvailableSolutionStacksOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) ListAvailableSolutionStacksRequest(input *ListAvailableSolutionStacksInput) (req *request.Request, output *ListAvailableSolutionStacksOutput) {
+	op := &request.Operation{
 		Name:       opListAvailableSolutionStacks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -649,8 +649,8 @@ func (c *ElasticBeanstalk) ListAvailableSolutionStacks(input *ListAvailableSolut
 const opRebuildEnvironment = "RebuildEnvironment"
 
 // RebuildEnvironmentRequest generates a request for the RebuildEnvironment operation.
-func (c *ElasticBeanstalk) RebuildEnvironmentRequest(input *RebuildEnvironmentInput) (req *service.Request, output *RebuildEnvironmentOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) RebuildEnvironmentRequest(input *RebuildEnvironmentInput) (req *request.Request, output *RebuildEnvironmentOutput) {
+	op := &request.Operation{
 		Name:       opRebuildEnvironment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -677,8 +677,8 @@ func (c *ElasticBeanstalk) RebuildEnvironment(input *RebuildEnvironmentInput) (*
 const opRequestEnvironmentInfo = "RequestEnvironmentInfo"
 
 // RequestEnvironmentInfoRequest generates a request for the RequestEnvironmentInfo operation.
-func (c *ElasticBeanstalk) RequestEnvironmentInfoRequest(input *RequestEnvironmentInfoInput) (req *service.Request, output *RequestEnvironmentInfoOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) RequestEnvironmentInfoRequest(input *RequestEnvironmentInfoInput) (req *request.Request, output *RequestEnvironmentInfoOutput) {
+	op := &request.Operation{
 		Name:       opRequestEnvironmentInfo,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -718,8 +718,8 @@ func (c *ElasticBeanstalk) RequestEnvironmentInfo(input *RequestEnvironmentInfoI
 const opRestartAppServer = "RestartAppServer"
 
 // RestartAppServerRequest generates a request for the RestartAppServer operation.
-func (c *ElasticBeanstalk) RestartAppServerRequest(input *RestartAppServerInput) (req *service.Request, output *RestartAppServerOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) RestartAppServerRequest(input *RestartAppServerInput) (req *request.Request, output *RestartAppServerOutput) {
+	op := &request.Operation{
 		Name:       opRestartAppServer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -746,8 +746,8 @@ func (c *ElasticBeanstalk) RestartAppServer(input *RestartAppServerInput) (*Rest
 const opRetrieveEnvironmentInfo = "RetrieveEnvironmentInfo"
 
 // RetrieveEnvironmentInfoRequest generates a request for the RetrieveEnvironmentInfo operation.
-func (c *ElasticBeanstalk) RetrieveEnvironmentInfoRequest(input *RetrieveEnvironmentInfoInput) (req *service.Request, output *RetrieveEnvironmentInfoOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) RetrieveEnvironmentInfoRequest(input *RetrieveEnvironmentInfoInput) (req *request.Request, output *RetrieveEnvironmentInfoOutput) {
+	op := &request.Operation{
 		Name:       opRetrieveEnvironmentInfo,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -777,8 +777,8 @@ func (c *ElasticBeanstalk) RetrieveEnvironmentInfo(input *RetrieveEnvironmentInf
 const opSwapEnvironmentCNAMEs = "SwapEnvironmentCNAMEs"
 
 // SwapEnvironmentCNAMEsRequest generates a request for the SwapEnvironmentCNAMEs operation.
-func (c *ElasticBeanstalk) SwapEnvironmentCNAMEsRequest(input *SwapEnvironmentCNAMEsInput) (req *service.Request, output *SwapEnvironmentCNAMEsOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) SwapEnvironmentCNAMEsRequest(input *SwapEnvironmentCNAMEsInput) (req *request.Request, output *SwapEnvironmentCNAMEsOutput) {
+	op := &request.Operation{
 		Name:       opSwapEnvironmentCNAMEs,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -804,8 +804,8 @@ func (c *ElasticBeanstalk) SwapEnvironmentCNAMEs(input *SwapEnvironmentCNAMEsInp
 const opTerminateEnvironment = "TerminateEnvironment"
 
 // TerminateEnvironmentRequest generates a request for the TerminateEnvironment operation.
-func (c *ElasticBeanstalk) TerminateEnvironmentRequest(input *TerminateEnvironmentInput) (req *service.Request, output *EnvironmentDescription) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) TerminateEnvironmentRequest(input *TerminateEnvironmentInput) (req *request.Request, output *EnvironmentDescription) {
+	op := &request.Operation{
 		Name:       opTerminateEnvironment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -831,8 +831,8 @@ func (c *ElasticBeanstalk) TerminateEnvironment(input *TerminateEnvironmentInput
 const opUpdateApplication = "UpdateApplication"
 
 // UpdateApplicationRequest generates a request for the UpdateApplication operation.
-func (c *ElasticBeanstalk) UpdateApplicationRequest(input *UpdateApplicationInput) (req *service.Request, output *ApplicationDescriptionMessage) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) UpdateApplicationRequest(input *UpdateApplicationInput) (req *request.Request, output *ApplicationDescriptionMessage) {
+	op := &request.Operation{
 		Name:       opUpdateApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -861,8 +861,8 @@ func (c *ElasticBeanstalk) UpdateApplication(input *UpdateApplicationInput) (*Ap
 const opUpdateApplicationVersion = "UpdateApplicationVersion"
 
 // UpdateApplicationVersionRequest generates a request for the UpdateApplicationVersion operation.
-func (c *ElasticBeanstalk) UpdateApplicationVersionRequest(input *UpdateApplicationVersionInput) (req *service.Request, output *ApplicationVersionDescriptionMessage) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) UpdateApplicationVersionRequest(input *UpdateApplicationVersionInput) (req *request.Request, output *ApplicationVersionDescriptionMessage) {
+	op := &request.Operation{
 		Name:       opUpdateApplicationVersion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -891,8 +891,8 @@ func (c *ElasticBeanstalk) UpdateApplicationVersion(input *UpdateApplicationVers
 const opUpdateConfigurationTemplate = "UpdateConfigurationTemplate"
 
 // UpdateConfigurationTemplateRequest generates a request for the UpdateConfigurationTemplate operation.
-func (c *ElasticBeanstalk) UpdateConfigurationTemplateRequest(input *UpdateConfigurationTemplateInput) (req *service.Request, output *ConfigurationSettingsDescription) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) UpdateConfigurationTemplateRequest(input *UpdateConfigurationTemplateInput) (req *request.Request, output *ConfigurationSettingsDescription) {
+	op := &request.Operation{
 		Name:       opUpdateConfigurationTemplate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -925,8 +925,8 @@ func (c *ElasticBeanstalk) UpdateConfigurationTemplate(input *UpdateConfiguratio
 const opUpdateEnvironment = "UpdateEnvironment"
 
 // UpdateEnvironmentRequest generates a request for the UpdateEnvironment operation.
-func (c *ElasticBeanstalk) UpdateEnvironmentRequest(input *UpdateEnvironmentInput) (req *service.Request, output *EnvironmentDescription) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) UpdateEnvironmentRequest(input *UpdateEnvironmentInput) (req *request.Request, output *EnvironmentDescription) {
+	op := &request.Operation{
 		Name:       opUpdateEnvironment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -962,8 +962,8 @@ func (c *ElasticBeanstalk) UpdateEnvironment(input *UpdateEnvironmentInput) (*En
 const opValidateConfigurationSettings = "ValidateConfigurationSettings"
 
 // ValidateConfigurationSettingsRequest generates a request for the ValidateConfigurationSettings operation.
-func (c *ElasticBeanstalk) ValidateConfigurationSettingsRequest(input *ValidateConfigurationSettingsInput) (req *service.Request, output *ValidateConfigurationSettingsOutput) {
-	op := &service.Operation{
+func (c *ElasticBeanstalk) ValidateConfigurationSettingsRequest(input *ValidateConfigurationSettingsInput) (req *request.Request, output *ValidateConfigurationSettingsOutput) {
+	op := &request.Operation{
 		Name:       opValidateConfigurationSettings,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/elasticbeanstalk/elasticbeanstalkiface/interface.go
+++ b/service/elasticbeanstalk/elasticbeanstalkiface/interface.go
@@ -4,139 +4,139 @@
 package elasticbeanstalkiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/elasticbeanstalk"
 )
 
 // ElasticBeanstalkAPI is the interface type for elasticbeanstalk.ElasticBeanstalk.
 type ElasticBeanstalkAPI interface {
-	AbortEnvironmentUpdateRequest(*elasticbeanstalk.AbortEnvironmentUpdateInput) (*service.Request, *elasticbeanstalk.AbortEnvironmentUpdateOutput)
+	AbortEnvironmentUpdateRequest(*elasticbeanstalk.AbortEnvironmentUpdateInput) (*request.Request, *elasticbeanstalk.AbortEnvironmentUpdateOutput)
 
 	AbortEnvironmentUpdate(*elasticbeanstalk.AbortEnvironmentUpdateInput) (*elasticbeanstalk.AbortEnvironmentUpdateOutput, error)
 
-	CheckDNSAvailabilityRequest(*elasticbeanstalk.CheckDNSAvailabilityInput) (*service.Request, *elasticbeanstalk.CheckDNSAvailabilityOutput)
+	CheckDNSAvailabilityRequest(*elasticbeanstalk.CheckDNSAvailabilityInput) (*request.Request, *elasticbeanstalk.CheckDNSAvailabilityOutput)
 
 	CheckDNSAvailability(*elasticbeanstalk.CheckDNSAvailabilityInput) (*elasticbeanstalk.CheckDNSAvailabilityOutput, error)
 
-	CreateApplicationRequest(*elasticbeanstalk.CreateApplicationInput) (*service.Request, *elasticbeanstalk.ApplicationDescriptionMessage)
+	CreateApplicationRequest(*elasticbeanstalk.CreateApplicationInput) (*request.Request, *elasticbeanstalk.ApplicationDescriptionMessage)
 
 	CreateApplication(*elasticbeanstalk.CreateApplicationInput) (*elasticbeanstalk.ApplicationDescriptionMessage, error)
 
-	CreateApplicationVersionRequest(*elasticbeanstalk.CreateApplicationVersionInput) (*service.Request, *elasticbeanstalk.ApplicationVersionDescriptionMessage)
+	CreateApplicationVersionRequest(*elasticbeanstalk.CreateApplicationVersionInput) (*request.Request, *elasticbeanstalk.ApplicationVersionDescriptionMessage)
 
 	CreateApplicationVersion(*elasticbeanstalk.CreateApplicationVersionInput) (*elasticbeanstalk.ApplicationVersionDescriptionMessage, error)
 
-	CreateConfigurationTemplateRequest(*elasticbeanstalk.CreateConfigurationTemplateInput) (*service.Request, *elasticbeanstalk.ConfigurationSettingsDescription)
+	CreateConfigurationTemplateRequest(*elasticbeanstalk.CreateConfigurationTemplateInput) (*request.Request, *elasticbeanstalk.ConfigurationSettingsDescription)
 
 	CreateConfigurationTemplate(*elasticbeanstalk.CreateConfigurationTemplateInput) (*elasticbeanstalk.ConfigurationSettingsDescription, error)
 
-	CreateEnvironmentRequest(*elasticbeanstalk.CreateEnvironmentInput) (*service.Request, *elasticbeanstalk.EnvironmentDescription)
+	CreateEnvironmentRequest(*elasticbeanstalk.CreateEnvironmentInput) (*request.Request, *elasticbeanstalk.EnvironmentDescription)
 
 	CreateEnvironment(*elasticbeanstalk.CreateEnvironmentInput) (*elasticbeanstalk.EnvironmentDescription, error)
 
-	CreateStorageLocationRequest(*elasticbeanstalk.CreateStorageLocationInput) (*service.Request, *elasticbeanstalk.CreateStorageLocationOutput)
+	CreateStorageLocationRequest(*elasticbeanstalk.CreateStorageLocationInput) (*request.Request, *elasticbeanstalk.CreateStorageLocationOutput)
 
 	CreateStorageLocation(*elasticbeanstalk.CreateStorageLocationInput) (*elasticbeanstalk.CreateStorageLocationOutput, error)
 
-	DeleteApplicationRequest(*elasticbeanstalk.DeleteApplicationInput) (*service.Request, *elasticbeanstalk.DeleteApplicationOutput)
+	DeleteApplicationRequest(*elasticbeanstalk.DeleteApplicationInput) (*request.Request, *elasticbeanstalk.DeleteApplicationOutput)
 
 	DeleteApplication(*elasticbeanstalk.DeleteApplicationInput) (*elasticbeanstalk.DeleteApplicationOutput, error)
 
-	DeleteApplicationVersionRequest(*elasticbeanstalk.DeleteApplicationVersionInput) (*service.Request, *elasticbeanstalk.DeleteApplicationVersionOutput)
+	DeleteApplicationVersionRequest(*elasticbeanstalk.DeleteApplicationVersionInput) (*request.Request, *elasticbeanstalk.DeleteApplicationVersionOutput)
 
 	DeleteApplicationVersion(*elasticbeanstalk.DeleteApplicationVersionInput) (*elasticbeanstalk.DeleteApplicationVersionOutput, error)
 
-	DeleteConfigurationTemplateRequest(*elasticbeanstalk.DeleteConfigurationTemplateInput) (*service.Request, *elasticbeanstalk.DeleteConfigurationTemplateOutput)
+	DeleteConfigurationTemplateRequest(*elasticbeanstalk.DeleteConfigurationTemplateInput) (*request.Request, *elasticbeanstalk.DeleteConfigurationTemplateOutput)
 
 	DeleteConfigurationTemplate(*elasticbeanstalk.DeleteConfigurationTemplateInput) (*elasticbeanstalk.DeleteConfigurationTemplateOutput, error)
 
-	DeleteEnvironmentConfigurationRequest(*elasticbeanstalk.DeleteEnvironmentConfigurationInput) (*service.Request, *elasticbeanstalk.DeleteEnvironmentConfigurationOutput)
+	DeleteEnvironmentConfigurationRequest(*elasticbeanstalk.DeleteEnvironmentConfigurationInput) (*request.Request, *elasticbeanstalk.DeleteEnvironmentConfigurationOutput)
 
 	DeleteEnvironmentConfiguration(*elasticbeanstalk.DeleteEnvironmentConfigurationInput) (*elasticbeanstalk.DeleteEnvironmentConfigurationOutput, error)
 
-	DescribeApplicationVersionsRequest(*elasticbeanstalk.DescribeApplicationVersionsInput) (*service.Request, *elasticbeanstalk.DescribeApplicationVersionsOutput)
+	DescribeApplicationVersionsRequest(*elasticbeanstalk.DescribeApplicationVersionsInput) (*request.Request, *elasticbeanstalk.DescribeApplicationVersionsOutput)
 
 	DescribeApplicationVersions(*elasticbeanstalk.DescribeApplicationVersionsInput) (*elasticbeanstalk.DescribeApplicationVersionsOutput, error)
 
-	DescribeApplicationsRequest(*elasticbeanstalk.DescribeApplicationsInput) (*service.Request, *elasticbeanstalk.DescribeApplicationsOutput)
+	DescribeApplicationsRequest(*elasticbeanstalk.DescribeApplicationsInput) (*request.Request, *elasticbeanstalk.DescribeApplicationsOutput)
 
 	DescribeApplications(*elasticbeanstalk.DescribeApplicationsInput) (*elasticbeanstalk.DescribeApplicationsOutput, error)
 
-	DescribeConfigurationOptionsRequest(*elasticbeanstalk.DescribeConfigurationOptionsInput) (*service.Request, *elasticbeanstalk.DescribeConfigurationOptionsOutput)
+	DescribeConfigurationOptionsRequest(*elasticbeanstalk.DescribeConfigurationOptionsInput) (*request.Request, *elasticbeanstalk.DescribeConfigurationOptionsOutput)
 
 	DescribeConfigurationOptions(*elasticbeanstalk.DescribeConfigurationOptionsInput) (*elasticbeanstalk.DescribeConfigurationOptionsOutput, error)
 
-	DescribeConfigurationSettingsRequest(*elasticbeanstalk.DescribeConfigurationSettingsInput) (*service.Request, *elasticbeanstalk.DescribeConfigurationSettingsOutput)
+	DescribeConfigurationSettingsRequest(*elasticbeanstalk.DescribeConfigurationSettingsInput) (*request.Request, *elasticbeanstalk.DescribeConfigurationSettingsOutput)
 
 	DescribeConfigurationSettings(*elasticbeanstalk.DescribeConfigurationSettingsInput) (*elasticbeanstalk.DescribeConfigurationSettingsOutput, error)
 
-	DescribeEnvironmentHealthRequest(*elasticbeanstalk.DescribeEnvironmentHealthInput) (*service.Request, *elasticbeanstalk.DescribeEnvironmentHealthOutput)
+	DescribeEnvironmentHealthRequest(*elasticbeanstalk.DescribeEnvironmentHealthInput) (*request.Request, *elasticbeanstalk.DescribeEnvironmentHealthOutput)
 
 	DescribeEnvironmentHealth(*elasticbeanstalk.DescribeEnvironmentHealthInput) (*elasticbeanstalk.DescribeEnvironmentHealthOutput, error)
 
-	DescribeEnvironmentResourcesRequest(*elasticbeanstalk.DescribeEnvironmentResourcesInput) (*service.Request, *elasticbeanstalk.DescribeEnvironmentResourcesOutput)
+	DescribeEnvironmentResourcesRequest(*elasticbeanstalk.DescribeEnvironmentResourcesInput) (*request.Request, *elasticbeanstalk.DescribeEnvironmentResourcesOutput)
 
 	DescribeEnvironmentResources(*elasticbeanstalk.DescribeEnvironmentResourcesInput) (*elasticbeanstalk.DescribeEnvironmentResourcesOutput, error)
 
-	DescribeEnvironmentsRequest(*elasticbeanstalk.DescribeEnvironmentsInput) (*service.Request, *elasticbeanstalk.DescribeEnvironmentsOutput)
+	DescribeEnvironmentsRequest(*elasticbeanstalk.DescribeEnvironmentsInput) (*request.Request, *elasticbeanstalk.DescribeEnvironmentsOutput)
 
 	DescribeEnvironments(*elasticbeanstalk.DescribeEnvironmentsInput) (*elasticbeanstalk.DescribeEnvironmentsOutput, error)
 
-	DescribeEventsRequest(*elasticbeanstalk.DescribeEventsInput) (*service.Request, *elasticbeanstalk.DescribeEventsOutput)
+	DescribeEventsRequest(*elasticbeanstalk.DescribeEventsInput) (*request.Request, *elasticbeanstalk.DescribeEventsOutput)
 
 	DescribeEvents(*elasticbeanstalk.DescribeEventsInput) (*elasticbeanstalk.DescribeEventsOutput, error)
 
 	DescribeEventsPages(*elasticbeanstalk.DescribeEventsInput, func(*elasticbeanstalk.DescribeEventsOutput, bool) bool) error
 
-	DescribeInstancesHealthRequest(*elasticbeanstalk.DescribeInstancesHealthInput) (*service.Request, *elasticbeanstalk.DescribeInstancesHealthOutput)
+	DescribeInstancesHealthRequest(*elasticbeanstalk.DescribeInstancesHealthInput) (*request.Request, *elasticbeanstalk.DescribeInstancesHealthOutput)
 
 	DescribeInstancesHealth(*elasticbeanstalk.DescribeInstancesHealthInput) (*elasticbeanstalk.DescribeInstancesHealthOutput, error)
 
-	ListAvailableSolutionStacksRequest(*elasticbeanstalk.ListAvailableSolutionStacksInput) (*service.Request, *elasticbeanstalk.ListAvailableSolutionStacksOutput)
+	ListAvailableSolutionStacksRequest(*elasticbeanstalk.ListAvailableSolutionStacksInput) (*request.Request, *elasticbeanstalk.ListAvailableSolutionStacksOutput)
 
 	ListAvailableSolutionStacks(*elasticbeanstalk.ListAvailableSolutionStacksInput) (*elasticbeanstalk.ListAvailableSolutionStacksOutput, error)
 
-	RebuildEnvironmentRequest(*elasticbeanstalk.RebuildEnvironmentInput) (*service.Request, *elasticbeanstalk.RebuildEnvironmentOutput)
+	RebuildEnvironmentRequest(*elasticbeanstalk.RebuildEnvironmentInput) (*request.Request, *elasticbeanstalk.RebuildEnvironmentOutput)
 
 	RebuildEnvironment(*elasticbeanstalk.RebuildEnvironmentInput) (*elasticbeanstalk.RebuildEnvironmentOutput, error)
 
-	RequestEnvironmentInfoRequest(*elasticbeanstalk.RequestEnvironmentInfoInput) (*service.Request, *elasticbeanstalk.RequestEnvironmentInfoOutput)
+	RequestEnvironmentInfoRequest(*elasticbeanstalk.RequestEnvironmentInfoInput) (*request.Request, *elasticbeanstalk.RequestEnvironmentInfoOutput)
 
 	RequestEnvironmentInfo(*elasticbeanstalk.RequestEnvironmentInfoInput) (*elasticbeanstalk.RequestEnvironmentInfoOutput, error)
 
-	RestartAppServerRequest(*elasticbeanstalk.RestartAppServerInput) (*service.Request, *elasticbeanstalk.RestartAppServerOutput)
+	RestartAppServerRequest(*elasticbeanstalk.RestartAppServerInput) (*request.Request, *elasticbeanstalk.RestartAppServerOutput)
 
 	RestartAppServer(*elasticbeanstalk.RestartAppServerInput) (*elasticbeanstalk.RestartAppServerOutput, error)
 
-	RetrieveEnvironmentInfoRequest(*elasticbeanstalk.RetrieveEnvironmentInfoInput) (*service.Request, *elasticbeanstalk.RetrieveEnvironmentInfoOutput)
+	RetrieveEnvironmentInfoRequest(*elasticbeanstalk.RetrieveEnvironmentInfoInput) (*request.Request, *elasticbeanstalk.RetrieveEnvironmentInfoOutput)
 
 	RetrieveEnvironmentInfo(*elasticbeanstalk.RetrieveEnvironmentInfoInput) (*elasticbeanstalk.RetrieveEnvironmentInfoOutput, error)
 
-	SwapEnvironmentCNAMEsRequest(*elasticbeanstalk.SwapEnvironmentCNAMEsInput) (*service.Request, *elasticbeanstalk.SwapEnvironmentCNAMEsOutput)
+	SwapEnvironmentCNAMEsRequest(*elasticbeanstalk.SwapEnvironmentCNAMEsInput) (*request.Request, *elasticbeanstalk.SwapEnvironmentCNAMEsOutput)
 
 	SwapEnvironmentCNAMEs(*elasticbeanstalk.SwapEnvironmentCNAMEsInput) (*elasticbeanstalk.SwapEnvironmentCNAMEsOutput, error)
 
-	TerminateEnvironmentRequest(*elasticbeanstalk.TerminateEnvironmentInput) (*service.Request, *elasticbeanstalk.EnvironmentDescription)
+	TerminateEnvironmentRequest(*elasticbeanstalk.TerminateEnvironmentInput) (*request.Request, *elasticbeanstalk.EnvironmentDescription)
 
 	TerminateEnvironment(*elasticbeanstalk.TerminateEnvironmentInput) (*elasticbeanstalk.EnvironmentDescription, error)
 
-	UpdateApplicationRequest(*elasticbeanstalk.UpdateApplicationInput) (*service.Request, *elasticbeanstalk.ApplicationDescriptionMessage)
+	UpdateApplicationRequest(*elasticbeanstalk.UpdateApplicationInput) (*request.Request, *elasticbeanstalk.ApplicationDescriptionMessage)
 
 	UpdateApplication(*elasticbeanstalk.UpdateApplicationInput) (*elasticbeanstalk.ApplicationDescriptionMessage, error)
 
-	UpdateApplicationVersionRequest(*elasticbeanstalk.UpdateApplicationVersionInput) (*service.Request, *elasticbeanstalk.ApplicationVersionDescriptionMessage)
+	UpdateApplicationVersionRequest(*elasticbeanstalk.UpdateApplicationVersionInput) (*request.Request, *elasticbeanstalk.ApplicationVersionDescriptionMessage)
 
 	UpdateApplicationVersion(*elasticbeanstalk.UpdateApplicationVersionInput) (*elasticbeanstalk.ApplicationVersionDescriptionMessage, error)
 
-	UpdateConfigurationTemplateRequest(*elasticbeanstalk.UpdateConfigurationTemplateInput) (*service.Request, *elasticbeanstalk.ConfigurationSettingsDescription)
+	UpdateConfigurationTemplateRequest(*elasticbeanstalk.UpdateConfigurationTemplateInput) (*request.Request, *elasticbeanstalk.ConfigurationSettingsDescription)
 
 	UpdateConfigurationTemplate(*elasticbeanstalk.UpdateConfigurationTemplateInput) (*elasticbeanstalk.ConfigurationSettingsDescription, error)
 
-	UpdateEnvironmentRequest(*elasticbeanstalk.UpdateEnvironmentInput) (*service.Request, *elasticbeanstalk.EnvironmentDescription)
+	UpdateEnvironmentRequest(*elasticbeanstalk.UpdateEnvironmentInput) (*request.Request, *elasticbeanstalk.EnvironmentDescription)
 
 	UpdateEnvironment(*elasticbeanstalk.UpdateEnvironmentInput) (*elasticbeanstalk.EnvironmentDescription, error)
 
-	ValidateConfigurationSettingsRequest(*elasticbeanstalk.ValidateConfigurationSettingsInput) (*service.Request, *elasticbeanstalk.ValidateConfigurationSettingsOutput)
+	ValidateConfigurationSettingsRequest(*elasticbeanstalk.ValidateConfigurationSettingsInput) (*request.Request, *elasticbeanstalk.ValidateConfigurationSettingsOutput)
 
 	ValidateConfigurationSettings(*elasticbeanstalk.ValidateConfigurationSettingsInput) (*elasticbeanstalk.ValidateConfigurationSettingsOutput, error)
 }

--- a/service/elasticbeanstalk/service.go
+++ b/service/elasticbeanstalk/service.go
@@ -5,7 +5,9 @@ package elasticbeanstalk
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -39,14 +41,16 @@ type ElasticBeanstalk struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new ElasticBeanstalk client.
 func New(config *aws.Config) *ElasticBeanstalk {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "elasticbeanstalk",
-		APIVersion:  "2010-12-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "elasticbeanstalk",
+			APIVersion:  "2010-12-01",
+		},
 	}
 	service.Initialize()
 
@@ -67,8 +71,8 @@ func New(config *aws.Config) *ElasticBeanstalk {
 
 // newRequest creates a new request for a ElasticBeanstalk operation and runs any
 // custom request initialization.
-func (c *ElasticBeanstalk) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *ElasticBeanstalk) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/elastictranscoder/api.go
+++ b/service/elastictranscoder/api.go
@@ -5,14 +5,14 @@ package elastictranscoder
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCancelJob = "CancelJob"
 
 // CancelJobRequest generates a request for the CancelJob operation.
-func (c *ElasticTranscoder) CancelJobRequest(input *CancelJobInput) (req *service.Request, output *CancelJobOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) CancelJobRequest(input *CancelJobInput) (req *request.Request, output *CancelJobOutput) {
+	op := &request.Operation{
 		Name:       opCancelJob,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2012-09-25/jobs/{Id}",
@@ -42,8 +42,8 @@ func (c *ElasticTranscoder) CancelJob(input *CancelJobInput) (*CancelJobOutput, 
 const opCreateJob = "CreateJob"
 
 // CreateJobRequest generates a request for the CreateJob operation.
-func (c *ElasticTranscoder) CreateJobRequest(input *CreateJobInput) (req *service.Request, output *CreateJobResponse) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) CreateJobRequest(input *CreateJobInput) (req *request.Request, output *CreateJobResponse) {
+	op := &request.Operation{
 		Name:       opCreateJob,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2012-09-25/jobs",
@@ -75,8 +75,8 @@ func (c *ElasticTranscoder) CreateJob(input *CreateJobInput) (*CreateJobResponse
 const opCreatePipeline = "CreatePipeline"
 
 // CreatePipelineRequest generates a request for the CreatePipeline operation.
-func (c *ElasticTranscoder) CreatePipelineRequest(input *CreatePipelineInput) (req *service.Request, output *CreatePipelineOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) CreatePipelineRequest(input *CreatePipelineInput) (req *request.Request, output *CreatePipelineOutput) {
+	op := &request.Operation{
 		Name:       opCreatePipeline,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2012-09-25/pipelines",
@@ -102,8 +102,8 @@ func (c *ElasticTranscoder) CreatePipeline(input *CreatePipelineInput) (*CreateP
 const opCreatePreset = "CreatePreset"
 
 // CreatePresetRequest generates a request for the CreatePreset operation.
-func (c *ElasticTranscoder) CreatePresetRequest(input *CreatePresetInput) (req *service.Request, output *CreatePresetOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) CreatePresetRequest(input *CreatePresetInput) (req *request.Request, output *CreatePresetOutput) {
+	op := &request.Operation{
 		Name:       opCreatePreset,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2012-09-25/presets",
@@ -143,8 +143,8 @@ func (c *ElasticTranscoder) CreatePreset(input *CreatePresetInput) (*CreatePrese
 const opDeletePipeline = "DeletePipeline"
 
 // DeletePipelineRequest generates a request for the DeletePipeline operation.
-func (c *ElasticTranscoder) DeletePipelineRequest(input *DeletePipelineInput) (req *service.Request, output *DeletePipelineOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) DeletePipelineRequest(input *DeletePipelineInput) (req *request.Request, output *DeletePipelineOutput) {
+	op := &request.Operation{
 		Name:       opDeletePipeline,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2012-09-25/pipelines/{Id}",
@@ -174,8 +174,8 @@ func (c *ElasticTranscoder) DeletePipeline(input *DeletePipelineInput) (*DeleteP
 const opDeletePreset = "DeletePreset"
 
 // DeletePresetRequest generates a request for the DeletePreset operation.
-func (c *ElasticTranscoder) DeletePresetRequest(input *DeletePresetInput) (req *service.Request, output *DeletePresetOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) DeletePresetRequest(input *DeletePresetInput) (req *request.Request, output *DeletePresetOutput) {
+	op := &request.Operation{
 		Name:       opDeletePreset,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2012-09-25/presets/{Id}",
@@ -203,12 +203,12 @@ func (c *ElasticTranscoder) DeletePreset(input *DeletePresetInput) (*DeletePrese
 const opListJobsByPipeline = "ListJobsByPipeline"
 
 // ListJobsByPipelineRequest generates a request for the ListJobsByPipeline operation.
-func (c *ElasticTranscoder) ListJobsByPipelineRequest(input *ListJobsByPipelineInput) (req *service.Request, output *ListJobsByPipelineOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) ListJobsByPipelineRequest(input *ListJobsByPipelineInput) (req *request.Request, output *ListJobsByPipelineOutput) {
+	op := &request.Operation{
 		Name:       opListJobsByPipeline,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2012-09-25/jobsByPipeline/{PipelineId}",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"PageToken"},
 			OutputTokens:    []string{"NextPageToken"},
 			LimitToken:      "",
@@ -247,12 +247,12 @@ func (c *ElasticTranscoder) ListJobsByPipelinePages(input *ListJobsByPipelineInp
 const opListJobsByStatus = "ListJobsByStatus"
 
 // ListJobsByStatusRequest generates a request for the ListJobsByStatus operation.
-func (c *ElasticTranscoder) ListJobsByStatusRequest(input *ListJobsByStatusInput) (req *service.Request, output *ListJobsByStatusOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) ListJobsByStatusRequest(input *ListJobsByStatusInput) (req *request.Request, output *ListJobsByStatusOutput) {
+	op := &request.Operation{
 		Name:       opListJobsByStatus,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2012-09-25/jobsByStatus/{Status}",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"PageToken"},
 			OutputTokens:    []string{"NextPageToken"},
 			LimitToken:      "",
@@ -289,12 +289,12 @@ func (c *ElasticTranscoder) ListJobsByStatusPages(input *ListJobsByStatusInput, 
 const opListPipelines = "ListPipelines"
 
 // ListPipelinesRequest generates a request for the ListPipelines operation.
-func (c *ElasticTranscoder) ListPipelinesRequest(input *ListPipelinesInput) (req *service.Request, output *ListPipelinesOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) ListPipelinesRequest(input *ListPipelinesInput) (req *request.Request, output *ListPipelinesOutput) {
+	op := &request.Operation{
 		Name:       opListPipelines,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2012-09-25/pipelines",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"PageToken"},
 			OutputTokens:    []string{"NextPageToken"},
 			LimitToken:      "",
@@ -330,12 +330,12 @@ func (c *ElasticTranscoder) ListPipelinesPages(input *ListPipelinesInput, fn fun
 const opListPresets = "ListPresets"
 
 // ListPresetsRequest generates a request for the ListPresets operation.
-func (c *ElasticTranscoder) ListPresetsRequest(input *ListPresetsInput) (req *service.Request, output *ListPresetsOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) ListPresetsRequest(input *ListPresetsInput) (req *request.Request, output *ListPresetsOutput) {
+	op := &request.Operation{
 		Name:       opListPresets,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2012-09-25/presets",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"PageToken"},
 			OutputTokens:    []string{"NextPageToken"},
 			LimitToken:      "",
@@ -371,8 +371,8 @@ func (c *ElasticTranscoder) ListPresetsPages(input *ListPresetsInput, fn func(p 
 const opReadJob = "ReadJob"
 
 // ReadJobRequest generates a request for the ReadJob operation.
-func (c *ElasticTranscoder) ReadJobRequest(input *ReadJobInput) (req *service.Request, output *ReadJobOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) ReadJobRequest(input *ReadJobInput) (req *request.Request, output *ReadJobOutput) {
+	op := &request.Operation{
 		Name:       opReadJob,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2012-09-25/jobs/{Id}",
@@ -398,8 +398,8 @@ func (c *ElasticTranscoder) ReadJob(input *ReadJobInput) (*ReadJobOutput, error)
 const opReadPipeline = "ReadPipeline"
 
 // ReadPipelineRequest generates a request for the ReadPipeline operation.
-func (c *ElasticTranscoder) ReadPipelineRequest(input *ReadPipelineInput) (req *service.Request, output *ReadPipelineOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) ReadPipelineRequest(input *ReadPipelineInput) (req *request.Request, output *ReadPipelineOutput) {
+	op := &request.Operation{
 		Name:       opReadPipeline,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2012-09-25/pipelines/{Id}",
@@ -425,8 +425,8 @@ func (c *ElasticTranscoder) ReadPipeline(input *ReadPipelineInput) (*ReadPipelin
 const opReadPreset = "ReadPreset"
 
 // ReadPresetRequest generates a request for the ReadPreset operation.
-func (c *ElasticTranscoder) ReadPresetRequest(input *ReadPresetInput) (req *service.Request, output *ReadPresetOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) ReadPresetRequest(input *ReadPresetInput) (req *request.Request, output *ReadPresetOutput) {
+	op := &request.Operation{
 		Name:       opReadPreset,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2012-09-25/presets/{Id}",
@@ -452,8 +452,8 @@ func (c *ElasticTranscoder) ReadPreset(input *ReadPresetInput) (*ReadPresetOutpu
 const opTestRole = "TestRole"
 
 // TestRoleRequest generates a request for the TestRole operation.
-func (c *ElasticTranscoder) TestRoleRequest(input *TestRoleInput) (req *service.Request, output *TestRoleOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) TestRoleRequest(input *TestRoleInput) (req *request.Request, output *TestRoleOutput) {
+	op := &request.Operation{
 		Name:       opTestRole,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2012-09-25/roleTests",
@@ -485,8 +485,8 @@ func (c *ElasticTranscoder) TestRole(input *TestRoleInput) (*TestRoleOutput, err
 const opUpdatePipeline = "UpdatePipeline"
 
 // UpdatePipelineRequest generates a request for the UpdatePipeline operation.
-func (c *ElasticTranscoder) UpdatePipelineRequest(input *UpdatePipelineInput) (req *service.Request, output *UpdatePipelineOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) UpdatePipelineRequest(input *UpdatePipelineInput) (req *request.Request, output *UpdatePipelineOutput) {
+	op := &request.Operation{
 		Name:       opUpdatePipeline,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2012-09-25/pipelines/{Id}",
@@ -516,8 +516,8 @@ func (c *ElasticTranscoder) UpdatePipeline(input *UpdatePipelineInput) (*UpdateP
 const opUpdatePipelineNotifications = "UpdatePipelineNotifications"
 
 // UpdatePipelineNotificationsRequest generates a request for the UpdatePipelineNotifications operation.
-func (c *ElasticTranscoder) UpdatePipelineNotificationsRequest(input *UpdatePipelineNotificationsInput) (req *service.Request, output *UpdatePipelineNotificationsOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) UpdatePipelineNotificationsRequest(input *UpdatePipelineNotificationsInput) (req *request.Request, output *UpdatePipelineNotificationsOutput) {
+	op := &request.Operation{
 		Name:       opUpdatePipelineNotifications,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2012-09-25/pipelines/{Id}/notifications",
@@ -547,8 +547,8 @@ func (c *ElasticTranscoder) UpdatePipelineNotifications(input *UpdatePipelineNot
 const opUpdatePipelineStatus = "UpdatePipelineStatus"
 
 // UpdatePipelineStatusRequest generates a request for the UpdatePipelineStatus operation.
-func (c *ElasticTranscoder) UpdatePipelineStatusRequest(input *UpdatePipelineStatusInput) (req *service.Request, output *UpdatePipelineStatusOutput) {
-	op := &service.Operation{
+func (c *ElasticTranscoder) UpdatePipelineStatusRequest(input *UpdatePipelineStatusInput) (req *request.Request, output *UpdatePipelineStatusOutput) {
+	op := &request.Operation{
 		Name:       opUpdatePipelineStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2012-09-25/pipelines/{Id}/status",

--- a/service/elastictranscoder/elastictranscoderiface/interface.go
+++ b/service/elastictranscoder/elastictranscoderiface/interface.go
@@ -4,85 +4,85 @@
 package elastictranscoderiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/elastictranscoder"
 )
 
 // ElasticTranscoderAPI is the interface type for elastictranscoder.ElasticTranscoder.
 type ElasticTranscoderAPI interface {
-	CancelJobRequest(*elastictranscoder.CancelJobInput) (*service.Request, *elastictranscoder.CancelJobOutput)
+	CancelJobRequest(*elastictranscoder.CancelJobInput) (*request.Request, *elastictranscoder.CancelJobOutput)
 
 	CancelJob(*elastictranscoder.CancelJobInput) (*elastictranscoder.CancelJobOutput, error)
 
-	CreateJobRequest(*elastictranscoder.CreateJobInput) (*service.Request, *elastictranscoder.CreateJobResponse)
+	CreateJobRequest(*elastictranscoder.CreateJobInput) (*request.Request, *elastictranscoder.CreateJobResponse)
 
 	CreateJob(*elastictranscoder.CreateJobInput) (*elastictranscoder.CreateJobResponse, error)
 
-	CreatePipelineRequest(*elastictranscoder.CreatePipelineInput) (*service.Request, *elastictranscoder.CreatePipelineOutput)
+	CreatePipelineRequest(*elastictranscoder.CreatePipelineInput) (*request.Request, *elastictranscoder.CreatePipelineOutput)
 
 	CreatePipeline(*elastictranscoder.CreatePipelineInput) (*elastictranscoder.CreatePipelineOutput, error)
 
-	CreatePresetRequest(*elastictranscoder.CreatePresetInput) (*service.Request, *elastictranscoder.CreatePresetOutput)
+	CreatePresetRequest(*elastictranscoder.CreatePresetInput) (*request.Request, *elastictranscoder.CreatePresetOutput)
 
 	CreatePreset(*elastictranscoder.CreatePresetInput) (*elastictranscoder.CreatePresetOutput, error)
 
-	DeletePipelineRequest(*elastictranscoder.DeletePipelineInput) (*service.Request, *elastictranscoder.DeletePipelineOutput)
+	DeletePipelineRequest(*elastictranscoder.DeletePipelineInput) (*request.Request, *elastictranscoder.DeletePipelineOutput)
 
 	DeletePipeline(*elastictranscoder.DeletePipelineInput) (*elastictranscoder.DeletePipelineOutput, error)
 
-	DeletePresetRequest(*elastictranscoder.DeletePresetInput) (*service.Request, *elastictranscoder.DeletePresetOutput)
+	DeletePresetRequest(*elastictranscoder.DeletePresetInput) (*request.Request, *elastictranscoder.DeletePresetOutput)
 
 	DeletePreset(*elastictranscoder.DeletePresetInput) (*elastictranscoder.DeletePresetOutput, error)
 
-	ListJobsByPipelineRequest(*elastictranscoder.ListJobsByPipelineInput) (*service.Request, *elastictranscoder.ListJobsByPipelineOutput)
+	ListJobsByPipelineRequest(*elastictranscoder.ListJobsByPipelineInput) (*request.Request, *elastictranscoder.ListJobsByPipelineOutput)
 
 	ListJobsByPipeline(*elastictranscoder.ListJobsByPipelineInput) (*elastictranscoder.ListJobsByPipelineOutput, error)
 
 	ListJobsByPipelinePages(*elastictranscoder.ListJobsByPipelineInput, func(*elastictranscoder.ListJobsByPipelineOutput, bool) bool) error
 
-	ListJobsByStatusRequest(*elastictranscoder.ListJobsByStatusInput) (*service.Request, *elastictranscoder.ListJobsByStatusOutput)
+	ListJobsByStatusRequest(*elastictranscoder.ListJobsByStatusInput) (*request.Request, *elastictranscoder.ListJobsByStatusOutput)
 
 	ListJobsByStatus(*elastictranscoder.ListJobsByStatusInput) (*elastictranscoder.ListJobsByStatusOutput, error)
 
 	ListJobsByStatusPages(*elastictranscoder.ListJobsByStatusInput, func(*elastictranscoder.ListJobsByStatusOutput, bool) bool) error
 
-	ListPipelinesRequest(*elastictranscoder.ListPipelinesInput) (*service.Request, *elastictranscoder.ListPipelinesOutput)
+	ListPipelinesRequest(*elastictranscoder.ListPipelinesInput) (*request.Request, *elastictranscoder.ListPipelinesOutput)
 
 	ListPipelines(*elastictranscoder.ListPipelinesInput) (*elastictranscoder.ListPipelinesOutput, error)
 
 	ListPipelinesPages(*elastictranscoder.ListPipelinesInput, func(*elastictranscoder.ListPipelinesOutput, bool) bool) error
 
-	ListPresetsRequest(*elastictranscoder.ListPresetsInput) (*service.Request, *elastictranscoder.ListPresetsOutput)
+	ListPresetsRequest(*elastictranscoder.ListPresetsInput) (*request.Request, *elastictranscoder.ListPresetsOutput)
 
 	ListPresets(*elastictranscoder.ListPresetsInput) (*elastictranscoder.ListPresetsOutput, error)
 
 	ListPresetsPages(*elastictranscoder.ListPresetsInput, func(*elastictranscoder.ListPresetsOutput, bool) bool) error
 
-	ReadJobRequest(*elastictranscoder.ReadJobInput) (*service.Request, *elastictranscoder.ReadJobOutput)
+	ReadJobRequest(*elastictranscoder.ReadJobInput) (*request.Request, *elastictranscoder.ReadJobOutput)
 
 	ReadJob(*elastictranscoder.ReadJobInput) (*elastictranscoder.ReadJobOutput, error)
 
-	ReadPipelineRequest(*elastictranscoder.ReadPipelineInput) (*service.Request, *elastictranscoder.ReadPipelineOutput)
+	ReadPipelineRequest(*elastictranscoder.ReadPipelineInput) (*request.Request, *elastictranscoder.ReadPipelineOutput)
 
 	ReadPipeline(*elastictranscoder.ReadPipelineInput) (*elastictranscoder.ReadPipelineOutput, error)
 
-	ReadPresetRequest(*elastictranscoder.ReadPresetInput) (*service.Request, *elastictranscoder.ReadPresetOutput)
+	ReadPresetRequest(*elastictranscoder.ReadPresetInput) (*request.Request, *elastictranscoder.ReadPresetOutput)
 
 	ReadPreset(*elastictranscoder.ReadPresetInput) (*elastictranscoder.ReadPresetOutput, error)
 
-	TestRoleRequest(*elastictranscoder.TestRoleInput) (*service.Request, *elastictranscoder.TestRoleOutput)
+	TestRoleRequest(*elastictranscoder.TestRoleInput) (*request.Request, *elastictranscoder.TestRoleOutput)
 
 	TestRole(*elastictranscoder.TestRoleInput) (*elastictranscoder.TestRoleOutput, error)
 
-	UpdatePipelineRequest(*elastictranscoder.UpdatePipelineInput) (*service.Request, *elastictranscoder.UpdatePipelineOutput)
+	UpdatePipelineRequest(*elastictranscoder.UpdatePipelineInput) (*request.Request, *elastictranscoder.UpdatePipelineOutput)
 
 	UpdatePipeline(*elastictranscoder.UpdatePipelineInput) (*elastictranscoder.UpdatePipelineOutput, error)
 
-	UpdatePipelineNotificationsRequest(*elastictranscoder.UpdatePipelineNotificationsInput) (*service.Request, *elastictranscoder.UpdatePipelineNotificationsOutput)
+	UpdatePipelineNotificationsRequest(*elastictranscoder.UpdatePipelineNotificationsInput) (*request.Request, *elastictranscoder.UpdatePipelineNotificationsOutput)
 
 	UpdatePipelineNotifications(*elastictranscoder.UpdatePipelineNotificationsInput) (*elastictranscoder.UpdatePipelineNotificationsOutput, error)
 
-	UpdatePipelineStatusRequest(*elastictranscoder.UpdatePipelineStatusInput) (*service.Request, *elastictranscoder.UpdatePipelineStatusOutput)
+	UpdatePipelineStatusRequest(*elastictranscoder.UpdatePipelineStatusInput) (*request.Request, *elastictranscoder.UpdatePipelineStatusOutput)
 
 	UpdatePipelineStatus(*elastictranscoder.UpdatePipelineStatusInput) (*elastictranscoder.UpdatePipelineStatusOutput, error)
 }

--- a/service/elastictranscoder/service.go
+++ b/service/elastictranscoder/service.go
@@ -5,7 +5,9 @@ package elastictranscoder
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -19,14 +21,16 @@ type ElasticTranscoder struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new ElasticTranscoder client.
 func New(config *aws.Config) *ElasticTranscoder {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "elastictranscoder",
-		APIVersion:  "2012-09-25",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "elastictranscoder",
+			APIVersion:  "2012-09-25",
+		},
 	}
 	service.Initialize()
 
@@ -47,8 +51,8 @@ func New(config *aws.Config) *ElasticTranscoder {
 
 // newRequest creates a new request for a ElasticTranscoder operation and runs any
 // custom request initialization.
-func (c *ElasticTranscoder) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *ElasticTranscoder) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/elb/api.go
+++ b/service/elb/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddTags = "AddTags"
 
 // AddTagsRequest generates a request for the AddTags operation.
-func (c *ELB) AddTagsRequest(input *AddTagsInput) (req *service.Request, output *AddTagsOutput) {
-	op := &service.Operation{
+func (c *ELB) AddTagsRequest(input *AddTagsInput) (req *request.Request, output *AddTagsOutput) {
+	op := &request.Operation{
 		Name:       opAddTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -47,8 +47,8 @@ func (c *ELB) AddTags(input *AddTagsInput) (*AddTagsOutput, error) {
 const opApplySecurityGroupsToLoadBalancer = "ApplySecurityGroupsToLoadBalancer"
 
 // ApplySecurityGroupsToLoadBalancerRequest generates a request for the ApplySecurityGroupsToLoadBalancer operation.
-func (c *ELB) ApplySecurityGroupsToLoadBalancerRequest(input *ApplySecurityGroupsToLoadBalancerInput) (req *service.Request, output *ApplySecurityGroupsToLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *ELB) ApplySecurityGroupsToLoadBalancerRequest(input *ApplySecurityGroupsToLoadBalancerInput) (req *request.Request, output *ApplySecurityGroupsToLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opApplySecurityGroupsToLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -79,8 +79,8 @@ func (c *ELB) ApplySecurityGroupsToLoadBalancer(input *ApplySecurityGroupsToLoad
 const opAttachLoadBalancerToSubnets = "AttachLoadBalancerToSubnets"
 
 // AttachLoadBalancerToSubnetsRequest generates a request for the AttachLoadBalancerToSubnets operation.
-func (c *ELB) AttachLoadBalancerToSubnetsRequest(input *AttachLoadBalancerToSubnetsInput) (req *service.Request, output *AttachLoadBalancerToSubnetsOutput) {
-	op := &service.Operation{
+func (c *ELB) AttachLoadBalancerToSubnetsRequest(input *AttachLoadBalancerToSubnetsInput) (req *request.Request, output *AttachLoadBalancerToSubnetsOutput) {
+	op := &request.Operation{
 		Name:       opAttachLoadBalancerToSubnets,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -112,8 +112,8 @@ func (c *ELB) AttachLoadBalancerToSubnets(input *AttachLoadBalancerToSubnetsInpu
 const opConfigureHealthCheck = "ConfigureHealthCheck"
 
 // ConfigureHealthCheckRequest generates a request for the ConfigureHealthCheck operation.
-func (c *ELB) ConfigureHealthCheckRequest(input *ConfigureHealthCheckInput) (req *service.Request, output *ConfigureHealthCheckOutput) {
-	op := &service.Operation{
+func (c *ELB) ConfigureHealthCheckRequest(input *ConfigureHealthCheckInput) (req *request.Request, output *ConfigureHealthCheckOutput) {
+	op := &request.Operation{
 		Name:       opConfigureHealthCheck,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -143,8 +143,8 @@ func (c *ELB) ConfigureHealthCheck(input *ConfigureHealthCheckInput) (*Configure
 const opCreateAppCookieStickinessPolicy = "CreateAppCookieStickinessPolicy"
 
 // CreateAppCookieStickinessPolicyRequest generates a request for the CreateAppCookieStickinessPolicy operation.
-func (c *ELB) CreateAppCookieStickinessPolicyRequest(input *CreateAppCookieStickinessPolicyInput) (req *service.Request, output *CreateAppCookieStickinessPolicyOutput) {
-	op := &service.Operation{
+func (c *ELB) CreateAppCookieStickinessPolicyRequest(input *CreateAppCookieStickinessPolicyInput) (req *request.Request, output *CreateAppCookieStickinessPolicyOutput) {
+	op := &request.Operation{
 		Name:       opCreateAppCookieStickinessPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -184,8 +184,8 @@ func (c *ELB) CreateAppCookieStickinessPolicy(input *CreateAppCookieStickinessPo
 const opCreateLBCookieStickinessPolicy = "CreateLBCookieStickinessPolicy"
 
 // CreateLBCookieStickinessPolicyRequest generates a request for the CreateLBCookieStickinessPolicy operation.
-func (c *ELB) CreateLBCookieStickinessPolicyRequest(input *CreateLBCookieStickinessPolicyInput) (req *service.Request, output *CreateLBCookieStickinessPolicyOutput) {
-	op := &service.Operation{
+func (c *ELB) CreateLBCookieStickinessPolicyRequest(input *CreateLBCookieStickinessPolicyInput) (req *request.Request, output *CreateLBCookieStickinessPolicyOutput) {
+	op := &request.Operation{
 		Name:       opCreateLBCookieStickinessPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -227,8 +227,8 @@ func (c *ELB) CreateLBCookieStickinessPolicy(input *CreateLBCookieStickinessPoli
 const opCreateLoadBalancer = "CreateLoadBalancer"
 
 // CreateLoadBalancerRequest generates a request for the CreateLoadBalancer operation.
-func (c *ELB) CreateLoadBalancerRequest(input *CreateLoadBalancerInput) (req *service.Request, output *CreateLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *ELB) CreateLoadBalancerRequest(input *CreateLoadBalancerInput) (req *request.Request, output *CreateLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opCreateLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -265,8 +265,8 @@ func (c *ELB) CreateLoadBalancer(input *CreateLoadBalancerInput) (*CreateLoadBal
 const opCreateLoadBalancerListeners = "CreateLoadBalancerListeners"
 
 // CreateLoadBalancerListenersRequest generates a request for the CreateLoadBalancerListeners operation.
-func (c *ELB) CreateLoadBalancerListenersRequest(input *CreateLoadBalancerListenersInput) (req *service.Request, output *CreateLoadBalancerListenersOutput) {
-	op := &service.Operation{
+func (c *ELB) CreateLoadBalancerListenersRequest(input *CreateLoadBalancerListenersInput) (req *request.Request, output *CreateLoadBalancerListenersOutput) {
+	op := &request.Operation{
 		Name:       opCreateLoadBalancerListeners,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -298,8 +298,8 @@ func (c *ELB) CreateLoadBalancerListeners(input *CreateLoadBalancerListenersInpu
 const opCreateLoadBalancerPolicy = "CreateLoadBalancerPolicy"
 
 // CreateLoadBalancerPolicyRequest generates a request for the CreateLoadBalancerPolicy operation.
-func (c *ELB) CreateLoadBalancerPolicyRequest(input *CreateLoadBalancerPolicyInput) (req *service.Request, output *CreateLoadBalancerPolicyOutput) {
-	op := &service.Operation{
+func (c *ELB) CreateLoadBalancerPolicyRequest(input *CreateLoadBalancerPolicyInput) (req *request.Request, output *CreateLoadBalancerPolicyOutput) {
+	op := &request.Operation{
 		Name:       opCreateLoadBalancerPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -329,8 +329,8 @@ func (c *ELB) CreateLoadBalancerPolicy(input *CreateLoadBalancerPolicyInput) (*C
 const opDeleteLoadBalancer = "DeleteLoadBalancer"
 
 // DeleteLoadBalancerRequest generates a request for the DeleteLoadBalancer operation.
-func (c *ELB) DeleteLoadBalancerRequest(input *DeleteLoadBalancerInput) (req *service.Request, output *DeleteLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *ELB) DeleteLoadBalancerRequest(input *DeleteLoadBalancerInput) (req *request.Request, output *DeleteLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -365,8 +365,8 @@ func (c *ELB) DeleteLoadBalancer(input *DeleteLoadBalancerInput) (*DeleteLoadBal
 const opDeleteLoadBalancerListeners = "DeleteLoadBalancerListeners"
 
 // DeleteLoadBalancerListenersRequest generates a request for the DeleteLoadBalancerListeners operation.
-func (c *ELB) DeleteLoadBalancerListenersRequest(input *DeleteLoadBalancerListenersInput) (req *service.Request, output *DeleteLoadBalancerListenersOutput) {
-	op := &service.Operation{
+func (c *ELB) DeleteLoadBalancerListenersRequest(input *DeleteLoadBalancerListenersInput) (req *request.Request, output *DeleteLoadBalancerListenersOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLoadBalancerListeners,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -392,8 +392,8 @@ func (c *ELB) DeleteLoadBalancerListeners(input *DeleteLoadBalancerListenersInpu
 const opDeleteLoadBalancerPolicy = "DeleteLoadBalancerPolicy"
 
 // DeleteLoadBalancerPolicyRequest generates a request for the DeleteLoadBalancerPolicy operation.
-func (c *ELB) DeleteLoadBalancerPolicyRequest(input *DeleteLoadBalancerPolicyInput) (req *service.Request, output *DeleteLoadBalancerPolicyOutput) {
-	op := &service.Operation{
+func (c *ELB) DeleteLoadBalancerPolicyRequest(input *DeleteLoadBalancerPolicyInput) (req *request.Request, output *DeleteLoadBalancerPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLoadBalancerPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -420,8 +420,8 @@ func (c *ELB) DeleteLoadBalancerPolicy(input *DeleteLoadBalancerPolicyInput) (*D
 const opDeregisterInstancesFromLoadBalancer = "DeregisterInstancesFromLoadBalancer"
 
 // DeregisterInstancesFromLoadBalancerRequest generates a request for the DeregisterInstancesFromLoadBalancer operation.
-func (c *ELB) DeregisterInstancesFromLoadBalancerRequest(input *DeregisterInstancesFromLoadBalancerInput) (req *service.Request, output *DeregisterInstancesFromLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *ELB) DeregisterInstancesFromLoadBalancerRequest(input *DeregisterInstancesFromLoadBalancerInput) (req *request.Request, output *DeregisterInstancesFromLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterInstancesFromLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -455,8 +455,8 @@ func (c *ELB) DeregisterInstancesFromLoadBalancer(input *DeregisterInstancesFrom
 const opDescribeInstanceHealth = "DescribeInstanceHealth"
 
 // DescribeInstanceHealthRequest generates a request for the DescribeInstanceHealth operation.
-func (c *ELB) DescribeInstanceHealthRequest(input *DescribeInstanceHealthInput) (req *service.Request, output *DescribeInstanceHealthOutput) {
-	op := &service.Operation{
+func (c *ELB) DescribeInstanceHealthRequest(input *DescribeInstanceHealthInput) (req *request.Request, output *DescribeInstanceHealthOutput) {
+	op := &request.Operation{
 		Name:       opDescribeInstanceHealth,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -485,8 +485,8 @@ func (c *ELB) DescribeInstanceHealth(input *DescribeInstanceHealthInput) (*Descr
 const opDescribeLoadBalancerAttributes = "DescribeLoadBalancerAttributes"
 
 // DescribeLoadBalancerAttributesRequest generates a request for the DescribeLoadBalancerAttributes operation.
-func (c *ELB) DescribeLoadBalancerAttributesRequest(input *DescribeLoadBalancerAttributesInput) (req *service.Request, output *DescribeLoadBalancerAttributesOutput) {
-	op := &service.Operation{
+func (c *ELB) DescribeLoadBalancerAttributesRequest(input *DescribeLoadBalancerAttributesInput) (req *request.Request, output *DescribeLoadBalancerAttributesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLoadBalancerAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -512,8 +512,8 @@ func (c *ELB) DescribeLoadBalancerAttributes(input *DescribeLoadBalancerAttribut
 const opDescribeLoadBalancerPolicies = "DescribeLoadBalancerPolicies"
 
 // DescribeLoadBalancerPoliciesRequest generates a request for the DescribeLoadBalancerPolicies operation.
-func (c *ELB) DescribeLoadBalancerPoliciesRequest(input *DescribeLoadBalancerPoliciesInput) (req *service.Request, output *DescribeLoadBalancerPoliciesOutput) {
-	op := &service.Operation{
+func (c *ELB) DescribeLoadBalancerPoliciesRequest(input *DescribeLoadBalancerPoliciesInput) (req *request.Request, output *DescribeLoadBalancerPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLoadBalancerPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -546,8 +546,8 @@ func (c *ELB) DescribeLoadBalancerPolicies(input *DescribeLoadBalancerPoliciesIn
 const opDescribeLoadBalancerPolicyTypes = "DescribeLoadBalancerPolicyTypes"
 
 // DescribeLoadBalancerPolicyTypesRequest generates a request for the DescribeLoadBalancerPolicyTypes operation.
-func (c *ELB) DescribeLoadBalancerPolicyTypesRequest(input *DescribeLoadBalancerPolicyTypesInput) (req *service.Request, output *DescribeLoadBalancerPolicyTypesOutput) {
-	op := &service.Operation{
+func (c *ELB) DescribeLoadBalancerPolicyTypesRequest(input *DescribeLoadBalancerPolicyTypesInput) (req *request.Request, output *DescribeLoadBalancerPolicyTypesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLoadBalancerPolicyTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -576,12 +576,12 @@ func (c *ELB) DescribeLoadBalancerPolicyTypes(input *DescribeLoadBalancerPolicyT
 const opDescribeLoadBalancers = "DescribeLoadBalancers"
 
 // DescribeLoadBalancersRequest generates a request for the DescribeLoadBalancers operation.
-func (c *ELB) DescribeLoadBalancersRequest(input *DescribeLoadBalancersInput) (req *service.Request, output *DescribeLoadBalancersOutput) {
-	op := &service.Operation{
+func (c *ELB) DescribeLoadBalancersRequest(input *DescribeLoadBalancersInput) (req *request.Request, output *DescribeLoadBalancersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLoadBalancers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "",
@@ -617,8 +617,8 @@ func (c *ELB) DescribeLoadBalancersPages(input *DescribeLoadBalancersInput, fn f
 const opDescribeTags = "DescribeTags"
 
 // DescribeTagsRequest generates a request for the DescribeTags operation.
-func (c *ELB) DescribeTagsRequest(input *DescribeTagsInput) (req *service.Request, output *DescribeTagsOutput) {
-	op := &service.Operation{
+func (c *ELB) DescribeTagsRequest(input *DescribeTagsInput) (req *request.Request, output *DescribeTagsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -644,8 +644,8 @@ func (c *ELB) DescribeTags(input *DescribeTagsInput) (*DescribeTagsOutput, error
 const opDetachLoadBalancerFromSubnets = "DetachLoadBalancerFromSubnets"
 
 // DetachLoadBalancerFromSubnetsRequest generates a request for the DetachLoadBalancerFromSubnets operation.
-func (c *ELB) DetachLoadBalancerFromSubnetsRequest(input *DetachLoadBalancerFromSubnetsInput) (req *service.Request, output *DetachLoadBalancerFromSubnetsOutput) {
-	op := &service.Operation{
+func (c *ELB) DetachLoadBalancerFromSubnetsRequest(input *DetachLoadBalancerFromSubnetsInput) (req *request.Request, output *DetachLoadBalancerFromSubnetsOutput) {
+	op := &request.Operation{
 		Name:       opDetachLoadBalancerFromSubnets,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -676,8 +676,8 @@ func (c *ELB) DetachLoadBalancerFromSubnets(input *DetachLoadBalancerFromSubnets
 const opDisableAvailabilityZonesForLoadBalancer = "DisableAvailabilityZonesForLoadBalancer"
 
 // DisableAvailabilityZonesForLoadBalancerRequest generates a request for the DisableAvailabilityZonesForLoadBalancer operation.
-func (c *ELB) DisableAvailabilityZonesForLoadBalancerRequest(input *DisableAvailabilityZonesForLoadBalancerInput) (req *service.Request, output *DisableAvailabilityZonesForLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *ELB) DisableAvailabilityZonesForLoadBalancerRequest(input *DisableAvailabilityZonesForLoadBalancerInput) (req *request.Request, output *DisableAvailabilityZonesForLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opDisableAvailabilityZonesForLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -714,8 +714,8 @@ func (c *ELB) DisableAvailabilityZonesForLoadBalancer(input *DisableAvailability
 const opEnableAvailabilityZonesForLoadBalancer = "EnableAvailabilityZonesForLoadBalancer"
 
 // EnableAvailabilityZonesForLoadBalancerRequest generates a request for the EnableAvailabilityZonesForLoadBalancer operation.
-func (c *ELB) EnableAvailabilityZonesForLoadBalancerRequest(input *EnableAvailabilityZonesForLoadBalancerInput) (req *service.Request, output *EnableAvailabilityZonesForLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *ELB) EnableAvailabilityZonesForLoadBalancerRequest(input *EnableAvailabilityZonesForLoadBalancerInput) (req *request.Request, output *EnableAvailabilityZonesForLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opEnableAvailabilityZonesForLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -748,8 +748,8 @@ func (c *ELB) EnableAvailabilityZonesForLoadBalancer(input *EnableAvailabilityZo
 const opModifyLoadBalancerAttributes = "ModifyLoadBalancerAttributes"
 
 // ModifyLoadBalancerAttributesRequest generates a request for the ModifyLoadBalancerAttributes operation.
-func (c *ELB) ModifyLoadBalancerAttributesRequest(input *ModifyLoadBalancerAttributesInput) (req *service.Request, output *ModifyLoadBalancerAttributesOutput) {
-	op := &service.Operation{
+func (c *ELB) ModifyLoadBalancerAttributesRequest(input *ModifyLoadBalancerAttributesInput) (req *request.Request, output *ModifyLoadBalancerAttributesOutput) {
+	op := &request.Operation{
 		Name:       opModifyLoadBalancerAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -788,8 +788,8 @@ func (c *ELB) ModifyLoadBalancerAttributes(input *ModifyLoadBalancerAttributesIn
 const opRegisterInstancesWithLoadBalancer = "RegisterInstancesWithLoadBalancer"
 
 // RegisterInstancesWithLoadBalancerRequest generates a request for the RegisterInstancesWithLoadBalancer operation.
-func (c *ELB) RegisterInstancesWithLoadBalancerRequest(input *RegisterInstancesWithLoadBalancerInput) (req *service.Request, output *RegisterInstancesWithLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *ELB) RegisterInstancesWithLoadBalancerRequest(input *RegisterInstancesWithLoadBalancerInput) (req *request.Request, output *RegisterInstancesWithLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opRegisterInstancesWithLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -841,8 +841,8 @@ func (c *ELB) RegisterInstancesWithLoadBalancer(input *RegisterInstancesWithLoad
 const opRemoveTags = "RemoveTags"
 
 // RemoveTagsRequest generates a request for the RemoveTags operation.
-func (c *ELB) RemoveTagsRequest(input *RemoveTagsInput) (req *service.Request, output *RemoveTagsOutput) {
-	op := &service.Operation{
+func (c *ELB) RemoveTagsRequest(input *RemoveTagsInput) (req *request.Request, output *RemoveTagsOutput) {
+	op := &request.Operation{
 		Name:       opRemoveTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -868,8 +868,8 @@ func (c *ELB) RemoveTags(input *RemoveTagsInput) (*RemoveTagsOutput, error) {
 const opSetLoadBalancerListenerSSLCertificate = "SetLoadBalancerListenerSSLCertificate"
 
 // SetLoadBalancerListenerSSLCertificateRequest generates a request for the SetLoadBalancerListenerSSLCertificate operation.
-func (c *ELB) SetLoadBalancerListenerSSLCertificateRequest(input *SetLoadBalancerListenerSSLCertificateInput) (req *service.Request, output *SetLoadBalancerListenerSSLCertificateOutput) {
-	op := &service.Operation{
+func (c *ELB) SetLoadBalancerListenerSSLCertificateRequest(input *SetLoadBalancerListenerSSLCertificateInput) (req *request.Request, output *SetLoadBalancerListenerSSLCertificateOutput) {
+	op := &request.Operation{
 		Name:       opSetLoadBalancerListenerSSLCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -901,8 +901,8 @@ func (c *ELB) SetLoadBalancerListenerSSLCertificate(input *SetLoadBalancerListen
 const opSetLoadBalancerPoliciesForBackendServer = "SetLoadBalancerPoliciesForBackendServer"
 
 // SetLoadBalancerPoliciesForBackendServerRequest generates a request for the SetLoadBalancerPoliciesForBackendServer operation.
-func (c *ELB) SetLoadBalancerPoliciesForBackendServerRequest(input *SetLoadBalancerPoliciesForBackendServerInput) (req *service.Request, output *SetLoadBalancerPoliciesForBackendServerOutput) {
-	op := &service.Operation{
+func (c *ELB) SetLoadBalancerPoliciesForBackendServerRequest(input *SetLoadBalancerPoliciesForBackendServerInput) (req *request.Request, output *SetLoadBalancerPoliciesForBackendServerOutput) {
+	op := &request.Operation{
 		Name:       opSetLoadBalancerPoliciesForBackendServer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -938,8 +938,8 @@ func (c *ELB) SetLoadBalancerPoliciesForBackendServer(input *SetLoadBalancerPoli
 const opSetLoadBalancerPoliciesOfListener = "SetLoadBalancerPoliciesOfListener"
 
 // SetLoadBalancerPoliciesOfListenerRequest generates a request for the SetLoadBalancerPoliciesOfListener operation.
-func (c *ELB) SetLoadBalancerPoliciesOfListenerRequest(input *SetLoadBalancerPoliciesOfListenerInput) (req *service.Request, output *SetLoadBalancerPoliciesOfListenerOutput) {
-	op := &service.Operation{
+func (c *ELB) SetLoadBalancerPoliciesOfListenerRequest(input *SetLoadBalancerPoliciesOfListenerInput) (req *request.Request, output *SetLoadBalancerPoliciesOfListenerOutput) {
+	op := &request.Operation{
 		Name:       opSetLoadBalancerPoliciesOfListener,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/elb/elbiface/interface.go
+++ b/service/elb/elbiface/interface.go
@@ -4,123 +4,123 @@
 package elbiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/elb"
 )
 
 // ELBAPI is the interface type for elb.ELB.
 type ELBAPI interface {
-	AddTagsRequest(*elb.AddTagsInput) (*service.Request, *elb.AddTagsOutput)
+	AddTagsRequest(*elb.AddTagsInput) (*request.Request, *elb.AddTagsOutput)
 
 	AddTags(*elb.AddTagsInput) (*elb.AddTagsOutput, error)
 
-	ApplySecurityGroupsToLoadBalancerRequest(*elb.ApplySecurityGroupsToLoadBalancerInput) (*service.Request, *elb.ApplySecurityGroupsToLoadBalancerOutput)
+	ApplySecurityGroupsToLoadBalancerRequest(*elb.ApplySecurityGroupsToLoadBalancerInput) (*request.Request, *elb.ApplySecurityGroupsToLoadBalancerOutput)
 
 	ApplySecurityGroupsToLoadBalancer(*elb.ApplySecurityGroupsToLoadBalancerInput) (*elb.ApplySecurityGroupsToLoadBalancerOutput, error)
 
-	AttachLoadBalancerToSubnetsRequest(*elb.AttachLoadBalancerToSubnetsInput) (*service.Request, *elb.AttachLoadBalancerToSubnetsOutput)
+	AttachLoadBalancerToSubnetsRequest(*elb.AttachLoadBalancerToSubnetsInput) (*request.Request, *elb.AttachLoadBalancerToSubnetsOutput)
 
 	AttachLoadBalancerToSubnets(*elb.AttachLoadBalancerToSubnetsInput) (*elb.AttachLoadBalancerToSubnetsOutput, error)
 
-	ConfigureHealthCheckRequest(*elb.ConfigureHealthCheckInput) (*service.Request, *elb.ConfigureHealthCheckOutput)
+	ConfigureHealthCheckRequest(*elb.ConfigureHealthCheckInput) (*request.Request, *elb.ConfigureHealthCheckOutput)
 
 	ConfigureHealthCheck(*elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error)
 
-	CreateAppCookieStickinessPolicyRequest(*elb.CreateAppCookieStickinessPolicyInput) (*service.Request, *elb.CreateAppCookieStickinessPolicyOutput)
+	CreateAppCookieStickinessPolicyRequest(*elb.CreateAppCookieStickinessPolicyInput) (*request.Request, *elb.CreateAppCookieStickinessPolicyOutput)
 
 	CreateAppCookieStickinessPolicy(*elb.CreateAppCookieStickinessPolicyInput) (*elb.CreateAppCookieStickinessPolicyOutput, error)
 
-	CreateLBCookieStickinessPolicyRequest(*elb.CreateLBCookieStickinessPolicyInput) (*service.Request, *elb.CreateLBCookieStickinessPolicyOutput)
+	CreateLBCookieStickinessPolicyRequest(*elb.CreateLBCookieStickinessPolicyInput) (*request.Request, *elb.CreateLBCookieStickinessPolicyOutput)
 
 	CreateLBCookieStickinessPolicy(*elb.CreateLBCookieStickinessPolicyInput) (*elb.CreateLBCookieStickinessPolicyOutput, error)
 
-	CreateLoadBalancerRequest(*elb.CreateLoadBalancerInput) (*service.Request, *elb.CreateLoadBalancerOutput)
+	CreateLoadBalancerRequest(*elb.CreateLoadBalancerInput) (*request.Request, *elb.CreateLoadBalancerOutput)
 
 	CreateLoadBalancer(*elb.CreateLoadBalancerInput) (*elb.CreateLoadBalancerOutput, error)
 
-	CreateLoadBalancerListenersRequest(*elb.CreateLoadBalancerListenersInput) (*service.Request, *elb.CreateLoadBalancerListenersOutput)
+	CreateLoadBalancerListenersRequest(*elb.CreateLoadBalancerListenersInput) (*request.Request, *elb.CreateLoadBalancerListenersOutput)
 
 	CreateLoadBalancerListeners(*elb.CreateLoadBalancerListenersInput) (*elb.CreateLoadBalancerListenersOutput, error)
 
-	CreateLoadBalancerPolicyRequest(*elb.CreateLoadBalancerPolicyInput) (*service.Request, *elb.CreateLoadBalancerPolicyOutput)
+	CreateLoadBalancerPolicyRequest(*elb.CreateLoadBalancerPolicyInput) (*request.Request, *elb.CreateLoadBalancerPolicyOutput)
 
 	CreateLoadBalancerPolicy(*elb.CreateLoadBalancerPolicyInput) (*elb.CreateLoadBalancerPolicyOutput, error)
 
-	DeleteLoadBalancerRequest(*elb.DeleteLoadBalancerInput) (*service.Request, *elb.DeleteLoadBalancerOutput)
+	DeleteLoadBalancerRequest(*elb.DeleteLoadBalancerInput) (*request.Request, *elb.DeleteLoadBalancerOutput)
 
 	DeleteLoadBalancer(*elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error)
 
-	DeleteLoadBalancerListenersRequest(*elb.DeleteLoadBalancerListenersInput) (*service.Request, *elb.DeleteLoadBalancerListenersOutput)
+	DeleteLoadBalancerListenersRequest(*elb.DeleteLoadBalancerListenersInput) (*request.Request, *elb.DeleteLoadBalancerListenersOutput)
 
 	DeleteLoadBalancerListeners(*elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error)
 
-	DeleteLoadBalancerPolicyRequest(*elb.DeleteLoadBalancerPolicyInput) (*service.Request, *elb.DeleteLoadBalancerPolicyOutput)
+	DeleteLoadBalancerPolicyRequest(*elb.DeleteLoadBalancerPolicyInput) (*request.Request, *elb.DeleteLoadBalancerPolicyOutput)
 
 	DeleteLoadBalancerPolicy(*elb.DeleteLoadBalancerPolicyInput) (*elb.DeleteLoadBalancerPolicyOutput, error)
 
-	DeregisterInstancesFromLoadBalancerRequest(*elb.DeregisterInstancesFromLoadBalancerInput) (*service.Request, *elb.DeregisterInstancesFromLoadBalancerOutput)
+	DeregisterInstancesFromLoadBalancerRequest(*elb.DeregisterInstancesFromLoadBalancerInput) (*request.Request, *elb.DeregisterInstancesFromLoadBalancerOutput)
 
 	DeregisterInstancesFromLoadBalancer(*elb.DeregisterInstancesFromLoadBalancerInput) (*elb.DeregisterInstancesFromLoadBalancerOutput, error)
 
-	DescribeInstanceHealthRequest(*elb.DescribeInstanceHealthInput) (*service.Request, *elb.DescribeInstanceHealthOutput)
+	DescribeInstanceHealthRequest(*elb.DescribeInstanceHealthInput) (*request.Request, *elb.DescribeInstanceHealthOutput)
 
 	DescribeInstanceHealth(*elb.DescribeInstanceHealthInput) (*elb.DescribeInstanceHealthOutput, error)
 
-	DescribeLoadBalancerAttributesRequest(*elb.DescribeLoadBalancerAttributesInput) (*service.Request, *elb.DescribeLoadBalancerAttributesOutput)
+	DescribeLoadBalancerAttributesRequest(*elb.DescribeLoadBalancerAttributesInput) (*request.Request, *elb.DescribeLoadBalancerAttributesOutput)
 
 	DescribeLoadBalancerAttributes(*elb.DescribeLoadBalancerAttributesInput) (*elb.DescribeLoadBalancerAttributesOutput, error)
 
-	DescribeLoadBalancerPoliciesRequest(*elb.DescribeLoadBalancerPoliciesInput) (*service.Request, *elb.DescribeLoadBalancerPoliciesOutput)
+	DescribeLoadBalancerPoliciesRequest(*elb.DescribeLoadBalancerPoliciesInput) (*request.Request, *elb.DescribeLoadBalancerPoliciesOutput)
 
 	DescribeLoadBalancerPolicies(*elb.DescribeLoadBalancerPoliciesInput) (*elb.DescribeLoadBalancerPoliciesOutput, error)
 
-	DescribeLoadBalancerPolicyTypesRequest(*elb.DescribeLoadBalancerPolicyTypesInput) (*service.Request, *elb.DescribeLoadBalancerPolicyTypesOutput)
+	DescribeLoadBalancerPolicyTypesRequest(*elb.DescribeLoadBalancerPolicyTypesInput) (*request.Request, *elb.DescribeLoadBalancerPolicyTypesOutput)
 
 	DescribeLoadBalancerPolicyTypes(*elb.DescribeLoadBalancerPolicyTypesInput) (*elb.DescribeLoadBalancerPolicyTypesOutput, error)
 
-	DescribeLoadBalancersRequest(*elb.DescribeLoadBalancersInput) (*service.Request, *elb.DescribeLoadBalancersOutput)
+	DescribeLoadBalancersRequest(*elb.DescribeLoadBalancersInput) (*request.Request, *elb.DescribeLoadBalancersOutput)
 
 	DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
 
 	DescribeLoadBalancersPages(*elb.DescribeLoadBalancersInput, func(*elb.DescribeLoadBalancersOutput, bool) bool) error
 
-	DescribeTagsRequest(*elb.DescribeTagsInput) (*service.Request, *elb.DescribeTagsOutput)
+	DescribeTagsRequest(*elb.DescribeTagsInput) (*request.Request, *elb.DescribeTagsOutput)
 
 	DescribeTags(*elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error)
 
-	DetachLoadBalancerFromSubnetsRequest(*elb.DetachLoadBalancerFromSubnetsInput) (*service.Request, *elb.DetachLoadBalancerFromSubnetsOutput)
+	DetachLoadBalancerFromSubnetsRequest(*elb.DetachLoadBalancerFromSubnetsInput) (*request.Request, *elb.DetachLoadBalancerFromSubnetsOutput)
 
 	DetachLoadBalancerFromSubnets(*elb.DetachLoadBalancerFromSubnetsInput) (*elb.DetachLoadBalancerFromSubnetsOutput, error)
 
-	DisableAvailabilityZonesForLoadBalancerRequest(*elb.DisableAvailabilityZonesForLoadBalancerInput) (*service.Request, *elb.DisableAvailabilityZonesForLoadBalancerOutput)
+	DisableAvailabilityZonesForLoadBalancerRequest(*elb.DisableAvailabilityZonesForLoadBalancerInput) (*request.Request, *elb.DisableAvailabilityZonesForLoadBalancerOutput)
 
 	DisableAvailabilityZonesForLoadBalancer(*elb.DisableAvailabilityZonesForLoadBalancerInput) (*elb.DisableAvailabilityZonesForLoadBalancerOutput, error)
 
-	EnableAvailabilityZonesForLoadBalancerRequest(*elb.EnableAvailabilityZonesForLoadBalancerInput) (*service.Request, *elb.EnableAvailabilityZonesForLoadBalancerOutput)
+	EnableAvailabilityZonesForLoadBalancerRequest(*elb.EnableAvailabilityZonesForLoadBalancerInput) (*request.Request, *elb.EnableAvailabilityZonesForLoadBalancerOutput)
 
 	EnableAvailabilityZonesForLoadBalancer(*elb.EnableAvailabilityZonesForLoadBalancerInput) (*elb.EnableAvailabilityZonesForLoadBalancerOutput, error)
 
-	ModifyLoadBalancerAttributesRequest(*elb.ModifyLoadBalancerAttributesInput) (*service.Request, *elb.ModifyLoadBalancerAttributesOutput)
+	ModifyLoadBalancerAttributesRequest(*elb.ModifyLoadBalancerAttributesInput) (*request.Request, *elb.ModifyLoadBalancerAttributesOutput)
 
 	ModifyLoadBalancerAttributes(*elb.ModifyLoadBalancerAttributesInput) (*elb.ModifyLoadBalancerAttributesOutput, error)
 
-	RegisterInstancesWithLoadBalancerRequest(*elb.RegisterInstancesWithLoadBalancerInput) (*service.Request, *elb.RegisterInstancesWithLoadBalancerOutput)
+	RegisterInstancesWithLoadBalancerRequest(*elb.RegisterInstancesWithLoadBalancerInput) (*request.Request, *elb.RegisterInstancesWithLoadBalancerOutput)
 
 	RegisterInstancesWithLoadBalancer(*elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error)
 
-	RemoveTagsRequest(*elb.RemoveTagsInput) (*service.Request, *elb.RemoveTagsOutput)
+	RemoveTagsRequest(*elb.RemoveTagsInput) (*request.Request, *elb.RemoveTagsOutput)
 
 	RemoveTags(*elb.RemoveTagsInput) (*elb.RemoveTagsOutput, error)
 
-	SetLoadBalancerListenerSSLCertificateRequest(*elb.SetLoadBalancerListenerSSLCertificateInput) (*service.Request, *elb.SetLoadBalancerListenerSSLCertificateOutput)
+	SetLoadBalancerListenerSSLCertificateRequest(*elb.SetLoadBalancerListenerSSLCertificateInput) (*request.Request, *elb.SetLoadBalancerListenerSSLCertificateOutput)
 
 	SetLoadBalancerListenerSSLCertificate(*elb.SetLoadBalancerListenerSSLCertificateInput) (*elb.SetLoadBalancerListenerSSLCertificateOutput, error)
 
-	SetLoadBalancerPoliciesForBackendServerRequest(*elb.SetLoadBalancerPoliciesForBackendServerInput) (*service.Request, *elb.SetLoadBalancerPoliciesForBackendServerOutput)
+	SetLoadBalancerPoliciesForBackendServerRequest(*elb.SetLoadBalancerPoliciesForBackendServerInput) (*request.Request, *elb.SetLoadBalancerPoliciesForBackendServerOutput)
 
 	SetLoadBalancerPoliciesForBackendServer(*elb.SetLoadBalancerPoliciesForBackendServerInput) (*elb.SetLoadBalancerPoliciesForBackendServerOutput, error)
 
-	SetLoadBalancerPoliciesOfListenerRequest(*elb.SetLoadBalancerPoliciesOfListenerInput) (*service.Request, *elb.SetLoadBalancerPoliciesOfListenerOutput)
+	SetLoadBalancerPoliciesOfListenerRequest(*elb.SetLoadBalancerPoliciesOfListenerInput) (*request.Request, *elb.SetLoadBalancerPoliciesOfListenerOutput)
 
 	SetLoadBalancerPoliciesOfListener(*elb.SetLoadBalancerPoliciesOfListenerInput) (*elb.SetLoadBalancerPoliciesOfListenerOutput, error)
 }

--- a/service/elb/service.go
+++ b/service/elb/service.go
@@ -5,7 +5,9 @@ package elb
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -31,14 +33,16 @@ type ELB struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new ELB client.
 func New(config *aws.Config) *ELB {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "elasticloadbalancing",
-		APIVersion:  "2012-06-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "elasticloadbalancing",
+			APIVersion:  "2012-06-01",
+		},
 	}
 	service.Initialize()
 
@@ -59,8 +63,8 @@ func New(config *aws.Config) *ELB {
 
 // newRequest creates a new request for a ELB operation and runs any
 // custom request initialization.
-func (c *ELB) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *ELB) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/emr/api.go
+++ b/service/emr/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddInstanceGroups = "AddInstanceGroups"
 
 // AddInstanceGroupsRequest generates a request for the AddInstanceGroups operation.
-func (c *EMR) AddInstanceGroupsRequest(input *AddInstanceGroupsInput) (req *service.Request, output *AddInstanceGroupsOutput) {
-	op := &service.Operation{
+func (c *EMR) AddInstanceGroupsRequest(input *AddInstanceGroupsInput) (req *request.Request, output *AddInstanceGroupsOutput) {
+	op := &request.Operation{
 		Name:       opAddInstanceGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -40,8 +40,8 @@ func (c *EMR) AddInstanceGroups(input *AddInstanceGroupsInput) (*AddInstanceGrou
 const opAddJobFlowSteps = "AddJobFlowSteps"
 
 // AddJobFlowStepsRequest generates a request for the AddJobFlowSteps operation.
-func (c *EMR) AddJobFlowStepsRequest(input *AddJobFlowStepsInput) (req *service.Request, output *AddJobFlowStepsOutput) {
-	op := &service.Operation{
+func (c *EMR) AddJobFlowStepsRequest(input *AddJobFlowStepsInput) (req *request.Request, output *AddJobFlowStepsOutput) {
+	op := &request.Operation{
 		Name:       opAddJobFlowSteps,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -90,8 +90,8 @@ func (c *EMR) AddJobFlowSteps(input *AddJobFlowStepsInput) (*AddJobFlowStepsOutp
 const opAddTags = "AddTags"
 
 // AddTagsRequest generates a request for the AddTags operation.
-func (c *EMR) AddTagsRequest(input *AddTagsInput) (req *service.Request, output *AddTagsOutput) {
-	op := &service.Operation{
+func (c *EMR) AddTagsRequest(input *AddTagsInput) (req *request.Request, output *AddTagsOutput) {
+	op := &request.Operation{
 		Name:       opAddTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -120,8 +120,8 @@ func (c *EMR) AddTags(input *AddTagsInput) (*AddTagsOutput, error) {
 const opDescribeCluster = "DescribeCluster"
 
 // DescribeClusterRequest generates a request for the DescribeCluster operation.
-func (c *EMR) DescribeClusterRequest(input *DescribeClusterInput) (req *service.Request, output *DescribeClusterOutput) {
-	op := &service.Operation{
+func (c *EMR) DescribeClusterRequest(input *DescribeClusterInput) (req *request.Request, output *DescribeClusterOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -148,8 +148,8 @@ func (c *EMR) DescribeCluster(input *DescribeClusterInput) (*DescribeClusterOutp
 const opDescribeJobFlows = "DescribeJobFlows"
 
 // DescribeJobFlowsRequest generates a request for the DescribeJobFlows operation.
-func (c *EMR) DescribeJobFlowsRequest(input *DescribeJobFlowsInput) (req *service.Request, output *DescribeJobFlowsOutput) {
-	op := &service.Operation{
+func (c *EMR) DescribeJobFlowsRequest(input *DescribeJobFlowsInput) (req *request.Request, output *DescribeJobFlowsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeJobFlows,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -192,8 +192,8 @@ func (c *EMR) DescribeJobFlows(input *DescribeJobFlowsInput) (*DescribeJobFlowsO
 const opDescribeStep = "DescribeStep"
 
 // DescribeStepRequest generates a request for the DescribeStep operation.
-func (c *EMR) DescribeStepRequest(input *DescribeStepInput) (req *service.Request, output *DescribeStepOutput) {
-	op := &service.Operation{
+func (c *EMR) DescribeStepRequest(input *DescribeStepInput) (req *request.Request, output *DescribeStepOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStep,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -219,12 +219,12 @@ func (c *EMR) DescribeStep(input *DescribeStepInput) (*DescribeStepOutput, error
 const opListBootstrapActions = "ListBootstrapActions"
 
 // ListBootstrapActionsRequest generates a request for the ListBootstrapActions operation.
-func (c *EMR) ListBootstrapActionsRequest(input *ListBootstrapActionsInput) (req *service.Request, output *ListBootstrapActionsOutput) {
-	op := &service.Operation{
+func (c *EMR) ListBootstrapActionsRequest(input *ListBootstrapActionsInput) (req *request.Request, output *ListBootstrapActionsOutput) {
+	op := &request.Operation{
 		Name:       opListBootstrapActions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "",
@@ -259,12 +259,12 @@ func (c *EMR) ListBootstrapActionsPages(input *ListBootstrapActionsInput, fn fun
 const opListClusters = "ListClusters"
 
 // ListClustersRequest generates a request for the ListClusters operation.
-func (c *EMR) ListClustersRequest(input *ListClustersInput) (req *service.Request, output *ListClustersOutput) {
-	op := &service.Operation{
+func (c *EMR) ListClustersRequest(input *ListClustersInput) (req *request.Request, output *ListClustersOutput) {
+	op := &request.Operation{
 		Name:       opListClusters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "",
@@ -303,12 +303,12 @@ func (c *EMR) ListClustersPages(input *ListClustersInput, fn func(p *ListCluster
 const opListInstanceGroups = "ListInstanceGroups"
 
 // ListInstanceGroupsRequest generates a request for the ListInstanceGroups operation.
-func (c *EMR) ListInstanceGroupsRequest(input *ListInstanceGroupsInput) (req *service.Request, output *ListInstanceGroupsOutput) {
-	op := &service.Operation{
+func (c *EMR) ListInstanceGroupsRequest(input *ListInstanceGroupsInput) (req *request.Request, output *ListInstanceGroupsOutput) {
+	op := &request.Operation{
 		Name:       opListInstanceGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "",
@@ -343,12 +343,12 @@ func (c *EMR) ListInstanceGroupsPages(input *ListInstanceGroupsInput, fn func(p 
 const opListInstances = "ListInstances"
 
 // ListInstancesRequest generates a request for the ListInstances operation.
-func (c *EMR) ListInstancesRequest(input *ListInstancesInput) (req *service.Request, output *ListInstancesOutput) {
-	op := &service.Operation{
+func (c *EMR) ListInstancesRequest(input *ListInstancesInput) (req *request.Request, output *ListInstancesOutput) {
+	op := &request.Operation{
 		Name:       opListInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "",
@@ -387,12 +387,12 @@ func (c *EMR) ListInstancesPages(input *ListInstancesInput, fn func(p *ListInsta
 const opListSteps = "ListSteps"
 
 // ListStepsRequest generates a request for the ListSteps operation.
-func (c *EMR) ListStepsRequest(input *ListStepsInput) (req *service.Request, output *ListStepsOutput) {
-	op := &service.Operation{
+func (c *EMR) ListStepsRequest(input *ListStepsInput) (req *request.Request, output *ListStepsOutput) {
+	op := &request.Operation{
 		Name:       opListSteps,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "",
@@ -427,8 +427,8 @@ func (c *EMR) ListStepsPages(input *ListStepsInput, fn func(p *ListStepsOutput, 
 const opModifyInstanceGroups = "ModifyInstanceGroups"
 
 // ModifyInstanceGroupsRequest generates a request for the ModifyInstanceGroups operation.
-func (c *EMR) ModifyInstanceGroupsRequest(input *ModifyInstanceGroupsInput) (req *service.Request, output *ModifyInstanceGroupsOutput) {
-	op := &service.Operation{
+func (c *EMR) ModifyInstanceGroupsRequest(input *ModifyInstanceGroupsInput) (req *request.Request, output *ModifyInstanceGroupsOutput) {
+	op := &request.Operation{
 		Name:       opModifyInstanceGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -457,8 +457,8 @@ func (c *EMR) ModifyInstanceGroups(input *ModifyInstanceGroupsInput) (*ModifyIns
 const opRemoveTags = "RemoveTags"
 
 // RemoveTagsRequest generates a request for the RemoveTags operation.
-func (c *EMR) RemoveTagsRequest(input *RemoveTagsInput) (req *service.Request, output *RemoveTagsOutput) {
-	op := &service.Operation{
+func (c *EMR) RemoveTagsRequest(input *RemoveTagsInput) (req *request.Request, output *RemoveTagsOutput) {
+	op := &request.Operation{
 		Name:       opRemoveTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -489,8 +489,8 @@ func (c *EMR) RemoveTags(input *RemoveTagsInput) (*RemoveTagsOutput, error) {
 const opRunJobFlow = "RunJobFlow"
 
 // RunJobFlowRequest generates a request for the RunJobFlow operation.
-func (c *EMR) RunJobFlowRequest(input *RunJobFlowInput) (req *service.Request, output *RunJobFlowOutput) {
-	op := &service.Operation{
+func (c *EMR) RunJobFlowRequest(input *RunJobFlowInput) (req *request.Request, output *RunJobFlowOutput) {
+	op := &request.Operation{
 		Name:       opRunJobFlow,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -538,8 +538,8 @@ func (c *EMR) RunJobFlow(input *RunJobFlowInput) (*RunJobFlowOutput, error) {
 const opSetTerminationProtection = "SetTerminationProtection"
 
 // SetTerminationProtectionRequest generates a request for the SetTerminationProtection operation.
-func (c *EMR) SetTerminationProtectionRequest(input *SetTerminationProtectionInput) (req *service.Request, output *SetTerminationProtectionOutput) {
-	op := &service.Operation{
+func (c *EMR) SetTerminationProtectionRequest(input *SetTerminationProtectionInput) (req *request.Request, output *SetTerminationProtectionOutput) {
+	op := &request.Operation{
 		Name:       opSetTerminationProtection,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -581,8 +581,8 @@ func (c *EMR) SetTerminationProtection(input *SetTerminationProtectionInput) (*S
 const opSetVisibleToAllUsers = "SetVisibleToAllUsers"
 
 // SetVisibleToAllUsersRequest generates a request for the SetVisibleToAllUsers operation.
-func (c *EMR) SetVisibleToAllUsersRequest(input *SetVisibleToAllUsersInput) (req *service.Request, output *SetVisibleToAllUsersOutput) {
-	op := &service.Operation{
+func (c *EMR) SetVisibleToAllUsersRequest(input *SetVisibleToAllUsersInput) (req *request.Request, output *SetVisibleToAllUsersOutput) {
+	op := &request.Operation{
 		Name:       opSetVisibleToAllUsers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -613,8 +613,8 @@ func (c *EMR) SetVisibleToAllUsers(input *SetVisibleToAllUsersInput) (*SetVisibl
 const opTerminateJobFlows = "TerminateJobFlows"
 
 // TerminateJobFlowsRequest generates a request for the TerminateJobFlows operation.
-func (c *EMR) TerminateJobFlowsRequest(input *TerminateJobFlowsInput) (req *service.Request, output *TerminateJobFlowsOutput) {
-	op := &service.Operation{
+func (c *EMR) TerminateJobFlowsRequest(input *TerminateJobFlowsInput) (req *request.Request, output *TerminateJobFlowsOutput) {
+	op := &request.Operation{
 		Name:       opTerminateJobFlows,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/emr/emriface/interface.go
+++ b/service/emr/emriface/interface.go
@@ -4,87 +4,87 @@
 package emriface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/emr"
 )
 
 // EMRAPI is the interface type for emr.EMR.
 type EMRAPI interface {
-	AddInstanceGroupsRequest(*emr.AddInstanceGroupsInput) (*service.Request, *emr.AddInstanceGroupsOutput)
+	AddInstanceGroupsRequest(*emr.AddInstanceGroupsInput) (*request.Request, *emr.AddInstanceGroupsOutput)
 
 	AddInstanceGroups(*emr.AddInstanceGroupsInput) (*emr.AddInstanceGroupsOutput, error)
 
-	AddJobFlowStepsRequest(*emr.AddJobFlowStepsInput) (*service.Request, *emr.AddJobFlowStepsOutput)
+	AddJobFlowStepsRequest(*emr.AddJobFlowStepsInput) (*request.Request, *emr.AddJobFlowStepsOutput)
 
 	AddJobFlowSteps(*emr.AddJobFlowStepsInput) (*emr.AddJobFlowStepsOutput, error)
 
-	AddTagsRequest(*emr.AddTagsInput) (*service.Request, *emr.AddTagsOutput)
+	AddTagsRequest(*emr.AddTagsInput) (*request.Request, *emr.AddTagsOutput)
 
 	AddTags(*emr.AddTagsInput) (*emr.AddTagsOutput, error)
 
-	DescribeClusterRequest(*emr.DescribeClusterInput) (*service.Request, *emr.DescribeClusterOutput)
+	DescribeClusterRequest(*emr.DescribeClusterInput) (*request.Request, *emr.DescribeClusterOutput)
 
 	DescribeCluster(*emr.DescribeClusterInput) (*emr.DescribeClusterOutput, error)
 
-	DescribeJobFlowsRequest(*emr.DescribeJobFlowsInput) (*service.Request, *emr.DescribeJobFlowsOutput)
+	DescribeJobFlowsRequest(*emr.DescribeJobFlowsInput) (*request.Request, *emr.DescribeJobFlowsOutput)
 
 	DescribeJobFlows(*emr.DescribeJobFlowsInput) (*emr.DescribeJobFlowsOutput, error)
 
-	DescribeStepRequest(*emr.DescribeStepInput) (*service.Request, *emr.DescribeStepOutput)
+	DescribeStepRequest(*emr.DescribeStepInput) (*request.Request, *emr.DescribeStepOutput)
 
 	DescribeStep(*emr.DescribeStepInput) (*emr.DescribeStepOutput, error)
 
-	ListBootstrapActionsRequest(*emr.ListBootstrapActionsInput) (*service.Request, *emr.ListBootstrapActionsOutput)
+	ListBootstrapActionsRequest(*emr.ListBootstrapActionsInput) (*request.Request, *emr.ListBootstrapActionsOutput)
 
 	ListBootstrapActions(*emr.ListBootstrapActionsInput) (*emr.ListBootstrapActionsOutput, error)
 
 	ListBootstrapActionsPages(*emr.ListBootstrapActionsInput, func(*emr.ListBootstrapActionsOutput, bool) bool) error
 
-	ListClustersRequest(*emr.ListClustersInput) (*service.Request, *emr.ListClustersOutput)
+	ListClustersRequest(*emr.ListClustersInput) (*request.Request, *emr.ListClustersOutput)
 
 	ListClusters(*emr.ListClustersInput) (*emr.ListClustersOutput, error)
 
 	ListClustersPages(*emr.ListClustersInput, func(*emr.ListClustersOutput, bool) bool) error
 
-	ListInstanceGroupsRequest(*emr.ListInstanceGroupsInput) (*service.Request, *emr.ListInstanceGroupsOutput)
+	ListInstanceGroupsRequest(*emr.ListInstanceGroupsInput) (*request.Request, *emr.ListInstanceGroupsOutput)
 
 	ListInstanceGroups(*emr.ListInstanceGroupsInput) (*emr.ListInstanceGroupsOutput, error)
 
 	ListInstanceGroupsPages(*emr.ListInstanceGroupsInput, func(*emr.ListInstanceGroupsOutput, bool) bool) error
 
-	ListInstancesRequest(*emr.ListInstancesInput) (*service.Request, *emr.ListInstancesOutput)
+	ListInstancesRequest(*emr.ListInstancesInput) (*request.Request, *emr.ListInstancesOutput)
 
 	ListInstances(*emr.ListInstancesInput) (*emr.ListInstancesOutput, error)
 
 	ListInstancesPages(*emr.ListInstancesInput, func(*emr.ListInstancesOutput, bool) bool) error
 
-	ListStepsRequest(*emr.ListStepsInput) (*service.Request, *emr.ListStepsOutput)
+	ListStepsRequest(*emr.ListStepsInput) (*request.Request, *emr.ListStepsOutput)
 
 	ListSteps(*emr.ListStepsInput) (*emr.ListStepsOutput, error)
 
 	ListStepsPages(*emr.ListStepsInput, func(*emr.ListStepsOutput, bool) bool) error
 
-	ModifyInstanceGroupsRequest(*emr.ModifyInstanceGroupsInput) (*service.Request, *emr.ModifyInstanceGroupsOutput)
+	ModifyInstanceGroupsRequest(*emr.ModifyInstanceGroupsInput) (*request.Request, *emr.ModifyInstanceGroupsOutput)
 
 	ModifyInstanceGroups(*emr.ModifyInstanceGroupsInput) (*emr.ModifyInstanceGroupsOutput, error)
 
-	RemoveTagsRequest(*emr.RemoveTagsInput) (*service.Request, *emr.RemoveTagsOutput)
+	RemoveTagsRequest(*emr.RemoveTagsInput) (*request.Request, *emr.RemoveTagsOutput)
 
 	RemoveTags(*emr.RemoveTagsInput) (*emr.RemoveTagsOutput, error)
 
-	RunJobFlowRequest(*emr.RunJobFlowInput) (*service.Request, *emr.RunJobFlowOutput)
+	RunJobFlowRequest(*emr.RunJobFlowInput) (*request.Request, *emr.RunJobFlowOutput)
 
 	RunJobFlow(*emr.RunJobFlowInput) (*emr.RunJobFlowOutput, error)
 
-	SetTerminationProtectionRequest(*emr.SetTerminationProtectionInput) (*service.Request, *emr.SetTerminationProtectionOutput)
+	SetTerminationProtectionRequest(*emr.SetTerminationProtectionInput) (*request.Request, *emr.SetTerminationProtectionOutput)
 
 	SetTerminationProtection(*emr.SetTerminationProtectionInput) (*emr.SetTerminationProtectionOutput, error)
 
-	SetVisibleToAllUsersRequest(*emr.SetVisibleToAllUsersInput) (*service.Request, *emr.SetVisibleToAllUsersOutput)
+	SetVisibleToAllUsersRequest(*emr.SetVisibleToAllUsersInput) (*request.Request, *emr.SetVisibleToAllUsersOutput)
 
 	SetVisibleToAllUsers(*emr.SetVisibleToAllUsersInput) (*emr.SetVisibleToAllUsersOutput, error)
 
-	TerminateJobFlowsRequest(*emr.TerminateJobFlowsInput) (*service.Request, *emr.TerminateJobFlowsOutput)
+	TerminateJobFlowsRequest(*emr.TerminateJobFlowsInput) (*request.Request, *emr.TerminateJobFlowsOutput)
 
 	TerminateJobFlows(*emr.TerminateJobFlowsInput) (*emr.TerminateJobFlowsOutput, error)
 }

--- a/service/emr/service.go
+++ b/service/emr/service.go
@@ -5,7 +5,9 @@ package emr
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -23,16 +25,18 @@ type EMR struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new EMR client.
 func New(config *aws.Config) *EMR {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "elasticmapreduce",
-		APIVersion:   "2009-03-31",
-		JSONVersion:  "1.1",
-		TargetPrefix: "ElasticMapReduce",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "elasticmapreduce",
+			APIVersion:   "2009-03-31",
+			JSONVersion:  "1.1",
+			TargetPrefix: "ElasticMapReduce",
+		},
 	}
 	service.Initialize()
 
@@ -53,8 +57,8 @@ func New(config *aws.Config) *EMR {
 
 // newRequest creates a new request for a EMR operation and runs any
 // custom request initialization.
-func (c *EMR) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *EMR) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/glacier/api.go
+++ b/service/glacier/api.go
@@ -7,14 +7,14 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAbortMultipartUpload = "AbortMultipartUpload"
 
 // AbortMultipartUploadRequest generates a request for the AbortMultipartUpload operation.
-func (c *Glacier) AbortMultipartUploadRequest(input *AbortMultipartUploadInput) (req *service.Request, output *AbortMultipartUploadOutput) {
-	op := &service.Operation{
+func (c *Glacier) AbortMultipartUploadRequest(input *AbortMultipartUploadInput) (req *request.Request, output *AbortMultipartUploadOutput) {
+	op := &request.Operation{
 		Name:       opAbortMultipartUpload,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}",
@@ -59,8 +59,8 @@ func (c *Glacier) AbortMultipartUpload(input *AbortMultipartUploadInput) (*Abort
 const opAbortVaultLock = "AbortVaultLock"
 
 // AbortVaultLockRequest generates a request for the AbortVaultLock operation.
-func (c *Glacier) AbortVaultLockRequest(input *AbortVaultLockInput) (req *service.Request, output *AbortVaultLockOutput) {
-	op := &service.Operation{
+func (c *Glacier) AbortVaultLockRequest(input *AbortVaultLockInput) (req *request.Request, output *AbortVaultLockOutput) {
+	op := &request.Operation{
 		Name:       opAbortVaultLock,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/lock-policy",
@@ -101,8 +101,8 @@ func (c *Glacier) AbortVaultLock(input *AbortVaultLockInput) (*AbortVaultLockOut
 const opAddTagsToVault = "AddTagsToVault"
 
 // AddTagsToVaultRequest generates a request for the AddTagsToVault operation.
-func (c *Glacier) AddTagsToVaultRequest(input *AddTagsToVaultInput) (req *service.Request, output *AddTagsToVaultOutput) {
-	op := &service.Operation{
+func (c *Glacier) AddTagsToVaultRequest(input *AddTagsToVaultInput) (req *request.Request, output *AddTagsToVaultOutput) {
+	op := &request.Operation{
 		Name:       opAddTagsToVault,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/tags?operation=add",
@@ -133,8 +133,8 @@ func (c *Glacier) AddTagsToVault(input *AddTagsToVaultInput) (*AddTagsToVaultOut
 const opCompleteMultipartUpload = "CompleteMultipartUpload"
 
 // CompleteMultipartUploadRequest generates a request for the CompleteMultipartUpload operation.
-func (c *Glacier) CompleteMultipartUploadRequest(input *CompleteMultipartUploadInput) (req *service.Request, output *ArchiveCreationOutput) {
-	op := &service.Operation{
+func (c *Glacier) CompleteMultipartUploadRequest(input *CompleteMultipartUploadInput) (req *request.Request, output *ArchiveCreationOutput) {
+	op := &request.Operation{
 		Name:       opCompleteMultipartUpload,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}",
@@ -203,8 +203,8 @@ func (c *Glacier) CompleteMultipartUpload(input *CompleteMultipartUploadInput) (
 const opCompleteVaultLock = "CompleteVaultLock"
 
 // CompleteVaultLockRequest generates a request for the CompleteVaultLock operation.
-func (c *Glacier) CompleteVaultLockRequest(input *CompleteVaultLockInput) (req *service.Request, output *CompleteVaultLockOutput) {
-	op := &service.Operation{
+func (c *Glacier) CompleteVaultLockRequest(input *CompleteVaultLockInput) (req *request.Request, output *CompleteVaultLockOutput) {
+	op := &request.Operation{
 		Name:       opCompleteVaultLock,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/lock-policy/{lockId}",
@@ -244,8 +244,8 @@ func (c *Glacier) CompleteVaultLock(input *CompleteVaultLockInput) (*CompleteVau
 const opCreateVault = "CreateVault"
 
 // CreateVaultRequest generates a request for the CreateVault operation.
-func (c *Glacier) CreateVaultRequest(input *CreateVaultInput) (req *service.Request, output *CreateVaultOutput) {
-	op := &service.Operation{
+func (c *Glacier) CreateVaultRequest(input *CreateVaultInput) (req *request.Request, output *CreateVaultOutput) {
+	op := &request.Operation{
 		Name:       opCreateVault,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}",
@@ -294,8 +294,8 @@ func (c *Glacier) CreateVault(input *CreateVaultInput) (*CreateVaultOutput, erro
 const opDeleteArchive = "DeleteArchive"
 
 // DeleteArchiveRequest generates a request for the DeleteArchive operation.
-func (c *Glacier) DeleteArchiveRequest(input *DeleteArchiveInput) (req *service.Request, output *DeleteArchiveOutput) {
-	op := &service.Operation{
+func (c *Glacier) DeleteArchiveRequest(input *DeleteArchiveInput) (req *request.Request, output *DeleteArchiveOutput) {
+	op := &request.Operation{
 		Name:       opDeleteArchive,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/archives/{archiveId}",
@@ -341,8 +341,8 @@ func (c *Glacier) DeleteArchive(input *DeleteArchiveInput) (*DeleteArchiveOutput
 const opDeleteVault = "DeleteVault"
 
 // DeleteVaultRequest generates a request for the DeleteVault operation.
-func (c *Glacier) DeleteVaultRequest(input *DeleteVaultInput) (req *service.Request, output *DeleteVaultOutput) {
-	op := &service.Operation{
+func (c *Glacier) DeleteVaultRequest(input *DeleteVaultInput) (req *request.Request, output *DeleteVaultOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVault,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}",
@@ -390,8 +390,8 @@ func (c *Glacier) DeleteVault(input *DeleteVaultInput) (*DeleteVaultOutput, erro
 const opDeleteVaultAccessPolicy = "DeleteVaultAccessPolicy"
 
 // DeleteVaultAccessPolicyRequest generates a request for the DeleteVaultAccessPolicy operation.
-func (c *Glacier) DeleteVaultAccessPolicyRequest(input *DeleteVaultAccessPolicyInput) (req *service.Request, output *DeleteVaultAccessPolicyOutput) {
-	op := &service.Operation{
+func (c *Glacier) DeleteVaultAccessPolicyRequest(input *DeleteVaultAccessPolicyInput) (req *request.Request, output *DeleteVaultAccessPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVaultAccessPolicy,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/access-policy",
@@ -426,8 +426,8 @@ func (c *Glacier) DeleteVaultAccessPolicy(input *DeleteVaultAccessPolicyInput) (
 const opDeleteVaultNotifications = "DeleteVaultNotifications"
 
 // DeleteVaultNotificationsRequest generates a request for the DeleteVaultNotifications operation.
-func (c *Glacier) DeleteVaultNotificationsRequest(input *DeleteVaultNotificationsInput) (req *service.Request, output *DeleteVaultNotificationsOutput) {
-	op := &service.Operation{
+func (c *Glacier) DeleteVaultNotificationsRequest(input *DeleteVaultNotificationsInput) (req *request.Request, output *DeleteVaultNotificationsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVaultNotifications,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/notification-configuration",
@@ -467,8 +467,8 @@ func (c *Glacier) DeleteVaultNotifications(input *DeleteVaultNotificationsInput)
 const opDescribeJob = "DescribeJob"
 
 // DescribeJobRequest generates a request for the DescribeJob operation.
-func (c *Glacier) DescribeJobRequest(input *DescribeJobInput) (req *service.Request, output *JobDescription) {
-	op := &service.Operation{
+func (c *Glacier) DescribeJobRequest(input *DescribeJobInput) (req *request.Request, output *JobDescription) {
+	op := &request.Operation{
 		Name:       opDescribeJob,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/jobs/{jobId}",
@@ -515,8 +515,8 @@ func (c *Glacier) DescribeJob(input *DescribeJobInput) (*JobDescription, error) 
 const opDescribeVault = "DescribeVault"
 
 // DescribeVaultRequest generates a request for the DescribeVault operation.
-func (c *Glacier) DescribeVaultRequest(input *DescribeVaultInput) (req *service.Request, output *DescribeVaultOutput) {
-	op := &service.Operation{
+func (c *Glacier) DescribeVaultRequest(input *DescribeVaultInput) (req *request.Request, output *DescribeVaultOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVault,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}",
@@ -561,8 +561,8 @@ func (c *Glacier) DescribeVault(input *DescribeVaultInput) (*DescribeVaultOutput
 const opGetDataRetrievalPolicy = "GetDataRetrievalPolicy"
 
 // GetDataRetrievalPolicyRequest generates a request for the GetDataRetrievalPolicy operation.
-func (c *Glacier) GetDataRetrievalPolicyRequest(input *GetDataRetrievalPolicyInput) (req *service.Request, output *GetDataRetrievalPolicyOutput) {
-	op := &service.Operation{
+func (c *Glacier) GetDataRetrievalPolicyRequest(input *GetDataRetrievalPolicyInput) (req *request.Request, output *GetDataRetrievalPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetDataRetrievalPolicy,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/policies/data-retrieval",
@@ -590,8 +590,8 @@ func (c *Glacier) GetDataRetrievalPolicy(input *GetDataRetrievalPolicyInput) (*G
 const opGetJobOutput = "GetJobOutput"
 
 // GetJobOutputRequest generates a request for the GetJobOutput operation.
-func (c *Glacier) GetJobOutputRequest(input *GetJobOutputInput) (req *service.Request, output *GetJobOutputOutput) {
-	op := &service.Operation{
+func (c *Glacier) GetJobOutputRequest(input *GetJobOutputInput) (req *request.Request, output *GetJobOutputOutput) {
+	op := &request.Operation{
 		Name:       opGetJobOutput,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/jobs/{jobId}/output",
@@ -660,8 +660,8 @@ func (c *Glacier) GetJobOutput(input *GetJobOutputInput) (*GetJobOutputOutput, e
 const opGetVaultAccessPolicy = "GetVaultAccessPolicy"
 
 // GetVaultAccessPolicyRequest generates a request for the GetVaultAccessPolicy operation.
-func (c *Glacier) GetVaultAccessPolicyRequest(input *GetVaultAccessPolicyInput) (req *service.Request, output *GetVaultAccessPolicyOutput) {
-	op := &service.Operation{
+func (c *Glacier) GetVaultAccessPolicyRequest(input *GetVaultAccessPolicyInput) (req *request.Request, output *GetVaultAccessPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetVaultAccessPolicy,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/access-policy",
@@ -692,8 +692,8 @@ func (c *Glacier) GetVaultAccessPolicy(input *GetVaultAccessPolicyInput) (*GetVa
 const opGetVaultLock = "GetVaultLock"
 
 // GetVaultLockRequest generates a request for the GetVaultLock operation.
-func (c *Glacier) GetVaultLockRequest(input *GetVaultLockInput) (req *service.Request, output *GetVaultLockOutput) {
-	op := &service.Operation{
+func (c *Glacier) GetVaultLockRequest(input *GetVaultLockInput) (req *request.Request, output *GetVaultLockOutput) {
+	op := &request.Operation{
 		Name:       opGetVaultLock,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/lock-policy",
@@ -736,8 +736,8 @@ func (c *Glacier) GetVaultLock(input *GetVaultLockInput) (*GetVaultLockOutput, e
 const opGetVaultNotifications = "GetVaultNotifications"
 
 // GetVaultNotificationsRequest generates a request for the GetVaultNotifications operation.
-func (c *Glacier) GetVaultNotificationsRequest(input *GetVaultNotificationsInput) (req *service.Request, output *GetVaultNotificationsOutput) {
-	op := &service.Operation{
+func (c *Glacier) GetVaultNotificationsRequest(input *GetVaultNotificationsInput) (req *request.Request, output *GetVaultNotificationsOutput) {
+	op := &request.Operation{
 		Name:       opGetVaultNotifications,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/notification-configuration",
@@ -781,8 +781,8 @@ func (c *Glacier) GetVaultNotifications(input *GetVaultNotificationsInput) (*Get
 const opInitiateJob = "InitiateJob"
 
 // InitiateJobRequest generates a request for the InitiateJob operation.
-func (c *Glacier) InitiateJobRequest(input *InitiateJobInput) (req *service.Request, output *InitiateJobOutput) {
-	op := &service.Operation{
+func (c *Glacier) InitiateJobRequest(input *InitiateJobInput) (req *request.Request, output *InitiateJobOutput) {
+	op := &request.Operation{
 		Name:       opInitiateJob,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/jobs",
@@ -923,8 +923,8 @@ func (c *Glacier) InitiateJob(input *InitiateJobInput) (*InitiateJobOutput, erro
 const opInitiateMultipartUpload = "InitiateMultipartUpload"
 
 // InitiateMultipartUploadRequest generates a request for the InitiateMultipartUpload operation.
-func (c *Glacier) InitiateMultipartUploadRequest(input *InitiateMultipartUploadInput) (req *service.Request, output *InitiateMultipartUploadOutput) {
-	op := &service.Operation{
+func (c *Glacier) InitiateMultipartUploadRequest(input *InitiateMultipartUploadInput) (req *request.Request, output *InitiateMultipartUploadOutput) {
+	op := &request.Operation{
 		Name:       opInitiateMultipartUpload,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/multipart-uploads",
@@ -984,8 +984,8 @@ func (c *Glacier) InitiateMultipartUpload(input *InitiateMultipartUploadInput) (
 const opInitiateVaultLock = "InitiateVaultLock"
 
 // InitiateVaultLockRequest generates a request for the InitiateVaultLock operation.
-func (c *Glacier) InitiateVaultLockRequest(input *InitiateVaultLockInput) (req *service.Request, output *InitiateVaultLockOutput) {
-	op := &service.Operation{
+func (c *Glacier) InitiateVaultLockRequest(input *InitiateVaultLockInput) (req *request.Request, output *InitiateVaultLockOutput) {
+	op := &request.Operation{
 		Name:       opInitiateVaultLock,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/lock-policy",
@@ -1038,12 +1038,12 @@ func (c *Glacier) InitiateVaultLock(input *InitiateVaultLockInput) (*InitiateVau
 const opListJobs = "ListJobs"
 
 // ListJobsRequest generates a request for the ListJobs operation.
-func (c *Glacier) ListJobsRequest(input *ListJobsInput) (req *service.Request, output *ListJobsOutput) {
-	op := &service.Operation{
+func (c *Glacier) ListJobsRequest(input *ListJobsInput) (req *request.Request, output *ListJobsOutput) {
+	op := &request.Operation{
 		Name:       opListJobs,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/jobs",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "limit",
@@ -1117,12 +1117,12 @@ func (c *Glacier) ListJobsPages(input *ListJobsInput, fn func(p *ListJobsOutput,
 const opListMultipartUploads = "ListMultipartUploads"
 
 // ListMultipartUploadsRequest generates a request for the ListMultipartUploads operation.
-func (c *Glacier) ListMultipartUploadsRequest(input *ListMultipartUploadsInput) (req *service.Request, output *ListMultipartUploadsOutput) {
-	op := &service.Operation{
+func (c *Glacier) ListMultipartUploadsRequest(input *ListMultipartUploadsInput) (req *request.Request, output *ListMultipartUploadsOutput) {
+	op := &request.Operation{
 		Name:       opListMultipartUploads,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/multipart-uploads",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "limit",
@@ -1186,12 +1186,12 @@ func (c *Glacier) ListMultipartUploadsPages(input *ListMultipartUploadsInput, fn
 const opListParts = "ListParts"
 
 // ListPartsRequest generates a request for the ListParts operation.
-func (c *Glacier) ListPartsRequest(input *ListPartsInput) (req *service.Request, output *ListPartsOutput) {
-	op := &service.Operation{
+func (c *Glacier) ListPartsRequest(input *ListPartsInput) (req *request.Request, output *ListPartsOutput) {
+	op := &request.Operation{
 		Name:       opListParts,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "limit",
@@ -1249,8 +1249,8 @@ func (c *Glacier) ListPartsPages(input *ListPartsInput, fn func(p *ListPartsOutp
 const opListTagsForVault = "ListTagsForVault"
 
 // ListTagsForVaultRequest generates a request for the ListTagsForVault operation.
-func (c *Glacier) ListTagsForVaultRequest(input *ListTagsForVaultInput) (req *service.Request, output *ListTagsForVaultOutput) {
-	op := &service.Operation{
+func (c *Glacier) ListTagsForVaultRequest(input *ListTagsForVaultInput) (req *request.Request, output *ListTagsForVaultOutput) {
+	op := &request.Operation{
 		Name:       opListTagsForVault,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/tags",
@@ -1278,12 +1278,12 @@ func (c *Glacier) ListTagsForVault(input *ListTagsForVaultInput) (*ListTagsForVa
 const opListVaults = "ListVaults"
 
 // ListVaultsRequest generates a request for the ListVaults operation.
-func (c *Glacier) ListVaultsRequest(input *ListVaultsInput) (req *service.Request, output *ListVaultsOutput) {
-	op := &service.Operation{
+func (c *Glacier) ListVaultsRequest(input *ListVaultsInput) (req *request.Request, output *ListVaultsOutput) {
+	op := &request.Operation{
 		Name:       opListVaults,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{accountId}/vaults",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "limit",
@@ -1339,8 +1339,8 @@ func (c *Glacier) ListVaultsPages(input *ListVaultsInput, fn func(p *ListVaultsO
 const opRemoveTagsFromVault = "RemoveTagsFromVault"
 
 // RemoveTagsFromVaultRequest generates a request for the RemoveTagsFromVault operation.
-func (c *Glacier) RemoveTagsFromVaultRequest(input *RemoveTagsFromVaultInput) (req *service.Request, output *RemoveTagsFromVaultOutput) {
-	op := &service.Operation{
+func (c *Glacier) RemoveTagsFromVaultRequest(input *RemoveTagsFromVaultInput) (req *request.Request, output *RemoveTagsFromVaultOutput) {
+	op := &request.Operation{
 		Name:       opRemoveTagsFromVault,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/tags?operation=remove",
@@ -1370,8 +1370,8 @@ func (c *Glacier) RemoveTagsFromVault(input *RemoveTagsFromVaultInput) (*RemoveT
 const opSetDataRetrievalPolicy = "SetDataRetrievalPolicy"
 
 // SetDataRetrievalPolicyRequest generates a request for the SetDataRetrievalPolicy operation.
-func (c *Glacier) SetDataRetrievalPolicyRequest(input *SetDataRetrievalPolicyInput) (req *service.Request, output *SetDataRetrievalPolicyOutput) {
-	op := &service.Operation{
+func (c *Glacier) SetDataRetrievalPolicyRequest(input *SetDataRetrievalPolicyInput) (req *request.Request, output *SetDataRetrievalPolicyOutput) {
+	op := &request.Operation{
 		Name:       opSetDataRetrievalPolicy,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{accountId}/policies/data-retrieval",
@@ -1403,8 +1403,8 @@ func (c *Glacier) SetDataRetrievalPolicy(input *SetDataRetrievalPolicyInput) (*S
 const opSetVaultAccessPolicy = "SetVaultAccessPolicy"
 
 // SetVaultAccessPolicyRequest generates a request for the SetVaultAccessPolicy operation.
-func (c *Glacier) SetVaultAccessPolicyRequest(input *SetVaultAccessPolicyInput) (req *service.Request, output *SetVaultAccessPolicyOutput) {
-	op := &service.Operation{
+func (c *Glacier) SetVaultAccessPolicyRequest(input *SetVaultAccessPolicyInput) (req *request.Request, output *SetVaultAccessPolicyOutput) {
+	op := &request.Operation{
 		Name:       opSetVaultAccessPolicy,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/access-policy",
@@ -1436,8 +1436,8 @@ func (c *Glacier) SetVaultAccessPolicy(input *SetVaultAccessPolicyInput) (*SetVa
 const opSetVaultNotifications = "SetVaultNotifications"
 
 // SetVaultNotificationsRequest generates a request for the SetVaultNotifications operation.
-func (c *Glacier) SetVaultNotificationsRequest(input *SetVaultNotificationsInput) (req *service.Request, output *SetVaultNotificationsOutput) {
-	op := &service.Operation{
+func (c *Glacier) SetVaultNotificationsRequest(input *SetVaultNotificationsInput) (req *request.Request, output *SetVaultNotificationsOutput) {
+	op := &request.Operation{
 		Name:       opSetVaultNotifications,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/notification-configuration",
@@ -1491,8 +1491,8 @@ func (c *Glacier) SetVaultNotifications(input *SetVaultNotificationsInput) (*Set
 const opUploadArchive = "UploadArchive"
 
 // UploadArchiveRequest generates a request for the UploadArchive operation.
-func (c *Glacier) UploadArchiveRequest(input *UploadArchiveInput) (req *service.Request, output *ArchiveCreationOutput) {
-	op := &service.Operation{
+func (c *Glacier) UploadArchiveRequest(input *UploadArchiveInput) (req *request.Request, output *ArchiveCreationOutput) {
+	op := &request.Operation{
 		Name:       opUploadArchive,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/archives",
@@ -1553,8 +1553,8 @@ func (c *Glacier) UploadArchive(input *UploadArchiveInput) (*ArchiveCreationOutp
 const opUploadMultipartPart = "UploadMultipartPart"
 
 // UploadMultipartPartRequest generates a request for the UploadMultipartPart operation.
-func (c *Glacier) UploadMultipartPartRequest(input *UploadMultipartPartInput) (req *service.Request, output *UploadMultipartPartOutput) {
-	op := &service.Operation{
+func (c *Glacier) UploadMultipartPartRequest(input *UploadMultipartPartInput) (req *request.Request, output *UploadMultipartPartOutput) {
+	op := &request.Operation{
 		Name:       opUploadMultipartPart,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}",

--- a/service/glacier/customizations.go
+++ b/service/glacier/customizations.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 var (
@@ -13,7 +13,7 @@ var (
 )
 
 func init() {
-	initRequest = func(r *service.Request) {
+	initRequest = func(r *request.Request) {
 		r.Handlers.Validate.PushFront(addAccountID)
 		r.Handlers.Validate.PushFront(copyParams) // this happens first
 		r.Handlers.Build.PushBack(addChecksum)
@@ -21,11 +21,11 @@ func init() {
 	}
 }
 
-func copyParams(r *service.Request) {
+func copyParams(r *request.Request) {
 	r.Params = awsutil.CopyOf(r.Params)
 }
 
-func addAccountID(r *service.Request) {
+func addAccountID(r *request.Request) {
 	if !r.ParamsFilled() {
 		return
 	}
@@ -36,7 +36,7 @@ func addAccountID(r *service.Request) {
 	}
 }
 
-func addChecksum(r *service.Request) {
+func addChecksum(r *request.Request) {
 	if r.Body == nil {
 		return
 	}
@@ -53,6 +53,6 @@ func addChecksum(r *service.Request) {
 	}
 }
 
-func addAPIVersion(r *service.Request) {
+func addAPIVersion(r *request.Request) {
 	r.HTTPRequest.Header.Set("X-Amz-Glacier-Version", r.Service.APIVersion)
 }

--- a/service/glacier/glacieriface/interface.go
+++ b/service/glacier/glacieriface/interface.go
@@ -4,141 +4,141 @@
 package glacieriface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/glacier"
 )
 
 // GlacierAPI is the interface type for glacier.Glacier.
 type GlacierAPI interface {
-	AbortMultipartUploadRequest(*glacier.AbortMultipartUploadInput) (*service.Request, *glacier.AbortMultipartUploadOutput)
+	AbortMultipartUploadRequest(*glacier.AbortMultipartUploadInput) (*request.Request, *glacier.AbortMultipartUploadOutput)
 
 	AbortMultipartUpload(*glacier.AbortMultipartUploadInput) (*glacier.AbortMultipartUploadOutput, error)
 
-	AbortVaultLockRequest(*glacier.AbortVaultLockInput) (*service.Request, *glacier.AbortVaultLockOutput)
+	AbortVaultLockRequest(*glacier.AbortVaultLockInput) (*request.Request, *glacier.AbortVaultLockOutput)
 
 	AbortVaultLock(*glacier.AbortVaultLockInput) (*glacier.AbortVaultLockOutput, error)
 
-	AddTagsToVaultRequest(*glacier.AddTagsToVaultInput) (*service.Request, *glacier.AddTagsToVaultOutput)
+	AddTagsToVaultRequest(*glacier.AddTagsToVaultInput) (*request.Request, *glacier.AddTagsToVaultOutput)
 
 	AddTagsToVault(*glacier.AddTagsToVaultInput) (*glacier.AddTagsToVaultOutput, error)
 
-	CompleteMultipartUploadRequest(*glacier.CompleteMultipartUploadInput) (*service.Request, *glacier.ArchiveCreationOutput)
+	CompleteMultipartUploadRequest(*glacier.CompleteMultipartUploadInput) (*request.Request, *glacier.ArchiveCreationOutput)
 
 	CompleteMultipartUpload(*glacier.CompleteMultipartUploadInput) (*glacier.ArchiveCreationOutput, error)
 
-	CompleteVaultLockRequest(*glacier.CompleteVaultLockInput) (*service.Request, *glacier.CompleteVaultLockOutput)
+	CompleteVaultLockRequest(*glacier.CompleteVaultLockInput) (*request.Request, *glacier.CompleteVaultLockOutput)
 
 	CompleteVaultLock(*glacier.CompleteVaultLockInput) (*glacier.CompleteVaultLockOutput, error)
 
-	CreateVaultRequest(*glacier.CreateVaultInput) (*service.Request, *glacier.CreateVaultOutput)
+	CreateVaultRequest(*glacier.CreateVaultInput) (*request.Request, *glacier.CreateVaultOutput)
 
 	CreateVault(*glacier.CreateVaultInput) (*glacier.CreateVaultOutput, error)
 
-	DeleteArchiveRequest(*glacier.DeleteArchiveInput) (*service.Request, *glacier.DeleteArchiveOutput)
+	DeleteArchiveRequest(*glacier.DeleteArchiveInput) (*request.Request, *glacier.DeleteArchiveOutput)
 
 	DeleteArchive(*glacier.DeleteArchiveInput) (*glacier.DeleteArchiveOutput, error)
 
-	DeleteVaultRequest(*glacier.DeleteVaultInput) (*service.Request, *glacier.DeleteVaultOutput)
+	DeleteVaultRequest(*glacier.DeleteVaultInput) (*request.Request, *glacier.DeleteVaultOutput)
 
 	DeleteVault(*glacier.DeleteVaultInput) (*glacier.DeleteVaultOutput, error)
 
-	DeleteVaultAccessPolicyRequest(*glacier.DeleteVaultAccessPolicyInput) (*service.Request, *glacier.DeleteVaultAccessPolicyOutput)
+	DeleteVaultAccessPolicyRequest(*glacier.DeleteVaultAccessPolicyInput) (*request.Request, *glacier.DeleteVaultAccessPolicyOutput)
 
 	DeleteVaultAccessPolicy(*glacier.DeleteVaultAccessPolicyInput) (*glacier.DeleteVaultAccessPolicyOutput, error)
 
-	DeleteVaultNotificationsRequest(*glacier.DeleteVaultNotificationsInput) (*service.Request, *glacier.DeleteVaultNotificationsOutput)
+	DeleteVaultNotificationsRequest(*glacier.DeleteVaultNotificationsInput) (*request.Request, *glacier.DeleteVaultNotificationsOutput)
 
 	DeleteVaultNotifications(*glacier.DeleteVaultNotificationsInput) (*glacier.DeleteVaultNotificationsOutput, error)
 
-	DescribeJobRequest(*glacier.DescribeJobInput) (*service.Request, *glacier.JobDescription)
+	DescribeJobRequest(*glacier.DescribeJobInput) (*request.Request, *glacier.JobDescription)
 
 	DescribeJob(*glacier.DescribeJobInput) (*glacier.JobDescription, error)
 
-	DescribeVaultRequest(*glacier.DescribeVaultInput) (*service.Request, *glacier.DescribeVaultOutput)
+	DescribeVaultRequest(*glacier.DescribeVaultInput) (*request.Request, *glacier.DescribeVaultOutput)
 
 	DescribeVault(*glacier.DescribeVaultInput) (*glacier.DescribeVaultOutput, error)
 
-	GetDataRetrievalPolicyRequest(*glacier.GetDataRetrievalPolicyInput) (*service.Request, *glacier.GetDataRetrievalPolicyOutput)
+	GetDataRetrievalPolicyRequest(*glacier.GetDataRetrievalPolicyInput) (*request.Request, *glacier.GetDataRetrievalPolicyOutput)
 
 	GetDataRetrievalPolicy(*glacier.GetDataRetrievalPolicyInput) (*glacier.GetDataRetrievalPolicyOutput, error)
 
-	GetJobOutputRequest(*glacier.GetJobOutputInput) (*service.Request, *glacier.GetJobOutputOutput)
+	GetJobOutputRequest(*glacier.GetJobOutputInput) (*request.Request, *glacier.GetJobOutputOutput)
 
 	GetJobOutput(*glacier.GetJobOutputInput) (*glacier.GetJobOutputOutput, error)
 
-	GetVaultAccessPolicyRequest(*glacier.GetVaultAccessPolicyInput) (*service.Request, *glacier.GetVaultAccessPolicyOutput)
+	GetVaultAccessPolicyRequest(*glacier.GetVaultAccessPolicyInput) (*request.Request, *glacier.GetVaultAccessPolicyOutput)
 
 	GetVaultAccessPolicy(*glacier.GetVaultAccessPolicyInput) (*glacier.GetVaultAccessPolicyOutput, error)
 
-	GetVaultLockRequest(*glacier.GetVaultLockInput) (*service.Request, *glacier.GetVaultLockOutput)
+	GetVaultLockRequest(*glacier.GetVaultLockInput) (*request.Request, *glacier.GetVaultLockOutput)
 
 	GetVaultLock(*glacier.GetVaultLockInput) (*glacier.GetVaultLockOutput, error)
 
-	GetVaultNotificationsRequest(*glacier.GetVaultNotificationsInput) (*service.Request, *glacier.GetVaultNotificationsOutput)
+	GetVaultNotificationsRequest(*glacier.GetVaultNotificationsInput) (*request.Request, *glacier.GetVaultNotificationsOutput)
 
 	GetVaultNotifications(*glacier.GetVaultNotificationsInput) (*glacier.GetVaultNotificationsOutput, error)
 
-	InitiateJobRequest(*glacier.InitiateJobInput) (*service.Request, *glacier.InitiateJobOutput)
+	InitiateJobRequest(*glacier.InitiateJobInput) (*request.Request, *glacier.InitiateJobOutput)
 
 	InitiateJob(*glacier.InitiateJobInput) (*glacier.InitiateJobOutput, error)
 
-	InitiateMultipartUploadRequest(*glacier.InitiateMultipartUploadInput) (*service.Request, *glacier.InitiateMultipartUploadOutput)
+	InitiateMultipartUploadRequest(*glacier.InitiateMultipartUploadInput) (*request.Request, *glacier.InitiateMultipartUploadOutput)
 
 	InitiateMultipartUpload(*glacier.InitiateMultipartUploadInput) (*glacier.InitiateMultipartUploadOutput, error)
 
-	InitiateVaultLockRequest(*glacier.InitiateVaultLockInput) (*service.Request, *glacier.InitiateVaultLockOutput)
+	InitiateVaultLockRequest(*glacier.InitiateVaultLockInput) (*request.Request, *glacier.InitiateVaultLockOutput)
 
 	InitiateVaultLock(*glacier.InitiateVaultLockInput) (*glacier.InitiateVaultLockOutput, error)
 
-	ListJobsRequest(*glacier.ListJobsInput) (*service.Request, *glacier.ListJobsOutput)
+	ListJobsRequest(*glacier.ListJobsInput) (*request.Request, *glacier.ListJobsOutput)
 
 	ListJobs(*glacier.ListJobsInput) (*glacier.ListJobsOutput, error)
 
 	ListJobsPages(*glacier.ListJobsInput, func(*glacier.ListJobsOutput, bool) bool) error
 
-	ListMultipartUploadsRequest(*glacier.ListMultipartUploadsInput) (*service.Request, *glacier.ListMultipartUploadsOutput)
+	ListMultipartUploadsRequest(*glacier.ListMultipartUploadsInput) (*request.Request, *glacier.ListMultipartUploadsOutput)
 
 	ListMultipartUploads(*glacier.ListMultipartUploadsInput) (*glacier.ListMultipartUploadsOutput, error)
 
 	ListMultipartUploadsPages(*glacier.ListMultipartUploadsInput, func(*glacier.ListMultipartUploadsOutput, bool) bool) error
 
-	ListPartsRequest(*glacier.ListPartsInput) (*service.Request, *glacier.ListPartsOutput)
+	ListPartsRequest(*glacier.ListPartsInput) (*request.Request, *glacier.ListPartsOutput)
 
 	ListParts(*glacier.ListPartsInput) (*glacier.ListPartsOutput, error)
 
 	ListPartsPages(*glacier.ListPartsInput, func(*glacier.ListPartsOutput, bool) bool) error
 
-	ListTagsForVaultRequest(*glacier.ListTagsForVaultInput) (*service.Request, *glacier.ListTagsForVaultOutput)
+	ListTagsForVaultRequest(*glacier.ListTagsForVaultInput) (*request.Request, *glacier.ListTagsForVaultOutput)
 
 	ListTagsForVault(*glacier.ListTagsForVaultInput) (*glacier.ListTagsForVaultOutput, error)
 
-	ListVaultsRequest(*glacier.ListVaultsInput) (*service.Request, *glacier.ListVaultsOutput)
+	ListVaultsRequest(*glacier.ListVaultsInput) (*request.Request, *glacier.ListVaultsOutput)
 
 	ListVaults(*glacier.ListVaultsInput) (*glacier.ListVaultsOutput, error)
 
 	ListVaultsPages(*glacier.ListVaultsInput, func(*glacier.ListVaultsOutput, bool) bool) error
 
-	RemoveTagsFromVaultRequest(*glacier.RemoveTagsFromVaultInput) (*service.Request, *glacier.RemoveTagsFromVaultOutput)
+	RemoveTagsFromVaultRequest(*glacier.RemoveTagsFromVaultInput) (*request.Request, *glacier.RemoveTagsFromVaultOutput)
 
 	RemoveTagsFromVault(*glacier.RemoveTagsFromVaultInput) (*glacier.RemoveTagsFromVaultOutput, error)
 
-	SetDataRetrievalPolicyRequest(*glacier.SetDataRetrievalPolicyInput) (*service.Request, *glacier.SetDataRetrievalPolicyOutput)
+	SetDataRetrievalPolicyRequest(*glacier.SetDataRetrievalPolicyInput) (*request.Request, *glacier.SetDataRetrievalPolicyOutput)
 
 	SetDataRetrievalPolicy(*glacier.SetDataRetrievalPolicyInput) (*glacier.SetDataRetrievalPolicyOutput, error)
 
-	SetVaultAccessPolicyRequest(*glacier.SetVaultAccessPolicyInput) (*service.Request, *glacier.SetVaultAccessPolicyOutput)
+	SetVaultAccessPolicyRequest(*glacier.SetVaultAccessPolicyInput) (*request.Request, *glacier.SetVaultAccessPolicyOutput)
 
 	SetVaultAccessPolicy(*glacier.SetVaultAccessPolicyInput) (*glacier.SetVaultAccessPolicyOutput, error)
 
-	SetVaultNotificationsRequest(*glacier.SetVaultNotificationsInput) (*service.Request, *glacier.SetVaultNotificationsOutput)
+	SetVaultNotificationsRequest(*glacier.SetVaultNotificationsInput) (*request.Request, *glacier.SetVaultNotificationsOutput)
 
 	SetVaultNotifications(*glacier.SetVaultNotificationsInput) (*glacier.SetVaultNotificationsOutput, error)
 
-	UploadArchiveRequest(*glacier.UploadArchiveInput) (*service.Request, *glacier.ArchiveCreationOutput)
+	UploadArchiveRequest(*glacier.UploadArchiveInput) (*request.Request, *glacier.ArchiveCreationOutput)
 
 	UploadArchive(*glacier.UploadArchiveInput) (*glacier.ArchiveCreationOutput, error)
 
-	UploadMultipartPartRequest(*glacier.UploadMultipartPartInput) (*service.Request, *glacier.UploadMultipartPartOutput)
+	UploadMultipartPartRequest(*glacier.UploadMultipartPartInput) (*request.Request, *glacier.UploadMultipartPartOutput)
 
 	UploadMultipartPart(*glacier.UploadMultipartPartInput) (*glacier.UploadMultipartPartOutput, error)
 }

--- a/service/glacier/service.go
+++ b/service/glacier/service.go
@@ -5,7 +5,9 @@ package glacier
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -49,14 +51,16 @@ type Glacier struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new Glacier client.
 func New(config *aws.Config) *Glacier {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "glacier",
-		APIVersion:  "2012-06-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "glacier",
+			APIVersion:  "2012-06-01",
+		},
 	}
 	service.Initialize()
 
@@ -77,8 +81,8 @@ func New(config *aws.Config) *Glacier {
 
 // newRequest creates a new request for a Glacier operation and runs any
 // custom request initialization.
-func (c *Glacier) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *Glacier) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/iam/api.go
+++ b/service/iam/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddClientIDToOpenIDConnectProvider = "AddClientIDToOpenIDConnectProvider"
 
 // AddClientIDToOpenIDConnectProviderRequest generates a request for the AddClientIDToOpenIDConnectProvider operation.
-func (c *IAM) AddClientIDToOpenIDConnectProviderRequest(input *AddClientIDToOpenIDConnectProviderInput) (req *service.Request, output *AddClientIDToOpenIDConnectProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) AddClientIDToOpenIDConnectProviderRequest(input *AddClientIDToOpenIDConnectProviderInput) (req *request.Request, output *AddClientIDToOpenIDConnectProviderOutput) {
+	op := &request.Operation{
 		Name:       opAddClientIDToOpenIDConnectProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -44,8 +44,8 @@ func (c *IAM) AddClientIDToOpenIDConnectProvider(input *AddClientIDToOpenIDConne
 const opAddRoleToInstanceProfile = "AddRoleToInstanceProfile"
 
 // AddRoleToInstanceProfileRequest generates a request for the AddRoleToInstanceProfile operation.
-func (c *IAM) AddRoleToInstanceProfileRequest(input *AddRoleToInstanceProfileInput) (req *service.Request, output *AddRoleToInstanceProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) AddRoleToInstanceProfileRequest(input *AddRoleToInstanceProfileInput) (req *request.Request, output *AddRoleToInstanceProfileOutput) {
+	op := &request.Operation{
 		Name:       opAddRoleToInstanceProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -74,8 +74,8 @@ func (c *IAM) AddRoleToInstanceProfile(input *AddRoleToInstanceProfileInput) (*A
 const opAddUserToGroup = "AddUserToGroup"
 
 // AddUserToGroupRequest generates a request for the AddUserToGroup operation.
-func (c *IAM) AddUserToGroupRequest(input *AddUserToGroupInput) (req *service.Request, output *AddUserToGroupOutput) {
-	op := &service.Operation{
+func (c *IAM) AddUserToGroupRequest(input *AddUserToGroupInput) (req *request.Request, output *AddUserToGroupOutput) {
+	op := &request.Operation{
 		Name:       opAddUserToGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -101,8 +101,8 @@ func (c *IAM) AddUserToGroup(input *AddUserToGroupInput) (*AddUserToGroupOutput,
 const opAttachGroupPolicy = "AttachGroupPolicy"
 
 // AttachGroupPolicyRequest generates a request for the AttachGroupPolicy operation.
-func (c *IAM) AttachGroupPolicyRequest(input *AttachGroupPolicyInput) (req *service.Request, output *AttachGroupPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) AttachGroupPolicyRequest(input *AttachGroupPolicyInput) (req *request.Request, output *AttachGroupPolicyOutput) {
+	op := &request.Operation{
 		Name:       opAttachGroupPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -135,8 +135,8 @@ func (c *IAM) AttachGroupPolicy(input *AttachGroupPolicyInput) (*AttachGroupPoli
 const opAttachRolePolicy = "AttachRolePolicy"
 
 // AttachRolePolicyRequest generates a request for the AttachRolePolicy operation.
-func (c *IAM) AttachRolePolicyRequest(input *AttachRolePolicyInput) (req *service.Request, output *AttachRolePolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) AttachRolePolicyRequest(input *AttachRolePolicyInput) (req *request.Request, output *AttachRolePolicyOutput) {
+	op := &request.Operation{
 		Name:       opAttachRolePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -173,8 +173,8 @@ func (c *IAM) AttachRolePolicy(input *AttachRolePolicyInput) (*AttachRolePolicyO
 const opAttachUserPolicy = "AttachUserPolicy"
 
 // AttachUserPolicyRequest generates a request for the AttachUserPolicy operation.
-func (c *IAM) AttachUserPolicyRequest(input *AttachUserPolicyInput) (req *service.Request, output *AttachUserPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) AttachUserPolicyRequest(input *AttachUserPolicyInput) (req *request.Request, output *AttachUserPolicyOutput) {
+	op := &request.Operation{
 		Name:       opAttachUserPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -207,8 +207,8 @@ func (c *IAM) AttachUserPolicy(input *AttachUserPolicyInput) (*AttachUserPolicyO
 const opChangePassword = "ChangePassword"
 
 // ChangePasswordRequest generates a request for the ChangePassword operation.
-func (c *IAM) ChangePasswordRequest(input *ChangePasswordInput) (req *service.Request, output *ChangePasswordOutput) {
-	op := &service.Operation{
+func (c *IAM) ChangePasswordRequest(input *ChangePasswordInput) (req *request.Request, output *ChangePasswordOutput) {
+	op := &request.Operation{
 		Name:       opChangePassword,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -239,8 +239,8 @@ func (c *IAM) ChangePassword(input *ChangePasswordInput) (*ChangePasswordOutput,
 const opCreateAccessKey = "CreateAccessKey"
 
 // CreateAccessKeyRequest generates a request for the CreateAccessKey operation.
-func (c *IAM) CreateAccessKeyRequest(input *CreateAccessKeyInput) (req *service.Request, output *CreateAccessKeyOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateAccessKeyRequest(input *CreateAccessKeyInput) (req *request.Request, output *CreateAccessKeyOutput) {
+	op := &request.Operation{
 		Name:       opCreateAccessKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -282,8 +282,8 @@ func (c *IAM) CreateAccessKey(input *CreateAccessKeyInput) (*CreateAccessKeyOutp
 const opCreateAccountAlias = "CreateAccountAlias"
 
 // CreateAccountAliasRequest generates a request for the CreateAccountAlias operation.
-func (c *IAM) CreateAccountAliasRequest(input *CreateAccountAliasInput) (req *service.Request, output *CreateAccountAliasOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateAccountAliasRequest(input *CreateAccountAliasInput) (req *request.Request, output *CreateAccountAliasOutput) {
+	op := &request.Operation{
 		Name:       opCreateAccountAlias,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -311,8 +311,8 @@ func (c *IAM) CreateAccountAlias(input *CreateAccountAliasInput) (*CreateAccount
 const opCreateGroup = "CreateGroup"
 
 // CreateGroupRequest generates a request for the CreateGroup operation.
-func (c *IAM) CreateGroupRequest(input *CreateGroupInput) (req *service.Request, output *CreateGroupOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateGroupRequest(input *CreateGroupInput) (req *request.Request, output *CreateGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -342,8 +342,8 @@ func (c *IAM) CreateGroup(input *CreateGroupInput) (*CreateGroupOutput, error) {
 const opCreateInstanceProfile = "CreateInstanceProfile"
 
 // CreateInstanceProfileRequest generates a request for the CreateInstanceProfile operation.
-func (c *IAM) CreateInstanceProfileRequest(input *CreateInstanceProfileInput) (req *service.Request, output *CreateInstanceProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateInstanceProfileRequest(input *CreateInstanceProfileInput) (req *request.Request, output *CreateInstanceProfileOutput) {
+	op := &request.Operation{
 		Name:       opCreateInstanceProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -374,8 +374,8 @@ func (c *IAM) CreateInstanceProfile(input *CreateInstanceProfileInput) (*CreateI
 const opCreateLoginProfile = "CreateLoginProfile"
 
 // CreateLoginProfileRequest generates a request for the CreateLoginProfile operation.
-func (c *IAM) CreateLoginProfileRequest(input *CreateLoginProfileInput) (req *service.Request, output *CreateLoginProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateLoginProfileRequest(input *CreateLoginProfileInput) (req *request.Request, output *CreateLoginProfileOutput) {
+	op := &request.Operation{
 		Name:       opCreateLoginProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -404,8 +404,8 @@ func (c *IAM) CreateLoginProfile(input *CreateLoginProfileInput) (*CreateLoginPr
 const opCreateOpenIDConnectProvider = "CreateOpenIDConnectProvider"
 
 // CreateOpenIDConnectProviderRequest generates a request for the CreateOpenIDConnectProvider operation.
-func (c *IAM) CreateOpenIDConnectProviderRequest(input *CreateOpenIDConnectProviderInput) (req *service.Request, output *CreateOpenIDConnectProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateOpenIDConnectProviderRequest(input *CreateOpenIDConnectProviderInput) (req *request.Request, output *CreateOpenIDConnectProviderOutput) {
+	op := &request.Operation{
 		Name:       opCreateOpenIDConnectProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -447,8 +447,8 @@ func (c *IAM) CreateOpenIDConnectProvider(input *CreateOpenIDConnectProviderInpu
 const opCreatePolicy = "CreatePolicy"
 
 // CreatePolicyRequest generates a request for the CreatePolicy operation.
-func (c *IAM) CreatePolicyRequest(input *CreatePolicyInput) (req *service.Request, output *CreatePolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) CreatePolicyRequest(input *CreatePolicyInput) (req *request.Request, output *CreatePolicyOutput) {
+	op := &request.Operation{
 		Name:       opCreatePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -483,8 +483,8 @@ func (c *IAM) CreatePolicy(input *CreatePolicyInput) (*CreatePolicyOutput, error
 const opCreatePolicyVersion = "CreatePolicyVersion"
 
 // CreatePolicyVersionRequest generates a request for the CreatePolicyVersion operation.
-func (c *IAM) CreatePolicyVersionRequest(input *CreatePolicyVersionInput) (req *service.Request, output *CreatePolicyVersionOutput) {
-	op := &service.Operation{
+func (c *IAM) CreatePolicyVersionRequest(input *CreatePolicyVersionInput) (req *request.Request, output *CreatePolicyVersionOutput) {
+	op := &request.Operation{
 		Name:       opCreatePolicyVersion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -522,8 +522,8 @@ func (c *IAM) CreatePolicyVersion(input *CreatePolicyVersionInput) (*CreatePolic
 const opCreateRole = "CreateRole"
 
 // CreateRoleRequest generates a request for the CreateRole operation.
-func (c *IAM) CreateRoleRequest(input *CreateRoleInput) (req *service.Request, output *CreateRoleOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateRoleRequest(input *CreateRoleInput) (req *request.Request, output *CreateRoleOutput) {
+	op := &request.Operation{
 		Name:       opCreateRole,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -556,8 +556,8 @@ func (c *IAM) CreateRole(input *CreateRoleInput) (*CreateRoleOutput, error) {
 const opCreateSAMLProvider = "CreateSAMLProvider"
 
 // CreateSAMLProviderRequest generates a request for the CreateSAMLProvider operation.
-func (c *IAM) CreateSAMLProviderRequest(input *CreateSAMLProviderInput) (req *service.Request, output *CreateSAMLProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateSAMLProviderRequest(input *CreateSAMLProviderInput) (req *request.Request, output *CreateSAMLProviderOutput) {
+	op := &request.Operation{
 		Name:       opCreateSAMLProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -602,8 +602,8 @@ func (c *IAM) CreateSAMLProvider(input *CreateSAMLProviderInput) (*CreateSAMLPro
 const opCreateUser = "CreateUser"
 
 // CreateUserRequest generates a request for the CreateUser operation.
-func (c *IAM) CreateUserRequest(input *CreateUserInput) (req *service.Request, output *CreateUserOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateUserRequest(input *CreateUserInput) (req *request.Request, output *CreateUserOutput) {
+	op := &request.Operation{
 		Name:       opCreateUser,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -633,8 +633,8 @@ func (c *IAM) CreateUser(input *CreateUserInput) (*CreateUserOutput, error) {
 const opCreateVirtualMFADevice = "CreateVirtualMFADevice"
 
 // CreateVirtualMFADeviceRequest generates a request for the CreateVirtualMFADevice operation.
-func (c *IAM) CreateVirtualMFADeviceRequest(input *CreateVirtualMFADeviceInput) (req *service.Request, output *CreateVirtualMFADeviceOutput) {
-	op := &service.Operation{
+func (c *IAM) CreateVirtualMFADeviceRequest(input *CreateVirtualMFADeviceInput) (req *request.Request, output *CreateVirtualMFADeviceOutput) {
+	op := &request.Operation{
 		Name:       opCreateVirtualMFADevice,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -673,8 +673,8 @@ func (c *IAM) CreateVirtualMFADevice(input *CreateVirtualMFADeviceInput) (*Creat
 const opDeactivateMFADevice = "DeactivateMFADevice"
 
 // DeactivateMFADeviceRequest generates a request for the DeactivateMFADevice operation.
-func (c *IAM) DeactivateMFADeviceRequest(input *DeactivateMFADeviceInput) (req *service.Request, output *DeactivateMFADeviceOutput) {
-	op := &service.Operation{
+func (c *IAM) DeactivateMFADeviceRequest(input *DeactivateMFADeviceInput) (req *request.Request, output *DeactivateMFADeviceOutput) {
+	op := &request.Operation{
 		Name:       opDeactivateMFADevice,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -705,8 +705,8 @@ func (c *IAM) DeactivateMFADevice(input *DeactivateMFADeviceInput) (*DeactivateM
 const opDeleteAccessKey = "DeleteAccessKey"
 
 // DeleteAccessKeyRequest generates a request for the DeleteAccessKey operation.
-func (c *IAM) DeleteAccessKeyRequest(input *DeleteAccessKeyInput) (req *service.Request, output *DeleteAccessKeyOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteAccessKeyRequest(input *DeleteAccessKeyInput) (req *request.Request, output *DeleteAccessKeyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteAccessKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -737,8 +737,8 @@ func (c *IAM) DeleteAccessKey(input *DeleteAccessKeyInput) (*DeleteAccessKeyOutp
 const opDeleteAccountAlias = "DeleteAccountAlias"
 
 // DeleteAccountAliasRequest generates a request for the DeleteAccountAlias operation.
-func (c *IAM) DeleteAccountAliasRequest(input *DeleteAccountAliasInput) (req *service.Request, output *DeleteAccountAliasOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteAccountAliasRequest(input *DeleteAccountAliasInput) (req *request.Request, output *DeleteAccountAliasOutput) {
+	op := &request.Operation{
 		Name:       opDeleteAccountAlias,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -766,8 +766,8 @@ func (c *IAM) DeleteAccountAlias(input *DeleteAccountAliasInput) (*DeleteAccount
 const opDeleteAccountPasswordPolicy = "DeleteAccountPasswordPolicy"
 
 // DeleteAccountPasswordPolicyRequest generates a request for the DeleteAccountPasswordPolicy operation.
-func (c *IAM) DeleteAccountPasswordPolicyRequest(input *DeleteAccountPasswordPolicyInput) (req *service.Request, output *DeleteAccountPasswordPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteAccountPasswordPolicyRequest(input *DeleteAccountPasswordPolicyInput) (req *request.Request, output *DeleteAccountPasswordPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteAccountPasswordPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -793,8 +793,8 @@ func (c *IAM) DeleteAccountPasswordPolicy(input *DeleteAccountPasswordPolicyInpu
 const opDeleteGroup = "DeleteGroup"
 
 // DeleteGroupRequest generates a request for the DeleteGroup operation.
-func (c *IAM) DeleteGroupRequest(input *DeleteGroupInput) (req *service.Request, output *DeleteGroupOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteGroupRequest(input *DeleteGroupInput) (req *request.Request, output *DeleteGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -821,8 +821,8 @@ func (c *IAM) DeleteGroup(input *DeleteGroupInput) (*DeleteGroupOutput, error) {
 const opDeleteGroupPolicy = "DeleteGroupPolicy"
 
 // DeleteGroupPolicyRequest generates a request for the DeleteGroupPolicy operation.
-func (c *IAM) DeleteGroupPolicyRequest(input *DeleteGroupPolicyInput) (req *service.Request, output *DeleteGroupPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteGroupPolicyRequest(input *DeleteGroupPolicyInput) (req *request.Request, output *DeleteGroupPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteGroupPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -853,8 +853,8 @@ func (c *IAM) DeleteGroupPolicy(input *DeleteGroupPolicyInput) (*DeleteGroupPoli
 const opDeleteInstanceProfile = "DeleteInstanceProfile"
 
 // DeleteInstanceProfileRequest generates a request for the DeleteInstanceProfile operation.
-func (c *IAM) DeleteInstanceProfileRequest(input *DeleteInstanceProfileInput) (req *service.Request, output *DeleteInstanceProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteInstanceProfileRequest(input *DeleteInstanceProfileInput) (req *request.Request, output *DeleteInstanceProfileOutput) {
+	op := &request.Operation{
 		Name:       opDeleteInstanceProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -887,8 +887,8 @@ func (c *IAM) DeleteInstanceProfile(input *DeleteInstanceProfileInput) (*DeleteI
 const opDeleteLoginProfile = "DeleteLoginProfile"
 
 // DeleteLoginProfileRequest generates a request for the DeleteLoginProfile operation.
-func (c *IAM) DeleteLoginProfileRequest(input *DeleteLoginProfileInput) (req *service.Request, output *DeleteLoginProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteLoginProfileRequest(input *DeleteLoginProfileInput) (req *request.Request, output *DeleteLoginProfileOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLoginProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -920,8 +920,8 @@ func (c *IAM) DeleteLoginProfile(input *DeleteLoginProfileInput) (*DeleteLoginPr
 const opDeleteOpenIDConnectProvider = "DeleteOpenIDConnectProvider"
 
 // DeleteOpenIDConnectProviderRequest generates a request for the DeleteOpenIDConnectProvider operation.
-func (c *IAM) DeleteOpenIDConnectProviderRequest(input *DeleteOpenIDConnectProviderInput) (req *service.Request, output *DeleteOpenIDConnectProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteOpenIDConnectProviderRequest(input *DeleteOpenIDConnectProviderInput) (req *request.Request, output *DeleteOpenIDConnectProviderOutput) {
+	op := &request.Operation{
 		Name:       opDeleteOpenIDConnectProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -954,8 +954,8 @@ func (c *IAM) DeleteOpenIDConnectProvider(input *DeleteOpenIDConnectProviderInpu
 const opDeletePolicy = "DeletePolicy"
 
 // DeletePolicyRequest generates a request for the DeletePolicy operation.
-func (c *IAM) DeletePolicyRequest(input *DeletePolicyInput) (req *service.Request, output *DeletePolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) DeletePolicyRequest(input *DeletePolicyInput) (req *request.Request, output *DeletePolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeletePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -998,8 +998,8 @@ func (c *IAM) DeletePolicy(input *DeletePolicyInput) (*DeletePolicyOutput, error
 const opDeletePolicyVersion = "DeletePolicyVersion"
 
 // DeletePolicyVersionRequest generates a request for the DeletePolicyVersion operation.
-func (c *IAM) DeletePolicyVersionRequest(input *DeletePolicyVersionInput) (req *service.Request, output *DeletePolicyVersionOutput) {
-	op := &service.Operation{
+func (c *IAM) DeletePolicyVersionRequest(input *DeletePolicyVersionInput) (req *request.Request, output *DeletePolicyVersionOutput) {
+	op := &request.Operation{
 		Name:       opDeletePolicyVersion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1033,8 +1033,8 @@ func (c *IAM) DeletePolicyVersion(input *DeletePolicyVersionInput) (*DeletePolic
 const opDeleteRole = "DeleteRole"
 
 // DeleteRoleRequest generates a request for the DeleteRole operation.
-func (c *IAM) DeleteRoleRequest(input *DeleteRoleInput) (req *service.Request, output *DeleteRoleOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteRoleRequest(input *DeleteRoleInput) (req *request.Request, output *DeleteRoleOutput) {
+	op := &request.Operation{
 		Name:       opDeleteRole,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1065,8 +1065,8 @@ func (c *IAM) DeleteRole(input *DeleteRoleInput) (*DeleteRoleOutput, error) {
 const opDeleteRolePolicy = "DeleteRolePolicy"
 
 // DeleteRolePolicyRequest generates a request for the DeleteRolePolicy operation.
-func (c *IAM) DeleteRolePolicyRequest(input *DeleteRolePolicyInput) (req *service.Request, output *DeleteRolePolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteRolePolicyRequest(input *DeleteRolePolicyInput) (req *request.Request, output *DeleteRolePolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteRolePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1097,8 +1097,8 @@ func (c *IAM) DeleteRolePolicy(input *DeleteRolePolicyInput) (*DeleteRolePolicyO
 const opDeleteSAMLProvider = "DeleteSAMLProvider"
 
 // DeleteSAMLProviderRequest generates a request for the DeleteSAMLProvider operation.
-func (c *IAM) DeleteSAMLProviderRequest(input *DeleteSAMLProviderInput) (req *service.Request, output *DeleteSAMLProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteSAMLProviderRequest(input *DeleteSAMLProviderInput) (req *request.Request, output *DeleteSAMLProviderOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSAMLProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1130,8 +1130,8 @@ func (c *IAM) DeleteSAMLProvider(input *DeleteSAMLProviderInput) (*DeleteSAMLPro
 const opDeleteSSHPublicKey = "DeleteSSHPublicKey"
 
 // DeleteSSHPublicKeyRequest generates a request for the DeleteSSHPublicKey operation.
-func (c *IAM) DeleteSSHPublicKeyRequest(input *DeleteSSHPublicKeyInput) (req *service.Request, output *DeleteSSHPublicKeyOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteSSHPublicKeyRequest(input *DeleteSSHPublicKeyInput) (req *request.Request, output *DeleteSSHPublicKeyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSSHPublicKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1163,8 +1163,8 @@ func (c *IAM) DeleteSSHPublicKey(input *DeleteSSHPublicKeyInput) (*DeleteSSHPubl
 const opDeleteServerCertificate = "DeleteServerCertificate"
 
 // DeleteServerCertificateRequest generates a request for the DeleteServerCertificate operation.
-func (c *IAM) DeleteServerCertificateRequest(input *DeleteServerCertificateInput) (req *service.Request, output *DeleteServerCertificateOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteServerCertificateRequest(input *DeleteServerCertificateInput) (req *request.Request, output *DeleteServerCertificateOutput) {
+	op := &request.Operation{
 		Name:       opDeleteServerCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1200,8 +1200,8 @@ func (c *IAM) DeleteServerCertificate(input *DeleteServerCertificateInput) (*Del
 const opDeleteSigningCertificate = "DeleteSigningCertificate"
 
 // DeleteSigningCertificateRequest generates a request for the DeleteSigningCertificate operation.
-func (c *IAM) DeleteSigningCertificateRequest(input *DeleteSigningCertificateInput) (req *service.Request, output *DeleteSigningCertificateOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteSigningCertificateRequest(input *DeleteSigningCertificateInput) (req *request.Request, output *DeleteSigningCertificateOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSigningCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1232,8 +1232,8 @@ func (c *IAM) DeleteSigningCertificate(input *DeleteSigningCertificateInput) (*D
 const opDeleteUser = "DeleteUser"
 
 // DeleteUserRequest generates a request for the DeleteUser operation.
-func (c *IAM) DeleteUserRequest(input *DeleteUserInput) (req *service.Request, output *DeleteUserOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteUserRequest(input *DeleteUserInput) (req *request.Request, output *DeleteUserOutput) {
+	op := &request.Operation{
 		Name:       opDeleteUser,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1260,8 +1260,8 @@ func (c *IAM) DeleteUser(input *DeleteUserInput) (*DeleteUserOutput, error) {
 const opDeleteUserPolicy = "DeleteUserPolicy"
 
 // DeleteUserPolicyRequest generates a request for the DeleteUserPolicy operation.
-func (c *IAM) DeleteUserPolicyRequest(input *DeleteUserPolicyInput) (req *service.Request, output *DeleteUserPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteUserPolicyRequest(input *DeleteUserPolicyInput) (req *request.Request, output *DeleteUserPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteUserPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1292,8 +1292,8 @@ func (c *IAM) DeleteUserPolicy(input *DeleteUserPolicyInput) (*DeleteUserPolicyO
 const opDeleteVirtualMFADevice = "DeleteVirtualMFADevice"
 
 // DeleteVirtualMFADeviceRequest generates a request for the DeleteVirtualMFADevice operation.
-func (c *IAM) DeleteVirtualMFADeviceRequest(input *DeleteVirtualMFADeviceInput) (req *service.Request, output *DeleteVirtualMFADeviceOutput) {
-	op := &service.Operation{
+func (c *IAM) DeleteVirtualMFADeviceRequest(input *DeleteVirtualMFADeviceInput) (req *request.Request, output *DeleteVirtualMFADeviceOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVirtualMFADevice,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1322,8 +1322,8 @@ func (c *IAM) DeleteVirtualMFADevice(input *DeleteVirtualMFADeviceInput) (*Delet
 const opDetachGroupPolicy = "DetachGroupPolicy"
 
 // DetachGroupPolicyRequest generates a request for the DetachGroupPolicy operation.
-func (c *IAM) DetachGroupPolicyRequest(input *DetachGroupPolicyInput) (req *service.Request, output *DetachGroupPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) DetachGroupPolicyRequest(input *DetachGroupPolicyInput) (req *request.Request, output *DetachGroupPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDetachGroupPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1354,8 +1354,8 @@ func (c *IAM) DetachGroupPolicy(input *DetachGroupPolicyInput) (*DetachGroupPoli
 const opDetachRolePolicy = "DetachRolePolicy"
 
 // DetachRolePolicyRequest generates a request for the DetachRolePolicy operation.
-func (c *IAM) DetachRolePolicyRequest(input *DetachRolePolicyInput) (req *service.Request, output *DetachRolePolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) DetachRolePolicyRequest(input *DetachRolePolicyInput) (req *request.Request, output *DetachRolePolicyOutput) {
+	op := &request.Operation{
 		Name:       opDetachRolePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1386,8 +1386,8 @@ func (c *IAM) DetachRolePolicy(input *DetachRolePolicyInput) (*DetachRolePolicyO
 const opDetachUserPolicy = "DetachUserPolicy"
 
 // DetachUserPolicyRequest generates a request for the DetachUserPolicy operation.
-func (c *IAM) DetachUserPolicyRequest(input *DetachUserPolicyInput) (req *service.Request, output *DetachUserPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) DetachUserPolicyRequest(input *DetachUserPolicyInput) (req *request.Request, output *DetachUserPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDetachUserPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1418,8 +1418,8 @@ func (c *IAM) DetachUserPolicy(input *DetachUserPolicyInput) (*DetachUserPolicyO
 const opEnableMFADevice = "EnableMFADevice"
 
 // EnableMFADeviceRequest generates a request for the EnableMFADevice operation.
-func (c *IAM) EnableMFADeviceRequest(input *EnableMFADeviceInput) (req *service.Request, output *EnableMFADeviceOutput) {
-	op := &service.Operation{
+func (c *IAM) EnableMFADeviceRequest(input *EnableMFADeviceInput) (req *request.Request, output *EnableMFADeviceOutput) {
+	op := &request.Operation{
 		Name:       opEnableMFADevice,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1447,8 +1447,8 @@ func (c *IAM) EnableMFADevice(input *EnableMFADeviceInput) (*EnableMFADeviceOutp
 const opGenerateCredentialReport = "GenerateCredentialReport"
 
 // GenerateCredentialReportRequest generates a request for the GenerateCredentialReport operation.
-func (c *IAM) GenerateCredentialReportRequest(input *GenerateCredentialReportInput) (req *service.Request, output *GenerateCredentialReportOutput) {
-	op := &service.Operation{
+func (c *IAM) GenerateCredentialReportRequest(input *GenerateCredentialReportInput) (req *request.Request, output *GenerateCredentialReportOutput) {
+	op := &request.Operation{
 		Name:       opGenerateCredentialReport,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1476,8 +1476,8 @@ func (c *IAM) GenerateCredentialReport(input *GenerateCredentialReportInput) (*G
 const opGetAccessKeyLastUsed = "GetAccessKeyLastUsed"
 
 // GetAccessKeyLastUsedRequest generates a request for the GetAccessKeyLastUsed operation.
-func (c *IAM) GetAccessKeyLastUsedRequest(input *GetAccessKeyLastUsedInput) (req *service.Request, output *GetAccessKeyLastUsedOutput) {
-	op := &service.Operation{
+func (c *IAM) GetAccessKeyLastUsedRequest(input *GetAccessKeyLastUsedInput) (req *request.Request, output *GetAccessKeyLastUsedOutput) {
+	op := &request.Operation{
 		Name:       opGetAccessKeyLastUsed,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1506,12 +1506,12 @@ func (c *IAM) GetAccessKeyLastUsed(input *GetAccessKeyLastUsedInput) (*GetAccess
 const opGetAccountAuthorizationDetails = "GetAccountAuthorizationDetails"
 
 // GetAccountAuthorizationDetailsRequest generates a request for the GetAccountAuthorizationDetails operation.
-func (c *IAM) GetAccountAuthorizationDetailsRequest(input *GetAccountAuthorizationDetailsInput) (req *service.Request, output *GetAccountAuthorizationDetailsOutput) {
-	op := &service.Operation{
+func (c *IAM) GetAccountAuthorizationDetailsRequest(input *GetAccountAuthorizationDetailsInput) (req *request.Request, output *GetAccountAuthorizationDetailsOutput) {
+	op := &request.Operation{
 		Name:       opGetAccountAuthorizationDetails,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -1552,8 +1552,8 @@ func (c *IAM) GetAccountAuthorizationDetailsPages(input *GetAccountAuthorization
 const opGetAccountPasswordPolicy = "GetAccountPasswordPolicy"
 
 // GetAccountPasswordPolicyRequest generates a request for the GetAccountPasswordPolicy operation.
-func (c *IAM) GetAccountPasswordPolicyRequest(input *GetAccountPasswordPolicyInput) (req *service.Request, output *GetAccountPasswordPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) GetAccountPasswordPolicyRequest(input *GetAccountPasswordPolicyInput) (req *request.Request, output *GetAccountPasswordPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetAccountPasswordPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1580,8 +1580,8 @@ func (c *IAM) GetAccountPasswordPolicy(input *GetAccountPasswordPolicyInput) (*G
 const opGetAccountSummary = "GetAccountSummary"
 
 // GetAccountSummaryRequest generates a request for the GetAccountSummary operation.
-func (c *IAM) GetAccountSummaryRequest(input *GetAccountSummaryInput) (req *service.Request, output *GetAccountSummaryOutput) {
-	op := &service.Operation{
+func (c *IAM) GetAccountSummaryRequest(input *GetAccountSummaryInput) (req *request.Request, output *GetAccountSummaryOutput) {
+	op := &request.Operation{
 		Name:       opGetAccountSummary,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1611,8 +1611,8 @@ func (c *IAM) GetAccountSummary(input *GetAccountSummaryInput) (*GetAccountSumma
 const opGetCredentialReport = "GetCredentialReport"
 
 // GetCredentialReportRequest generates a request for the GetCredentialReport operation.
-func (c *IAM) GetCredentialReportRequest(input *GetCredentialReportInput) (req *service.Request, output *GetCredentialReportOutput) {
-	op := &service.Operation{
+func (c *IAM) GetCredentialReportRequest(input *GetCredentialReportInput) (req *request.Request, output *GetCredentialReportOutput) {
+	op := &request.Operation{
 		Name:       opGetCredentialReport,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1640,12 +1640,12 @@ func (c *IAM) GetCredentialReport(input *GetCredentialReportInput) (*GetCredenti
 const opGetGroup = "GetGroup"
 
 // GetGroupRequest generates a request for the GetGroup operation.
-func (c *IAM) GetGroupRequest(input *GetGroupInput) (req *service.Request, output *GetGroupOutput) {
-	op := &service.Operation{
+func (c *IAM) GetGroupRequest(input *GetGroupInput) (req *request.Request, output *GetGroupOutput) {
+	op := &request.Operation{
 		Name:       opGetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -1681,8 +1681,8 @@ func (c *IAM) GetGroupPages(input *GetGroupInput, fn func(p *GetGroupOutput, las
 const opGetGroupPolicy = "GetGroupPolicy"
 
 // GetGroupPolicyRequest generates a request for the GetGroupPolicy operation.
-func (c *IAM) GetGroupPolicyRequest(input *GetGroupPolicyInput) (req *service.Request, output *GetGroupPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) GetGroupPolicyRequest(input *GetGroupPolicyInput) (req *request.Request, output *GetGroupPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetGroupPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1718,8 +1718,8 @@ func (c *IAM) GetGroupPolicy(input *GetGroupPolicyInput) (*GetGroupPolicyOutput,
 const opGetInstanceProfile = "GetInstanceProfile"
 
 // GetInstanceProfileRequest generates a request for the GetInstanceProfile operation.
-func (c *IAM) GetInstanceProfileRequest(input *GetInstanceProfileInput) (req *service.Request, output *GetInstanceProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) GetInstanceProfileRequest(input *GetInstanceProfileInput) (req *request.Request, output *GetInstanceProfileOutput) {
+	op := &request.Operation{
 		Name:       opGetInstanceProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1748,8 +1748,8 @@ func (c *IAM) GetInstanceProfile(input *GetInstanceProfileInput) (*GetInstancePr
 const opGetLoginProfile = "GetLoginProfile"
 
 // GetLoginProfileRequest generates a request for the GetLoginProfile operation.
-func (c *IAM) GetLoginProfileRequest(input *GetLoginProfileInput) (req *service.Request, output *GetLoginProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) GetLoginProfileRequest(input *GetLoginProfileInput) (req *request.Request, output *GetLoginProfileOutput) {
+	op := &request.Operation{
 		Name:       opGetLoginProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1777,8 +1777,8 @@ func (c *IAM) GetLoginProfile(input *GetLoginProfileInput) (*GetLoginProfileOutp
 const opGetOpenIDConnectProvider = "GetOpenIDConnectProvider"
 
 // GetOpenIDConnectProviderRequest generates a request for the GetOpenIDConnectProvider operation.
-func (c *IAM) GetOpenIDConnectProviderRequest(input *GetOpenIDConnectProviderInput) (req *service.Request, output *GetOpenIDConnectProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) GetOpenIDConnectProviderRequest(input *GetOpenIDConnectProviderInput) (req *request.Request, output *GetOpenIDConnectProviderOutput) {
+	op := &request.Operation{
 		Name:       opGetOpenIDConnectProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1804,8 +1804,8 @@ func (c *IAM) GetOpenIDConnectProvider(input *GetOpenIDConnectProviderInput) (*G
 const opGetPolicy = "GetPolicy"
 
 // GetPolicyRequest generates a request for the GetPolicy operation.
-func (c *IAM) GetPolicyRequest(input *GetPolicyInput) (req *service.Request, output *GetPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) GetPolicyRequest(input *GetPolicyInput) (req *request.Request, output *GetPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1844,8 +1844,8 @@ func (c *IAM) GetPolicy(input *GetPolicyInput) (*GetPolicyOutput, error) {
 const opGetPolicyVersion = "GetPolicyVersion"
 
 // GetPolicyVersionRequest generates a request for the GetPolicyVersion operation.
-func (c *IAM) GetPolicyVersionRequest(input *GetPolicyVersionInput) (req *service.Request, output *GetPolicyVersionOutput) {
-	op := &service.Operation{
+func (c *IAM) GetPolicyVersionRequest(input *GetPolicyVersionInput) (req *request.Request, output *GetPolicyVersionOutput) {
+	op := &request.Operation{
 		Name:       opGetPolicyVersion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1882,8 +1882,8 @@ func (c *IAM) GetPolicyVersion(input *GetPolicyVersionInput) (*GetPolicyVersionO
 const opGetRole = "GetRole"
 
 // GetRoleRequest generates a request for the GetRole operation.
-func (c *IAM) GetRoleRequest(input *GetRoleInput) (req *service.Request, output *GetRoleOutput) {
-	op := &service.Operation{
+func (c *IAM) GetRoleRequest(input *GetRoleInput) (req *request.Request, output *GetRoleOutput) {
+	op := &request.Operation{
 		Name:       opGetRole,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1912,8 +1912,8 @@ func (c *IAM) GetRole(input *GetRoleInput) (*GetRoleOutput, error) {
 const opGetRolePolicy = "GetRolePolicy"
 
 // GetRolePolicyRequest generates a request for the GetRolePolicy operation.
-func (c *IAM) GetRolePolicyRequest(input *GetRolePolicyInput) (req *service.Request, output *GetRolePolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) GetRolePolicyRequest(input *GetRolePolicyInput) (req *request.Request, output *GetRolePolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetRolePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1952,8 +1952,8 @@ func (c *IAM) GetRolePolicy(input *GetRolePolicyInput) (*GetRolePolicyOutput, er
 const opGetSAMLProvider = "GetSAMLProvider"
 
 // GetSAMLProviderRequest generates a request for the GetSAMLProvider operation.
-func (c *IAM) GetSAMLProviderRequest(input *GetSAMLProviderInput) (req *service.Request, output *GetSAMLProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) GetSAMLProviderRequest(input *GetSAMLProviderInput) (req *request.Request, output *GetSAMLProviderOutput) {
+	op := &request.Operation{
 		Name:       opGetSAMLProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1982,8 +1982,8 @@ func (c *IAM) GetSAMLProvider(input *GetSAMLProviderInput) (*GetSAMLProviderOutp
 const opGetSSHPublicKey = "GetSSHPublicKey"
 
 // GetSSHPublicKeyRequest generates a request for the GetSSHPublicKey operation.
-func (c *IAM) GetSSHPublicKeyRequest(input *GetSSHPublicKeyInput) (req *service.Request, output *GetSSHPublicKeyOutput) {
-	op := &service.Operation{
+func (c *IAM) GetSSHPublicKeyRequest(input *GetSSHPublicKeyInput) (req *request.Request, output *GetSSHPublicKeyOutput) {
+	op := &request.Operation{
 		Name:       opGetSSHPublicKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2015,8 +2015,8 @@ func (c *IAM) GetSSHPublicKey(input *GetSSHPublicKeyInput) (*GetSSHPublicKeyOutp
 const opGetServerCertificate = "GetServerCertificate"
 
 // GetServerCertificateRequest generates a request for the GetServerCertificate operation.
-func (c *IAM) GetServerCertificateRequest(input *GetServerCertificateInput) (req *service.Request, output *GetServerCertificateOutput) {
-	op := &service.Operation{
+func (c *IAM) GetServerCertificateRequest(input *GetServerCertificateInput) (req *request.Request, output *GetServerCertificateOutput) {
+	op := &request.Operation{
 		Name:       opGetServerCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2042,8 +2042,8 @@ func (c *IAM) GetServerCertificate(input *GetServerCertificateInput) (*GetServer
 const opGetUser = "GetUser"
 
 // GetUserRequest generates a request for the GetUser operation.
-func (c *IAM) GetUserRequest(input *GetUserInput) (req *service.Request, output *GetUserOutput) {
-	op := &service.Operation{
+func (c *IAM) GetUserRequest(input *GetUserInput) (req *request.Request, output *GetUserOutput) {
+	op := &request.Operation{
 		Name:       opGetUser,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2073,8 +2073,8 @@ func (c *IAM) GetUser(input *GetUserInput) (*GetUserOutput, error) {
 const opGetUserPolicy = "GetUserPolicy"
 
 // GetUserPolicyRequest generates a request for the GetUserPolicy operation.
-func (c *IAM) GetUserPolicyRequest(input *GetUserPolicyInput) (req *service.Request, output *GetUserPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) GetUserPolicyRequest(input *GetUserPolicyInput) (req *request.Request, output *GetUserPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetUserPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2110,12 +2110,12 @@ func (c *IAM) GetUserPolicy(input *GetUserPolicyInput) (*GetUserPolicyOutput, er
 const opListAccessKeys = "ListAccessKeys"
 
 // ListAccessKeysRequest generates a request for the ListAccessKeys operation.
-func (c *IAM) ListAccessKeysRequest(input *ListAccessKeysInput) (req *service.Request, output *ListAccessKeysOutput) {
-	op := &service.Operation{
+func (c *IAM) ListAccessKeysRequest(input *ListAccessKeysInput) (req *request.Request, output *ListAccessKeysOutput) {
+	op := &request.Operation{
 		Name:       opListAccessKeys,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2162,12 +2162,12 @@ func (c *IAM) ListAccessKeysPages(input *ListAccessKeysInput, fn func(p *ListAcc
 const opListAccountAliases = "ListAccountAliases"
 
 // ListAccountAliasesRequest generates a request for the ListAccountAliases operation.
-func (c *IAM) ListAccountAliasesRequest(input *ListAccountAliasesInput) (req *service.Request, output *ListAccountAliasesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListAccountAliasesRequest(input *ListAccountAliasesInput) (req *request.Request, output *ListAccountAliasesOutput) {
+	op := &request.Operation{
 		Name:       opListAccountAliases,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2206,12 +2206,12 @@ func (c *IAM) ListAccountAliasesPages(input *ListAccountAliasesInput, fn func(p 
 const opListAttachedGroupPolicies = "ListAttachedGroupPolicies"
 
 // ListAttachedGroupPoliciesRequest generates a request for the ListAttachedGroupPolicies operation.
-func (c *IAM) ListAttachedGroupPoliciesRequest(input *ListAttachedGroupPoliciesInput) (req *service.Request, output *ListAttachedGroupPoliciesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListAttachedGroupPoliciesRequest(input *ListAttachedGroupPoliciesInput) (req *request.Request, output *ListAttachedGroupPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListAttachedGroupPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2257,12 +2257,12 @@ func (c *IAM) ListAttachedGroupPoliciesPages(input *ListAttachedGroupPoliciesInp
 const opListAttachedRolePolicies = "ListAttachedRolePolicies"
 
 // ListAttachedRolePoliciesRequest generates a request for the ListAttachedRolePolicies operation.
-func (c *IAM) ListAttachedRolePoliciesRequest(input *ListAttachedRolePoliciesInput) (req *service.Request, output *ListAttachedRolePoliciesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListAttachedRolePoliciesRequest(input *ListAttachedRolePoliciesInput) (req *request.Request, output *ListAttachedRolePoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListAttachedRolePolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2308,12 +2308,12 @@ func (c *IAM) ListAttachedRolePoliciesPages(input *ListAttachedRolePoliciesInput
 const opListAttachedUserPolicies = "ListAttachedUserPolicies"
 
 // ListAttachedUserPoliciesRequest generates a request for the ListAttachedUserPolicies operation.
-func (c *IAM) ListAttachedUserPoliciesRequest(input *ListAttachedUserPoliciesInput) (req *service.Request, output *ListAttachedUserPoliciesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListAttachedUserPoliciesRequest(input *ListAttachedUserPoliciesInput) (req *request.Request, output *ListAttachedUserPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListAttachedUserPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2359,12 +2359,12 @@ func (c *IAM) ListAttachedUserPoliciesPages(input *ListAttachedUserPoliciesInput
 const opListEntitiesForPolicy = "ListEntitiesForPolicy"
 
 // ListEntitiesForPolicyRequest generates a request for the ListEntitiesForPolicy operation.
-func (c *IAM) ListEntitiesForPolicyRequest(input *ListEntitiesForPolicyInput) (req *service.Request, output *ListEntitiesForPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) ListEntitiesForPolicyRequest(input *ListEntitiesForPolicyInput) (req *request.Request, output *ListEntitiesForPolicyOutput) {
+	op := &request.Operation{
 		Name:       opListEntitiesForPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2407,12 +2407,12 @@ func (c *IAM) ListEntitiesForPolicyPages(input *ListEntitiesForPolicyInput, fn f
 const opListGroupPolicies = "ListGroupPolicies"
 
 // ListGroupPoliciesRequest generates a request for the ListGroupPolicies operation.
-func (c *IAM) ListGroupPoliciesRequest(input *ListGroupPoliciesInput) (req *service.Request, output *ListGroupPoliciesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListGroupPoliciesRequest(input *ListGroupPoliciesInput) (req *request.Request, output *ListGroupPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListGroupPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2458,12 +2458,12 @@ func (c *IAM) ListGroupPoliciesPages(input *ListGroupPoliciesInput, fn func(p *L
 const opListGroups = "ListGroups"
 
 // ListGroupsRequest generates a request for the ListGroups operation.
-func (c *IAM) ListGroupsRequest(input *ListGroupsInput) (req *service.Request, output *ListGroupsOutput) {
-	op := &service.Operation{
+func (c *IAM) ListGroupsRequest(input *ListGroupsInput) (req *request.Request, output *ListGroupsOutput) {
+	op := &request.Operation{
 		Name:       opListGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2500,12 +2500,12 @@ func (c *IAM) ListGroupsPages(input *ListGroupsInput, fn func(p *ListGroupsOutpu
 const opListGroupsForUser = "ListGroupsForUser"
 
 // ListGroupsForUserRequest generates a request for the ListGroupsForUser operation.
-func (c *IAM) ListGroupsForUserRequest(input *ListGroupsForUserInput) (req *service.Request, output *ListGroupsForUserOutput) {
-	op := &service.Operation{
+func (c *IAM) ListGroupsForUserRequest(input *ListGroupsForUserInput) (req *request.Request, output *ListGroupsForUserOutput) {
+	op := &request.Operation{
 		Name:       opListGroupsForUser,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2542,12 +2542,12 @@ func (c *IAM) ListGroupsForUserPages(input *ListGroupsForUserInput, fn func(p *L
 const opListInstanceProfiles = "ListInstanceProfiles"
 
 // ListInstanceProfilesRequest generates a request for the ListInstanceProfiles operation.
-func (c *IAM) ListInstanceProfilesRequest(input *ListInstanceProfilesInput) (req *service.Request, output *ListInstanceProfilesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListInstanceProfilesRequest(input *ListInstanceProfilesInput) (req *request.Request, output *ListInstanceProfilesOutput) {
+	op := &request.Operation{
 		Name:       opListInstanceProfiles,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2586,12 +2586,12 @@ func (c *IAM) ListInstanceProfilesPages(input *ListInstanceProfilesInput, fn fun
 const opListInstanceProfilesForRole = "ListInstanceProfilesForRole"
 
 // ListInstanceProfilesForRoleRequest generates a request for the ListInstanceProfilesForRole operation.
-func (c *IAM) ListInstanceProfilesForRoleRequest(input *ListInstanceProfilesForRoleInput) (req *service.Request, output *ListInstanceProfilesForRoleOutput) {
-	op := &service.Operation{
+func (c *IAM) ListInstanceProfilesForRoleRequest(input *ListInstanceProfilesForRoleInput) (req *request.Request, output *ListInstanceProfilesForRoleOutput) {
+	op := &request.Operation{
 		Name:       opListInstanceProfilesForRole,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2630,12 +2630,12 @@ func (c *IAM) ListInstanceProfilesForRolePages(input *ListInstanceProfilesForRol
 const opListMFADevices = "ListMFADevices"
 
 // ListMFADevicesRequest generates a request for the ListMFADevices operation.
-func (c *IAM) ListMFADevicesRequest(input *ListMFADevicesInput) (req *service.Request, output *ListMFADevicesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListMFADevicesRequest(input *ListMFADevicesInput) (req *request.Request, output *ListMFADevicesOutput) {
+	op := &request.Operation{
 		Name:       opListMFADevices,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2675,8 +2675,8 @@ func (c *IAM) ListMFADevicesPages(input *ListMFADevicesInput, fn func(p *ListMFA
 const opListOpenIDConnectProviders = "ListOpenIDConnectProviders"
 
 // ListOpenIDConnectProvidersRequest generates a request for the ListOpenIDConnectProviders operation.
-func (c *IAM) ListOpenIDConnectProvidersRequest(input *ListOpenIDConnectProvidersInput) (req *service.Request, output *ListOpenIDConnectProvidersOutput) {
-	op := &service.Operation{
+func (c *IAM) ListOpenIDConnectProvidersRequest(input *ListOpenIDConnectProvidersInput) (req *request.Request, output *ListOpenIDConnectProvidersOutput) {
+	op := &request.Operation{
 		Name:       opListOpenIDConnectProviders,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2702,12 +2702,12 @@ func (c *IAM) ListOpenIDConnectProviders(input *ListOpenIDConnectProvidersInput)
 const opListPolicies = "ListPolicies"
 
 // ListPoliciesRequest generates a request for the ListPolicies operation.
-func (c *IAM) ListPoliciesRequest(input *ListPoliciesInput) (req *service.Request, output *ListPoliciesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListPoliciesRequest(input *ListPoliciesInput) (req *request.Request, output *ListPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2754,8 +2754,8 @@ func (c *IAM) ListPoliciesPages(input *ListPoliciesInput, fn func(p *ListPolicie
 const opListPolicyVersions = "ListPolicyVersions"
 
 // ListPolicyVersionsRequest generates a request for the ListPolicyVersions operation.
-func (c *IAM) ListPolicyVersionsRequest(input *ListPolicyVersionsInput) (req *service.Request, output *ListPolicyVersionsOutput) {
-	op := &service.Operation{
+func (c *IAM) ListPolicyVersionsRequest(input *ListPolicyVersionsInput) (req *request.Request, output *ListPolicyVersionsOutput) {
+	op := &request.Operation{
 		Name:       opListPolicyVersions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2786,12 +2786,12 @@ func (c *IAM) ListPolicyVersions(input *ListPolicyVersionsInput) (*ListPolicyVer
 const opListRolePolicies = "ListRolePolicies"
 
 // ListRolePoliciesRequest generates a request for the ListRolePolicies operation.
-func (c *IAM) ListRolePoliciesRequest(input *ListRolePoliciesInput) (req *service.Request, output *ListRolePoliciesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListRolePoliciesRequest(input *ListRolePoliciesInput) (req *request.Request, output *ListRolePoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListRolePolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2837,12 +2837,12 @@ func (c *IAM) ListRolePoliciesPages(input *ListRolePoliciesInput, fn func(p *Lis
 const opListRoles = "ListRoles"
 
 // ListRolesRequest generates a request for the ListRoles operation.
-func (c *IAM) ListRolesRequest(input *ListRolesInput) (req *service.Request, output *ListRolesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListRolesRequest(input *ListRolesInput) (req *request.Request, output *ListRolesOutput) {
+	op := &request.Operation{
 		Name:       opListRoles,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2881,8 +2881,8 @@ func (c *IAM) ListRolesPages(input *ListRolesInput, fn func(p *ListRolesOutput, 
 const opListSAMLProviders = "ListSAMLProviders"
 
 // ListSAMLProvidersRequest generates a request for the ListSAMLProviders operation.
-func (c *IAM) ListSAMLProvidersRequest(input *ListSAMLProvidersInput) (req *service.Request, output *ListSAMLProvidersOutput) {
-	op := &service.Operation{
+func (c *IAM) ListSAMLProvidersRequest(input *ListSAMLProvidersInput) (req *request.Request, output *ListSAMLProvidersOutput) {
+	op := &request.Operation{
 		Name:       opListSAMLProviders,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2910,8 +2910,8 @@ func (c *IAM) ListSAMLProviders(input *ListSAMLProvidersInput) (*ListSAMLProvide
 const opListSSHPublicKeys = "ListSSHPublicKeys"
 
 // ListSSHPublicKeysRequest generates a request for the ListSSHPublicKeys operation.
-func (c *IAM) ListSSHPublicKeysRequest(input *ListSSHPublicKeysInput) (req *service.Request, output *ListSSHPublicKeysOutput) {
-	op := &service.Operation{
+func (c *IAM) ListSSHPublicKeysRequest(input *ListSSHPublicKeysInput) (req *request.Request, output *ListSSHPublicKeysOutput) {
+	op := &request.Operation{
 		Name:       opListSSHPublicKeys,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2947,12 +2947,12 @@ func (c *IAM) ListSSHPublicKeys(input *ListSSHPublicKeysInput) (*ListSSHPublicKe
 const opListServerCertificates = "ListServerCertificates"
 
 // ListServerCertificatesRequest generates a request for the ListServerCertificates operation.
-func (c *IAM) ListServerCertificatesRequest(input *ListServerCertificatesInput) (req *service.Request, output *ListServerCertificatesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListServerCertificatesRequest(input *ListServerCertificatesInput) (req *request.Request, output *ListServerCertificatesOutput) {
+	op := &request.Operation{
 		Name:       opListServerCertificates,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -2990,12 +2990,12 @@ func (c *IAM) ListServerCertificatesPages(input *ListServerCertificatesInput, fn
 const opListSigningCertificates = "ListSigningCertificates"
 
 // ListSigningCertificatesRequest generates a request for the ListSigningCertificates operation.
-func (c *IAM) ListSigningCertificatesRequest(input *ListSigningCertificatesInput) (req *service.Request, output *ListSigningCertificatesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListSigningCertificatesRequest(input *ListSigningCertificatesInput) (req *request.Request, output *ListSigningCertificatesOutput) {
+	op := &request.Operation{
 		Name:       opListSigningCertificates,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -3039,12 +3039,12 @@ func (c *IAM) ListSigningCertificatesPages(input *ListSigningCertificatesInput, 
 const opListUserPolicies = "ListUserPolicies"
 
 // ListUserPoliciesRequest generates a request for the ListUserPolicies operation.
-func (c *IAM) ListUserPoliciesRequest(input *ListUserPoliciesInput) (req *service.Request, output *ListUserPoliciesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListUserPoliciesRequest(input *ListUserPoliciesInput) (req *request.Request, output *ListUserPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListUserPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -3089,12 +3089,12 @@ func (c *IAM) ListUserPoliciesPages(input *ListUserPoliciesInput, fn func(p *Lis
 const opListUsers = "ListUsers"
 
 // ListUsersRequest generates a request for the ListUsers operation.
-func (c *IAM) ListUsersRequest(input *ListUsersInput) (req *service.Request, output *ListUsersOutput) {
-	op := &service.Operation{
+func (c *IAM) ListUsersRequest(input *ListUsersInput) (req *request.Request, output *ListUsersOutput) {
+	op := &request.Operation{
 		Name:       opListUsers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -3133,12 +3133,12 @@ func (c *IAM) ListUsersPages(input *ListUsersInput, fn func(p *ListUsersOutput, 
 const opListVirtualMFADevices = "ListVirtualMFADevices"
 
 // ListVirtualMFADevicesRequest generates a request for the ListVirtualMFADevices operation.
-func (c *IAM) ListVirtualMFADevicesRequest(input *ListVirtualMFADevicesInput) (req *service.Request, output *ListVirtualMFADevicesOutput) {
-	op := &service.Operation{
+func (c *IAM) ListVirtualMFADevicesRequest(input *ListVirtualMFADevicesInput) (req *request.Request, output *ListVirtualMFADevicesOutput) {
+	op := &request.Operation{
 		Name:       opListVirtualMFADevices,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxItems",
@@ -3178,8 +3178,8 @@ func (c *IAM) ListVirtualMFADevicesPages(input *ListVirtualMFADevicesInput, fn f
 const opPutGroupPolicy = "PutGroupPolicy"
 
 // PutGroupPolicyRequest generates a request for the PutGroupPolicy operation.
-func (c *IAM) PutGroupPolicyRequest(input *PutGroupPolicyInput) (req *service.Request, output *PutGroupPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) PutGroupPolicyRequest(input *PutGroupPolicyInput) (req *request.Request, output *PutGroupPolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutGroupPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3221,8 +3221,8 @@ func (c *IAM) PutGroupPolicy(input *PutGroupPolicyInput) (*PutGroupPolicyOutput,
 const opPutRolePolicy = "PutRolePolicy"
 
 // PutRolePolicyRequest generates a request for the PutRolePolicy operation.
-func (c *IAM) PutRolePolicyRequest(input *PutRolePolicyInput) (req *service.Request, output *PutRolePolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) PutRolePolicyRequest(input *PutRolePolicyInput) (req *request.Request, output *PutRolePolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutRolePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3270,8 +3270,8 @@ func (c *IAM) PutRolePolicy(input *PutRolePolicyInput) (*PutRolePolicyOutput, er
 const opPutUserPolicy = "PutUserPolicy"
 
 // PutUserPolicyRequest generates a request for the PutUserPolicy operation.
-func (c *IAM) PutUserPolicyRequest(input *PutUserPolicyInput) (req *service.Request, output *PutUserPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) PutUserPolicyRequest(input *PutUserPolicyInput) (req *request.Request, output *PutUserPolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutUserPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3313,8 +3313,8 @@ func (c *IAM) PutUserPolicy(input *PutUserPolicyInput) (*PutUserPolicyOutput, er
 const opRemoveClientIDFromOpenIDConnectProvider = "RemoveClientIDFromOpenIDConnectProvider"
 
 // RemoveClientIDFromOpenIDConnectProviderRequest generates a request for the RemoveClientIDFromOpenIDConnectProvider operation.
-func (c *IAM) RemoveClientIDFromOpenIDConnectProviderRequest(input *RemoveClientIDFromOpenIDConnectProviderInput) (req *service.Request, output *RemoveClientIDFromOpenIDConnectProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) RemoveClientIDFromOpenIDConnectProviderRequest(input *RemoveClientIDFromOpenIDConnectProviderInput) (req *request.Request, output *RemoveClientIDFromOpenIDConnectProviderOutput) {
+	op := &request.Operation{
 		Name:       opRemoveClientIDFromOpenIDConnectProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3344,8 +3344,8 @@ func (c *IAM) RemoveClientIDFromOpenIDConnectProvider(input *RemoveClientIDFromO
 const opRemoveRoleFromInstanceProfile = "RemoveRoleFromInstanceProfile"
 
 // RemoveRoleFromInstanceProfileRequest generates a request for the RemoveRoleFromInstanceProfile operation.
-func (c *IAM) RemoveRoleFromInstanceProfileRequest(input *RemoveRoleFromInstanceProfileInput) (req *service.Request, output *RemoveRoleFromInstanceProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) RemoveRoleFromInstanceProfileRequest(input *RemoveRoleFromInstanceProfileInput) (req *request.Request, output *RemoveRoleFromInstanceProfileOutput) {
+	op := &request.Operation{
 		Name:       opRemoveRoleFromInstanceProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3379,8 +3379,8 @@ func (c *IAM) RemoveRoleFromInstanceProfile(input *RemoveRoleFromInstanceProfile
 const opRemoveUserFromGroup = "RemoveUserFromGroup"
 
 // RemoveUserFromGroupRequest generates a request for the RemoveUserFromGroup operation.
-func (c *IAM) RemoveUserFromGroupRequest(input *RemoveUserFromGroupInput) (req *service.Request, output *RemoveUserFromGroupOutput) {
-	op := &service.Operation{
+func (c *IAM) RemoveUserFromGroupRequest(input *RemoveUserFromGroupInput) (req *request.Request, output *RemoveUserFromGroupOutput) {
+	op := &request.Operation{
 		Name:       opRemoveUserFromGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3406,8 +3406,8 @@ func (c *IAM) RemoveUserFromGroup(input *RemoveUserFromGroupInput) (*RemoveUserF
 const opResyncMFADevice = "ResyncMFADevice"
 
 // ResyncMFADeviceRequest generates a request for the ResyncMFADevice operation.
-func (c *IAM) ResyncMFADeviceRequest(input *ResyncMFADeviceInput) (req *service.Request, output *ResyncMFADeviceOutput) {
-	op := &service.Operation{
+func (c *IAM) ResyncMFADeviceRequest(input *ResyncMFADeviceInput) (req *request.Request, output *ResyncMFADeviceOutput) {
+	op := &request.Operation{
 		Name:       opResyncMFADevice,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3437,8 +3437,8 @@ func (c *IAM) ResyncMFADevice(input *ResyncMFADeviceInput) (*ResyncMFADeviceOutp
 const opSetDefaultPolicyVersion = "SetDefaultPolicyVersion"
 
 // SetDefaultPolicyVersionRequest generates a request for the SetDefaultPolicyVersion operation.
-func (c *IAM) SetDefaultPolicyVersionRequest(input *SetDefaultPolicyVersionInput) (req *service.Request, output *SetDefaultPolicyVersionOutput) {
-	op := &service.Operation{
+func (c *IAM) SetDefaultPolicyVersionRequest(input *SetDefaultPolicyVersionInput) (req *request.Request, output *SetDefaultPolicyVersionOutput) {
+	op := &request.Operation{
 		Name:       opSetDefaultPolicyVersion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3473,8 +3473,8 @@ func (c *IAM) SetDefaultPolicyVersion(input *SetDefaultPolicyVersionInput) (*Set
 const opUpdateAccessKey = "UpdateAccessKey"
 
 // UpdateAccessKeyRequest generates a request for the UpdateAccessKey operation.
-func (c *IAM) UpdateAccessKeyRequest(input *UpdateAccessKeyInput) (req *service.Request, output *UpdateAccessKeyOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateAccessKeyRequest(input *UpdateAccessKeyInput) (req *request.Request, output *UpdateAccessKeyOutput) {
+	op := &request.Operation{
 		Name:       opUpdateAccessKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3511,8 +3511,8 @@ func (c *IAM) UpdateAccessKey(input *UpdateAccessKeyInput) (*UpdateAccessKeyOutp
 const opUpdateAccountPasswordPolicy = "UpdateAccountPasswordPolicy"
 
 // UpdateAccountPasswordPolicyRequest generates a request for the UpdateAccountPasswordPolicy operation.
-func (c *IAM) UpdateAccountPasswordPolicyRequest(input *UpdateAccountPasswordPolicyInput) (req *service.Request, output *UpdateAccountPasswordPolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateAccountPasswordPolicyRequest(input *UpdateAccountPasswordPolicyInput) (req *request.Request, output *UpdateAccountPasswordPolicyOutput) {
+	op := &request.Operation{
 		Name:       opUpdateAccountPasswordPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3547,8 +3547,8 @@ func (c *IAM) UpdateAccountPasswordPolicy(input *UpdateAccountPasswordPolicyInpu
 const opUpdateAssumeRolePolicy = "UpdateAssumeRolePolicy"
 
 // UpdateAssumeRolePolicyRequest generates a request for the UpdateAssumeRolePolicy operation.
-func (c *IAM) UpdateAssumeRolePolicyRequest(input *UpdateAssumeRolePolicyInput) (req *service.Request, output *UpdateAssumeRolePolicyOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateAssumeRolePolicyRequest(input *UpdateAssumeRolePolicyInput) (req *request.Request, output *UpdateAssumeRolePolicyOutput) {
+	op := &request.Operation{
 		Name:       opUpdateAssumeRolePolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3576,8 +3576,8 @@ func (c *IAM) UpdateAssumeRolePolicy(input *UpdateAssumeRolePolicyInput) (*Updat
 const opUpdateGroup = "UpdateGroup"
 
 // UpdateGroupRequest generates a request for the UpdateGroup operation.
-func (c *IAM) UpdateGroupRequest(input *UpdateGroupInput) (req *service.Request, output *UpdateGroupOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateGroupRequest(input *UpdateGroupInput) (req *request.Request, output *UpdateGroupOutput) {
+	op := &request.Operation{
 		Name:       opUpdateGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3612,8 +3612,8 @@ func (c *IAM) UpdateGroup(input *UpdateGroupInput) (*UpdateGroupOutput, error) {
 const opUpdateLoginProfile = "UpdateLoginProfile"
 
 // UpdateLoginProfileRequest generates a request for the UpdateLoginProfile operation.
-func (c *IAM) UpdateLoginProfileRequest(input *UpdateLoginProfileInput) (req *service.Request, output *UpdateLoginProfileOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateLoginProfileRequest(input *UpdateLoginProfileInput) (req *request.Request, output *UpdateLoginProfileOutput) {
+	op := &request.Operation{
 		Name:       opUpdateLoginProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3643,8 +3643,8 @@ func (c *IAM) UpdateLoginProfile(input *UpdateLoginProfileInput) (*UpdateLoginPr
 const opUpdateOpenIDConnectProviderThumbprint = "UpdateOpenIDConnectProviderThumbprint"
 
 // UpdateOpenIDConnectProviderThumbprintRequest generates a request for the UpdateOpenIDConnectProviderThumbprint operation.
-func (c *IAM) UpdateOpenIDConnectProviderThumbprintRequest(input *UpdateOpenIDConnectProviderThumbprintInput) (req *service.Request, output *UpdateOpenIDConnectProviderThumbprintOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateOpenIDConnectProviderThumbprintRequest(input *UpdateOpenIDConnectProviderThumbprintInput) (req *request.Request, output *UpdateOpenIDConnectProviderThumbprintOutput) {
+	op := &request.Operation{
 		Name:       opUpdateOpenIDConnectProviderThumbprint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3683,8 +3683,8 @@ func (c *IAM) UpdateOpenIDConnectProviderThumbprint(input *UpdateOpenIDConnectPr
 const opUpdateSAMLProvider = "UpdateSAMLProvider"
 
 // UpdateSAMLProviderRequest generates a request for the UpdateSAMLProvider operation.
-func (c *IAM) UpdateSAMLProviderRequest(input *UpdateSAMLProviderInput) (req *service.Request, output *UpdateSAMLProviderOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateSAMLProviderRequest(input *UpdateSAMLProviderInput) (req *request.Request, output *UpdateSAMLProviderOutput) {
+	op := &request.Operation{
 		Name:       opUpdateSAMLProvider,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3712,8 +3712,8 @@ func (c *IAM) UpdateSAMLProvider(input *UpdateSAMLProviderInput) (*UpdateSAMLPro
 const opUpdateSSHPublicKey = "UpdateSSHPublicKey"
 
 // UpdateSSHPublicKeyRequest generates a request for the UpdateSSHPublicKey operation.
-func (c *IAM) UpdateSSHPublicKeyRequest(input *UpdateSSHPublicKeyInput) (req *service.Request, output *UpdateSSHPublicKeyOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateSSHPublicKeyRequest(input *UpdateSSHPublicKeyInput) (req *request.Request, output *UpdateSSHPublicKeyOutput) {
+	op := &request.Operation{
 		Name:       opUpdateSSHPublicKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3748,8 +3748,8 @@ func (c *IAM) UpdateSSHPublicKey(input *UpdateSSHPublicKeyInput) (*UpdateSSHPubl
 const opUpdateServerCertificate = "UpdateServerCertificate"
 
 // UpdateServerCertificateRequest generates a request for the UpdateServerCertificate operation.
-func (c *IAM) UpdateServerCertificateRequest(input *UpdateServerCertificateInput) (req *service.Request, output *UpdateServerCertificateOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateServerCertificateRequest(input *UpdateServerCertificateInput) (req *request.Request, output *UpdateServerCertificateOutput) {
+	op := &request.Operation{
 		Name:       opUpdateServerCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3785,8 +3785,8 @@ func (c *IAM) UpdateServerCertificate(input *UpdateServerCertificateInput) (*Upd
 const opUpdateSigningCertificate = "UpdateSigningCertificate"
 
 // UpdateSigningCertificateRequest generates a request for the UpdateSigningCertificate operation.
-func (c *IAM) UpdateSigningCertificateRequest(input *UpdateSigningCertificateInput) (req *service.Request, output *UpdateSigningCertificateOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateSigningCertificateRequest(input *UpdateSigningCertificateInput) (req *request.Request, output *UpdateSigningCertificateOutput) {
+	op := &request.Operation{
 		Name:       opUpdateSigningCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3819,8 +3819,8 @@ func (c *IAM) UpdateSigningCertificate(input *UpdateSigningCertificateInput) (*U
 const opUpdateUser = "UpdateUser"
 
 // UpdateUserRequest generates a request for the UpdateUser operation.
-func (c *IAM) UpdateUserRequest(input *UpdateUserInput) (req *service.Request, output *UpdateUserOutput) {
-	op := &service.Operation{
+func (c *IAM) UpdateUserRequest(input *UpdateUserInput) (req *request.Request, output *UpdateUserOutput) {
+	op := &request.Operation{
 		Name:       opUpdateUser,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3855,8 +3855,8 @@ func (c *IAM) UpdateUser(input *UpdateUserInput) (*UpdateUserOutput, error) {
 const opUploadSSHPublicKey = "UploadSSHPublicKey"
 
 // UploadSSHPublicKeyRequest generates a request for the UploadSSHPublicKey operation.
-func (c *IAM) UploadSSHPublicKeyRequest(input *UploadSSHPublicKeyInput) (req *service.Request, output *UploadSSHPublicKeyOutput) {
-	op := &service.Operation{
+func (c *IAM) UploadSSHPublicKeyRequest(input *UploadSSHPublicKeyInput) (req *request.Request, output *UploadSSHPublicKeyOutput) {
+	op := &request.Operation{
 		Name:       opUploadSSHPublicKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3888,8 +3888,8 @@ func (c *IAM) UploadSSHPublicKey(input *UploadSSHPublicKeyInput) (*UploadSSHPubl
 const opUploadServerCertificate = "UploadServerCertificate"
 
 // UploadServerCertificateRequest generates a request for the UploadServerCertificate operation.
-func (c *IAM) UploadServerCertificateRequest(input *UploadServerCertificateInput) (req *service.Request, output *UploadServerCertificateOutput) {
-	op := &service.Operation{
+func (c *IAM) UploadServerCertificateRequest(input *UploadServerCertificateInput) (req *request.Request, output *UploadServerCertificateOutput) {
+	op := &request.Operation{
 		Name:       opUploadServerCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -3929,8 +3929,8 @@ func (c *IAM) UploadServerCertificate(input *UploadServerCertificateInput) (*Upl
 const opUploadSigningCertificate = "UploadSigningCertificate"
 
 // UploadSigningCertificateRequest generates a request for the UploadSigningCertificate operation.
-func (c *IAM) UploadSigningCertificateRequest(input *UploadSigningCertificateInput) (req *service.Request, output *UploadSigningCertificateOutput) {
-	op := &service.Operation{
+func (c *IAM) UploadSigningCertificateRequest(input *UploadSigningCertificateInput) (req *request.Request, output *UploadSigningCertificateOutput) {
+	op := &request.Operation{
 		Name:       opUploadSigningCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/iam/iamiface/interface.go
+++ b/service/iam/iamiface/interface.go
@@ -4,489 +4,489 @@
 package iamiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
 // IAMAPI is the interface type for iam.IAM.
 type IAMAPI interface {
-	AddClientIDToOpenIDConnectProviderRequest(*iam.AddClientIDToOpenIDConnectProviderInput) (*service.Request, *iam.AddClientIDToOpenIDConnectProviderOutput)
+	AddClientIDToOpenIDConnectProviderRequest(*iam.AddClientIDToOpenIDConnectProviderInput) (*request.Request, *iam.AddClientIDToOpenIDConnectProviderOutput)
 
 	AddClientIDToOpenIDConnectProvider(*iam.AddClientIDToOpenIDConnectProviderInput) (*iam.AddClientIDToOpenIDConnectProviderOutput, error)
 
-	AddRoleToInstanceProfileRequest(*iam.AddRoleToInstanceProfileInput) (*service.Request, *iam.AddRoleToInstanceProfileOutput)
+	AddRoleToInstanceProfileRequest(*iam.AddRoleToInstanceProfileInput) (*request.Request, *iam.AddRoleToInstanceProfileOutput)
 
 	AddRoleToInstanceProfile(*iam.AddRoleToInstanceProfileInput) (*iam.AddRoleToInstanceProfileOutput, error)
 
-	AddUserToGroupRequest(*iam.AddUserToGroupInput) (*service.Request, *iam.AddUserToGroupOutput)
+	AddUserToGroupRequest(*iam.AddUserToGroupInput) (*request.Request, *iam.AddUserToGroupOutput)
 
 	AddUserToGroup(*iam.AddUserToGroupInput) (*iam.AddUserToGroupOutput, error)
 
-	AttachGroupPolicyRequest(*iam.AttachGroupPolicyInput) (*service.Request, *iam.AttachGroupPolicyOutput)
+	AttachGroupPolicyRequest(*iam.AttachGroupPolicyInput) (*request.Request, *iam.AttachGroupPolicyOutput)
 
 	AttachGroupPolicy(*iam.AttachGroupPolicyInput) (*iam.AttachGroupPolicyOutput, error)
 
-	AttachRolePolicyRequest(*iam.AttachRolePolicyInput) (*service.Request, *iam.AttachRolePolicyOutput)
+	AttachRolePolicyRequest(*iam.AttachRolePolicyInput) (*request.Request, *iam.AttachRolePolicyOutput)
 
 	AttachRolePolicy(*iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error)
 
-	AttachUserPolicyRequest(*iam.AttachUserPolicyInput) (*service.Request, *iam.AttachUserPolicyOutput)
+	AttachUserPolicyRequest(*iam.AttachUserPolicyInput) (*request.Request, *iam.AttachUserPolicyOutput)
 
 	AttachUserPolicy(*iam.AttachUserPolicyInput) (*iam.AttachUserPolicyOutput, error)
 
-	ChangePasswordRequest(*iam.ChangePasswordInput) (*service.Request, *iam.ChangePasswordOutput)
+	ChangePasswordRequest(*iam.ChangePasswordInput) (*request.Request, *iam.ChangePasswordOutput)
 
 	ChangePassword(*iam.ChangePasswordInput) (*iam.ChangePasswordOutput, error)
 
-	CreateAccessKeyRequest(*iam.CreateAccessKeyInput) (*service.Request, *iam.CreateAccessKeyOutput)
+	CreateAccessKeyRequest(*iam.CreateAccessKeyInput) (*request.Request, *iam.CreateAccessKeyOutput)
 
 	CreateAccessKey(*iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error)
 
-	CreateAccountAliasRequest(*iam.CreateAccountAliasInput) (*service.Request, *iam.CreateAccountAliasOutput)
+	CreateAccountAliasRequest(*iam.CreateAccountAliasInput) (*request.Request, *iam.CreateAccountAliasOutput)
 
 	CreateAccountAlias(*iam.CreateAccountAliasInput) (*iam.CreateAccountAliasOutput, error)
 
-	CreateGroupRequest(*iam.CreateGroupInput) (*service.Request, *iam.CreateGroupOutput)
+	CreateGroupRequest(*iam.CreateGroupInput) (*request.Request, *iam.CreateGroupOutput)
 
 	CreateGroup(*iam.CreateGroupInput) (*iam.CreateGroupOutput, error)
 
-	CreateInstanceProfileRequest(*iam.CreateInstanceProfileInput) (*service.Request, *iam.CreateInstanceProfileOutput)
+	CreateInstanceProfileRequest(*iam.CreateInstanceProfileInput) (*request.Request, *iam.CreateInstanceProfileOutput)
 
 	CreateInstanceProfile(*iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error)
 
-	CreateLoginProfileRequest(*iam.CreateLoginProfileInput) (*service.Request, *iam.CreateLoginProfileOutput)
+	CreateLoginProfileRequest(*iam.CreateLoginProfileInput) (*request.Request, *iam.CreateLoginProfileOutput)
 
 	CreateLoginProfile(*iam.CreateLoginProfileInput) (*iam.CreateLoginProfileOutput, error)
 
-	CreateOpenIDConnectProviderRequest(*iam.CreateOpenIDConnectProviderInput) (*service.Request, *iam.CreateOpenIDConnectProviderOutput)
+	CreateOpenIDConnectProviderRequest(*iam.CreateOpenIDConnectProviderInput) (*request.Request, *iam.CreateOpenIDConnectProviderOutput)
 
 	CreateOpenIDConnectProvider(*iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error)
 
-	CreatePolicyRequest(*iam.CreatePolicyInput) (*service.Request, *iam.CreatePolicyOutput)
+	CreatePolicyRequest(*iam.CreatePolicyInput) (*request.Request, *iam.CreatePolicyOutput)
 
 	CreatePolicy(*iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error)
 
-	CreatePolicyVersionRequest(*iam.CreatePolicyVersionInput) (*service.Request, *iam.CreatePolicyVersionOutput)
+	CreatePolicyVersionRequest(*iam.CreatePolicyVersionInput) (*request.Request, *iam.CreatePolicyVersionOutput)
 
 	CreatePolicyVersion(*iam.CreatePolicyVersionInput) (*iam.CreatePolicyVersionOutput, error)
 
-	CreateRoleRequest(*iam.CreateRoleInput) (*service.Request, *iam.CreateRoleOutput)
+	CreateRoleRequest(*iam.CreateRoleInput) (*request.Request, *iam.CreateRoleOutput)
 
 	CreateRole(*iam.CreateRoleInput) (*iam.CreateRoleOutput, error)
 
-	CreateSAMLProviderRequest(*iam.CreateSAMLProviderInput) (*service.Request, *iam.CreateSAMLProviderOutput)
+	CreateSAMLProviderRequest(*iam.CreateSAMLProviderInput) (*request.Request, *iam.CreateSAMLProviderOutput)
 
 	CreateSAMLProvider(*iam.CreateSAMLProviderInput) (*iam.CreateSAMLProviderOutput, error)
 
-	CreateUserRequest(*iam.CreateUserInput) (*service.Request, *iam.CreateUserOutput)
+	CreateUserRequest(*iam.CreateUserInput) (*request.Request, *iam.CreateUserOutput)
 
 	CreateUser(*iam.CreateUserInput) (*iam.CreateUserOutput, error)
 
-	CreateVirtualMFADeviceRequest(*iam.CreateVirtualMFADeviceInput) (*service.Request, *iam.CreateVirtualMFADeviceOutput)
+	CreateVirtualMFADeviceRequest(*iam.CreateVirtualMFADeviceInput) (*request.Request, *iam.CreateVirtualMFADeviceOutput)
 
 	CreateVirtualMFADevice(*iam.CreateVirtualMFADeviceInput) (*iam.CreateVirtualMFADeviceOutput, error)
 
-	DeactivateMFADeviceRequest(*iam.DeactivateMFADeviceInput) (*service.Request, *iam.DeactivateMFADeviceOutput)
+	DeactivateMFADeviceRequest(*iam.DeactivateMFADeviceInput) (*request.Request, *iam.DeactivateMFADeviceOutput)
 
 	DeactivateMFADevice(*iam.DeactivateMFADeviceInput) (*iam.DeactivateMFADeviceOutput, error)
 
-	DeleteAccessKeyRequest(*iam.DeleteAccessKeyInput) (*service.Request, *iam.DeleteAccessKeyOutput)
+	DeleteAccessKeyRequest(*iam.DeleteAccessKeyInput) (*request.Request, *iam.DeleteAccessKeyOutput)
 
 	DeleteAccessKey(*iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error)
 
-	DeleteAccountAliasRequest(*iam.DeleteAccountAliasInput) (*service.Request, *iam.DeleteAccountAliasOutput)
+	DeleteAccountAliasRequest(*iam.DeleteAccountAliasInput) (*request.Request, *iam.DeleteAccountAliasOutput)
 
 	DeleteAccountAlias(*iam.DeleteAccountAliasInput) (*iam.DeleteAccountAliasOutput, error)
 
-	DeleteAccountPasswordPolicyRequest(*iam.DeleteAccountPasswordPolicyInput) (*service.Request, *iam.DeleteAccountPasswordPolicyOutput)
+	DeleteAccountPasswordPolicyRequest(*iam.DeleteAccountPasswordPolicyInput) (*request.Request, *iam.DeleteAccountPasswordPolicyOutput)
 
 	DeleteAccountPasswordPolicy(*iam.DeleteAccountPasswordPolicyInput) (*iam.DeleteAccountPasswordPolicyOutput, error)
 
-	DeleteGroupRequest(*iam.DeleteGroupInput) (*service.Request, *iam.DeleteGroupOutput)
+	DeleteGroupRequest(*iam.DeleteGroupInput) (*request.Request, *iam.DeleteGroupOutput)
 
 	DeleteGroup(*iam.DeleteGroupInput) (*iam.DeleteGroupOutput, error)
 
-	DeleteGroupPolicyRequest(*iam.DeleteGroupPolicyInput) (*service.Request, *iam.DeleteGroupPolicyOutput)
+	DeleteGroupPolicyRequest(*iam.DeleteGroupPolicyInput) (*request.Request, *iam.DeleteGroupPolicyOutput)
 
 	DeleteGroupPolicy(*iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error)
 
-	DeleteInstanceProfileRequest(*iam.DeleteInstanceProfileInput) (*service.Request, *iam.DeleteInstanceProfileOutput)
+	DeleteInstanceProfileRequest(*iam.DeleteInstanceProfileInput) (*request.Request, *iam.DeleteInstanceProfileOutput)
 
 	DeleteInstanceProfile(*iam.DeleteInstanceProfileInput) (*iam.DeleteInstanceProfileOutput, error)
 
-	DeleteLoginProfileRequest(*iam.DeleteLoginProfileInput) (*service.Request, *iam.DeleteLoginProfileOutput)
+	DeleteLoginProfileRequest(*iam.DeleteLoginProfileInput) (*request.Request, *iam.DeleteLoginProfileOutput)
 
 	DeleteLoginProfile(*iam.DeleteLoginProfileInput) (*iam.DeleteLoginProfileOutput, error)
 
-	DeleteOpenIDConnectProviderRequest(*iam.DeleteOpenIDConnectProviderInput) (*service.Request, *iam.DeleteOpenIDConnectProviderOutput)
+	DeleteOpenIDConnectProviderRequest(*iam.DeleteOpenIDConnectProviderInput) (*request.Request, *iam.DeleteOpenIDConnectProviderOutput)
 
 	DeleteOpenIDConnectProvider(*iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error)
 
-	DeletePolicyRequest(*iam.DeletePolicyInput) (*service.Request, *iam.DeletePolicyOutput)
+	DeletePolicyRequest(*iam.DeletePolicyInput) (*request.Request, *iam.DeletePolicyOutput)
 
 	DeletePolicy(*iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error)
 
-	DeletePolicyVersionRequest(*iam.DeletePolicyVersionInput) (*service.Request, *iam.DeletePolicyVersionOutput)
+	DeletePolicyVersionRequest(*iam.DeletePolicyVersionInput) (*request.Request, *iam.DeletePolicyVersionOutput)
 
 	DeletePolicyVersion(*iam.DeletePolicyVersionInput) (*iam.DeletePolicyVersionOutput, error)
 
-	DeleteRoleRequest(*iam.DeleteRoleInput) (*service.Request, *iam.DeleteRoleOutput)
+	DeleteRoleRequest(*iam.DeleteRoleInput) (*request.Request, *iam.DeleteRoleOutput)
 
 	DeleteRole(*iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error)
 
-	DeleteRolePolicyRequest(*iam.DeleteRolePolicyInput) (*service.Request, *iam.DeleteRolePolicyOutput)
+	DeleteRolePolicyRequest(*iam.DeleteRolePolicyInput) (*request.Request, *iam.DeleteRolePolicyOutput)
 
 	DeleteRolePolicy(*iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error)
 
-	DeleteSAMLProviderRequest(*iam.DeleteSAMLProviderInput) (*service.Request, *iam.DeleteSAMLProviderOutput)
+	DeleteSAMLProviderRequest(*iam.DeleteSAMLProviderInput) (*request.Request, *iam.DeleteSAMLProviderOutput)
 
 	DeleteSAMLProvider(*iam.DeleteSAMLProviderInput) (*iam.DeleteSAMLProviderOutput, error)
 
-	DeleteSSHPublicKeyRequest(*iam.DeleteSSHPublicKeyInput) (*service.Request, *iam.DeleteSSHPublicKeyOutput)
+	DeleteSSHPublicKeyRequest(*iam.DeleteSSHPublicKeyInput) (*request.Request, *iam.DeleteSSHPublicKeyOutput)
 
 	DeleteSSHPublicKey(*iam.DeleteSSHPublicKeyInput) (*iam.DeleteSSHPublicKeyOutput, error)
 
-	DeleteServerCertificateRequest(*iam.DeleteServerCertificateInput) (*service.Request, *iam.DeleteServerCertificateOutput)
+	DeleteServerCertificateRequest(*iam.DeleteServerCertificateInput) (*request.Request, *iam.DeleteServerCertificateOutput)
 
 	DeleteServerCertificate(*iam.DeleteServerCertificateInput) (*iam.DeleteServerCertificateOutput, error)
 
-	DeleteSigningCertificateRequest(*iam.DeleteSigningCertificateInput) (*service.Request, *iam.DeleteSigningCertificateOutput)
+	DeleteSigningCertificateRequest(*iam.DeleteSigningCertificateInput) (*request.Request, *iam.DeleteSigningCertificateOutput)
 
 	DeleteSigningCertificate(*iam.DeleteSigningCertificateInput) (*iam.DeleteSigningCertificateOutput, error)
 
-	DeleteUserRequest(*iam.DeleteUserInput) (*service.Request, *iam.DeleteUserOutput)
+	DeleteUserRequest(*iam.DeleteUserInput) (*request.Request, *iam.DeleteUserOutput)
 
 	DeleteUser(*iam.DeleteUserInput) (*iam.DeleteUserOutput, error)
 
-	DeleteUserPolicyRequest(*iam.DeleteUserPolicyInput) (*service.Request, *iam.DeleteUserPolicyOutput)
+	DeleteUserPolicyRequest(*iam.DeleteUserPolicyInput) (*request.Request, *iam.DeleteUserPolicyOutput)
 
 	DeleteUserPolicy(*iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error)
 
-	DeleteVirtualMFADeviceRequest(*iam.DeleteVirtualMFADeviceInput) (*service.Request, *iam.DeleteVirtualMFADeviceOutput)
+	DeleteVirtualMFADeviceRequest(*iam.DeleteVirtualMFADeviceInput) (*request.Request, *iam.DeleteVirtualMFADeviceOutput)
 
 	DeleteVirtualMFADevice(*iam.DeleteVirtualMFADeviceInput) (*iam.DeleteVirtualMFADeviceOutput, error)
 
-	DetachGroupPolicyRequest(*iam.DetachGroupPolicyInput) (*service.Request, *iam.DetachGroupPolicyOutput)
+	DetachGroupPolicyRequest(*iam.DetachGroupPolicyInput) (*request.Request, *iam.DetachGroupPolicyOutput)
 
 	DetachGroupPolicy(*iam.DetachGroupPolicyInput) (*iam.DetachGroupPolicyOutput, error)
 
-	DetachRolePolicyRequest(*iam.DetachRolePolicyInput) (*service.Request, *iam.DetachRolePolicyOutput)
+	DetachRolePolicyRequest(*iam.DetachRolePolicyInput) (*request.Request, *iam.DetachRolePolicyOutput)
 
 	DetachRolePolicy(*iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error)
 
-	DetachUserPolicyRequest(*iam.DetachUserPolicyInput) (*service.Request, *iam.DetachUserPolicyOutput)
+	DetachUserPolicyRequest(*iam.DetachUserPolicyInput) (*request.Request, *iam.DetachUserPolicyOutput)
 
 	DetachUserPolicy(*iam.DetachUserPolicyInput) (*iam.DetachUserPolicyOutput, error)
 
-	EnableMFADeviceRequest(*iam.EnableMFADeviceInput) (*service.Request, *iam.EnableMFADeviceOutput)
+	EnableMFADeviceRequest(*iam.EnableMFADeviceInput) (*request.Request, *iam.EnableMFADeviceOutput)
 
 	EnableMFADevice(*iam.EnableMFADeviceInput) (*iam.EnableMFADeviceOutput, error)
 
-	GenerateCredentialReportRequest(*iam.GenerateCredentialReportInput) (*service.Request, *iam.GenerateCredentialReportOutput)
+	GenerateCredentialReportRequest(*iam.GenerateCredentialReportInput) (*request.Request, *iam.GenerateCredentialReportOutput)
 
 	GenerateCredentialReport(*iam.GenerateCredentialReportInput) (*iam.GenerateCredentialReportOutput, error)
 
-	GetAccessKeyLastUsedRequest(*iam.GetAccessKeyLastUsedInput) (*service.Request, *iam.GetAccessKeyLastUsedOutput)
+	GetAccessKeyLastUsedRequest(*iam.GetAccessKeyLastUsedInput) (*request.Request, *iam.GetAccessKeyLastUsedOutput)
 
 	GetAccessKeyLastUsed(*iam.GetAccessKeyLastUsedInput) (*iam.GetAccessKeyLastUsedOutput, error)
 
-	GetAccountAuthorizationDetailsRequest(*iam.GetAccountAuthorizationDetailsInput) (*service.Request, *iam.GetAccountAuthorizationDetailsOutput)
+	GetAccountAuthorizationDetailsRequest(*iam.GetAccountAuthorizationDetailsInput) (*request.Request, *iam.GetAccountAuthorizationDetailsOutput)
 
 	GetAccountAuthorizationDetails(*iam.GetAccountAuthorizationDetailsInput) (*iam.GetAccountAuthorizationDetailsOutput, error)
 
 	GetAccountAuthorizationDetailsPages(*iam.GetAccountAuthorizationDetailsInput, func(*iam.GetAccountAuthorizationDetailsOutput, bool) bool) error
 
-	GetAccountPasswordPolicyRequest(*iam.GetAccountPasswordPolicyInput) (*service.Request, *iam.GetAccountPasswordPolicyOutput)
+	GetAccountPasswordPolicyRequest(*iam.GetAccountPasswordPolicyInput) (*request.Request, *iam.GetAccountPasswordPolicyOutput)
 
 	GetAccountPasswordPolicy(*iam.GetAccountPasswordPolicyInput) (*iam.GetAccountPasswordPolicyOutput, error)
 
-	GetAccountSummaryRequest(*iam.GetAccountSummaryInput) (*service.Request, *iam.GetAccountSummaryOutput)
+	GetAccountSummaryRequest(*iam.GetAccountSummaryInput) (*request.Request, *iam.GetAccountSummaryOutput)
 
 	GetAccountSummary(*iam.GetAccountSummaryInput) (*iam.GetAccountSummaryOutput, error)
 
-	GetCredentialReportRequest(*iam.GetCredentialReportInput) (*service.Request, *iam.GetCredentialReportOutput)
+	GetCredentialReportRequest(*iam.GetCredentialReportInput) (*request.Request, *iam.GetCredentialReportOutput)
 
 	GetCredentialReport(*iam.GetCredentialReportInput) (*iam.GetCredentialReportOutput, error)
 
-	GetGroupRequest(*iam.GetGroupInput) (*service.Request, *iam.GetGroupOutput)
+	GetGroupRequest(*iam.GetGroupInput) (*request.Request, *iam.GetGroupOutput)
 
 	GetGroup(*iam.GetGroupInput) (*iam.GetGroupOutput, error)
 
 	GetGroupPages(*iam.GetGroupInput, func(*iam.GetGroupOutput, bool) bool) error
 
-	GetGroupPolicyRequest(*iam.GetGroupPolicyInput) (*service.Request, *iam.GetGroupPolicyOutput)
+	GetGroupPolicyRequest(*iam.GetGroupPolicyInput) (*request.Request, *iam.GetGroupPolicyOutput)
 
 	GetGroupPolicy(*iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error)
 
-	GetInstanceProfileRequest(*iam.GetInstanceProfileInput) (*service.Request, *iam.GetInstanceProfileOutput)
+	GetInstanceProfileRequest(*iam.GetInstanceProfileInput) (*request.Request, *iam.GetInstanceProfileOutput)
 
 	GetInstanceProfile(*iam.GetInstanceProfileInput) (*iam.GetInstanceProfileOutput, error)
 
-	GetLoginProfileRequest(*iam.GetLoginProfileInput) (*service.Request, *iam.GetLoginProfileOutput)
+	GetLoginProfileRequest(*iam.GetLoginProfileInput) (*request.Request, *iam.GetLoginProfileOutput)
 
 	GetLoginProfile(*iam.GetLoginProfileInput) (*iam.GetLoginProfileOutput, error)
 
-	GetOpenIDConnectProviderRequest(*iam.GetOpenIDConnectProviderInput) (*service.Request, *iam.GetOpenIDConnectProviderOutput)
+	GetOpenIDConnectProviderRequest(*iam.GetOpenIDConnectProviderInput) (*request.Request, *iam.GetOpenIDConnectProviderOutput)
 
 	GetOpenIDConnectProvider(*iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error)
 
-	GetPolicyRequest(*iam.GetPolicyInput) (*service.Request, *iam.GetPolicyOutput)
+	GetPolicyRequest(*iam.GetPolicyInput) (*request.Request, *iam.GetPolicyOutput)
 
 	GetPolicy(*iam.GetPolicyInput) (*iam.GetPolicyOutput, error)
 
-	GetPolicyVersionRequest(*iam.GetPolicyVersionInput) (*service.Request, *iam.GetPolicyVersionOutput)
+	GetPolicyVersionRequest(*iam.GetPolicyVersionInput) (*request.Request, *iam.GetPolicyVersionOutput)
 
 	GetPolicyVersion(*iam.GetPolicyVersionInput) (*iam.GetPolicyVersionOutput, error)
 
-	GetRoleRequest(*iam.GetRoleInput) (*service.Request, *iam.GetRoleOutput)
+	GetRoleRequest(*iam.GetRoleInput) (*request.Request, *iam.GetRoleOutput)
 
 	GetRole(*iam.GetRoleInput) (*iam.GetRoleOutput, error)
 
-	GetRolePolicyRequest(*iam.GetRolePolicyInput) (*service.Request, *iam.GetRolePolicyOutput)
+	GetRolePolicyRequest(*iam.GetRolePolicyInput) (*request.Request, *iam.GetRolePolicyOutput)
 
 	GetRolePolicy(*iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error)
 
-	GetSAMLProviderRequest(*iam.GetSAMLProviderInput) (*service.Request, *iam.GetSAMLProviderOutput)
+	GetSAMLProviderRequest(*iam.GetSAMLProviderInput) (*request.Request, *iam.GetSAMLProviderOutput)
 
 	GetSAMLProvider(*iam.GetSAMLProviderInput) (*iam.GetSAMLProviderOutput, error)
 
-	GetSSHPublicKeyRequest(*iam.GetSSHPublicKeyInput) (*service.Request, *iam.GetSSHPublicKeyOutput)
+	GetSSHPublicKeyRequest(*iam.GetSSHPublicKeyInput) (*request.Request, *iam.GetSSHPublicKeyOutput)
 
 	GetSSHPublicKey(*iam.GetSSHPublicKeyInput) (*iam.GetSSHPublicKeyOutput, error)
 
-	GetServerCertificateRequest(*iam.GetServerCertificateInput) (*service.Request, *iam.GetServerCertificateOutput)
+	GetServerCertificateRequest(*iam.GetServerCertificateInput) (*request.Request, *iam.GetServerCertificateOutput)
 
 	GetServerCertificate(*iam.GetServerCertificateInput) (*iam.GetServerCertificateOutput, error)
 
-	GetUserRequest(*iam.GetUserInput) (*service.Request, *iam.GetUserOutput)
+	GetUserRequest(*iam.GetUserInput) (*request.Request, *iam.GetUserOutput)
 
 	GetUser(*iam.GetUserInput) (*iam.GetUserOutput, error)
 
-	GetUserPolicyRequest(*iam.GetUserPolicyInput) (*service.Request, *iam.GetUserPolicyOutput)
+	GetUserPolicyRequest(*iam.GetUserPolicyInput) (*request.Request, *iam.GetUserPolicyOutput)
 
 	GetUserPolicy(*iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error)
 
-	ListAccessKeysRequest(*iam.ListAccessKeysInput) (*service.Request, *iam.ListAccessKeysOutput)
+	ListAccessKeysRequest(*iam.ListAccessKeysInput) (*request.Request, *iam.ListAccessKeysOutput)
 
 	ListAccessKeys(*iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error)
 
 	ListAccessKeysPages(*iam.ListAccessKeysInput, func(*iam.ListAccessKeysOutput, bool) bool) error
 
-	ListAccountAliasesRequest(*iam.ListAccountAliasesInput) (*service.Request, *iam.ListAccountAliasesOutput)
+	ListAccountAliasesRequest(*iam.ListAccountAliasesInput) (*request.Request, *iam.ListAccountAliasesOutput)
 
 	ListAccountAliases(*iam.ListAccountAliasesInput) (*iam.ListAccountAliasesOutput, error)
 
 	ListAccountAliasesPages(*iam.ListAccountAliasesInput, func(*iam.ListAccountAliasesOutput, bool) bool) error
 
-	ListAttachedGroupPoliciesRequest(*iam.ListAttachedGroupPoliciesInput) (*service.Request, *iam.ListAttachedGroupPoliciesOutput)
+	ListAttachedGroupPoliciesRequest(*iam.ListAttachedGroupPoliciesInput) (*request.Request, *iam.ListAttachedGroupPoliciesOutput)
 
 	ListAttachedGroupPolicies(*iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error)
 
 	ListAttachedGroupPoliciesPages(*iam.ListAttachedGroupPoliciesInput, func(*iam.ListAttachedGroupPoliciesOutput, bool) bool) error
 
-	ListAttachedRolePoliciesRequest(*iam.ListAttachedRolePoliciesInput) (*service.Request, *iam.ListAttachedRolePoliciesOutput)
+	ListAttachedRolePoliciesRequest(*iam.ListAttachedRolePoliciesInput) (*request.Request, *iam.ListAttachedRolePoliciesOutput)
 
 	ListAttachedRolePolicies(*iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error)
 
 	ListAttachedRolePoliciesPages(*iam.ListAttachedRolePoliciesInput, func(*iam.ListAttachedRolePoliciesOutput, bool) bool) error
 
-	ListAttachedUserPoliciesRequest(*iam.ListAttachedUserPoliciesInput) (*service.Request, *iam.ListAttachedUserPoliciesOutput)
+	ListAttachedUserPoliciesRequest(*iam.ListAttachedUserPoliciesInput) (*request.Request, *iam.ListAttachedUserPoliciesOutput)
 
 	ListAttachedUserPolicies(*iam.ListAttachedUserPoliciesInput) (*iam.ListAttachedUserPoliciesOutput, error)
 
 	ListAttachedUserPoliciesPages(*iam.ListAttachedUserPoliciesInput, func(*iam.ListAttachedUserPoliciesOutput, bool) bool) error
 
-	ListEntitiesForPolicyRequest(*iam.ListEntitiesForPolicyInput) (*service.Request, *iam.ListEntitiesForPolicyOutput)
+	ListEntitiesForPolicyRequest(*iam.ListEntitiesForPolicyInput) (*request.Request, *iam.ListEntitiesForPolicyOutput)
 
 	ListEntitiesForPolicy(*iam.ListEntitiesForPolicyInput) (*iam.ListEntitiesForPolicyOutput, error)
 
 	ListEntitiesForPolicyPages(*iam.ListEntitiesForPolicyInput, func(*iam.ListEntitiesForPolicyOutput, bool) bool) error
 
-	ListGroupPoliciesRequest(*iam.ListGroupPoliciesInput) (*service.Request, *iam.ListGroupPoliciesOutput)
+	ListGroupPoliciesRequest(*iam.ListGroupPoliciesInput) (*request.Request, *iam.ListGroupPoliciesOutput)
 
 	ListGroupPolicies(*iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error)
 
 	ListGroupPoliciesPages(*iam.ListGroupPoliciesInput, func(*iam.ListGroupPoliciesOutput, bool) bool) error
 
-	ListGroupsRequest(*iam.ListGroupsInput) (*service.Request, *iam.ListGroupsOutput)
+	ListGroupsRequest(*iam.ListGroupsInput) (*request.Request, *iam.ListGroupsOutput)
 
 	ListGroups(*iam.ListGroupsInput) (*iam.ListGroupsOutput, error)
 
 	ListGroupsPages(*iam.ListGroupsInput, func(*iam.ListGroupsOutput, bool) bool) error
 
-	ListGroupsForUserRequest(*iam.ListGroupsForUserInput) (*service.Request, *iam.ListGroupsForUserOutput)
+	ListGroupsForUserRequest(*iam.ListGroupsForUserInput) (*request.Request, *iam.ListGroupsForUserOutput)
 
 	ListGroupsForUser(*iam.ListGroupsForUserInput) (*iam.ListGroupsForUserOutput, error)
 
 	ListGroupsForUserPages(*iam.ListGroupsForUserInput, func(*iam.ListGroupsForUserOutput, bool) bool) error
 
-	ListInstanceProfilesRequest(*iam.ListInstanceProfilesInput) (*service.Request, *iam.ListInstanceProfilesOutput)
+	ListInstanceProfilesRequest(*iam.ListInstanceProfilesInput) (*request.Request, *iam.ListInstanceProfilesOutput)
 
 	ListInstanceProfiles(*iam.ListInstanceProfilesInput) (*iam.ListInstanceProfilesOutput, error)
 
 	ListInstanceProfilesPages(*iam.ListInstanceProfilesInput, func(*iam.ListInstanceProfilesOutput, bool) bool) error
 
-	ListInstanceProfilesForRoleRequest(*iam.ListInstanceProfilesForRoleInput) (*service.Request, *iam.ListInstanceProfilesForRoleOutput)
+	ListInstanceProfilesForRoleRequest(*iam.ListInstanceProfilesForRoleInput) (*request.Request, *iam.ListInstanceProfilesForRoleOutput)
 
 	ListInstanceProfilesForRole(*iam.ListInstanceProfilesForRoleInput) (*iam.ListInstanceProfilesForRoleOutput, error)
 
 	ListInstanceProfilesForRolePages(*iam.ListInstanceProfilesForRoleInput, func(*iam.ListInstanceProfilesForRoleOutput, bool) bool) error
 
-	ListMFADevicesRequest(*iam.ListMFADevicesInput) (*service.Request, *iam.ListMFADevicesOutput)
+	ListMFADevicesRequest(*iam.ListMFADevicesInput) (*request.Request, *iam.ListMFADevicesOutput)
 
 	ListMFADevices(*iam.ListMFADevicesInput) (*iam.ListMFADevicesOutput, error)
 
 	ListMFADevicesPages(*iam.ListMFADevicesInput, func(*iam.ListMFADevicesOutput, bool) bool) error
 
-	ListOpenIDConnectProvidersRequest(*iam.ListOpenIDConnectProvidersInput) (*service.Request, *iam.ListOpenIDConnectProvidersOutput)
+	ListOpenIDConnectProvidersRequest(*iam.ListOpenIDConnectProvidersInput) (*request.Request, *iam.ListOpenIDConnectProvidersOutput)
 
 	ListOpenIDConnectProviders(*iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error)
 
-	ListPoliciesRequest(*iam.ListPoliciesInput) (*service.Request, *iam.ListPoliciesOutput)
+	ListPoliciesRequest(*iam.ListPoliciesInput) (*request.Request, *iam.ListPoliciesOutput)
 
 	ListPolicies(*iam.ListPoliciesInput) (*iam.ListPoliciesOutput, error)
 
 	ListPoliciesPages(*iam.ListPoliciesInput, func(*iam.ListPoliciesOutput, bool) bool) error
 
-	ListPolicyVersionsRequest(*iam.ListPolicyVersionsInput) (*service.Request, *iam.ListPolicyVersionsOutput)
+	ListPolicyVersionsRequest(*iam.ListPolicyVersionsInput) (*request.Request, *iam.ListPolicyVersionsOutput)
 
 	ListPolicyVersions(*iam.ListPolicyVersionsInput) (*iam.ListPolicyVersionsOutput, error)
 
-	ListRolePoliciesRequest(*iam.ListRolePoliciesInput) (*service.Request, *iam.ListRolePoliciesOutput)
+	ListRolePoliciesRequest(*iam.ListRolePoliciesInput) (*request.Request, *iam.ListRolePoliciesOutput)
 
 	ListRolePolicies(*iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error)
 
 	ListRolePoliciesPages(*iam.ListRolePoliciesInput, func(*iam.ListRolePoliciesOutput, bool) bool) error
 
-	ListRolesRequest(*iam.ListRolesInput) (*service.Request, *iam.ListRolesOutput)
+	ListRolesRequest(*iam.ListRolesInput) (*request.Request, *iam.ListRolesOutput)
 
 	ListRoles(*iam.ListRolesInput) (*iam.ListRolesOutput, error)
 
 	ListRolesPages(*iam.ListRolesInput, func(*iam.ListRolesOutput, bool) bool) error
 
-	ListSAMLProvidersRequest(*iam.ListSAMLProvidersInput) (*service.Request, *iam.ListSAMLProvidersOutput)
+	ListSAMLProvidersRequest(*iam.ListSAMLProvidersInput) (*request.Request, *iam.ListSAMLProvidersOutput)
 
 	ListSAMLProviders(*iam.ListSAMLProvidersInput) (*iam.ListSAMLProvidersOutput, error)
 
-	ListSSHPublicKeysRequest(*iam.ListSSHPublicKeysInput) (*service.Request, *iam.ListSSHPublicKeysOutput)
+	ListSSHPublicKeysRequest(*iam.ListSSHPublicKeysInput) (*request.Request, *iam.ListSSHPublicKeysOutput)
 
 	ListSSHPublicKeys(*iam.ListSSHPublicKeysInput) (*iam.ListSSHPublicKeysOutput, error)
 
-	ListServerCertificatesRequest(*iam.ListServerCertificatesInput) (*service.Request, *iam.ListServerCertificatesOutput)
+	ListServerCertificatesRequest(*iam.ListServerCertificatesInput) (*request.Request, *iam.ListServerCertificatesOutput)
 
 	ListServerCertificates(*iam.ListServerCertificatesInput) (*iam.ListServerCertificatesOutput, error)
 
 	ListServerCertificatesPages(*iam.ListServerCertificatesInput, func(*iam.ListServerCertificatesOutput, bool) bool) error
 
-	ListSigningCertificatesRequest(*iam.ListSigningCertificatesInput) (*service.Request, *iam.ListSigningCertificatesOutput)
+	ListSigningCertificatesRequest(*iam.ListSigningCertificatesInput) (*request.Request, *iam.ListSigningCertificatesOutput)
 
 	ListSigningCertificates(*iam.ListSigningCertificatesInput) (*iam.ListSigningCertificatesOutput, error)
 
 	ListSigningCertificatesPages(*iam.ListSigningCertificatesInput, func(*iam.ListSigningCertificatesOutput, bool) bool) error
 
-	ListUserPoliciesRequest(*iam.ListUserPoliciesInput) (*service.Request, *iam.ListUserPoliciesOutput)
+	ListUserPoliciesRequest(*iam.ListUserPoliciesInput) (*request.Request, *iam.ListUserPoliciesOutput)
 
 	ListUserPolicies(*iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error)
 
 	ListUserPoliciesPages(*iam.ListUserPoliciesInput, func(*iam.ListUserPoliciesOutput, bool) bool) error
 
-	ListUsersRequest(*iam.ListUsersInput) (*service.Request, *iam.ListUsersOutput)
+	ListUsersRequest(*iam.ListUsersInput) (*request.Request, *iam.ListUsersOutput)
 
 	ListUsers(*iam.ListUsersInput) (*iam.ListUsersOutput, error)
 
 	ListUsersPages(*iam.ListUsersInput, func(*iam.ListUsersOutput, bool) bool) error
 
-	ListVirtualMFADevicesRequest(*iam.ListVirtualMFADevicesInput) (*service.Request, *iam.ListVirtualMFADevicesOutput)
+	ListVirtualMFADevicesRequest(*iam.ListVirtualMFADevicesInput) (*request.Request, *iam.ListVirtualMFADevicesOutput)
 
 	ListVirtualMFADevices(*iam.ListVirtualMFADevicesInput) (*iam.ListVirtualMFADevicesOutput, error)
 
 	ListVirtualMFADevicesPages(*iam.ListVirtualMFADevicesInput, func(*iam.ListVirtualMFADevicesOutput, bool) bool) error
 
-	PutGroupPolicyRequest(*iam.PutGroupPolicyInput) (*service.Request, *iam.PutGroupPolicyOutput)
+	PutGroupPolicyRequest(*iam.PutGroupPolicyInput) (*request.Request, *iam.PutGroupPolicyOutput)
 
 	PutGroupPolicy(*iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error)
 
-	PutRolePolicyRequest(*iam.PutRolePolicyInput) (*service.Request, *iam.PutRolePolicyOutput)
+	PutRolePolicyRequest(*iam.PutRolePolicyInput) (*request.Request, *iam.PutRolePolicyOutput)
 
 	PutRolePolicy(*iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error)
 
-	PutUserPolicyRequest(*iam.PutUserPolicyInput) (*service.Request, *iam.PutUserPolicyOutput)
+	PutUserPolicyRequest(*iam.PutUserPolicyInput) (*request.Request, *iam.PutUserPolicyOutput)
 
 	PutUserPolicy(*iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error)
 
-	RemoveClientIDFromOpenIDConnectProviderRequest(*iam.RemoveClientIDFromOpenIDConnectProviderInput) (*service.Request, *iam.RemoveClientIDFromOpenIDConnectProviderOutput)
+	RemoveClientIDFromOpenIDConnectProviderRequest(*iam.RemoveClientIDFromOpenIDConnectProviderInput) (*request.Request, *iam.RemoveClientIDFromOpenIDConnectProviderOutput)
 
 	RemoveClientIDFromOpenIDConnectProvider(*iam.RemoveClientIDFromOpenIDConnectProviderInput) (*iam.RemoveClientIDFromOpenIDConnectProviderOutput, error)
 
-	RemoveRoleFromInstanceProfileRequest(*iam.RemoveRoleFromInstanceProfileInput) (*service.Request, *iam.RemoveRoleFromInstanceProfileOutput)
+	RemoveRoleFromInstanceProfileRequest(*iam.RemoveRoleFromInstanceProfileInput) (*request.Request, *iam.RemoveRoleFromInstanceProfileOutput)
 
 	RemoveRoleFromInstanceProfile(*iam.RemoveRoleFromInstanceProfileInput) (*iam.RemoveRoleFromInstanceProfileOutput, error)
 
-	RemoveUserFromGroupRequest(*iam.RemoveUserFromGroupInput) (*service.Request, *iam.RemoveUserFromGroupOutput)
+	RemoveUserFromGroupRequest(*iam.RemoveUserFromGroupInput) (*request.Request, *iam.RemoveUserFromGroupOutput)
 
 	RemoveUserFromGroup(*iam.RemoveUserFromGroupInput) (*iam.RemoveUserFromGroupOutput, error)
 
-	ResyncMFADeviceRequest(*iam.ResyncMFADeviceInput) (*service.Request, *iam.ResyncMFADeviceOutput)
+	ResyncMFADeviceRequest(*iam.ResyncMFADeviceInput) (*request.Request, *iam.ResyncMFADeviceOutput)
 
 	ResyncMFADevice(*iam.ResyncMFADeviceInput) (*iam.ResyncMFADeviceOutput, error)
 
-	SetDefaultPolicyVersionRequest(*iam.SetDefaultPolicyVersionInput) (*service.Request, *iam.SetDefaultPolicyVersionOutput)
+	SetDefaultPolicyVersionRequest(*iam.SetDefaultPolicyVersionInput) (*request.Request, *iam.SetDefaultPolicyVersionOutput)
 
 	SetDefaultPolicyVersion(*iam.SetDefaultPolicyVersionInput) (*iam.SetDefaultPolicyVersionOutput, error)
 
-	UpdateAccessKeyRequest(*iam.UpdateAccessKeyInput) (*service.Request, *iam.UpdateAccessKeyOutput)
+	UpdateAccessKeyRequest(*iam.UpdateAccessKeyInput) (*request.Request, *iam.UpdateAccessKeyOutput)
 
 	UpdateAccessKey(*iam.UpdateAccessKeyInput) (*iam.UpdateAccessKeyOutput, error)
 
-	UpdateAccountPasswordPolicyRequest(*iam.UpdateAccountPasswordPolicyInput) (*service.Request, *iam.UpdateAccountPasswordPolicyOutput)
+	UpdateAccountPasswordPolicyRequest(*iam.UpdateAccountPasswordPolicyInput) (*request.Request, *iam.UpdateAccountPasswordPolicyOutput)
 
 	UpdateAccountPasswordPolicy(*iam.UpdateAccountPasswordPolicyInput) (*iam.UpdateAccountPasswordPolicyOutput, error)
 
-	UpdateAssumeRolePolicyRequest(*iam.UpdateAssumeRolePolicyInput) (*service.Request, *iam.UpdateAssumeRolePolicyOutput)
+	UpdateAssumeRolePolicyRequest(*iam.UpdateAssumeRolePolicyInput) (*request.Request, *iam.UpdateAssumeRolePolicyOutput)
 
 	UpdateAssumeRolePolicy(*iam.UpdateAssumeRolePolicyInput) (*iam.UpdateAssumeRolePolicyOutput, error)
 
-	UpdateGroupRequest(*iam.UpdateGroupInput) (*service.Request, *iam.UpdateGroupOutput)
+	UpdateGroupRequest(*iam.UpdateGroupInput) (*request.Request, *iam.UpdateGroupOutput)
 
 	UpdateGroup(*iam.UpdateGroupInput) (*iam.UpdateGroupOutput, error)
 
-	UpdateLoginProfileRequest(*iam.UpdateLoginProfileInput) (*service.Request, *iam.UpdateLoginProfileOutput)
+	UpdateLoginProfileRequest(*iam.UpdateLoginProfileInput) (*request.Request, *iam.UpdateLoginProfileOutput)
 
 	UpdateLoginProfile(*iam.UpdateLoginProfileInput) (*iam.UpdateLoginProfileOutput, error)
 
-	UpdateOpenIDConnectProviderThumbprintRequest(*iam.UpdateOpenIDConnectProviderThumbprintInput) (*service.Request, *iam.UpdateOpenIDConnectProviderThumbprintOutput)
+	UpdateOpenIDConnectProviderThumbprintRequest(*iam.UpdateOpenIDConnectProviderThumbprintInput) (*request.Request, *iam.UpdateOpenIDConnectProviderThumbprintOutput)
 
 	UpdateOpenIDConnectProviderThumbprint(*iam.UpdateOpenIDConnectProviderThumbprintInput) (*iam.UpdateOpenIDConnectProviderThumbprintOutput, error)
 
-	UpdateSAMLProviderRequest(*iam.UpdateSAMLProviderInput) (*service.Request, *iam.UpdateSAMLProviderOutput)
+	UpdateSAMLProviderRequest(*iam.UpdateSAMLProviderInput) (*request.Request, *iam.UpdateSAMLProviderOutput)
 
 	UpdateSAMLProvider(*iam.UpdateSAMLProviderInput) (*iam.UpdateSAMLProviderOutput, error)
 
-	UpdateSSHPublicKeyRequest(*iam.UpdateSSHPublicKeyInput) (*service.Request, *iam.UpdateSSHPublicKeyOutput)
+	UpdateSSHPublicKeyRequest(*iam.UpdateSSHPublicKeyInput) (*request.Request, *iam.UpdateSSHPublicKeyOutput)
 
 	UpdateSSHPublicKey(*iam.UpdateSSHPublicKeyInput) (*iam.UpdateSSHPublicKeyOutput, error)
 
-	UpdateServerCertificateRequest(*iam.UpdateServerCertificateInput) (*service.Request, *iam.UpdateServerCertificateOutput)
+	UpdateServerCertificateRequest(*iam.UpdateServerCertificateInput) (*request.Request, *iam.UpdateServerCertificateOutput)
 
 	UpdateServerCertificate(*iam.UpdateServerCertificateInput) (*iam.UpdateServerCertificateOutput, error)
 
-	UpdateSigningCertificateRequest(*iam.UpdateSigningCertificateInput) (*service.Request, *iam.UpdateSigningCertificateOutput)
+	UpdateSigningCertificateRequest(*iam.UpdateSigningCertificateInput) (*request.Request, *iam.UpdateSigningCertificateOutput)
 
 	UpdateSigningCertificate(*iam.UpdateSigningCertificateInput) (*iam.UpdateSigningCertificateOutput, error)
 
-	UpdateUserRequest(*iam.UpdateUserInput) (*service.Request, *iam.UpdateUserOutput)
+	UpdateUserRequest(*iam.UpdateUserInput) (*request.Request, *iam.UpdateUserOutput)
 
 	UpdateUser(*iam.UpdateUserInput) (*iam.UpdateUserOutput, error)
 
-	UploadSSHPublicKeyRequest(*iam.UploadSSHPublicKeyInput) (*service.Request, *iam.UploadSSHPublicKeyOutput)
+	UploadSSHPublicKeyRequest(*iam.UploadSSHPublicKeyInput) (*request.Request, *iam.UploadSSHPublicKeyOutput)
 
 	UploadSSHPublicKey(*iam.UploadSSHPublicKeyInput) (*iam.UploadSSHPublicKeyOutput, error)
 
-	UploadServerCertificateRequest(*iam.UploadServerCertificateInput) (*service.Request, *iam.UploadServerCertificateOutput)
+	UploadServerCertificateRequest(*iam.UploadServerCertificateInput) (*request.Request, *iam.UploadServerCertificateOutput)
 
 	UploadServerCertificate(*iam.UploadServerCertificateInput) (*iam.UploadServerCertificateOutput, error)
 
-	UploadSigningCertificateRequest(*iam.UploadSigningCertificateInput) (*service.Request, *iam.UploadSigningCertificateOutput)
+	UploadSigningCertificateRequest(*iam.UploadSigningCertificateInput) (*request.Request, *iam.UploadSigningCertificateOutput)
 
 	UploadSigningCertificate(*iam.UploadSigningCertificateInput) (*iam.UploadSigningCertificateOutput, error)
 }

--- a/service/iam/service.go
+++ b/service/iam/service.go
@@ -5,7 +5,9 @@ package iam
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -68,14 +70,16 @@ type IAM struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new IAM client.
 func New(config *aws.Config) *IAM {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "iam",
-		APIVersion:  "2010-05-08",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "iam",
+			APIVersion:  "2010-05-08",
+		},
 	}
 	service.Initialize()
 
@@ -96,8 +100,8 @@ func New(config *aws.Config) *IAM {
 
 // newRequest creates a new request for a IAM operation and runs any
 // custom request initialization.
-func (c *IAM) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *IAM) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/kinesis/api.go
+++ b/service/kinesis/api.go
@@ -5,14 +5,14 @@ package kinesis
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddTagsToStream = "AddTagsToStream"
 
 // AddTagsToStreamRequest generates a request for the AddTagsToStream operation.
-func (c *Kinesis) AddTagsToStreamRequest(input *AddTagsToStreamInput) (req *service.Request, output *AddTagsToStreamOutput) {
-	op := &service.Operation{
+func (c *Kinesis) AddTagsToStreamRequest(input *AddTagsToStreamInput) (req *request.Request, output *AddTagsToStreamOutput) {
+	op := &request.Operation{
 		Name:       opAddTagsToStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -42,8 +42,8 @@ func (c *Kinesis) AddTagsToStream(input *AddTagsToStreamInput) (*AddTagsToStream
 const opCreateStream = "CreateStream"
 
 // CreateStreamRequest generates a request for the CreateStream operation.
-func (c *Kinesis) CreateStreamRequest(input *CreateStreamInput) (req *service.Request, output *CreateStreamOutput) {
-	op := &service.Operation{
+func (c *Kinesis) CreateStreamRequest(input *CreateStreamInput) (req *request.Request, output *CreateStreamOutput) {
+	op := &request.Operation{
 		Name:       opCreateStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -104,8 +104,8 @@ func (c *Kinesis) CreateStream(input *CreateStreamInput) (*CreateStreamOutput, e
 const opDeleteStream = "DeleteStream"
 
 // DeleteStreamRequest generates a request for the DeleteStream operation.
-func (c *Kinesis) DeleteStreamRequest(input *DeleteStreamInput) (req *service.Request, output *DeleteStreamOutput) {
-	op := &service.Operation{
+func (c *Kinesis) DeleteStreamRequest(input *DeleteStreamInput) (req *request.Request, output *DeleteStreamOutput) {
+	op := &request.Operation{
 		Name:       opDeleteStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -149,12 +149,12 @@ func (c *Kinesis) DeleteStream(input *DeleteStreamInput) (*DeleteStreamOutput, e
 const opDescribeStream = "DescribeStream"
 
 // DescribeStreamRequest generates a request for the DescribeStream operation.
-func (c *Kinesis) DescribeStreamRequest(input *DescribeStreamInput) (req *service.Request, output *DescribeStreamOutput) {
-	op := &service.Operation{
+func (c *Kinesis) DescribeStreamRequest(input *DescribeStreamInput) (req *request.Request, output *DescribeStreamOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"ExclusiveStartShardId"},
 			OutputTokens:    []string{"StreamDescription.Shards[-1].ShardId"},
 			LimitToken:      "Limit",
@@ -210,8 +210,8 @@ func (c *Kinesis) DescribeStreamPages(input *DescribeStreamInput, fn func(p *Des
 const opGetRecords = "GetRecords"
 
 // GetRecordsRequest generates a request for the GetRecords operation.
-func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *service.Request, output *GetRecordsOutput) {
-	op := &service.Operation{
+func (c *Kinesis) GetRecordsRequest(input *GetRecordsInput) (req *request.Request, output *GetRecordsOutput) {
+	op := &request.Operation{
 		Name:       opGetRecords,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -280,8 +280,8 @@ func (c *Kinesis) GetRecords(input *GetRecordsInput) (*GetRecordsOutput, error) 
 const opGetShardIterator = "GetShardIterator"
 
 // GetShardIteratorRequest generates a request for the GetShardIterator operation.
-func (c *Kinesis) GetShardIteratorRequest(input *GetShardIteratorInput) (req *service.Request, output *GetShardIteratorOutput) {
-	op := &service.Operation{
+func (c *Kinesis) GetShardIteratorRequest(input *GetShardIteratorInput) (req *request.Request, output *GetShardIteratorOutput) {
+	op := &request.Operation{
 		Name:       opGetShardIterator,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -343,12 +343,12 @@ func (c *Kinesis) GetShardIterator(input *GetShardIteratorInput) (*GetShardItera
 const opListStreams = "ListStreams"
 
 // ListStreamsRequest generates a request for the ListStreams operation.
-func (c *Kinesis) ListStreamsRequest(input *ListStreamsInput) (req *service.Request, output *ListStreamsOutput) {
-	op := &service.Operation{
+func (c *Kinesis) ListStreamsRequest(input *ListStreamsInput) (req *request.Request, output *ListStreamsOutput) {
+	op := &request.Operation{
 		Name:       opListStreams,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"ExclusiveStartStreamName"},
 			OutputTokens:    []string{"StreamNames[-1]"},
 			LimitToken:      "Limit",
@@ -398,8 +398,8 @@ func (c *Kinesis) ListStreamsPages(input *ListStreamsInput, fn func(p *ListStrea
 const opListTagsForStream = "ListTagsForStream"
 
 // ListTagsForStreamRequest generates a request for the ListTagsForStream operation.
-func (c *Kinesis) ListTagsForStreamRequest(input *ListTagsForStreamInput) (req *service.Request, output *ListTagsForStreamOutput) {
-	op := &service.Operation{
+func (c *Kinesis) ListTagsForStreamRequest(input *ListTagsForStreamInput) (req *request.Request, output *ListTagsForStreamOutput) {
+	op := &request.Operation{
 		Name:       opListTagsForStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -425,8 +425,8 @@ func (c *Kinesis) ListTagsForStream(input *ListTagsForStreamInput) (*ListTagsFor
 const opMergeShards = "MergeShards"
 
 // MergeShardsRequest generates a request for the MergeShards operation.
-func (c *Kinesis) MergeShardsRequest(input *MergeShardsInput) (req *service.Request, output *MergeShardsOutput) {
-	op := &service.Operation{
+func (c *Kinesis) MergeShardsRequest(input *MergeShardsInput) (req *request.Request, output *MergeShardsOutput) {
+	op := &request.Operation{
 		Name:       opMergeShards,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -486,8 +486,8 @@ func (c *Kinesis) MergeShards(input *MergeShardsInput) (*MergeShardsOutput, erro
 const opPutRecord = "PutRecord"
 
 // PutRecordRequest generates a request for the PutRecord operation.
-func (c *Kinesis) PutRecordRequest(input *PutRecordInput) (req *service.Request, output *PutRecordOutput) {
-	op := &service.Operation{
+func (c *Kinesis) PutRecordRequest(input *PutRecordInput) (req *request.Request, output *PutRecordOutput) {
+	op := &request.Operation{
 		Name:       opPutRecord,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -550,8 +550,8 @@ func (c *Kinesis) PutRecord(input *PutRecordInput) (*PutRecordOutput, error) {
 const opPutRecords = "PutRecords"
 
 // PutRecordsRequest generates a request for the PutRecords operation.
-func (c *Kinesis) PutRecordsRequest(input *PutRecordsInput) (req *service.Request, output *PutRecordsOutput) {
-	op := &service.Operation{
+func (c *Kinesis) PutRecordsRequest(input *PutRecordsInput) (req *request.Request, output *PutRecordsOutput) {
+	op := &request.Operation{
 		Name:       opPutRecords,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -631,8 +631,8 @@ func (c *Kinesis) PutRecords(input *PutRecordsInput) (*PutRecordsOutput, error) 
 const opRemoveTagsFromStream = "RemoveTagsFromStream"
 
 // RemoveTagsFromStreamRequest generates a request for the RemoveTagsFromStream operation.
-func (c *Kinesis) RemoveTagsFromStreamRequest(input *RemoveTagsFromStreamInput) (req *service.Request, output *RemoveTagsFromStreamOutput) {
-	op := &service.Operation{
+func (c *Kinesis) RemoveTagsFromStreamRequest(input *RemoveTagsFromStreamInput) (req *request.Request, output *RemoveTagsFromStreamOutput) {
+	op := &request.Operation{
 		Name:       opRemoveTagsFromStream,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -660,8 +660,8 @@ func (c *Kinesis) RemoveTagsFromStream(input *RemoveTagsFromStreamInput) (*Remov
 const opSplitShard = "SplitShard"
 
 // SplitShardRequest generates a request for the SplitShard operation.
-func (c *Kinesis) SplitShardRequest(input *SplitShardInput) (req *service.Request, output *SplitShardOutput) {
-	op := &service.Operation{
+func (c *Kinesis) SplitShardRequest(input *SplitShardInput) (req *request.Request, output *SplitShardOutput) {
+	op := &request.Operation{
 		Name:       opSplitShard,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/kinesis/kinesisiface/interface.go
+++ b/service/kinesis/kinesisiface/interface.go
@@ -4,65 +4,65 @@
 package kinesisiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 )
 
 // KinesisAPI is the interface type for kinesis.Kinesis.
 type KinesisAPI interface {
-	AddTagsToStreamRequest(*kinesis.AddTagsToStreamInput) (*service.Request, *kinesis.AddTagsToStreamOutput)
+	AddTagsToStreamRequest(*kinesis.AddTagsToStreamInput) (*request.Request, *kinesis.AddTagsToStreamOutput)
 
 	AddTagsToStream(*kinesis.AddTagsToStreamInput) (*kinesis.AddTagsToStreamOutput, error)
 
-	CreateStreamRequest(*kinesis.CreateStreamInput) (*service.Request, *kinesis.CreateStreamOutput)
+	CreateStreamRequest(*kinesis.CreateStreamInput) (*request.Request, *kinesis.CreateStreamOutput)
 
 	CreateStream(*kinesis.CreateStreamInput) (*kinesis.CreateStreamOutput, error)
 
-	DeleteStreamRequest(*kinesis.DeleteStreamInput) (*service.Request, *kinesis.DeleteStreamOutput)
+	DeleteStreamRequest(*kinesis.DeleteStreamInput) (*request.Request, *kinesis.DeleteStreamOutput)
 
 	DeleteStream(*kinesis.DeleteStreamInput) (*kinesis.DeleteStreamOutput, error)
 
-	DescribeStreamRequest(*kinesis.DescribeStreamInput) (*service.Request, *kinesis.DescribeStreamOutput)
+	DescribeStreamRequest(*kinesis.DescribeStreamInput) (*request.Request, *kinesis.DescribeStreamOutput)
 
 	DescribeStream(*kinesis.DescribeStreamInput) (*kinesis.DescribeStreamOutput, error)
 
 	DescribeStreamPages(*kinesis.DescribeStreamInput, func(*kinesis.DescribeStreamOutput, bool) bool) error
 
-	GetRecordsRequest(*kinesis.GetRecordsInput) (*service.Request, *kinesis.GetRecordsOutput)
+	GetRecordsRequest(*kinesis.GetRecordsInput) (*request.Request, *kinesis.GetRecordsOutput)
 
 	GetRecords(*kinesis.GetRecordsInput) (*kinesis.GetRecordsOutput, error)
 
-	GetShardIteratorRequest(*kinesis.GetShardIteratorInput) (*service.Request, *kinesis.GetShardIteratorOutput)
+	GetShardIteratorRequest(*kinesis.GetShardIteratorInput) (*request.Request, *kinesis.GetShardIteratorOutput)
 
 	GetShardIterator(*kinesis.GetShardIteratorInput) (*kinesis.GetShardIteratorOutput, error)
 
-	ListStreamsRequest(*kinesis.ListStreamsInput) (*service.Request, *kinesis.ListStreamsOutput)
+	ListStreamsRequest(*kinesis.ListStreamsInput) (*request.Request, *kinesis.ListStreamsOutput)
 
 	ListStreams(*kinesis.ListStreamsInput) (*kinesis.ListStreamsOutput, error)
 
 	ListStreamsPages(*kinesis.ListStreamsInput, func(*kinesis.ListStreamsOutput, bool) bool) error
 
-	ListTagsForStreamRequest(*kinesis.ListTagsForStreamInput) (*service.Request, *kinesis.ListTagsForStreamOutput)
+	ListTagsForStreamRequest(*kinesis.ListTagsForStreamInput) (*request.Request, *kinesis.ListTagsForStreamOutput)
 
 	ListTagsForStream(*kinesis.ListTagsForStreamInput) (*kinesis.ListTagsForStreamOutput, error)
 
-	MergeShardsRequest(*kinesis.MergeShardsInput) (*service.Request, *kinesis.MergeShardsOutput)
+	MergeShardsRequest(*kinesis.MergeShardsInput) (*request.Request, *kinesis.MergeShardsOutput)
 
 	MergeShards(*kinesis.MergeShardsInput) (*kinesis.MergeShardsOutput, error)
 
-	PutRecordRequest(*kinesis.PutRecordInput) (*service.Request, *kinesis.PutRecordOutput)
+	PutRecordRequest(*kinesis.PutRecordInput) (*request.Request, *kinesis.PutRecordOutput)
 
 	PutRecord(*kinesis.PutRecordInput) (*kinesis.PutRecordOutput, error)
 
-	PutRecordsRequest(*kinesis.PutRecordsInput) (*service.Request, *kinesis.PutRecordsOutput)
+	PutRecordsRequest(*kinesis.PutRecordsInput) (*request.Request, *kinesis.PutRecordsOutput)
 
 	PutRecords(*kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error)
 
-	RemoveTagsFromStreamRequest(*kinesis.RemoveTagsFromStreamInput) (*service.Request, *kinesis.RemoveTagsFromStreamOutput)
+	RemoveTagsFromStreamRequest(*kinesis.RemoveTagsFromStreamInput) (*request.Request, *kinesis.RemoveTagsFromStreamOutput)
 
 	RemoveTagsFromStream(*kinesis.RemoveTagsFromStreamInput) (*kinesis.RemoveTagsFromStreamOutput, error)
 
-	SplitShardRequest(*kinesis.SplitShardInput) (*service.Request, *kinesis.SplitShardOutput)
+	SplitShardRequest(*kinesis.SplitShardInput) (*request.Request, *kinesis.SplitShardOutput)
 
 	SplitShard(*kinesis.SplitShardInput) (*kinesis.SplitShardOutput, error)
 }

--- a/service/kinesis/service.go
+++ b/service/kinesis/service.go
@@ -5,7 +5,9 @@ package kinesis
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -20,16 +22,18 @@ type Kinesis struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new Kinesis client.
 func New(config *aws.Config) *Kinesis {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "kinesis",
-		APIVersion:   "2013-12-02",
-		JSONVersion:  "1.1",
-		TargetPrefix: "Kinesis_20131202",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "kinesis",
+			APIVersion:   "2013-12-02",
+			JSONVersion:  "1.1",
+			TargetPrefix: "Kinesis_20131202",
+		},
 	}
 	service.Initialize()
 
@@ -50,8 +54,8 @@ func New(config *aws.Config) *Kinesis {
 
 // newRequest creates a new request for a Kinesis operation and runs any
 // custom request initialization.
-func (c *Kinesis) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *Kinesis) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateAlias = "CreateAlias"
 
 // CreateAliasRequest generates a request for the CreateAlias operation.
-func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *service.Request, output *CreateAliasOutput) {
-	op := &service.Operation{
+func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request, output *CreateAliasOutput) {
+	op := &request.Operation{
 		Name:       opCreateAlias,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -51,8 +51,8 @@ func (c *KMS) CreateAlias(input *CreateAliasInput) (*CreateAliasOutput, error) {
 const opCreateGrant = "CreateGrant"
 
 // CreateGrantRequest generates a request for the CreateGrant operation.
-func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *service.Request, output *CreateGrantOutput) {
-	op := &service.Operation{
+func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request, output *CreateGrantOutput) {
+	op := &request.Operation{
 		Name:       opCreateGrant,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -82,8 +82,8 @@ func (c *KMS) CreateGrant(input *CreateGrantInput) (*CreateGrantOutput, error) {
 const opCreateKey = "CreateKey"
 
 // CreateKeyRequest generates a request for the CreateKey operation.
-func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *service.Request, output *CreateKeyOutput) {
-	op := &service.Operation{
+func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, output *CreateKeyOutput) {
+	op := &request.Operation{
 		Name:       opCreateKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -112,8 +112,8 @@ func (c *KMS) CreateKey(input *CreateKeyInput) (*CreateKeyOutput, error) {
 const opDecrypt = "Decrypt"
 
 // DecryptRequest generates a request for the Decrypt operation.
-func (c *KMS) DecryptRequest(input *DecryptInput) (req *service.Request, output *DecryptOutput) {
-	op := &service.Operation{
+func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output *DecryptOutput) {
+	op := &request.Operation{
 		Name:       opDecrypt,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -150,8 +150,8 @@ func (c *KMS) Decrypt(input *DecryptInput) (*DecryptOutput, error) {
 const opDeleteAlias = "DeleteAlias"
 
 // DeleteAliasRequest generates a request for the DeleteAlias operation.
-func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *service.Request, output *DeleteAliasOutput) {
-	op := &service.Operation{
+func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Request, output *DeleteAliasOutput) {
+	op := &request.Operation{
 		Name:       opDeleteAlias,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -178,8 +178,8 @@ func (c *KMS) DeleteAlias(input *DeleteAliasInput) (*DeleteAliasOutput, error) {
 const opDescribeKey = "DescribeKey"
 
 // DescribeKeyRequest generates a request for the DescribeKey operation.
-func (c *KMS) DescribeKeyRequest(input *DescribeKeyInput) (req *service.Request, output *DescribeKeyOutput) {
-	op := &service.Operation{
+func (c *KMS) DescribeKeyRequest(input *DescribeKeyInput) (req *request.Request, output *DescribeKeyOutput) {
+	op := &request.Operation{
 		Name:       opDescribeKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -205,8 +205,8 @@ func (c *KMS) DescribeKey(input *DescribeKeyInput) (*DescribeKeyOutput, error) {
 const opDisableKey = "DisableKey"
 
 // DisableKeyRequest generates a request for the DisableKey operation.
-func (c *KMS) DisableKeyRequest(input *DisableKeyInput) (req *service.Request, output *DisableKeyOutput) {
-	op := &service.Operation{
+func (c *KMS) DisableKeyRequest(input *DisableKeyInput) (req *request.Request, output *DisableKeyOutput) {
+	op := &request.Operation{
 		Name:       opDisableKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -232,8 +232,8 @@ func (c *KMS) DisableKey(input *DisableKeyInput) (*DisableKeyOutput, error) {
 const opDisableKeyRotation = "DisableKeyRotation"
 
 // DisableKeyRotationRequest generates a request for the DisableKeyRotation operation.
-func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *service.Request, output *DisableKeyRotationOutput) {
-	op := &service.Operation{
+func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *request.Request, output *DisableKeyRotationOutput) {
+	op := &request.Operation{
 		Name:       opDisableKeyRotation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -259,8 +259,8 @@ func (c *KMS) DisableKeyRotation(input *DisableKeyRotationInput) (*DisableKeyRot
 const opEnableKey = "EnableKey"
 
 // EnableKeyRequest generates a request for the EnableKey operation.
-func (c *KMS) EnableKeyRequest(input *EnableKeyInput) (req *service.Request, output *EnableKeyOutput) {
-	op := &service.Operation{
+func (c *KMS) EnableKeyRequest(input *EnableKeyInput) (req *request.Request, output *EnableKeyOutput) {
+	op := &request.Operation{
 		Name:       opEnableKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -287,8 +287,8 @@ func (c *KMS) EnableKey(input *EnableKeyInput) (*EnableKeyOutput, error) {
 const opEnableKeyRotation = "EnableKeyRotation"
 
 // EnableKeyRotationRequest generates a request for the EnableKeyRotation operation.
-func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *service.Request, output *EnableKeyRotationOutput) {
-	op := &service.Operation{
+func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *request.Request, output *EnableKeyRotationOutput) {
+	op := &request.Operation{
 		Name:       opEnableKeyRotation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -314,8 +314,8 @@ func (c *KMS) EnableKeyRotation(input *EnableKeyRotationInput) (*EnableKeyRotati
 const opEncrypt = "Encrypt"
 
 // EncryptRequest generates a request for the Encrypt operation.
-func (c *KMS) EncryptRequest(input *EncryptInput) (req *service.Request, output *EncryptOutput) {
-	op := &service.Operation{
+func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output *EncryptOutput) {
+	op := &request.Operation{
 		Name:       opEncrypt,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -357,8 +357,8 @@ func (c *KMS) Encrypt(input *EncryptInput) (*EncryptOutput, error) {
 const opGenerateDataKey = "GenerateDataKey"
 
 // GenerateDataKeyRequest generates a request for the GenerateDataKey operation.
-func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *service.Request, output *GenerateDataKeyOutput) {
-	op := &service.Operation{
+func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.Request, output *GenerateDataKeyOutput) {
+	op := &request.Operation{
 		Name:       opGenerateDataKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -413,8 +413,8 @@ func (c *KMS) GenerateDataKey(input *GenerateDataKeyInput) (*GenerateDataKeyOutp
 const opGenerateDataKeyWithoutPlaintext = "GenerateDataKeyWithoutPlaintext"
 
 // GenerateDataKeyWithoutPlaintextRequest generates a request for the GenerateDataKeyWithoutPlaintext operation.
-func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWithoutPlaintextInput) (req *service.Request, output *GenerateDataKeyWithoutPlaintextOutput) {
-	op := &service.Operation{
+func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWithoutPlaintextInput) (req *request.Request, output *GenerateDataKeyWithoutPlaintextOutput) {
+	op := &request.Operation{
 		Name:       opGenerateDataKeyWithoutPlaintext,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -444,8 +444,8 @@ func (c *KMS) GenerateDataKeyWithoutPlaintext(input *GenerateDataKeyWithoutPlain
 const opGenerateRandom = "GenerateRandom"
 
 // GenerateRandomRequest generates a request for the GenerateRandom operation.
-func (c *KMS) GenerateRandomRequest(input *GenerateRandomInput) (req *service.Request, output *GenerateRandomOutput) {
-	op := &service.Operation{
+func (c *KMS) GenerateRandomRequest(input *GenerateRandomInput) (req *request.Request, output *GenerateRandomOutput) {
+	op := &request.Operation{
 		Name:       opGenerateRandom,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -471,8 +471,8 @@ func (c *KMS) GenerateRandom(input *GenerateRandomInput) (*GenerateRandomOutput,
 const opGetKeyPolicy = "GetKeyPolicy"
 
 // GetKeyPolicyRequest generates a request for the GetKeyPolicy operation.
-func (c *KMS) GetKeyPolicyRequest(input *GetKeyPolicyInput) (req *service.Request, output *GetKeyPolicyOutput) {
-	op := &service.Operation{
+func (c *KMS) GetKeyPolicyRequest(input *GetKeyPolicyInput) (req *request.Request, output *GetKeyPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetKeyPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -498,8 +498,8 @@ func (c *KMS) GetKeyPolicy(input *GetKeyPolicyInput) (*GetKeyPolicyOutput, error
 const opGetKeyRotationStatus = "GetKeyRotationStatus"
 
 // GetKeyRotationStatusRequest generates a request for the GetKeyRotationStatus operation.
-func (c *KMS) GetKeyRotationStatusRequest(input *GetKeyRotationStatusInput) (req *service.Request, output *GetKeyRotationStatusOutput) {
-	op := &service.Operation{
+func (c *KMS) GetKeyRotationStatusRequest(input *GetKeyRotationStatusInput) (req *request.Request, output *GetKeyRotationStatusOutput) {
+	op := &request.Operation{
 		Name:       opGetKeyRotationStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -526,12 +526,12 @@ func (c *KMS) GetKeyRotationStatus(input *GetKeyRotationStatusInput) (*GetKeyRot
 const opListAliases = "ListAliases"
 
 // ListAliasesRequest generates a request for the ListAliases operation.
-func (c *KMS) ListAliasesRequest(input *ListAliasesInput) (req *service.Request, output *ListAliasesOutput) {
-	op := &service.Operation{
+func (c *KMS) ListAliasesRequest(input *ListAliasesInput) (req *request.Request, output *ListAliasesOutput) {
+	op := &request.Operation{
 		Name:       opListAliases,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "Limit",
@@ -566,12 +566,12 @@ func (c *KMS) ListAliasesPages(input *ListAliasesInput, fn func(p *ListAliasesOu
 const opListGrants = "ListGrants"
 
 // ListGrantsRequest generates a request for the ListGrants operation.
-func (c *KMS) ListGrantsRequest(input *ListGrantsInput) (req *service.Request, output *ListGrantsOutput) {
-	op := &service.Operation{
+func (c *KMS) ListGrantsRequest(input *ListGrantsInput) (req *request.Request, output *ListGrantsOutput) {
+	op := &request.Operation{
 		Name:       opListGrants,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "Limit",
@@ -606,12 +606,12 @@ func (c *KMS) ListGrantsPages(input *ListGrantsInput, fn func(p *ListGrantsOutpu
 const opListKeyPolicies = "ListKeyPolicies"
 
 // ListKeyPoliciesRequest generates a request for the ListKeyPolicies operation.
-func (c *KMS) ListKeyPoliciesRequest(input *ListKeyPoliciesInput) (req *service.Request, output *ListKeyPoliciesOutput) {
-	op := &service.Operation{
+func (c *KMS) ListKeyPoliciesRequest(input *ListKeyPoliciesInput) (req *request.Request, output *ListKeyPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListKeyPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "Limit",
@@ -646,12 +646,12 @@ func (c *KMS) ListKeyPoliciesPages(input *ListKeyPoliciesInput, fn func(p *ListK
 const opListKeys = "ListKeys"
 
 // ListKeysRequest generates a request for the ListKeys operation.
-func (c *KMS) ListKeysRequest(input *ListKeysInput) (req *service.Request, output *ListKeysOutput) {
-	op := &service.Operation{
+func (c *KMS) ListKeysRequest(input *ListKeysInput) (req *request.Request, output *ListKeysOutput) {
+	op := &request.Operation{
 		Name:       opListKeys,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "Limit",
@@ -686,8 +686,8 @@ func (c *KMS) ListKeysPages(input *ListKeysInput, fn func(p *ListKeysOutput, las
 const opPutKeyPolicy = "PutKeyPolicy"
 
 // PutKeyPolicyRequest generates a request for the PutKeyPolicy operation.
-func (c *KMS) PutKeyPolicyRequest(input *PutKeyPolicyInput) (req *service.Request, output *PutKeyPolicyOutput) {
-	op := &service.Operation{
+func (c *KMS) PutKeyPolicyRequest(input *PutKeyPolicyInput) (req *request.Request, output *PutKeyPolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutKeyPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -713,8 +713,8 @@ func (c *KMS) PutKeyPolicy(input *PutKeyPolicyInput) (*PutKeyPolicyOutput, error
 const opReEncrypt = "ReEncrypt"
 
 // ReEncryptRequest generates a request for the ReEncrypt operation.
-func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *service.Request, output *ReEncryptOutput) {
-	op := &service.Operation{
+func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, output *ReEncryptOutput) {
+	op := &request.Operation{
 		Name:       opReEncrypt,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -751,8 +751,8 @@ func (c *KMS) ReEncrypt(input *ReEncryptInput) (*ReEncryptOutput, error) {
 const opRetireGrant = "RetireGrant"
 
 // RetireGrantRequest generates a request for the RetireGrant operation.
-func (c *KMS) RetireGrantRequest(input *RetireGrantInput) (req *service.Request, output *RetireGrantOutput) {
-	op := &service.Operation{
+func (c *KMS) RetireGrantRequest(input *RetireGrantInput) (req *request.Request, output *RetireGrantOutput) {
+	op := &request.Operation{
 		Name:       opRetireGrant,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -786,8 +786,8 @@ func (c *KMS) RetireGrant(input *RetireGrantInput) (*RetireGrantOutput, error) {
 const opRevokeGrant = "RevokeGrant"
 
 // RevokeGrantRequest generates a request for the RevokeGrant operation.
-func (c *KMS) RevokeGrantRequest(input *RevokeGrantInput) (req *service.Request, output *RevokeGrantOutput) {
-	op := &service.Operation{
+func (c *KMS) RevokeGrantRequest(input *RevokeGrantInput) (req *request.Request, output *RevokeGrantOutput) {
+	op := &request.Operation{
 		Name:       opRevokeGrant,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -814,8 +814,8 @@ func (c *KMS) RevokeGrant(input *RevokeGrantInput) (*RevokeGrantOutput, error) {
 const opUpdateAlias = "UpdateAlias"
 
 // UpdateAliasRequest generates a request for the UpdateAlias operation.
-func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *service.Request, output *UpdateAliasOutput) {
-	op := &service.Operation{
+func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request, output *UpdateAliasOutput) {
+	op := &request.Operation{
 		Name:       opUpdateAlias,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -853,8 +853,8 @@ func (c *KMS) UpdateAlias(input *UpdateAliasInput) (*UpdateAliasOutput, error) {
 const opUpdateKeyDescription = "UpdateKeyDescription"
 
 // UpdateKeyDescriptionRequest generates a request for the UpdateKeyDescription operation.
-func (c *KMS) UpdateKeyDescriptionRequest(input *UpdateKeyDescriptionInput) (req *service.Request, output *UpdateKeyDescriptionOutput) {
-	op := &service.Operation{
+func (c *KMS) UpdateKeyDescriptionRequest(input *UpdateKeyDescriptionInput) (req *request.Request, output *UpdateKeyDescriptionOutput) {
+	op := &request.Operation{
 		Name:       opUpdateKeyDescription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/kms/kmsiface/interface.go
+++ b/service/kms/kmsiface/interface.go
@@ -4,121 +4,121 @@
 package kmsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/kms"
 )
 
 // KMSAPI is the interface type for kms.KMS.
 type KMSAPI interface {
-	CreateAliasRequest(*kms.CreateAliasInput) (*service.Request, *kms.CreateAliasOutput)
+	CreateAliasRequest(*kms.CreateAliasInput) (*request.Request, *kms.CreateAliasOutput)
 
 	CreateAlias(*kms.CreateAliasInput) (*kms.CreateAliasOutput, error)
 
-	CreateGrantRequest(*kms.CreateGrantInput) (*service.Request, *kms.CreateGrantOutput)
+	CreateGrantRequest(*kms.CreateGrantInput) (*request.Request, *kms.CreateGrantOutput)
 
 	CreateGrant(*kms.CreateGrantInput) (*kms.CreateGrantOutput, error)
 
-	CreateKeyRequest(*kms.CreateKeyInput) (*service.Request, *kms.CreateKeyOutput)
+	CreateKeyRequest(*kms.CreateKeyInput) (*request.Request, *kms.CreateKeyOutput)
 
 	CreateKey(*kms.CreateKeyInput) (*kms.CreateKeyOutput, error)
 
-	DecryptRequest(*kms.DecryptInput) (*service.Request, *kms.DecryptOutput)
+	DecryptRequest(*kms.DecryptInput) (*request.Request, *kms.DecryptOutput)
 
 	Decrypt(*kms.DecryptInput) (*kms.DecryptOutput, error)
 
-	DeleteAliasRequest(*kms.DeleteAliasInput) (*service.Request, *kms.DeleteAliasOutput)
+	DeleteAliasRequest(*kms.DeleteAliasInput) (*request.Request, *kms.DeleteAliasOutput)
 
 	DeleteAlias(*kms.DeleteAliasInput) (*kms.DeleteAliasOutput, error)
 
-	DescribeKeyRequest(*kms.DescribeKeyInput) (*service.Request, *kms.DescribeKeyOutput)
+	DescribeKeyRequest(*kms.DescribeKeyInput) (*request.Request, *kms.DescribeKeyOutput)
 
 	DescribeKey(*kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error)
 
-	DisableKeyRequest(*kms.DisableKeyInput) (*service.Request, *kms.DisableKeyOutput)
+	DisableKeyRequest(*kms.DisableKeyInput) (*request.Request, *kms.DisableKeyOutput)
 
 	DisableKey(*kms.DisableKeyInput) (*kms.DisableKeyOutput, error)
 
-	DisableKeyRotationRequest(*kms.DisableKeyRotationInput) (*service.Request, *kms.DisableKeyRotationOutput)
+	DisableKeyRotationRequest(*kms.DisableKeyRotationInput) (*request.Request, *kms.DisableKeyRotationOutput)
 
 	DisableKeyRotation(*kms.DisableKeyRotationInput) (*kms.DisableKeyRotationOutput, error)
 
-	EnableKeyRequest(*kms.EnableKeyInput) (*service.Request, *kms.EnableKeyOutput)
+	EnableKeyRequest(*kms.EnableKeyInput) (*request.Request, *kms.EnableKeyOutput)
 
 	EnableKey(*kms.EnableKeyInput) (*kms.EnableKeyOutput, error)
 
-	EnableKeyRotationRequest(*kms.EnableKeyRotationInput) (*service.Request, *kms.EnableKeyRotationOutput)
+	EnableKeyRotationRequest(*kms.EnableKeyRotationInput) (*request.Request, *kms.EnableKeyRotationOutput)
 
 	EnableKeyRotation(*kms.EnableKeyRotationInput) (*kms.EnableKeyRotationOutput, error)
 
-	EncryptRequest(*kms.EncryptInput) (*service.Request, *kms.EncryptOutput)
+	EncryptRequest(*kms.EncryptInput) (*request.Request, *kms.EncryptOutput)
 
 	Encrypt(*kms.EncryptInput) (*kms.EncryptOutput, error)
 
-	GenerateDataKeyRequest(*kms.GenerateDataKeyInput) (*service.Request, *kms.GenerateDataKeyOutput)
+	GenerateDataKeyRequest(*kms.GenerateDataKeyInput) (*request.Request, *kms.GenerateDataKeyOutput)
 
 	GenerateDataKey(*kms.GenerateDataKeyInput) (*kms.GenerateDataKeyOutput, error)
 
-	GenerateDataKeyWithoutPlaintextRequest(*kms.GenerateDataKeyWithoutPlaintextInput) (*service.Request, *kms.GenerateDataKeyWithoutPlaintextOutput)
+	GenerateDataKeyWithoutPlaintextRequest(*kms.GenerateDataKeyWithoutPlaintextInput) (*request.Request, *kms.GenerateDataKeyWithoutPlaintextOutput)
 
 	GenerateDataKeyWithoutPlaintext(*kms.GenerateDataKeyWithoutPlaintextInput) (*kms.GenerateDataKeyWithoutPlaintextOutput, error)
 
-	GenerateRandomRequest(*kms.GenerateRandomInput) (*service.Request, *kms.GenerateRandomOutput)
+	GenerateRandomRequest(*kms.GenerateRandomInput) (*request.Request, *kms.GenerateRandomOutput)
 
 	GenerateRandom(*kms.GenerateRandomInput) (*kms.GenerateRandomOutput, error)
 
-	GetKeyPolicyRequest(*kms.GetKeyPolicyInput) (*service.Request, *kms.GetKeyPolicyOutput)
+	GetKeyPolicyRequest(*kms.GetKeyPolicyInput) (*request.Request, *kms.GetKeyPolicyOutput)
 
 	GetKeyPolicy(*kms.GetKeyPolicyInput) (*kms.GetKeyPolicyOutput, error)
 
-	GetKeyRotationStatusRequest(*kms.GetKeyRotationStatusInput) (*service.Request, *kms.GetKeyRotationStatusOutput)
+	GetKeyRotationStatusRequest(*kms.GetKeyRotationStatusInput) (*request.Request, *kms.GetKeyRotationStatusOutput)
 
 	GetKeyRotationStatus(*kms.GetKeyRotationStatusInput) (*kms.GetKeyRotationStatusOutput, error)
 
-	ListAliasesRequest(*kms.ListAliasesInput) (*service.Request, *kms.ListAliasesOutput)
+	ListAliasesRequest(*kms.ListAliasesInput) (*request.Request, *kms.ListAliasesOutput)
 
 	ListAliases(*kms.ListAliasesInput) (*kms.ListAliasesOutput, error)
 
 	ListAliasesPages(*kms.ListAliasesInput, func(*kms.ListAliasesOutput, bool) bool) error
 
-	ListGrantsRequest(*kms.ListGrantsInput) (*service.Request, *kms.ListGrantsOutput)
+	ListGrantsRequest(*kms.ListGrantsInput) (*request.Request, *kms.ListGrantsOutput)
 
 	ListGrants(*kms.ListGrantsInput) (*kms.ListGrantsOutput, error)
 
 	ListGrantsPages(*kms.ListGrantsInput, func(*kms.ListGrantsOutput, bool) bool) error
 
-	ListKeyPoliciesRequest(*kms.ListKeyPoliciesInput) (*service.Request, *kms.ListKeyPoliciesOutput)
+	ListKeyPoliciesRequest(*kms.ListKeyPoliciesInput) (*request.Request, *kms.ListKeyPoliciesOutput)
 
 	ListKeyPolicies(*kms.ListKeyPoliciesInput) (*kms.ListKeyPoliciesOutput, error)
 
 	ListKeyPoliciesPages(*kms.ListKeyPoliciesInput, func(*kms.ListKeyPoliciesOutput, bool) bool) error
 
-	ListKeysRequest(*kms.ListKeysInput) (*service.Request, *kms.ListKeysOutput)
+	ListKeysRequest(*kms.ListKeysInput) (*request.Request, *kms.ListKeysOutput)
 
 	ListKeys(*kms.ListKeysInput) (*kms.ListKeysOutput, error)
 
 	ListKeysPages(*kms.ListKeysInput, func(*kms.ListKeysOutput, bool) bool) error
 
-	PutKeyPolicyRequest(*kms.PutKeyPolicyInput) (*service.Request, *kms.PutKeyPolicyOutput)
+	PutKeyPolicyRequest(*kms.PutKeyPolicyInput) (*request.Request, *kms.PutKeyPolicyOutput)
 
 	PutKeyPolicy(*kms.PutKeyPolicyInput) (*kms.PutKeyPolicyOutput, error)
 
-	ReEncryptRequest(*kms.ReEncryptInput) (*service.Request, *kms.ReEncryptOutput)
+	ReEncryptRequest(*kms.ReEncryptInput) (*request.Request, *kms.ReEncryptOutput)
 
 	ReEncrypt(*kms.ReEncryptInput) (*kms.ReEncryptOutput, error)
 
-	RetireGrantRequest(*kms.RetireGrantInput) (*service.Request, *kms.RetireGrantOutput)
+	RetireGrantRequest(*kms.RetireGrantInput) (*request.Request, *kms.RetireGrantOutput)
 
 	RetireGrant(*kms.RetireGrantInput) (*kms.RetireGrantOutput, error)
 
-	RevokeGrantRequest(*kms.RevokeGrantInput) (*service.Request, *kms.RevokeGrantOutput)
+	RevokeGrantRequest(*kms.RevokeGrantInput) (*request.Request, *kms.RevokeGrantOutput)
 
 	RevokeGrant(*kms.RevokeGrantInput) (*kms.RevokeGrantOutput, error)
 
-	UpdateAliasRequest(*kms.UpdateAliasInput) (*service.Request, *kms.UpdateAliasOutput)
+	UpdateAliasRequest(*kms.UpdateAliasInput) (*request.Request, *kms.UpdateAliasOutput)
 
 	UpdateAlias(*kms.UpdateAliasInput) (*kms.UpdateAliasOutput, error)
 
-	UpdateKeyDescriptionRequest(*kms.UpdateKeyDescriptionInput) (*service.Request, *kms.UpdateKeyDescriptionOutput)
+	UpdateKeyDescriptionRequest(*kms.UpdateKeyDescriptionInput) (*request.Request, *kms.UpdateKeyDescriptionOutput)
 
 	UpdateKeyDescription(*kms.UpdateKeyDescriptionInput) (*kms.UpdateKeyDescriptionOutput, error)
 }

--- a/service/kms/service.go
+++ b/service/kms/service.go
@@ -5,7 +5,9 @@ package kms
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -74,16 +76,18 @@ type KMS struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new KMS client.
 func New(config *aws.Config) *KMS {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "kms",
-		APIVersion:   "2014-11-01",
-		JSONVersion:  "1.1",
-		TargetPrefix: "TrentService",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "kms",
+			APIVersion:   "2014-11-01",
+			JSONVersion:  "1.1",
+			TargetPrefix: "TrentService",
+		},
 	}
 	service.Initialize()
 
@@ -104,8 +108,8 @@ func New(config *aws.Config) *KMS {
 
 // newRequest creates a new request for a KMS operation and runs any
 // custom request initialization.
-func (c *KMS) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *KMS) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/lambda/api.go
+++ b/service/lambda/api.go
@@ -8,14 +8,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddPermission = "AddPermission"
 
 // AddPermissionRequest generates a request for the AddPermission operation.
-func (c *Lambda) AddPermissionRequest(input *AddPermissionInput) (req *service.Request, output *AddPermissionOutput) {
-	op := &service.Operation{
+func (c *Lambda) AddPermissionRequest(input *AddPermissionInput) (req *request.Request, output *AddPermissionOutput) {
+	op := &request.Operation{
 		Name:       opAddPermission,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}/versions/HEAD/policy",
@@ -50,8 +50,8 @@ func (c *Lambda) AddPermission(input *AddPermissionInput) (*AddPermissionOutput,
 const opCreateEventSourceMapping = "CreateEventSourceMapping"
 
 // CreateEventSourceMappingRequest generates a request for the CreateEventSourceMapping operation.
-func (c *Lambda) CreateEventSourceMappingRequest(input *CreateEventSourceMappingInput) (req *service.Request, output *EventSourceMappingConfiguration) {
-	op := &service.Operation{
+func (c *Lambda) CreateEventSourceMappingRequest(input *CreateEventSourceMappingInput) (req *request.Request, output *EventSourceMappingConfiguration) {
+	op := &request.Operation{
 		Name:       opCreateEventSourceMapping,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-03-31/event-source-mappings/",
@@ -95,8 +95,8 @@ func (c *Lambda) CreateEventSourceMapping(input *CreateEventSourceMappingInput) 
 const opCreateFunction = "CreateFunction"
 
 // CreateFunctionRequest generates a request for the CreateFunction operation.
-func (c *Lambda) CreateFunctionRequest(input *CreateFunctionInput) (req *service.Request, output *FunctionConfiguration) {
-	op := &service.Operation{
+func (c *Lambda) CreateFunctionRequest(input *CreateFunctionInput) (req *request.Request, output *FunctionConfiguration) {
+	op := &request.Operation{
 		Name:       opCreateFunction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-03-31/functions",
@@ -127,8 +127,8 @@ func (c *Lambda) CreateFunction(input *CreateFunctionInput) (*FunctionConfigurat
 const opDeleteEventSourceMapping = "DeleteEventSourceMapping"
 
 // DeleteEventSourceMappingRequest generates a request for the DeleteEventSourceMapping operation.
-func (c *Lambda) DeleteEventSourceMappingRequest(input *DeleteEventSourceMappingInput) (req *service.Request, output *EventSourceMappingConfiguration) {
-	op := &service.Operation{
+func (c *Lambda) DeleteEventSourceMappingRequest(input *DeleteEventSourceMappingInput) (req *request.Request, output *EventSourceMappingConfiguration) {
+	op := &request.Operation{
 		Name:       opDeleteEventSourceMapping,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-03-31/event-source-mappings/{UUID}",
@@ -158,8 +158,8 @@ func (c *Lambda) DeleteEventSourceMapping(input *DeleteEventSourceMappingInput) 
 const opDeleteFunction = "DeleteFunction"
 
 // DeleteFunctionRequest generates a request for the DeleteFunction operation.
-func (c *Lambda) DeleteFunctionRequest(input *DeleteFunctionInput) (req *service.Request, output *DeleteFunctionOutput) {
-	op := &service.Operation{
+func (c *Lambda) DeleteFunctionRequest(input *DeleteFunctionInput) (req *request.Request, output *DeleteFunctionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteFunction,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}",
@@ -190,8 +190,8 @@ func (c *Lambda) DeleteFunction(input *DeleteFunctionInput) (*DeleteFunctionOutp
 const opGetEventSourceMapping = "GetEventSourceMapping"
 
 // GetEventSourceMappingRequest generates a request for the GetEventSourceMapping operation.
-func (c *Lambda) GetEventSourceMappingRequest(input *GetEventSourceMappingInput) (req *service.Request, output *EventSourceMappingConfiguration) {
-	op := &service.Operation{
+func (c *Lambda) GetEventSourceMappingRequest(input *GetEventSourceMappingInput) (req *request.Request, output *EventSourceMappingConfiguration) {
+	op := &request.Operation{
 		Name:       opGetEventSourceMapping,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-03-31/event-source-mappings/{UUID}",
@@ -221,8 +221,8 @@ func (c *Lambda) GetEventSourceMapping(input *GetEventSourceMappingInput) (*Even
 const opGetFunction = "GetFunction"
 
 // GetFunctionRequest generates a request for the GetFunction operation.
-func (c *Lambda) GetFunctionRequest(input *GetFunctionInput) (req *service.Request, output *GetFunctionOutput) {
-	op := &service.Operation{
+func (c *Lambda) GetFunctionRequest(input *GetFunctionInput) (req *request.Request, output *GetFunctionOutput) {
+	op := &request.Operation{
 		Name:       opGetFunction,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}/versions/HEAD",
@@ -254,8 +254,8 @@ func (c *Lambda) GetFunction(input *GetFunctionInput) (*GetFunctionOutput, error
 const opGetFunctionConfiguration = "GetFunctionConfiguration"
 
 // GetFunctionConfigurationRequest generates a request for the GetFunctionConfiguration operation.
-func (c *Lambda) GetFunctionConfigurationRequest(input *GetFunctionConfigurationInput) (req *service.Request, output *FunctionConfiguration) {
-	op := &service.Operation{
+func (c *Lambda) GetFunctionConfigurationRequest(input *GetFunctionConfigurationInput) (req *request.Request, output *FunctionConfiguration) {
+	op := &request.Operation{
 		Name:       opGetFunctionConfiguration,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}/versions/HEAD/configuration",
@@ -286,8 +286,8 @@ func (c *Lambda) GetFunctionConfiguration(input *GetFunctionConfigurationInput) 
 const opGetPolicy = "GetPolicy"
 
 // GetPolicyRequest generates a request for the GetPolicy operation.
-func (c *Lambda) GetPolicyRequest(input *GetPolicyInput) (req *service.Request, output *GetPolicyOutput) {
-	op := &service.Operation{
+func (c *Lambda) GetPolicyRequest(input *GetPolicyInput) (req *request.Request, output *GetPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetPolicy,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}/versions/HEAD/policy",
@@ -316,8 +316,8 @@ func (c *Lambda) GetPolicy(input *GetPolicyInput) (*GetPolicyOutput, error) {
 const opInvoke = "Invoke"
 
 // InvokeRequest generates a request for the Invoke operation.
-func (c *Lambda) InvokeRequest(input *InvokeInput) (req *service.Request, output *InvokeOutput) {
-	op := &service.Operation{
+func (c *Lambda) InvokeRequest(input *InvokeInput) (req *request.Request, output *InvokeOutput) {
+	op := &request.Operation{
 		Name:       opInvoke,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}/invocations",
@@ -345,8 +345,8 @@ func (c *Lambda) Invoke(input *InvokeInput) (*InvokeOutput, error) {
 const opInvokeAsync = "InvokeAsync"
 
 // InvokeAsyncRequest generates a request for the InvokeAsync operation.
-func (c *Lambda) InvokeAsyncRequest(input *InvokeAsyncInput) (req *service.Request, output *InvokeAsyncOutput) {
-	op := &service.Operation{
+func (c *Lambda) InvokeAsyncRequest(input *InvokeAsyncInput) (req *request.Request, output *InvokeAsyncOutput) {
+	op := &request.Operation{
 		Name:       opInvokeAsync,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-11-13/functions/{FunctionName}/invoke-async/",
@@ -377,12 +377,12 @@ func (c *Lambda) InvokeAsync(input *InvokeAsyncInput) (*InvokeAsyncOutput, error
 const opListEventSourceMappings = "ListEventSourceMappings"
 
 // ListEventSourceMappingsRequest generates a request for the ListEventSourceMappings operation.
-func (c *Lambda) ListEventSourceMappingsRequest(input *ListEventSourceMappingsInput) (req *service.Request, output *ListEventSourceMappingsOutput) {
-	op := &service.Operation{
+func (c *Lambda) ListEventSourceMappingsRequest(input *ListEventSourceMappingsInput) (req *request.Request, output *ListEventSourceMappingsOutput) {
+	op := &request.Operation{
 		Name:       opListEventSourceMappings,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-03-31/event-source-mappings/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "MaxItems",
@@ -425,12 +425,12 @@ func (c *Lambda) ListEventSourceMappingsPages(input *ListEventSourceMappingsInpu
 const opListFunctions = "ListFunctions"
 
 // ListFunctionsRequest generates a request for the ListFunctions operation.
-func (c *Lambda) ListFunctionsRequest(input *ListFunctionsInput) (req *service.Request, output *ListFunctionsOutput) {
-	op := &service.Operation{
+func (c *Lambda) ListFunctionsRequest(input *ListFunctionsInput) (req *request.Request, output *ListFunctionsOutput) {
+	op := &request.Operation{
 		Name:       opListFunctions,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2015-03-31/functions/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "MaxItems",
@@ -469,8 +469,8 @@ func (c *Lambda) ListFunctionsPages(input *ListFunctionsInput, fn func(p *ListFu
 const opRemovePermission = "RemovePermission"
 
 // RemovePermissionRequest generates a request for the RemovePermission operation.
-func (c *Lambda) RemovePermissionRequest(input *RemovePermissionInput) (req *service.Request, output *RemovePermissionOutput) {
-	op := &service.Operation{
+func (c *Lambda) RemovePermissionRequest(input *RemovePermissionInput) (req *request.Request, output *RemovePermissionOutput) {
+	op := &request.Operation{
 		Name:       opRemovePermission,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}/versions/HEAD/policy/{StatementId}",
@@ -502,8 +502,8 @@ func (c *Lambda) RemovePermission(input *RemovePermissionInput) (*RemovePermissi
 const opUpdateEventSourceMapping = "UpdateEventSourceMapping"
 
 // UpdateEventSourceMappingRequest generates a request for the UpdateEventSourceMapping operation.
-func (c *Lambda) UpdateEventSourceMappingRequest(input *UpdateEventSourceMappingInput) (req *service.Request, output *EventSourceMappingConfiguration) {
-	op := &service.Operation{
+func (c *Lambda) UpdateEventSourceMappingRequest(input *UpdateEventSourceMappingInput) (req *request.Request, output *EventSourceMappingConfiguration) {
+	op := &request.Operation{
 		Name:       opUpdateEventSourceMapping,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2015-03-31/event-source-mappings/{UUID}",
@@ -535,8 +535,8 @@ func (c *Lambda) UpdateEventSourceMapping(input *UpdateEventSourceMappingInput) 
 const opUpdateFunctionCode = "UpdateFunctionCode"
 
 // UpdateFunctionCodeRequest generates a request for the UpdateFunctionCode operation.
-func (c *Lambda) UpdateFunctionCodeRequest(input *UpdateFunctionCodeInput) (req *service.Request, output *FunctionConfiguration) {
-	op := &service.Operation{
+func (c *Lambda) UpdateFunctionCodeRequest(input *UpdateFunctionCodeInput) (req *request.Request, output *FunctionConfiguration) {
+	op := &request.Operation{
 		Name:       opUpdateFunctionCode,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}/versions/HEAD/code",
@@ -566,8 +566,8 @@ func (c *Lambda) UpdateFunctionCode(input *UpdateFunctionCodeInput) (*FunctionCo
 const opUpdateFunctionConfiguration = "UpdateFunctionConfiguration"
 
 // UpdateFunctionConfigurationRequest generates a request for the UpdateFunctionConfiguration operation.
-func (c *Lambda) UpdateFunctionConfigurationRequest(input *UpdateFunctionConfigurationInput) (req *service.Request, output *FunctionConfiguration) {
-	op := &service.Operation{
+func (c *Lambda) UpdateFunctionConfigurationRequest(input *UpdateFunctionConfigurationInput) (req *request.Request, output *FunctionConfiguration) {
+	op := &request.Operation{
 		Name:       opUpdateFunctionConfiguration,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/2015-03-31/functions/{FunctionName}/versions/HEAD/configuration",

--- a/service/lambda/lambdaiface/interface.go
+++ b/service/lambda/lambdaiface/interface.go
@@ -4,81 +4,81 @@
 package lambdaiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/lambda"
 )
 
 // LambdaAPI is the interface type for lambda.Lambda.
 type LambdaAPI interface {
-	AddPermissionRequest(*lambda.AddPermissionInput) (*service.Request, *lambda.AddPermissionOutput)
+	AddPermissionRequest(*lambda.AddPermissionInput) (*request.Request, *lambda.AddPermissionOutput)
 
 	AddPermission(*lambda.AddPermissionInput) (*lambda.AddPermissionOutput, error)
 
-	CreateEventSourceMappingRequest(*lambda.CreateEventSourceMappingInput) (*service.Request, *lambda.EventSourceMappingConfiguration)
+	CreateEventSourceMappingRequest(*lambda.CreateEventSourceMappingInput) (*request.Request, *lambda.EventSourceMappingConfiguration)
 
 	CreateEventSourceMapping(*lambda.CreateEventSourceMappingInput) (*lambda.EventSourceMappingConfiguration, error)
 
-	CreateFunctionRequest(*lambda.CreateFunctionInput) (*service.Request, *lambda.FunctionConfiguration)
+	CreateFunctionRequest(*lambda.CreateFunctionInput) (*request.Request, *lambda.FunctionConfiguration)
 
 	CreateFunction(*lambda.CreateFunctionInput) (*lambda.FunctionConfiguration, error)
 
-	DeleteEventSourceMappingRequest(*lambda.DeleteEventSourceMappingInput) (*service.Request, *lambda.EventSourceMappingConfiguration)
+	DeleteEventSourceMappingRequest(*lambda.DeleteEventSourceMappingInput) (*request.Request, *lambda.EventSourceMappingConfiguration)
 
 	DeleteEventSourceMapping(*lambda.DeleteEventSourceMappingInput) (*lambda.EventSourceMappingConfiguration, error)
 
-	DeleteFunctionRequest(*lambda.DeleteFunctionInput) (*service.Request, *lambda.DeleteFunctionOutput)
+	DeleteFunctionRequest(*lambda.DeleteFunctionInput) (*request.Request, *lambda.DeleteFunctionOutput)
 
 	DeleteFunction(*lambda.DeleteFunctionInput) (*lambda.DeleteFunctionOutput, error)
 
-	GetEventSourceMappingRequest(*lambda.GetEventSourceMappingInput) (*service.Request, *lambda.EventSourceMappingConfiguration)
+	GetEventSourceMappingRequest(*lambda.GetEventSourceMappingInput) (*request.Request, *lambda.EventSourceMappingConfiguration)
 
 	GetEventSourceMapping(*lambda.GetEventSourceMappingInput) (*lambda.EventSourceMappingConfiguration, error)
 
-	GetFunctionRequest(*lambda.GetFunctionInput) (*service.Request, *lambda.GetFunctionOutput)
+	GetFunctionRequest(*lambda.GetFunctionInput) (*request.Request, *lambda.GetFunctionOutput)
 
 	GetFunction(*lambda.GetFunctionInput) (*lambda.GetFunctionOutput, error)
 
-	GetFunctionConfigurationRequest(*lambda.GetFunctionConfigurationInput) (*service.Request, *lambda.FunctionConfiguration)
+	GetFunctionConfigurationRequest(*lambda.GetFunctionConfigurationInput) (*request.Request, *lambda.FunctionConfiguration)
 
 	GetFunctionConfiguration(*lambda.GetFunctionConfigurationInput) (*lambda.FunctionConfiguration, error)
 
-	GetPolicyRequest(*lambda.GetPolicyInput) (*service.Request, *lambda.GetPolicyOutput)
+	GetPolicyRequest(*lambda.GetPolicyInput) (*request.Request, *lambda.GetPolicyOutput)
 
 	GetPolicy(*lambda.GetPolicyInput) (*lambda.GetPolicyOutput, error)
 
-	InvokeRequest(*lambda.InvokeInput) (*service.Request, *lambda.InvokeOutput)
+	InvokeRequest(*lambda.InvokeInput) (*request.Request, *lambda.InvokeOutput)
 
 	Invoke(*lambda.InvokeInput) (*lambda.InvokeOutput, error)
 
-	InvokeAsyncRequest(*lambda.InvokeAsyncInput) (*service.Request, *lambda.InvokeAsyncOutput)
+	InvokeAsyncRequest(*lambda.InvokeAsyncInput) (*request.Request, *lambda.InvokeAsyncOutput)
 
 	InvokeAsync(*lambda.InvokeAsyncInput) (*lambda.InvokeAsyncOutput, error)
 
-	ListEventSourceMappingsRequest(*lambda.ListEventSourceMappingsInput) (*service.Request, *lambda.ListEventSourceMappingsOutput)
+	ListEventSourceMappingsRequest(*lambda.ListEventSourceMappingsInput) (*request.Request, *lambda.ListEventSourceMappingsOutput)
 
 	ListEventSourceMappings(*lambda.ListEventSourceMappingsInput) (*lambda.ListEventSourceMappingsOutput, error)
 
 	ListEventSourceMappingsPages(*lambda.ListEventSourceMappingsInput, func(*lambda.ListEventSourceMappingsOutput, bool) bool) error
 
-	ListFunctionsRequest(*lambda.ListFunctionsInput) (*service.Request, *lambda.ListFunctionsOutput)
+	ListFunctionsRequest(*lambda.ListFunctionsInput) (*request.Request, *lambda.ListFunctionsOutput)
 
 	ListFunctions(*lambda.ListFunctionsInput) (*lambda.ListFunctionsOutput, error)
 
 	ListFunctionsPages(*lambda.ListFunctionsInput, func(*lambda.ListFunctionsOutput, bool) bool) error
 
-	RemovePermissionRequest(*lambda.RemovePermissionInput) (*service.Request, *lambda.RemovePermissionOutput)
+	RemovePermissionRequest(*lambda.RemovePermissionInput) (*request.Request, *lambda.RemovePermissionOutput)
 
 	RemovePermission(*lambda.RemovePermissionInput) (*lambda.RemovePermissionOutput, error)
 
-	UpdateEventSourceMappingRequest(*lambda.UpdateEventSourceMappingInput) (*service.Request, *lambda.EventSourceMappingConfiguration)
+	UpdateEventSourceMappingRequest(*lambda.UpdateEventSourceMappingInput) (*request.Request, *lambda.EventSourceMappingConfiguration)
 
 	UpdateEventSourceMapping(*lambda.UpdateEventSourceMappingInput) (*lambda.EventSourceMappingConfiguration, error)
 
-	UpdateFunctionCodeRequest(*lambda.UpdateFunctionCodeInput) (*service.Request, *lambda.FunctionConfiguration)
+	UpdateFunctionCodeRequest(*lambda.UpdateFunctionCodeInput) (*request.Request, *lambda.FunctionConfiguration)
 
 	UpdateFunctionCode(*lambda.UpdateFunctionCodeInput) (*lambda.FunctionConfiguration, error)
 
-	UpdateFunctionConfigurationRequest(*lambda.UpdateFunctionConfigurationInput) (*service.Request, *lambda.FunctionConfiguration)
+	UpdateFunctionConfigurationRequest(*lambda.UpdateFunctionConfigurationInput) (*request.Request, *lambda.FunctionConfiguration)
 
 	UpdateFunctionConfiguration(*lambda.UpdateFunctionConfigurationInput) (*lambda.FunctionConfiguration, error)
 }

--- a/service/lambda/service.go
+++ b/service/lambda/service.go
@@ -5,7 +5,9 @@ package lambda
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -25,14 +27,16 @@ type Lambda struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new Lambda client.
 func New(config *aws.Config) *Lambda {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "lambda",
-		APIVersion:  "2015-03-31",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "lambda",
+			APIVersion:  "2015-03-31",
+		},
 	}
 	service.Initialize()
 
@@ -53,8 +57,8 @@ func New(config *aws.Config) *Lambda {
 
 // newRequest creates a new request for a Lambda operation and runs any
 // custom request initialization.
-func (c *Lambda) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *Lambda) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/machinelearning/api.go
+++ b/service/machinelearning/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateBatchPrediction = "CreateBatchPrediction"
 
 // CreateBatchPredictionRequest generates a request for the CreateBatchPrediction operation.
-func (c *MachineLearning) CreateBatchPredictionRequest(input *CreateBatchPredictionInput) (req *service.Request, output *CreateBatchPredictionOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) CreateBatchPredictionRequest(input *CreateBatchPredictionInput) (req *request.Request, output *CreateBatchPredictionOutput) {
+	op := &request.Operation{
 		Name:       opCreateBatchPrediction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -53,8 +53,8 @@ func (c *MachineLearning) CreateBatchPrediction(input *CreateBatchPredictionInpu
 const opCreateDataSourceFromRDS = "CreateDataSourceFromRDS"
 
 // CreateDataSourceFromRDSRequest generates a request for the CreateDataSourceFromRDS operation.
-func (c *MachineLearning) CreateDataSourceFromRDSRequest(input *CreateDataSourceFromRDSInput) (req *service.Request, output *CreateDataSourceFromRDSOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) CreateDataSourceFromRDSRequest(input *CreateDataSourceFromRDSInput) (req *request.Request, output *CreateDataSourceFromRDSOutput) {
+	op := &request.Operation{
 		Name:       opCreateDataSourceFromRDS,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -93,8 +93,8 @@ func (c *MachineLearning) CreateDataSourceFromRDS(input *CreateDataSourceFromRDS
 const opCreateDataSourceFromRedshift = "CreateDataSourceFromRedshift"
 
 // CreateDataSourceFromRedshiftRequest generates a request for the CreateDataSourceFromRedshift operation.
-func (c *MachineLearning) CreateDataSourceFromRedshiftRequest(input *CreateDataSourceFromRedshiftInput) (req *service.Request, output *CreateDataSourceFromRedshiftOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) CreateDataSourceFromRedshiftRequest(input *CreateDataSourceFromRedshiftInput) (req *request.Request, output *CreateDataSourceFromRedshiftOutput) {
+	op := &request.Operation{
 		Name:       opCreateDataSourceFromRedshift,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -149,8 +149,8 @@ func (c *MachineLearning) CreateDataSourceFromRedshift(input *CreateDataSourceFr
 const opCreateDataSourceFromS3 = "CreateDataSourceFromS3"
 
 // CreateDataSourceFromS3Request generates a request for the CreateDataSourceFromS3 operation.
-func (c *MachineLearning) CreateDataSourceFromS3Request(input *CreateDataSourceFromS3Input) (req *service.Request, output *CreateDataSourceFromS3Output) {
-	op := &service.Operation{
+func (c *MachineLearning) CreateDataSourceFromS3Request(input *CreateDataSourceFromS3Input) (req *request.Request, output *CreateDataSourceFromS3Output) {
+	op := &request.Operation{
 		Name:       opCreateDataSourceFromS3,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -205,8 +205,8 @@ func (c *MachineLearning) CreateDataSourceFromS3(input *CreateDataSourceFromS3In
 const opCreateEvaluation = "CreateEvaluation"
 
 // CreateEvaluationRequest generates a request for the CreateEvaluation operation.
-func (c *MachineLearning) CreateEvaluationRequest(input *CreateEvaluationInput) (req *service.Request, output *CreateEvaluationOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) CreateEvaluationRequest(input *CreateEvaluationInput) (req *request.Request, output *CreateEvaluationOutput) {
+	op := &request.Operation{
 		Name:       opCreateEvaluation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -247,8 +247,8 @@ func (c *MachineLearning) CreateEvaluation(input *CreateEvaluationInput) (*Creat
 const opCreateMLModel = "CreateMLModel"
 
 // CreateMLModelRequest generates a request for the CreateMLModel operation.
-func (c *MachineLearning) CreateMLModelRequest(input *CreateMLModelInput) (req *service.Request, output *CreateMLModelOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) CreateMLModelRequest(input *CreateMLModelInput) (req *request.Request, output *CreateMLModelOutput) {
+	op := &request.Operation{
 		Name:       opCreateMLModel,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -290,8 +290,8 @@ func (c *MachineLearning) CreateMLModel(input *CreateMLModelInput) (*CreateMLMod
 const opCreateRealtimeEndpoint = "CreateRealtimeEndpoint"
 
 // CreateRealtimeEndpointRequest generates a request for the CreateRealtimeEndpoint operation.
-func (c *MachineLearning) CreateRealtimeEndpointRequest(input *CreateRealtimeEndpointInput) (req *service.Request, output *CreateRealtimeEndpointOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) CreateRealtimeEndpointRequest(input *CreateRealtimeEndpointInput) (req *request.Request, output *CreateRealtimeEndpointOutput) {
+	op := &request.Operation{
 		Name:       opCreateRealtimeEndpoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -319,8 +319,8 @@ func (c *MachineLearning) CreateRealtimeEndpoint(input *CreateRealtimeEndpointIn
 const opDeleteBatchPrediction = "DeleteBatchPrediction"
 
 // DeleteBatchPredictionRequest generates a request for the DeleteBatchPrediction operation.
-func (c *MachineLearning) DeleteBatchPredictionRequest(input *DeleteBatchPredictionInput) (req *service.Request, output *DeleteBatchPredictionOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DeleteBatchPredictionRequest(input *DeleteBatchPredictionInput) (req *request.Request, output *DeleteBatchPredictionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBatchPrediction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -351,8 +351,8 @@ func (c *MachineLearning) DeleteBatchPrediction(input *DeleteBatchPredictionInpu
 const opDeleteDataSource = "DeleteDataSource"
 
 // DeleteDataSourceRequest generates a request for the DeleteDataSource operation.
-func (c *MachineLearning) DeleteDataSourceRequest(input *DeleteDataSourceInput) (req *service.Request, output *DeleteDataSourceOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DeleteDataSourceRequest(input *DeleteDataSourceInput) (req *request.Request, output *DeleteDataSourceOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDataSource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -383,8 +383,8 @@ func (c *MachineLearning) DeleteDataSource(input *DeleteDataSourceInput) (*Delet
 const opDeleteEvaluation = "DeleteEvaluation"
 
 // DeleteEvaluationRequest generates a request for the DeleteEvaluation operation.
-func (c *MachineLearning) DeleteEvaluationRequest(input *DeleteEvaluationInput) (req *service.Request, output *DeleteEvaluationOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DeleteEvaluationRequest(input *DeleteEvaluationInput) (req *request.Request, output *DeleteEvaluationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteEvaluation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -415,8 +415,8 @@ func (c *MachineLearning) DeleteEvaluation(input *DeleteEvaluationInput) (*Delet
 const opDeleteMLModel = "DeleteMLModel"
 
 // DeleteMLModelRequest generates a request for the DeleteMLModel operation.
-func (c *MachineLearning) DeleteMLModelRequest(input *DeleteMLModelInput) (req *service.Request, output *DeleteMLModelOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DeleteMLModelRequest(input *DeleteMLModelInput) (req *request.Request, output *DeleteMLModelOutput) {
+	op := &request.Operation{
 		Name:       opDeleteMLModel,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -447,8 +447,8 @@ func (c *MachineLearning) DeleteMLModel(input *DeleteMLModelInput) (*DeleteMLMod
 const opDeleteRealtimeEndpoint = "DeleteRealtimeEndpoint"
 
 // DeleteRealtimeEndpointRequest generates a request for the DeleteRealtimeEndpoint operation.
-func (c *MachineLearning) DeleteRealtimeEndpointRequest(input *DeleteRealtimeEndpointInput) (req *service.Request, output *DeleteRealtimeEndpointOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DeleteRealtimeEndpointRequest(input *DeleteRealtimeEndpointInput) (req *request.Request, output *DeleteRealtimeEndpointOutput) {
+	op := &request.Operation{
 		Name:       opDeleteRealtimeEndpoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -474,12 +474,12 @@ func (c *MachineLearning) DeleteRealtimeEndpoint(input *DeleteRealtimeEndpointIn
 const opDescribeBatchPredictions = "DescribeBatchPredictions"
 
 // DescribeBatchPredictionsRequest generates a request for the DescribeBatchPredictions operation.
-func (c *MachineLearning) DescribeBatchPredictionsRequest(input *DescribeBatchPredictionsInput) (req *service.Request, output *DescribeBatchPredictionsOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DescribeBatchPredictionsRequest(input *DescribeBatchPredictionsInput) (req *request.Request, output *DescribeBatchPredictionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeBatchPredictions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "Limit",
@@ -515,12 +515,12 @@ func (c *MachineLearning) DescribeBatchPredictionsPages(input *DescribeBatchPred
 const opDescribeDataSources = "DescribeDataSources"
 
 // DescribeDataSourcesRequest generates a request for the DescribeDataSources operation.
-func (c *MachineLearning) DescribeDataSourcesRequest(input *DescribeDataSourcesInput) (req *service.Request, output *DescribeDataSourcesOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DescribeDataSourcesRequest(input *DescribeDataSourcesInput) (req *request.Request, output *DescribeDataSourcesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDataSources,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "Limit",
@@ -555,12 +555,12 @@ func (c *MachineLearning) DescribeDataSourcesPages(input *DescribeDataSourcesInp
 const opDescribeEvaluations = "DescribeEvaluations"
 
 // DescribeEvaluationsRequest generates a request for the DescribeEvaluations operation.
-func (c *MachineLearning) DescribeEvaluationsRequest(input *DescribeEvaluationsInput) (req *service.Request, output *DescribeEvaluationsOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DescribeEvaluationsRequest(input *DescribeEvaluationsInput) (req *request.Request, output *DescribeEvaluationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEvaluations,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "Limit",
@@ -596,12 +596,12 @@ func (c *MachineLearning) DescribeEvaluationsPages(input *DescribeEvaluationsInp
 const opDescribeMLModels = "DescribeMLModels"
 
 // DescribeMLModelsRequest generates a request for the DescribeMLModels operation.
-func (c *MachineLearning) DescribeMLModelsRequest(input *DescribeMLModelsInput) (req *service.Request, output *DescribeMLModelsOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) DescribeMLModelsRequest(input *DescribeMLModelsInput) (req *request.Request, output *DescribeMLModelsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeMLModels,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "Limit",
@@ -636,8 +636,8 @@ func (c *MachineLearning) DescribeMLModelsPages(input *DescribeMLModelsInput, fn
 const opGetBatchPrediction = "GetBatchPrediction"
 
 // GetBatchPredictionRequest generates a request for the GetBatchPrediction operation.
-func (c *MachineLearning) GetBatchPredictionRequest(input *GetBatchPredictionInput) (req *service.Request, output *GetBatchPredictionOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) GetBatchPredictionRequest(input *GetBatchPredictionInput) (req *request.Request, output *GetBatchPredictionOutput) {
+	op := &request.Operation{
 		Name:       opGetBatchPrediction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -664,8 +664,8 @@ func (c *MachineLearning) GetBatchPrediction(input *GetBatchPredictionInput) (*G
 const opGetDataSource = "GetDataSource"
 
 // GetDataSourceRequest generates a request for the GetDataSource operation.
-func (c *MachineLearning) GetDataSourceRequest(input *GetDataSourceInput) (req *service.Request, output *GetDataSourceOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) GetDataSourceRequest(input *GetDataSourceInput) (req *request.Request, output *GetDataSourceOutput) {
+	op := &request.Operation{
 		Name:       opGetDataSource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -696,8 +696,8 @@ func (c *MachineLearning) GetDataSource(input *GetDataSourceInput) (*GetDataSour
 const opGetEvaluation = "GetEvaluation"
 
 // GetEvaluationRequest generates a request for the GetEvaluation operation.
-func (c *MachineLearning) GetEvaluationRequest(input *GetEvaluationInput) (req *service.Request, output *GetEvaluationOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) GetEvaluationRequest(input *GetEvaluationInput) (req *request.Request, output *GetEvaluationOutput) {
+	op := &request.Operation{
 		Name:       opGetEvaluation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -724,8 +724,8 @@ func (c *MachineLearning) GetEvaluation(input *GetEvaluationInput) (*GetEvaluati
 const opGetMLModel = "GetMLModel"
 
 // GetMLModelRequest generates a request for the GetMLModel operation.
-func (c *MachineLearning) GetMLModelRequest(input *GetMLModelInput) (req *service.Request, output *GetMLModelOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) GetMLModelRequest(input *GetMLModelInput) (req *request.Request, output *GetMLModelOutput) {
+	op := &request.Operation{
 		Name:       opGetMLModel,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -754,8 +754,8 @@ func (c *MachineLearning) GetMLModel(input *GetMLModelInput) (*GetMLModelOutput,
 const opPredict = "Predict"
 
 // PredictRequest generates a request for the Predict operation.
-func (c *MachineLearning) PredictRequest(input *PredictInput) (req *service.Request, output *PredictOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) PredictRequest(input *PredictInput) (req *request.Request, output *PredictOutput) {
+	op := &request.Operation{
 		Name:       opPredict,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -784,8 +784,8 @@ func (c *MachineLearning) Predict(input *PredictInput) (*PredictOutput, error) {
 const opUpdateBatchPrediction = "UpdateBatchPrediction"
 
 // UpdateBatchPredictionRequest generates a request for the UpdateBatchPrediction operation.
-func (c *MachineLearning) UpdateBatchPredictionRequest(input *UpdateBatchPredictionInput) (req *service.Request, output *UpdateBatchPredictionOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) UpdateBatchPredictionRequest(input *UpdateBatchPredictionInput) (req *request.Request, output *UpdateBatchPredictionOutput) {
+	op := &request.Operation{
 		Name:       opUpdateBatchPrediction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -814,8 +814,8 @@ func (c *MachineLearning) UpdateBatchPrediction(input *UpdateBatchPredictionInpu
 const opUpdateDataSource = "UpdateDataSource"
 
 // UpdateDataSourceRequest generates a request for the UpdateDataSource operation.
-func (c *MachineLearning) UpdateDataSourceRequest(input *UpdateDataSourceInput) (req *service.Request, output *UpdateDataSourceOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) UpdateDataSourceRequest(input *UpdateDataSourceInput) (req *request.Request, output *UpdateDataSourceOutput) {
+	op := &request.Operation{
 		Name:       opUpdateDataSource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -844,8 +844,8 @@ func (c *MachineLearning) UpdateDataSource(input *UpdateDataSourceInput) (*Updat
 const opUpdateEvaluation = "UpdateEvaluation"
 
 // UpdateEvaluationRequest generates a request for the UpdateEvaluation operation.
-func (c *MachineLearning) UpdateEvaluationRequest(input *UpdateEvaluationInput) (req *service.Request, output *UpdateEvaluationOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) UpdateEvaluationRequest(input *UpdateEvaluationInput) (req *request.Request, output *UpdateEvaluationOutput) {
+	op := &request.Operation{
 		Name:       opUpdateEvaluation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -874,8 +874,8 @@ func (c *MachineLearning) UpdateEvaluation(input *UpdateEvaluationInput) (*Updat
 const opUpdateMLModel = "UpdateMLModel"
 
 // UpdateMLModelRequest generates a request for the UpdateMLModel operation.
-func (c *MachineLearning) UpdateMLModelRequest(input *UpdateMLModelInput) (req *service.Request, output *UpdateMLModelOutput) {
-	op := &service.Operation{
+func (c *MachineLearning) UpdateMLModelRequest(input *UpdateMLModelInput) (req *request.Request, output *UpdateMLModelOutput) {
+	op := &request.Operation{
 		Name:       opUpdateMLModel,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/machinelearning/customizations.go
+++ b/service/machinelearning/customizations.go
@@ -3,11 +3,11 @@ package machinelearning
 import (
 	"net/url"
 
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 func init() {
-	initRequest = func(r *service.Request) {
+	initRequest = func(r *request.Request) {
 		switch r.Operation.Name {
 		case opPredict:
 			r.Handlers.Build.PushBack(updatePredictEndpoint)
@@ -17,14 +17,14 @@ func init() {
 
 // updatePredictEndpoint rewrites the request endpoint to use the
 // "PredictEndpoint" parameter of the Predict operation.
-func updatePredictEndpoint(r *service.Request) {
+func updatePredictEndpoint(r *request.Request) {
 	if !r.ParamsFilled() {
 		return
 	}
 
-	r.Endpoint = *r.Params.(*PredictInput).PredictEndpoint
+	r.Service.Endpoint = *r.Params.(*PredictInput).PredictEndpoint
 
-	uri, err := url.Parse(r.Endpoint)
+	uri, err := url.Parse(r.Service.Endpoint)
 	if err != nil {
 		r.Error = err
 		return

--- a/service/machinelearning/customizations_test.go
+++ b/service/machinelearning/customizations_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/machinelearning"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +18,7 @@ var _ = unit.Imported
 func TestPredictEndpoint(t *testing.T) {
 	ml := machinelearning.New(nil)
 	ml.Handlers.Send.Clear()
-	ml.Handlers.Send.PushBack(func(r *service.Request) {
+	ml.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{},

--- a/service/machinelearning/machinelearningiface/interface.go
+++ b/service/machinelearning/machinelearningiface/interface.go
@@ -4,117 +4,117 @@
 package machinelearningiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/machinelearning"
 )
 
 // MachineLearningAPI is the interface type for machinelearning.MachineLearning.
 type MachineLearningAPI interface {
-	CreateBatchPredictionRequest(*machinelearning.CreateBatchPredictionInput) (*service.Request, *machinelearning.CreateBatchPredictionOutput)
+	CreateBatchPredictionRequest(*machinelearning.CreateBatchPredictionInput) (*request.Request, *machinelearning.CreateBatchPredictionOutput)
 
 	CreateBatchPrediction(*machinelearning.CreateBatchPredictionInput) (*machinelearning.CreateBatchPredictionOutput, error)
 
-	CreateDataSourceFromRDSRequest(*machinelearning.CreateDataSourceFromRDSInput) (*service.Request, *machinelearning.CreateDataSourceFromRDSOutput)
+	CreateDataSourceFromRDSRequest(*machinelearning.CreateDataSourceFromRDSInput) (*request.Request, *machinelearning.CreateDataSourceFromRDSOutput)
 
 	CreateDataSourceFromRDS(*machinelearning.CreateDataSourceFromRDSInput) (*machinelearning.CreateDataSourceFromRDSOutput, error)
 
-	CreateDataSourceFromRedshiftRequest(*machinelearning.CreateDataSourceFromRedshiftInput) (*service.Request, *machinelearning.CreateDataSourceFromRedshiftOutput)
+	CreateDataSourceFromRedshiftRequest(*machinelearning.CreateDataSourceFromRedshiftInput) (*request.Request, *machinelearning.CreateDataSourceFromRedshiftOutput)
 
 	CreateDataSourceFromRedshift(*machinelearning.CreateDataSourceFromRedshiftInput) (*machinelearning.CreateDataSourceFromRedshiftOutput, error)
 
-	CreateDataSourceFromS3Request(*machinelearning.CreateDataSourceFromS3Input) (*service.Request, *machinelearning.CreateDataSourceFromS3Output)
+	CreateDataSourceFromS3Request(*machinelearning.CreateDataSourceFromS3Input) (*request.Request, *machinelearning.CreateDataSourceFromS3Output)
 
 	CreateDataSourceFromS3(*machinelearning.CreateDataSourceFromS3Input) (*machinelearning.CreateDataSourceFromS3Output, error)
 
-	CreateEvaluationRequest(*machinelearning.CreateEvaluationInput) (*service.Request, *machinelearning.CreateEvaluationOutput)
+	CreateEvaluationRequest(*machinelearning.CreateEvaluationInput) (*request.Request, *machinelearning.CreateEvaluationOutput)
 
 	CreateEvaluation(*machinelearning.CreateEvaluationInput) (*machinelearning.CreateEvaluationOutput, error)
 
-	CreateMLModelRequest(*machinelearning.CreateMLModelInput) (*service.Request, *machinelearning.CreateMLModelOutput)
+	CreateMLModelRequest(*machinelearning.CreateMLModelInput) (*request.Request, *machinelearning.CreateMLModelOutput)
 
 	CreateMLModel(*machinelearning.CreateMLModelInput) (*machinelearning.CreateMLModelOutput, error)
 
-	CreateRealtimeEndpointRequest(*machinelearning.CreateRealtimeEndpointInput) (*service.Request, *machinelearning.CreateRealtimeEndpointOutput)
+	CreateRealtimeEndpointRequest(*machinelearning.CreateRealtimeEndpointInput) (*request.Request, *machinelearning.CreateRealtimeEndpointOutput)
 
 	CreateRealtimeEndpoint(*machinelearning.CreateRealtimeEndpointInput) (*machinelearning.CreateRealtimeEndpointOutput, error)
 
-	DeleteBatchPredictionRequest(*machinelearning.DeleteBatchPredictionInput) (*service.Request, *machinelearning.DeleteBatchPredictionOutput)
+	DeleteBatchPredictionRequest(*machinelearning.DeleteBatchPredictionInput) (*request.Request, *machinelearning.DeleteBatchPredictionOutput)
 
 	DeleteBatchPrediction(*machinelearning.DeleteBatchPredictionInput) (*machinelearning.DeleteBatchPredictionOutput, error)
 
-	DeleteDataSourceRequest(*machinelearning.DeleteDataSourceInput) (*service.Request, *machinelearning.DeleteDataSourceOutput)
+	DeleteDataSourceRequest(*machinelearning.DeleteDataSourceInput) (*request.Request, *machinelearning.DeleteDataSourceOutput)
 
 	DeleteDataSource(*machinelearning.DeleteDataSourceInput) (*machinelearning.DeleteDataSourceOutput, error)
 
-	DeleteEvaluationRequest(*machinelearning.DeleteEvaluationInput) (*service.Request, *machinelearning.DeleteEvaluationOutput)
+	DeleteEvaluationRequest(*machinelearning.DeleteEvaluationInput) (*request.Request, *machinelearning.DeleteEvaluationOutput)
 
 	DeleteEvaluation(*machinelearning.DeleteEvaluationInput) (*machinelearning.DeleteEvaluationOutput, error)
 
-	DeleteMLModelRequest(*machinelearning.DeleteMLModelInput) (*service.Request, *machinelearning.DeleteMLModelOutput)
+	DeleteMLModelRequest(*machinelearning.DeleteMLModelInput) (*request.Request, *machinelearning.DeleteMLModelOutput)
 
 	DeleteMLModel(*machinelearning.DeleteMLModelInput) (*machinelearning.DeleteMLModelOutput, error)
 
-	DeleteRealtimeEndpointRequest(*machinelearning.DeleteRealtimeEndpointInput) (*service.Request, *machinelearning.DeleteRealtimeEndpointOutput)
+	DeleteRealtimeEndpointRequest(*machinelearning.DeleteRealtimeEndpointInput) (*request.Request, *machinelearning.DeleteRealtimeEndpointOutput)
 
 	DeleteRealtimeEndpoint(*machinelearning.DeleteRealtimeEndpointInput) (*machinelearning.DeleteRealtimeEndpointOutput, error)
 
-	DescribeBatchPredictionsRequest(*machinelearning.DescribeBatchPredictionsInput) (*service.Request, *machinelearning.DescribeBatchPredictionsOutput)
+	DescribeBatchPredictionsRequest(*machinelearning.DescribeBatchPredictionsInput) (*request.Request, *machinelearning.DescribeBatchPredictionsOutput)
 
 	DescribeBatchPredictions(*machinelearning.DescribeBatchPredictionsInput) (*machinelearning.DescribeBatchPredictionsOutput, error)
 
 	DescribeBatchPredictionsPages(*machinelearning.DescribeBatchPredictionsInput, func(*machinelearning.DescribeBatchPredictionsOutput, bool) bool) error
 
-	DescribeDataSourcesRequest(*machinelearning.DescribeDataSourcesInput) (*service.Request, *machinelearning.DescribeDataSourcesOutput)
+	DescribeDataSourcesRequest(*machinelearning.DescribeDataSourcesInput) (*request.Request, *machinelearning.DescribeDataSourcesOutput)
 
 	DescribeDataSources(*machinelearning.DescribeDataSourcesInput) (*machinelearning.DescribeDataSourcesOutput, error)
 
 	DescribeDataSourcesPages(*machinelearning.DescribeDataSourcesInput, func(*machinelearning.DescribeDataSourcesOutput, bool) bool) error
 
-	DescribeEvaluationsRequest(*machinelearning.DescribeEvaluationsInput) (*service.Request, *machinelearning.DescribeEvaluationsOutput)
+	DescribeEvaluationsRequest(*machinelearning.DescribeEvaluationsInput) (*request.Request, *machinelearning.DescribeEvaluationsOutput)
 
 	DescribeEvaluations(*machinelearning.DescribeEvaluationsInput) (*machinelearning.DescribeEvaluationsOutput, error)
 
 	DescribeEvaluationsPages(*machinelearning.DescribeEvaluationsInput, func(*machinelearning.DescribeEvaluationsOutput, bool) bool) error
 
-	DescribeMLModelsRequest(*machinelearning.DescribeMLModelsInput) (*service.Request, *machinelearning.DescribeMLModelsOutput)
+	DescribeMLModelsRequest(*machinelearning.DescribeMLModelsInput) (*request.Request, *machinelearning.DescribeMLModelsOutput)
 
 	DescribeMLModels(*machinelearning.DescribeMLModelsInput) (*machinelearning.DescribeMLModelsOutput, error)
 
 	DescribeMLModelsPages(*machinelearning.DescribeMLModelsInput, func(*machinelearning.DescribeMLModelsOutput, bool) bool) error
 
-	GetBatchPredictionRequest(*machinelearning.GetBatchPredictionInput) (*service.Request, *machinelearning.GetBatchPredictionOutput)
+	GetBatchPredictionRequest(*machinelearning.GetBatchPredictionInput) (*request.Request, *machinelearning.GetBatchPredictionOutput)
 
 	GetBatchPrediction(*machinelearning.GetBatchPredictionInput) (*machinelearning.GetBatchPredictionOutput, error)
 
-	GetDataSourceRequest(*machinelearning.GetDataSourceInput) (*service.Request, *machinelearning.GetDataSourceOutput)
+	GetDataSourceRequest(*machinelearning.GetDataSourceInput) (*request.Request, *machinelearning.GetDataSourceOutput)
 
 	GetDataSource(*machinelearning.GetDataSourceInput) (*machinelearning.GetDataSourceOutput, error)
 
-	GetEvaluationRequest(*machinelearning.GetEvaluationInput) (*service.Request, *machinelearning.GetEvaluationOutput)
+	GetEvaluationRequest(*machinelearning.GetEvaluationInput) (*request.Request, *machinelearning.GetEvaluationOutput)
 
 	GetEvaluation(*machinelearning.GetEvaluationInput) (*machinelearning.GetEvaluationOutput, error)
 
-	GetMLModelRequest(*machinelearning.GetMLModelInput) (*service.Request, *machinelearning.GetMLModelOutput)
+	GetMLModelRequest(*machinelearning.GetMLModelInput) (*request.Request, *machinelearning.GetMLModelOutput)
 
 	GetMLModel(*machinelearning.GetMLModelInput) (*machinelearning.GetMLModelOutput, error)
 
-	PredictRequest(*machinelearning.PredictInput) (*service.Request, *machinelearning.PredictOutput)
+	PredictRequest(*machinelearning.PredictInput) (*request.Request, *machinelearning.PredictOutput)
 
 	Predict(*machinelearning.PredictInput) (*machinelearning.PredictOutput, error)
 
-	UpdateBatchPredictionRequest(*machinelearning.UpdateBatchPredictionInput) (*service.Request, *machinelearning.UpdateBatchPredictionOutput)
+	UpdateBatchPredictionRequest(*machinelearning.UpdateBatchPredictionInput) (*request.Request, *machinelearning.UpdateBatchPredictionOutput)
 
 	UpdateBatchPrediction(*machinelearning.UpdateBatchPredictionInput) (*machinelearning.UpdateBatchPredictionOutput, error)
 
-	UpdateDataSourceRequest(*machinelearning.UpdateDataSourceInput) (*service.Request, *machinelearning.UpdateDataSourceOutput)
+	UpdateDataSourceRequest(*machinelearning.UpdateDataSourceInput) (*request.Request, *machinelearning.UpdateDataSourceOutput)
 
 	UpdateDataSource(*machinelearning.UpdateDataSourceInput) (*machinelearning.UpdateDataSourceOutput, error)
 
-	UpdateEvaluationRequest(*machinelearning.UpdateEvaluationInput) (*service.Request, *machinelearning.UpdateEvaluationOutput)
+	UpdateEvaluationRequest(*machinelearning.UpdateEvaluationInput) (*request.Request, *machinelearning.UpdateEvaluationOutput)
 
 	UpdateEvaluation(*machinelearning.UpdateEvaluationInput) (*machinelearning.UpdateEvaluationOutput, error)
 
-	UpdateMLModelRequest(*machinelearning.UpdateMLModelInput) (*service.Request, *machinelearning.UpdateMLModelOutput)
+	UpdateMLModelRequest(*machinelearning.UpdateMLModelInput) (*request.Request, *machinelearning.UpdateMLModelOutput)
 
 	UpdateMLModel(*machinelearning.UpdateMLModelInput) (*machinelearning.UpdateMLModelOutput, error)
 }

--- a/service/machinelearning/service.go
+++ b/service/machinelearning/service.go
@@ -5,7 +5,9 @@ package machinelearning
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -19,16 +21,18 @@ type MachineLearning struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new MachineLearning client.
 func New(config *aws.Config) *MachineLearning {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "machinelearning",
-		APIVersion:   "2014-12-12",
-		JSONVersion:  "1.1",
-		TargetPrefix: "AmazonML_20141212",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "machinelearning",
+			APIVersion:   "2014-12-12",
+			JSONVersion:  "1.1",
+			TargetPrefix: "AmazonML_20141212",
+		},
 	}
 	service.Initialize()
 
@@ -49,8 +53,8 @@ func New(config *aws.Config) *MachineLearning {
 
 // newRequest creates a new request for a MachineLearning operation and runs any
 // custom request initialization.
-func (c *MachineLearning) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *MachineLearning) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/mobileanalytics/api.go
+++ b/service/mobileanalytics/api.go
@@ -5,14 +5,14 @@ package mobileanalytics
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opPutEvents = "PutEvents"
 
 // PutEventsRequest generates a request for the PutEvents operation.
-func (c *MobileAnalytics) PutEventsRequest(input *PutEventsInput) (req *service.Request, output *PutEventsOutput) {
-	op := &service.Operation{
+func (c *MobileAnalytics) PutEventsRequest(input *PutEventsInput) (req *request.Request, output *PutEventsOutput) {
+	op := &request.Operation{
 		Name:       opPutEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2014-06-05/events",

--- a/service/mobileanalytics/mobileanalyticsiface/interface.go
+++ b/service/mobileanalytics/mobileanalyticsiface/interface.go
@@ -4,13 +4,13 @@
 package mobileanalyticsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/mobileanalytics"
 )
 
 // MobileAnalyticsAPI is the interface type for mobileanalytics.MobileAnalytics.
 type MobileAnalyticsAPI interface {
-	PutEventsRequest(*mobileanalytics.PutEventsInput) (*service.Request, *mobileanalytics.PutEventsOutput)
+	PutEventsRequest(*mobileanalytics.PutEventsInput) (*request.Request, *mobileanalytics.PutEventsOutput)
 
 	PutEvents(*mobileanalytics.PutEventsInput) (*mobileanalytics.PutEventsOutput, error)
 }

--- a/service/mobileanalytics/service.go
+++ b/service/mobileanalytics/service.go
@@ -5,7 +5,9 @@ package mobileanalytics
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restjson"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -20,14 +22,16 @@ type MobileAnalytics struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new MobileAnalytics client.
 func New(config *aws.Config) *MobileAnalytics {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "mobileanalytics",
-		APIVersion:  "2014-06-05",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "mobileanalytics",
+			APIVersion:  "2014-06-05",
+		},
 	}
 	service.Initialize()
 
@@ -48,8 +52,8 @@ func New(config *aws.Config) *MobileAnalytics {
 
 // newRequest creates a new request for a MobileAnalytics operation and runs any
 // custom request initialization.
-func (c *MobileAnalytics) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *MobileAnalytics) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/opsworks/api.go
+++ b/service/opsworks/api.go
@@ -5,14 +5,14 @@ package opsworks
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAssignInstance = "AssignInstance"
 
 // AssignInstanceRequest generates a request for the AssignInstance operation.
-func (c *OpsWorks) AssignInstanceRequest(input *AssignInstanceInput) (req *service.Request, output *AssignInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) AssignInstanceRequest(input *AssignInstanceInput) (req *request.Request, output *AssignInstanceOutput) {
+	op := &request.Operation{
 		Name:       opAssignInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -46,8 +46,8 @@ func (c *OpsWorks) AssignInstance(input *AssignInstanceInput) (*AssignInstanceOu
 const opAssignVolume = "AssignVolume"
 
 // AssignVolumeRequest generates a request for the AssignVolume operation.
-func (c *OpsWorks) AssignVolumeRequest(input *AssignVolumeInput) (req *service.Request, output *AssignVolumeOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) AssignVolumeRequest(input *AssignVolumeInput) (req *request.Request, output *AssignVolumeOutput) {
+	op := &request.Operation{
 		Name:       opAssignVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -82,8 +82,8 @@ func (c *OpsWorks) AssignVolume(input *AssignVolumeInput) (*AssignVolumeOutput, 
 const opAssociateElasticIp = "AssociateElasticIp"
 
 // AssociateElasticIpRequest generates a request for the AssociateElasticIp operation.
-func (c *OpsWorks) AssociateElasticIpRequest(input *AssociateElasticIpInput) (req *service.Request, output *AssociateElasticIpOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) AssociateElasticIpRequest(input *AssociateElasticIpInput) (req *request.Request, output *AssociateElasticIpOutput) {
+	op := &request.Operation{
 		Name:       opAssociateElasticIp,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -116,8 +116,8 @@ func (c *OpsWorks) AssociateElasticIp(input *AssociateElasticIpInput) (*Associat
 const opAttachElasticLoadBalancer = "AttachElasticLoadBalancer"
 
 // AttachElasticLoadBalancerRequest generates a request for the AttachElasticLoadBalancer operation.
-func (c *OpsWorks) AttachElasticLoadBalancerRequest(input *AttachElasticLoadBalancerInput) (req *service.Request, output *AttachElasticLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) AttachElasticLoadBalancerRequest(input *AttachElasticLoadBalancerInput) (req *request.Request, output *AttachElasticLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opAttachElasticLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -153,8 +153,8 @@ func (c *OpsWorks) AttachElasticLoadBalancer(input *AttachElasticLoadBalancerInp
 const opCloneStack = "CloneStack"
 
 // CloneStackRequest generates a request for the CloneStack operation.
-func (c *OpsWorks) CloneStackRequest(input *CloneStackInput) (req *service.Request, output *CloneStackOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) CloneStackRequest(input *CloneStackInput) (req *request.Request, output *CloneStackOutput) {
+	op := &request.Operation{
 		Name:       opCloneStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -186,8 +186,8 @@ func (c *OpsWorks) CloneStack(input *CloneStackInput) (*CloneStackOutput, error)
 const opCreateApp = "CreateApp"
 
 // CreateAppRequest generates a request for the CreateApp operation.
-func (c *OpsWorks) CreateAppRequest(input *CreateAppInput) (req *service.Request, output *CreateAppOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) CreateAppRequest(input *CreateAppInput) (req *request.Request, output *CreateAppOutput) {
+	op := &request.Operation{
 		Name:       opCreateApp,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -219,8 +219,8 @@ func (c *OpsWorks) CreateApp(input *CreateAppInput) (*CreateAppOutput, error) {
 const opCreateDeployment = "CreateDeployment"
 
 // CreateDeploymentRequest generates a request for the CreateDeployment operation.
-func (c *OpsWorks) CreateDeploymentRequest(input *CreateDeploymentInput) (req *service.Request, output *CreateDeploymentOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) CreateDeploymentRequest(input *CreateDeploymentInput) (req *request.Request, output *CreateDeploymentOutput) {
+	op := &request.Operation{
 		Name:       opCreateDeployment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -253,8 +253,8 @@ func (c *OpsWorks) CreateDeployment(input *CreateDeploymentInput) (*CreateDeploy
 const opCreateInstance = "CreateInstance"
 
 // CreateInstanceRequest generates a request for the CreateInstance operation.
-func (c *OpsWorks) CreateInstanceRequest(input *CreateInstanceInput) (req *service.Request, output *CreateInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) CreateInstanceRequest(input *CreateInstanceInput) (req *request.Request, output *CreateInstanceOutput) {
+	op := &request.Operation{
 		Name:       opCreateInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -286,8 +286,8 @@ func (c *OpsWorks) CreateInstance(input *CreateInstanceInput) (*CreateInstanceOu
 const opCreateLayer = "CreateLayer"
 
 // CreateLayerRequest generates a request for the CreateLayer operation.
-func (c *OpsWorks) CreateLayerRequest(input *CreateLayerInput) (req *service.Request, output *CreateLayerOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) CreateLayerRequest(input *CreateLayerInput) (req *request.Request, output *CreateLayerOutput) {
+	op := &request.Operation{
 		Name:       opCreateLayer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -325,8 +325,8 @@ func (c *OpsWorks) CreateLayer(input *CreateLayerInput) (*CreateLayerOutput, err
 const opCreateStack = "CreateStack"
 
 // CreateStackRequest generates a request for the CreateStack operation.
-func (c *OpsWorks) CreateStackRequest(input *CreateStackInput) (req *service.Request, output *CreateStackOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) CreateStackRequest(input *CreateStackInput) (req *request.Request, output *CreateStackOutput) {
+	op := &request.Operation{
 		Name:       opCreateStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -356,8 +356,8 @@ func (c *OpsWorks) CreateStack(input *CreateStackInput) (*CreateStackOutput, err
 const opCreateUserProfile = "CreateUserProfile"
 
 // CreateUserProfileRequest generates a request for the CreateUserProfile operation.
-func (c *OpsWorks) CreateUserProfileRequest(input *CreateUserProfileInput) (req *service.Request, output *CreateUserProfileOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) CreateUserProfileRequest(input *CreateUserProfileInput) (req *request.Request, output *CreateUserProfileOutput) {
+	op := &request.Operation{
 		Name:       opCreateUserProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -387,8 +387,8 @@ func (c *OpsWorks) CreateUserProfile(input *CreateUserProfileInput) (*CreateUser
 const opDeleteApp = "DeleteApp"
 
 // DeleteAppRequest generates a request for the DeleteApp operation.
-func (c *OpsWorks) DeleteAppRequest(input *DeleteAppInput) (req *service.Request, output *DeleteAppOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeleteAppRequest(input *DeleteAppInput) (req *request.Request, output *DeleteAppOutput) {
+	op := &request.Operation{
 		Name:       opDeleteApp,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -419,8 +419,8 @@ func (c *OpsWorks) DeleteApp(input *DeleteAppInput) (*DeleteAppOutput, error) {
 const opDeleteInstance = "DeleteInstance"
 
 // DeleteInstanceRequest generates a request for the DeleteInstance operation.
-func (c *OpsWorks) DeleteInstanceRequest(input *DeleteInstanceInput) (req *service.Request, output *DeleteInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeleteInstanceRequest(input *DeleteInstanceInput) (req *request.Request, output *DeleteInstanceOutput) {
+	op := &request.Operation{
 		Name:       opDeleteInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -454,8 +454,8 @@ func (c *OpsWorks) DeleteInstance(input *DeleteInstanceInput) (*DeleteInstanceOu
 const opDeleteLayer = "DeleteLayer"
 
 // DeleteLayerRequest generates a request for the DeleteLayer operation.
-func (c *OpsWorks) DeleteLayerRequest(input *DeleteLayerInput) (req *service.Request, output *DeleteLayerOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeleteLayerRequest(input *DeleteLayerInput) (req *request.Request, output *DeleteLayerOutput) {
+	op := &request.Operation{
 		Name:       opDeleteLayer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -488,8 +488,8 @@ func (c *OpsWorks) DeleteLayer(input *DeleteLayerInput) (*DeleteLayerOutput, err
 const opDeleteStack = "DeleteStack"
 
 // DeleteStackRequest generates a request for the DeleteStack operation.
-func (c *OpsWorks) DeleteStackRequest(input *DeleteStackInput) (req *service.Request, output *DeleteStackOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeleteStackRequest(input *DeleteStackInput) (req *request.Request, output *DeleteStackOutput) {
+	op := &request.Operation{
 		Name:       opDeleteStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -522,8 +522,8 @@ func (c *OpsWorks) DeleteStack(input *DeleteStackInput) (*DeleteStackOutput, err
 const opDeleteUserProfile = "DeleteUserProfile"
 
 // DeleteUserProfileRequest generates a request for the DeleteUserProfile operation.
-func (c *OpsWorks) DeleteUserProfileRequest(input *DeleteUserProfileInput) (req *service.Request, output *DeleteUserProfileOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeleteUserProfileRequest(input *DeleteUserProfileInput) (req *request.Request, output *DeleteUserProfileOutput) {
+	op := &request.Operation{
 		Name:       opDeleteUserProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -553,8 +553,8 @@ func (c *OpsWorks) DeleteUserProfile(input *DeleteUserProfileInput) (*DeleteUser
 const opDeregisterEcsCluster = "DeregisterEcsCluster"
 
 // DeregisterEcsClusterRequest generates a request for the DeregisterEcsCluster operation.
-func (c *OpsWorks) DeregisterEcsClusterRequest(input *DeregisterEcsClusterInput) (req *service.Request, output *DeregisterEcsClusterOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeregisterEcsClusterRequest(input *DeregisterEcsClusterInput) (req *request.Request, output *DeregisterEcsClusterOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterEcsCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -585,8 +585,8 @@ func (c *OpsWorks) DeregisterEcsCluster(input *DeregisterEcsClusterInput) (*Dere
 const opDeregisterElasticIp = "DeregisterElasticIp"
 
 // DeregisterElasticIpRequest generates a request for the DeregisterElasticIp operation.
-func (c *OpsWorks) DeregisterElasticIpRequest(input *DeregisterElasticIpInput) (req *service.Request, output *DeregisterElasticIpOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeregisterElasticIpRequest(input *DeregisterElasticIpInput) (req *request.Request, output *DeregisterElasticIpOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterElasticIp,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -618,8 +618,8 @@ func (c *OpsWorks) DeregisterElasticIp(input *DeregisterElasticIpInput) (*Deregi
 const opDeregisterInstance = "DeregisterInstance"
 
 // DeregisterInstanceRequest generates a request for the DeregisterInstance operation.
-func (c *OpsWorks) DeregisterInstanceRequest(input *DeregisterInstanceInput) (req *service.Request, output *DeregisterInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeregisterInstanceRequest(input *DeregisterInstanceInput) (req *request.Request, output *DeregisterInstanceOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -652,8 +652,8 @@ func (c *OpsWorks) DeregisterInstance(input *DeregisterInstanceInput) (*Deregist
 const opDeregisterRdsDbInstance = "DeregisterRdsDbInstance"
 
 // DeregisterRdsDbInstanceRequest generates a request for the DeregisterRdsDbInstance operation.
-func (c *OpsWorks) DeregisterRdsDbInstanceRequest(input *DeregisterRdsDbInstanceInput) (req *service.Request, output *DeregisterRdsDbInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeregisterRdsDbInstanceRequest(input *DeregisterRdsDbInstanceInput) (req *request.Request, output *DeregisterRdsDbInstanceOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterRdsDbInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -684,8 +684,8 @@ func (c *OpsWorks) DeregisterRdsDbInstance(input *DeregisterRdsDbInstanceInput) 
 const opDeregisterVolume = "DeregisterVolume"
 
 // DeregisterVolumeRequest generates a request for the DeregisterVolume operation.
-func (c *OpsWorks) DeregisterVolumeRequest(input *DeregisterVolumeInput) (req *service.Request, output *DeregisterVolumeOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DeregisterVolumeRequest(input *DeregisterVolumeInput) (req *request.Request, output *DeregisterVolumeOutput) {
+	op := &request.Operation{
 		Name:       opDeregisterVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -717,8 +717,8 @@ func (c *OpsWorks) DeregisterVolume(input *DeregisterVolumeInput) (*DeregisterVo
 const opDescribeAgentVersions = "DescribeAgentVersions"
 
 // DescribeAgentVersionsRequest generates a request for the DescribeAgentVersions operation.
-func (c *OpsWorks) DescribeAgentVersionsRequest(input *DescribeAgentVersionsInput) (req *service.Request, output *DescribeAgentVersionsOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeAgentVersionsRequest(input *DescribeAgentVersionsInput) (req *request.Request, output *DescribeAgentVersionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAgentVersions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -746,8 +746,8 @@ func (c *OpsWorks) DescribeAgentVersions(input *DescribeAgentVersionsInput) (*De
 const opDescribeApps = "DescribeApps"
 
 // DescribeAppsRequest generates a request for the DescribeApps operation.
-func (c *OpsWorks) DescribeAppsRequest(input *DescribeAppsInput) (req *service.Request, output *DescribeAppsOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeAppsRequest(input *DescribeAppsInput) (req *request.Request, output *DescribeAppsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeApps,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -780,8 +780,8 @@ func (c *OpsWorks) DescribeApps(input *DescribeAppsInput) (*DescribeAppsOutput, 
 const opDescribeCommands = "DescribeCommands"
 
 // DescribeCommandsRequest generates a request for the DescribeCommands operation.
-func (c *OpsWorks) DescribeCommandsRequest(input *DescribeCommandsInput) (req *service.Request, output *DescribeCommandsOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeCommandsRequest(input *DescribeCommandsInput) (req *request.Request, output *DescribeCommandsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCommands,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -814,8 +814,8 @@ func (c *OpsWorks) DescribeCommands(input *DescribeCommandsInput) (*DescribeComm
 const opDescribeDeployments = "DescribeDeployments"
 
 // DescribeDeploymentsRequest generates a request for the DescribeDeployments operation.
-func (c *OpsWorks) DescribeDeploymentsRequest(input *DescribeDeploymentsInput) (req *service.Request, output *DescribeDeploymentsOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeDeploymentsRequest(input *DescribeDeploymentsInput) (req *request.Request, output *DescribeDeploymentsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDeployments,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -848,8 +848,8 @@ func (c *OpsWorks) DescribeDeployments(input *DescribeDeploymentsInput) (*Descri
 const opDescribeEcsClusters = "DescribeEcsClusters"
 
 // DescribeEcsClustersRequest generates a request for the DescribeEcsClusters operation.
-func (c *OpsWorks) DescribeEcsClustersRequest(input *DescribeEcsClustersInput) (req *service.Request, output *DescribeEcsClustersOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeEcsClustersRequest(input *DescribeEcsClustersInput) (req *request.Request, output *DescribeEcsClustersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEcsClusters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -883,8 +883,8 @@ func (c *OpsWorks) DescribeEcsClusters(input *DescribeEcsClustersInput) (*Descri
 const opDescribeElasticIps = "DescribeElasticIps"
 
 // DescribeElasticIpsRequest generates a request for the DescribeElasticIps operation.
-func (c *OpsWorks) DescribeElasticIpsRequest(input *DescribeElasticIpsInput) (req *service.Request, output *DescribeElasticIpsOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeElasticIpsRequest(input *DescribeElasticIpsInput) (req *request.Request, output *DescribeElasticIpsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeElasticIps,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -917,8 +917,8 @@ func (c *OpsWorks) DescribeElasticIps(input *DescribeElasticIpsInput) (*Describe
 const opDescribeElasticLoadBalancers = "DescribeElasticLoadBalancers"
 
 // DescribeElasticLoadBalancersRequest generates a request for the DescribeElasticLoadBalancers operation.
-func (c *OpsWorks) DescribeElasticLoadBalancersRequest(input *DescribeElasticLoadBalancersInput) (req *service.Request, output *DescribeElasticLoadBalancersOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeElasticLoadBalancersRequest(input *DescribeElasticLoadBalancersInput) (req *request.Request, output *DescribeElasticLoadBalancersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeElasticLoadBalancers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -951,8 +951,8 @@ func (c *OpsWorks) DescribeElasticLoadBalancers(input *DescribeElasticLoadBalanc
 const opDescribeInstances = "DescribeInstances"
 
 // DescribeInstancesRequest generates a request for the DescribeInstances operation.
-func (c *OpsWorks) DescribeInstancesRequest(input *DescribeInstancesInput) (req *service.Request, output *DescribeInstancesOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeInstancesRequest(input *DescribeInstancesInput) (req *request.Request, output *DescribeInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -985,8 +985,8 @@ func (c *OpsWorks) DescribeInstances(input *DescribeInstancesInput) (*DescribeIn
 const opDescribeLayers = "DescribeLayers"
 
 // DescribeLayersRequest generates a request for the DescribeLayers operation.
-func (c *OpsWorks) DescribeLayersRequest(input *DescribeLayersInput) (req *service.Request, output *DescribeLayersOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeLayersRequest(input *DescribeLayersInput) (req *request.Request, output *DescribeLayersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLayers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1019,8 +1019,8 @@ func (c *OpsWorks) DescribeLayers(input *DescribeLayersInput) (*DescribeLayersOu
 const opDescribeLoadBasedAutoScaling = "DescribeLoadBasedAutoScaling"
 
 // DescribeLoadBasedAutoScalingRequest generates a request for the DescribeLoadBasedAutoScaling operation.
-func (c *OpsWorks) DescribeLoadBasedAutoScalingRequest(input *DescribeLoadBasedAutoScalingInput) (req *service.Request, output *DescribeLoadBasedAutoScalingOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeLoadBasedAutoScalingRequest(input *DescribeLoadBasedAutoScalingInput) (req *request.Request, output *DescribeLoadBasedAutoScalingOutput) {
+	op := &request.Operation{
 		Name:       opDescribeLoadBasedAutoScaling,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1053,8 +1053,8 @@ func (c *OpsWorks) DescribeLoadBasedAutoScaling(input *DescribeLoadBasedAutoScal
 const opDescribeMyUserProfile = "DescribeMyUserProfile"
 
 // DescribeMyUserProfileRequest generates a request for the DescribeMyUserProfile operation.
-func (c *OpsWorks) DescribeMyUserProfileRequest(input *DescribeMyUserProfileInput) (req *service.Request, output *DescribeMyUserProfileOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeMyUserProfileRequest(input *DescribeMyUserProfileInput) (req *request.Request, output *DescribeMyUserProfileOutput) {
+	op := &request.Operation{
 		Name:       opDescribeMyUserProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1084,8 +1084,8 @@ func (c *OpsWorks) DescribeMyUserProfile(input *DescribeMyUserProfileInput) (*De
 const opDescribePermissions = "DescribePermissions"
 
 // DescribePermissionsRequest generates a request for the DescribePermissions operation.
-func (c *OpsWorks) DescribePermissionsRequest(input *DescribePermissionsInput) (req *service.Request, output *DescribePermissionsOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribePermissionsRequest(input *DescribePermissionsInput) (req *request.Request, output *DescribePermissionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribePermissions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1116,8 +1116,8 @@ func (c *OpsWorks) DescribePermissions(input *DescribePermissionsInput) (*Descri
 const opDescribeRaidArrays = "DescribeRaidArrays"
 
 // DescribeRaidArraysRequest generates a request for the DescribeRaidArrays operation.
-func (c *OpsWorks) DescribeRaidArraysRequest(input *DescribeRaidArraysInput) (req *service.Request, output *DescribeRaidArraysOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeRaidArraysRequest(input *DescribeRaidArraysInput) (req *request.Request, output *DescribeRaidArraysOutput) {
+	op := &request.Operation{
 		Name:       opDescribeRaidArrays,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1150,8 +1150,8 @@ func (c *OpsWorks) DescribeRaidArrays(input *DescribeRaidArraysInput) (*Describe
 const opDescribeRdsDbInstances = "DescribeRdsDbInstances"
 
 // DescribeRdsDbInstancesRequest generates a request for the DescribeRdsDbInstances operation.
-func (c *OpsWorks) DescribeRdsDbInstancesRequest(input *DescribeRdsDbInstancesInput) (req *service.Request, output *DescribeRdsDbInstancesOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeRdsDbInstancesRequest(input *DescribeRdsDbInstancesInput) (req *request.Request, output *DescribeRdsDbInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeRdsDbInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1182,8 +1182,8 @@ func (c *OpsWorks) DescribeRdsDbInstances(input *DescribeRdsDbInstancesInput) (*
 const opDescribeServiceErrors = "DescribeServiceErrors"
 
 // DescribeServiceErrorsRequest generates a request for the DescribeServiceErrors operation.
-func (c *OpsWorks) DescribeServiceErrorsRequest(input *DescribeServiceErrorsInput) (req *service.Request, output *DescribeServiceErrorsOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeServiceErrorsRequest(input *DescribeServiceErrorsInput) (req *request.Request, output *DescribeServiceErrorsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeServiceErrors,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1214,8 +1214,8 @@ func (c *OpsWorks) DescribeServiceErrors(input *DescribeServiceErrorsInput) (*De
 const opDescribeStackProvisioningParameters = "DescribeStackProvisioningParameters"
 
 // DescribeStackProvisioningParametersRequest generates a request for the DescribeStackProvisioningParameters operation.
-func (c *OpsWorks) DescribeStackProvisioningParametersRequest(input *DescribeStackProvisioningParametersInput) (req *service.Request, output *DescribeStackProvisioningParametersOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeStackProvisioningParametersRequest(input *DescribeStackProvisioningParametersInput) (req *request.Request, output *DescribeStackProvisioningParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStackProvisioningParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1246,8 +1246,8 @@ func (c *OpsWorks) DescribeStackProvisioningParameters(input *DescribeStackProvi
 const opDescribeStackSummary = "DescribeStackSummary"
 
 // DescribeStackSummaryRequest generates a request for the DescribeStackSummary operation.
-func (c *OpsWorks) DescribeStackSummaryRequest(input *DescribeStackSummaryInput) (req *service.Request, output *DescribeStackSummaryOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeStackSummaryRequest(input *DescribeStackSummaryInput) (req *request.Request, output *DescribeStackSummaryOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStackSummary,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1279,8 +1279,8 @@ func (c *OpsWorks) DescribeStackSummary(input *DescribeStackSummaryInput) (*Desc
 const opDescribeStacks = "DescribeStacks"
 
 // DescribeStacksRequest generates a request for the DescribeStacks operation.
-func (c *OpsWorks) DescribeStacksRequest(input *DescribeStacksInput) (req *service.Request, output *DescribeStacksOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeStacksRequest(input *DescribeStacksInput) (req *request.Request, output *DescribeStacksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStacks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1311,8 +1311,8 @@ func (c *OpsWorks) DescribeStacks(input *DescribeStacksInput) (*DescribeStacksOu
 const opDescribeTimeBasedAutoScaling = "DescribeTimeBasedAutoScaling"
 
 // DescribeTimeBasedAutoScalingRequest generates a request for the DescribeTimeBasedAutoScaling operation.
-func (c *OpsWorks) DescribeTimeBasedAutoScalingRequest(input *DescribeTimeBasedAutoScalingInput) (req *service.Request, output *DescribeTimeBasedAutoScalingOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeTimeBasedAutoScalingRequest(input *DescribeTimeBasedAutoScalingInput) (req *request.Request, output *DescribeTimeBasedAutoScalingOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTimeBasedAutoScaling,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1345,8 +1345,8 @@ func (c *OpsWorks) DescribeTimeBasedAutoScaling(input *DescribeTimeBasedAutoScal
 const opDescribeUserProfiles = "DescribeUserProfiles"
 
 // DescribeUserProfilesRequest generates a request for the DescribeUserProfiles operation.
-func (c *OpsWorks) DescribeUserProfilesRequest(input *DescribeUserProfilesInput) (req *service.Request, output *DescribeUserProfilesOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeUserProfilesRequest(input *DescribeUserProfilesInput) (req *request.Request, output *DescribeUserProfilesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeUserProfiles,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1376,8 +1376,8 @@ func (c *OpsWorks) DescribeUserProfiles(input *DescribeUserProfilesInput) (*Desc
 const opDescribeVolumes = "DescribeVolumes"
 
 // DescribeVolumesRequest generates a request for the DescribeVolumes operation.
-func (c *OpsWorks) DescribeVolumesRequest(input *DescribeVolumesInput) (req *service.Request, output *DescribeVolumesOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DescribeVolumesRequest(input *DescribeVolumesInput) (req *request.Request, output *DescribeVolumesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVolumes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1410,8 +1410,8 @@ func (c *OpsWorks) DescribeVolumes(input *DescribeVolumesInput) (*DescribeVolume
 const opDetachElasticLoadBalancer = "DetachElasticLoadBalancer"
 
 // DetachElasticLoadBalancerRequest generates a request for the DetachElasticLoadBalancer operation.
-func (c *OpsWorks) DetachElasticLoadBalancerRequest(input *DetachElasticLoadBalancerInput) (req *service.Request, output *DetachElasticLoadBalancerOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DetachElasticLoadBalancerRequest(input *DetachElasticLoadBalancerInput) (req *request.Request, output *DetachElasticLoadBalancerOutput) {
+	op := &request.Operation{
 		Name:       opDetachElasticLoadBalancer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1442,8 +1442,8 @@ func (c *OpsWorks) DetachElasticLoadBalancer(input *DetachElasticLoadBalancerInp
 const opDisassociateElasticIp = "DisassociateElasticIp"
 
 // DisassociateElasticIpRequest generates a request for the DisassociateElasticIp operation.
-func (c *OpsWorks) DisassociateElasticIpRequest(input *DisassociateElasticIpInput) (req *service.Request, output *DisassociateElasticIpOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) DisassociateElasticIpRequest(input *DisassociateElasticIpInput) (req *request.Request, output *DisassociateElasticIpOutput) {
+	op := &request.Operation{
 		Name:       opDisassociateElasticIp,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1476,8 +1476,8 @@ func (c *OpsWorks) DisassociateElasticIp(input *DisassociateElasticIpInput) (*Di
 const opGetHostnameSuggestion = "GetHostnameSuggestion"
 
 // GetHostnameSuggestionRequest generates a request for the GetHostnameSuggestion operation.
-func (c *OpsWorks) GetHostnameSuggestionRequest(input *GetHostnameSuggestionInput) (req *service.Request, output *GetHostnameSuggestionOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) GetHostnameSuggestionRequest(input *GetHostnameSuggestionInput) (req *request.Request, output *GetHostnameSuggestionOutput) {
+	op := &request.Operation{
 		Name:       opGetHostnameSuggestion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1509,8 +1509,8 @@ func (c *OpsWorks) GetHostnameSuggestion(input *GetHostnameSuggestionInput) (*Ge
 const opGrantAccess = "GrantAccess"
 
 // GrantAccessRequest generates a request for the GrantAccess operation.
-func (c *OpsWorks) GrantAccessRequest(input *GrantAccessInput) (req *service.Request, output *GrantAccessOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) GrantAccessRequest(input *GrantAccessInput) (req *request.Request, output *GrantAccessOutput) {
+	op := &request.Operation{
 		Name:       opGrantAccess,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1537,8 +1537,8 @@ func (c *OpsWorks) GrantAccess(input *GrantAccessInput) (*GrantAccessOutput, err
 const opRebootInstance = "RebootInstance"
 
 // RebootInstanceRequest generates a request for the RebootInstance operation.
-func (c *OpsWorks) RebootInstanceRequest(input *RebootInstanceInput) (req *service.Request, output *RebootInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) RebootInstanceRequest(input *RebootInstanceInput) (req *request.Request, output *RebootInstanceOutput) {
+	op := &request.Operation{
 		Name:       opRebootInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1570,8 +1570,8 @@ func (c *OpsWorks) RebootInstance(input *RebootInstanceInput) (*RebootInstanceOu
 const opRegisterEcsCluster = "RegisterEcsCluster"
 
 // RegisterEcsClusterRequest generates a request for the RegisterEcsCluster operation.
-func (c *OpsWorks) RegisterEcsClusterRequest(input *RegisterEcsClusterInput) (req *service.Request, output *RegisterEcsClusterOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) RegisterEcsClusterRequest(input *RegisterEcsClusterInput) (req *request.Request, output *RegisterEcsClusterOutput) {
+	op := &request.Operation{
 		Name:       opRegisterEcsCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1604,8 +1604,8 @@ func (c *OpsWorks) RegisterEcsCluster(input *RegisterEcsClusterInput) (*Register
 const opRegisterElasticIp = "RegisterElasticIp"
 
 // RegisterElasticIpRequest generates a request for the RegisterElasticIp operation.
-func (c *OpsWorks) RegisterElasticIpRequest(input *RegisterElasticIpInput) (req *service.Request, output *RegisterElasticIpOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) RegisterElasticIpRequest(input *RegisterElasticIpInput) (req *request.Request, output *RegisterElasticIpOutput) {
+	op := &request.Operation{
 		Name:       opRegisterElasticIp,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1639,8 +1639,8 @@ func (c *OpsWorks) RegisterElasticIp(input *RegisterElasticIpInput) (*RegisterEl
 const opRegisterInstance = "RegisterInstance"
 
 // RegisterInstanceRequest generates a request for the RegisterInstance operation.
-func (c *OpsWorks) RegisterInstanceRequest(input *RegisterInstanceInput) (req *service.Request, output *RegisterInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) RegisterInstanceRequest(input *RegisterInstanceInput) (req *request.Request, output *RegisterInstanceOutput) {
+	op := &request.Operation{
 		Name:       opRegisterInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1678,8 +1678,8 @@ func (c *OpsWorks) RegisterInstance(input *RegisterInstanceInput) (*RegisterInst
 const opRegisterRdsDbInstance = "RegisterRdsDbInstance"
 
 // RegisterRdsDbInstanceRequest generates a request for the RegisterRdsDbInstance operation.
-func (c *OpsWorks) RegisterRdsDbInstanceRequest(input *RegisterRdsDbInstanceInput) (req *service.Request, output *RegisterRdsDbInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) RegisterRdsDbInstanceRequest(input *RegisterRdsDbInstanceInput) (req *request.Request, output *RegisterRdsDbInstanceOutput) {
+	op := &request.Operation{
 		Name:       opRegisterRdsDbInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1710,8 +1710,8 @@ func (c *OpsWorks) RegisterRdsDbInstance(input *RegisterRdsDbInstanceInput) (*Re
 const opRegisterVolume = "RegisterVolume"
 
 // RegisterVolumeRequest generates a request for the RegisterVolume operation.
-func (c *OpsWorks) RegisterVolumeRequest(input *RegisterVolumeInput) (req *service.Request, output *RegisterVolumeOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) RegisterVolumeRequest(input *RegisterVolumeInput) (req *request.Request, output *RegisterVolumeOutput) {
+	op := &request.Operation{
 		Name:       opRegisterVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1745,8 +1745,8 @@ func (c *OpsWorks) RegisterVolume(input *RegisterVolumeInput) (*RegisterVolumeOu
 const opSetLoadBasedAutoScaling = "SetLoadBasedAutoScaling"
 
 // SetLoadBasedAutoScalingRequest generates a request for the SetLoadBasedAutoScaling operation.
-func (c *OpsWorks) SetLoadBasedAutoScalingRequest(input *SetLoadBasedAutoScalingInput) (req *service.Request, output *SetLoadBasedAutoScalingOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) SetLoadBasedAutoScalingRequest(input *SetLoadBasedAutoScalingInput) (req *request.Request, output *SetLoadBasedAutoScalingOutput) {
+	op := &request.Operation{
 		Name:       opSetLoadBasedAutoScaling,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1784,8 +1784,8 @@ func (c *OpsWorks) SetLoadBasedAutoScaling(input *SetLoadBasedAutoScalingInput) 
 const opSetPermission = "SetPermission"
 
 // SetPermissionRequest generates a request for the SetPermission operation.
-func (c *OpsWorks) SetPermissionRequest(input *SetPermissionInput) (req *service.Request, output *SetPermissionOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) SetPermissionRequest(input *SetPermissionInput) (req *request.Request, output *SetPermissionOutput) {
+	op := &request.Operation{
 		Name:       opSetPermission,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1817,8 +1817,8 @@ func (c *OpsWorks) SetPermission(input *SetPermissionInput) (*SetPermissionOutpu
 const opSetTimeBasedAutoScaling = "SetTimeBasedAutoScaling"
 
 // SetTimeBasedAutoScalingRequest generates a request for the SetTimeBasedAutoScaling operation.
-func (c *OpsWorks) SetTimeBasedAutoScalingRequest(input *SetTimeBasedAutoScalingInput) (req *service.Request, output *SetTimeBasedAutoScalingOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) SetTimeBasedAutoScalingRequest(input *SetTimeBasedAutoScalingInput) (req *request.Request, output *SetTimeBasedAutoScalingOutput) {
+	op := &request.Operation{
 		Name:       opSetTimeBasedAutoScaling,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1851,8 +1851,8 @@ func (c *OpsWorks) SetTimeBasedAutoScaling(input *SetTimeBasedAutoScalingInput) 
 const opStartInstance = "StartInstance"
 
 // StartInstanceRequest generates a request for the StartInstance operation.
-func (c *OpsWorks) StartInstanceRequest(input *StartInstanceInput) (req *service.Request, output *StartInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) StartInstanceRequest(input *StartInstanceInput) (req *request.Request, output *StartInstanceOutput) {
+	op := &request.Operation{
 		Name:       opStartInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1884,8 +1884,8 @@ func (c *OpsWorks) StartInstance(input *StartInstanceInput) (*StartInstanceOutpu
 const opStartStack = "StartStack"
 
 // StartStackRequest generates a request for the StartStack operation.
-func (c *OpsWorks) StartStackRequest(input *StartStackInput) (req *service.Request, output *StartStackOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) StartStackRequest(input *StartStackInput) (req *request.Request, output *StartStackOutput) {
+	op := &request.Operation{
 		Name:       opStartStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1916,8 +1916,8 @@ func (c *OpsWorks) StartStack(input *StartStackInput) (*StartStackOutput, error)
 const opStopInstance = "StopInstance"
 
 // StopInstanceRequest generates a request for the StopInstance operation.
-func (c *OpsWorks) StopInstanceRequest(input *StopInstanceInput) (req *service.Request, output *StopInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) StopInstanceRequest(input *StopInstanceInput) (req *request.Request, output *StopInstanceOutput) {
+	op := &request.Operation{
 		Name:       opStopInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1951,8 +1951,8 @@ func (c *OpsWorks) StopInstance(input *StopInstanceInput) (*StopInstanceOutput, 
 const opStopStack = "StopStack"
 
 // StopStackRequest generates a request for the StopStack operation.
-func (c *OpsWorks) StopStackRequest(input *StopStackInput) (req *service.Request, output *StopStackOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) StopStackRequest(input *StopStackInput) (req *request.Request, output *StopStackOutput) {
+	op := &request.Operation{
 		Name:       opStopStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1983,8 +1983,8 @@ func (c *OpsWorks) StopStack(input *StopStackInput) (*StopStackOutput, error) {
 const opUnassignInstance = "UnassignInstance"
 
 // UnassignInstanceRequest generates a request for the UnassignInstance operation.
-func (c *OpsWorks) UnassignInstanceRequest(input *UnassignInstanceInput) (req *service.Request, output *UnassignInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UnassignInstanceRequest(input *UnassignInstanceInput) (req *request.Request, output *UnassignInstanceOutput) {
+	op := &request.Operation{
 		Name:       opUnassignInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2018,8 +2018,8 @@ func (c *OpsWorks) UnassignInstance(input *UnassignInstanceInput) (*UnassignInst
 const opUnassignVolume = "UnassignVolume"
 
 // UnassignVolumeRequest generates a request for the UnassignVolume operation.
-func (c *OpsWorks) UnassignVolumeRequest(input *UnassignVolumeInput) (req *service.Request, output *UnassignVolumeOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UnassignVolumeRequest(input *UnassignVolumeInput) (req *request.Request, output *UnassignVolumeOutput) {
+	op := &request.Operation{
 		Name:       opUnassignVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2051,8 +2051,8 @@ func (c *OpsWorks) UnassignVolume(input *UnassignVolumeInput) (*UnassignVolumeOu
 const opUpdateApp = "UpdateApp"
 
 // UpdateAppRequest generates a request for the UpdateApp operation.
-func (c *OpsWorks) UpdateAppRequest(input *UpdateAppInput) (req *service.Request, output *UpdateAppOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateAppRequest(input *UpdateAppInput) (req *request.Request, output *UpdateAppOutput) {
+	op := &request.Operation{
 		Name:       opUpdateApp,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2083,8 +2083,8 @@ func (c *OpsWorks) UpdateApp(input *UpdateAppInput) (*UpdateAppOutput, error) {
 const opUpdateElasticIp = "UpdateElasticIp"
 
 // UpdateElasticIpRequest generates a request for the UpdateElasticIp operation.
-func (c *OpsWorks) UpdateElasticIpRequest(input *UpdateElasticIpInput) (req *service.Request, output *UpdateElasticIpOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateElasticIpRequest(input *UpdateElasticIpInput) (req *request.Request, output *UpdateElasticIpOutput) {
+	op := &request.Operation{
 		Name:       opUpdateElasticIp,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2116,8 +2116,8 @@ func (c *OpsWorks) UpdateElasticIp(input *UpdateElasticIpInput) (*UpdateElasticI
 const opUpdateInstance = "UpdateInstance"
 
 // UpdateInstanceRequest generates a request for the UpdateInstance operation.
-func (c *OpsWorks) UpdateInstanceRequest(input *UpdateInstanceInput) (req *service.Request, output *UpdateInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateInstanceRequest(input *UpdateInstanceInput) (req *request.Request, output *UpdateInstanceOutput) {
+	op := &request.Operation{
 		Name:       opUpdateInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2148,8 +2148,8 @@ func (c *OpsWorks) UpdateInstance(input *UpdateInstanceInput) (*UpdateInstanceOu
 const opUpdateLayer = "UpdateLayer"
 
 // UpdateLayerRequest generates a request for the UpdateLayer operation.
-func (c *OpsWorks) UpdateLayerRequest(input *UpdateLayerInput) (req *service.Request, output *UpdateLayerOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateLayerRequest(input *UpdateLayerInput) (req *request.Request, output *UpdateLayerOutput) {
+	op := &request.Operation{
 		Name:       opUpdateLayer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2180,8 +2180,8 @@ func (c *OpsWorks) UpdateLayer(input *UpdateLayerInput) (*UpdateLayerOutput, err
 const opUpdateMyUserProfile = "UpdateMyUserProfile"
 
 // UpdateMyUserProfileRequest generates a request for the UpdateMyUserProfile operation.
-func (c *OpsWorks) UpdateMyUserProfileRequest(input *UpdateMyUserProfileInput) (req *service.Request, output *UpdateMyUserProfileOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateMyUserProfileRequest(input *UpdateMyUserProfileInput) (req *request.Request, output *UpdateMyUserProfileOutput) {
+	op := &request.Operation{
 		Name:       opUpdateMyUserProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2211,8 +2211,8 @@ func (c *OpsWorks) UpdateMyUserProfile(input *UpdateMyUserProfileInput) (*Update
 const opUpdateRdsDbInstance = "UpdateRdsDbInstance"
 
 // UpdateRdsDbInstanceRequest generates a request for the UpdateRdsDbInstance operation.
-func (c *OpsWorks) UpdateRdsDbInstanceRequest(input *UpdateRdsDbInstanceInput) (req *service.Request, output *UpdateRdsDbInstanceOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateRdsDbInstanceRequest(input *UpdateRdsDbInstanceInput) (req *request.Request, output *UpdateRdsDbInstanceOutput) {
+	op := &request.Operation{
 		Name:       opUpdateRdsDbInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2243,8 +2243,8 @@ func (c *OpsWorks) UpdateRdsDbInstance(input *UpdateRdsDbInstanceInput) (*Update
 const opUpdateStack = "UpdateStack"
 
 // UpdateStackRequest generates a request for the UpdateStack operation.
-func (c *OpsWorks) UpdateStackRequest(input *UpdateStackInput) (req *service.Request, output *UpdateStackOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateStackRequest(input *UpdateStackInput) (req *request.Request, output *UpdateStackOutput) {
+	op := &request.Operation{
 		Name:       opUpdateStack,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2275,8 +2275,8 @@ func (c *OpsWorks) UpdateStack(input *UpdateStackInput) (*UpdateStackOutput, err
 const opUpdateUserProfile = "UpdateUserProfile"
 
 // UpdateUserProfileRequest generates a request for the UpdateUserProfile operation.
-func (c *OpsWorks) UpdateUserProfileRequest(input *UpdateUserProfileInput) (req *service.Request, output *UpdateUserProfileOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateUserProfileRequest(input *UpdateUserProfileInput) (req *request.Request, output *UpdateUserProfileOutput) {
+	op := &request.Operation{
 		Name:       opUpdateUserProfile,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2306,8 +2306,8 @@ func (c *OpsWorks) UpdateUserProfile(input *UpdateUserProfileInput) (*UpdateUser
 const opUpdateVolume = "UpdateVolume"
 
 // UpdateVolumeRequest generates a request for the UpdateVolume operation.
-func (c *OpsWorks) UpdateVolumeRequest(input *UpdateVolumeInput) (req *service.Request, output *UpdateVolumeOutput) {
-	op := &service.Operation{
+func (c *OpsWorks) UpdateVolumeRequest(input *UpdateVolumeInput) (req *request.Request, output *UpdateVolumeOutput) {
+	op := &request.Operation{
 		Name:       opUpdateVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/opsworks/opsworksiface/interface.go
+++ b/service/opsworks/opsworksiface/interface.go
@@ -4,289 +4,289 @@
 package opsworksiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/opsworks"
 )
 
 // OpsWorksAPI is the interface type for opsworks.OpsWorks.
 type OpsWorksAPI interface {
-	AssignInstanceRequest(*opsworks.AssignInstanceInput) (*service.Request, *opsworks.AssignInstanceOutput)
+	AssignInstanceRequest(*opsworks.AssignInstanceInput) (*request.Request, *opsworks.AssignInstanceOutput)
 
 	AssignInstance(*opsworks.AssignInstanceInput) (*opsworks.AssignInstanceOutput, error)
 
-	AssignVolumeRequest(*opsworks.AssignVolumeInput) (*service.Request, *opsworks.AssignVolumeOutput)
+	AssignVolumeRequest(*opsworks.AssignVolumeInput) (*request.Request, *opsworks.AssignVolumeOutput)
 
 	AssignVolume(*opsworks.AssignVolumeInput) (*opsworks.AssignVolumeOutput, error)
 
-	AssociateElasticIpRequest(*opsworks.AssociateElasticIpInput) (*service.Request, *opsworks.AssociateElasticIpOutput)
+	AssociateElasticIpRequest(*opsworks.AssociateElasticIpInput) (*request.Request, *opsworks.AssociateElasticIpOutput)
 
 	AssociateElasticIp(*opsworks.AssociateElasticIpInput) (*opsworks.AssociateElasticIpOutput, error)
 
-	AttachElasticLoadBalancerRequest(*opsworks.AttachElasticLoadBalancerInput) (*service.Request, *opsworks.AttachElasticLoadBalancerOutput)
+	AttachElasticLoadBalancerRequest(*opsworks.AttachElasticLoadBalancerInput) (*request.Request, *opsworks.AttachElasticLoadBalancerOutput)
 
 	AttachElasticLoadBalancer(*opsworks.AttachElasticLoadBalancerInput) (*opsworks.AttachElasticLoadBalancerOutput, error)
 
-	CloneStackRequest(*opsworks.CloneStackInput) (*service.Request, *opsworks.CloneStackOutput)
+	CloneStackRequest(*opsworks.CloneStackInput) (*request.Request, *opsworks.CloneStackOutput)
 
 	CloneStack(*opsworks.CloneStackInput) (*opsworks.CloneStackOutput, error)
 
-	CreateAppRequest(*opsworks.CreateAppInput) (*service.Request, *opsworks.CreateAppOutput)
+	CreateAppRequest(*opsworks.CreateAppInput) (*request.Request, *opsworks.CreateAppOutput)
 
 	CreateApp(*opsworks.CreateAppInput) (*opsworks.CreateAppOutput, error)
 
-	CreateDeploymentRequest(*opsworks.CreateDeploymentInput) (*service.Request, *opsworks.CreateDeploymentOutput)
+	CreateDeploymentRequest(*opsworks.CreateDeploymentInput) (*request.Request, *opsworks.CreateDeploymentOutput)
 
 	CreateDeployment(*opsworks.CreateDeploymentInput) (*opsworks.CreateDeploymentOutput, error)
 
-	CreateInstanceRequest(*opsworks.CreateInstanceInput) (*service.Request, *opsworks.CreateInstanceOutput)
+	CreateInstanceRequest(*opsworks.CreateInstanceInput) (*request.Request, *opsworks.CreateInstanceOutput)
 
 	CreateInstance(*opsworks.CreateInstanceInput) (*opsworks.CreateInstanceOutput, error)
 
-	CreateLayerRequest(*opsworks.CreateLayerInput) (*service.Request, *opsworks.CreateLayerOutput)
+	CreateLayerRequest(*opsworks.CreateLayerInput) (*request.Request, *opsworks.CreateLayerOutput)
 
 	CreateLayer(*opsworks.CreateLayerInput) (*opsworks.CreateLayerOutput, error)
 
-	CreateStackRequest(*opsworks.CreateStackInput) (*service.Request, *opsworks.CreateStackOutput)
+	CreateStackRequest(*opsworks.CreateStackInput) (*request.Request, *opsworks.CreateStackOutput)
 
 	CreateStack(*opsworks.CreateStackInput) (*opsworks.CreateStackOutput, error)
 
-	CreateUserProfileRequest(*opsworks.CreateUserProfileInput) (*service.Request, *opsworks.CreateUserProfileOutput)
+	CreateUserProfileRequest(*opsworks.CreateUserProfileInput) (*request.Request, *opsworks.CreateUserProfileOutput)
 
 	CreateUserProfile(*opsworks.CreateUserProfileInput) (*opsworks.CreateUserProfileOutput, error)
 
-	DeleteAppRequest(*opsworks.DeleteAppInput) (*service.Request, *opsworks.DeleteAppOutput)
+	DeleteAppRequest(*opsworks.DeleteAppInput) (*request.Request, *opsworks.DeleteAppOutput)
 
 	DeleteApp(*opsworks.DeleteAppInput) (*opsworks.DeleteAppOutput, error)
 
-	DeleteInstanceRequest(*opsworks.DeleteInstanceInput) (*service.Request, *opsworks.DeleteInstanceOutput)
+	DeleteInstanceRequest(*opsworks.DeleteInstanceInput) (*request.Request, *opsworks.DeleteInstanceOutput)
 
 	DeleteInstance(*opsworks.DeleteInstanceInput) (*opsworks.DeleteInstanceOutput, error)
 
-	DeleteLayerRequest(*opsworks.DeleteLayerInput) (*service.Request, *opsworks.DeleteLayerOutput)
+	DeleteLayerRequest(*opsworks.DeleteLayerInput) (*request.Request, *opsworks.DeleteLayerOutput)
 
 	DeleteLayer(*opsworks.DeleteLayerInput) (*opsworks.DeleteLayerOutput, error)
 
-	DeleteStackRequest(*opsworks.DeleteStackInput) (*service.Request, *opsworks.DeleteStackOutput)
+	DeleteStackRequest(*opsworks.DeleteStackInput) (*request.Request, *opsworks.DeleteStackOutput)
 
 	DeleteStack(*opsworks.DeleteStackInput) (*opsworks.DeleteStackOutput, error)
 
-	DeleteUserProfileRequest(*opsworks.DeleteUserProfileInput) (*service.Request, *opsworks.DeleteUserProfileOutput)
+	DeleteUserProfileRequest(*opsworks.DeleteUserProfileInput) (*request.Request, *opsworks.DeleteUserProfileOutput)
 
 	DeleteUserProfile(*opsworks.DeleteUserProfileInput) (*opsworks.DeleteUserProfileOutput, error)
 
-	DeregisterEcsClusterRequest(*opsworks.DeregisterEcsClusterInput) (*service.Request, *opsworks.DeregisterEcsClusterOutput)
+	DeregisterEcsClusterRequest(*opsworks.DeregisterEcsClusterInput) (*request.Request, *opsworks.DeregisterEcsClusterOutput)
 
 	DeregisterEcsCluster(*opsworks.DeregisterEcsClusterInput) (*opsworks.DeregisterEcsClusterOutput, error)
 
-	DeregisterElasticIpRequest(*opsworks.DeregisterElasticIpInput) (*service.Request, *opsworks.DeregisterElasticIpOutput)
+	DeregisterElasticIpRequest(*opsworks.DeregisterElasticIpInput) (*request.Request, *opsworks.DeregisterElasticIpOutput)
 
 	DeregisterElasticIp(*opsworks.DeregisterElasticIpInput) (*opsworks.DeregisterElasticIpOutput, error)
 
-	DeregisterInstanceRequest(*opsworks.DeregisterInstanceInput) (*service.Request, *opsworks.DeregisterInstanceOutput)
+	DeregisterInstanceRequest(*opsworks.DeregisterInstanceInput) (*request.Request, *opsworks.DeregisterInstanceOutput)
 
 	DeregisterInstance(*opsworks.DeregisterInstanceInput) (*opsworks.DeregisterInstanceOutput, error)
 
-	DeregisterRdsDbInstanceRequest(*opsworks.DeregisterRdsDbInstanceInput) (*service.Request, *opsworks.DeregisterRdsDbInstanceOutput)
+	DeregisterRdsDbInstanceRequest(*opsworks.DeregisterRdsDbInstanceInput) (*request.Request, *opsworks.DeregisterRdsDbInstanceOutput)
 
 	DeregisterRdsDbInstance(*opsworks.DeregisterRdsDbInstanceInput) (*opsworks.DeregisterRdsDbInstanceOutput, error)
 
-	DeregisterVolumeRequest(*opsworks.DeregisterVolumeInput) (*service.Request, *opsworks.DeregisterVolumeOutput)
+	DeregisterVolumeRequest(*opsworks.DeregisterVolumeInput) (*request.Request, *opsworks.DeregisterVolumeOutput)
 
 	DeregisterVolume(*opsworks.DeregisterVolumeInput) (*opsworks.DeregisterVolumeOutput, error)
 
-	DescribeAgentVersionsRequest(*opsworks.DescribeAgentVersionsInput) (*service.Request, *opsworks.DescribeAgentVersionsOutput)
+	DescribeAgentVersionsRequest(*opsworks.DescribeAgentVersionsInput) (*request.Request, *opsworks.DescribeAgentVersionsOutput)
 
 	DescribeAgentVersions(*opsworks.DescribeAgentVersionsInput) (*opsworks.DescribeAgentVersionsOutput, error)
 
-	DescribeAppsRequest(*opsworks.DescribeAppsInput) (*service.Request, *opsworks.DescribeAppsOutput)
+	DescribeAppsRequest(*opsworks.DescribeAppsInput) (*request.Request, *opsworks.DescribeAppsOutput)
 
 	DescribeApps(*opsworks.DescribeAppsInput) (*opsworks.DescribeAppsOutput, error)
 
-	DescribeCommandsRequest(*opsworks.DescribeCommandsInput) (*service.Request, *opsworks.DescribeCommandsOutput)
+	DescribeCommandsRequest(*opsworks.DescribeCommandsInput) (*request.Request, *opsworks.DescribeCommandsOutput)
 
 	DescribeCommands(*opsworks.DescribeCommandsInput) (*opsworks.DescribeCommandsOutput, error)
 
-	DescribeDeploymentsRequest(*opsworks.DescribeDeploymentsInput) (*service.Request, *opsworks.DescribeDeploymentsOutput)
+	DescribeDeploymentsRequest(*opsworks.DescribeDeploymentsInput) (*request.Request, *opsworks.DescribeDeploymentsOutput)
 
 	DescribeDeployments(*opsworks.DescribeDeploymentsInput) (*opsworks.DescribeDeploymentsOutput, error)
 
-	DescribeEcsClustersRequest(*opsworks.DescribeEcsClustersInput) (*service.Request, *opsworks.DescribeEcsClustersOutput)
+	DescribeEcsClustersRequest(*opsworks.DescribeEcsClustersInput) (*request.Request, *opsworks.DescribeEcsClustersOutput)
 
 	DescribeEcsClusters(*opsworks.DescribeEcsClustersInput) (*opsworks.DescribeEcsClustersOutput, error)
 
-	DescribeElasticIpsRequest(*opsworks.DescribeElasticIpsInput) (*service.Request, *opsworks.DescribeElasticIpsOutput)
+	DescribeElasticIpsRequest(*opsworks.DescribeElasticIpsInput) (*request.Request, *opsworks.DescribeElasticIpsOutput)
 
 	DescribeElasticIps(*opsworks.DescribeElasticIpsInput) (*opsworks.DescribeElasticIpsOutput, error)
 
-	DescribeElasticLoadBalancersRequest(*opsworks.DescribeElasticLoadBalancersInput) (*service.Request, *opsworks.DescribeElasticLoadBalancersOutput)
+	DescribeElasticLoadBalancersRequest(*opsworks.DescribeElasticLoadBalancersInput) (*request.Request, *opsworks.DescribeElasticLoadBalancersOutput)
 
 	DescribeElasticLoadBalancers(*opsworks.DescribeElasticLoadBalancersInput) (*opsworks.DescribeElasticLoadBalancersOutput, error)
 
-	DescribeInstancesRequest(*opsworks.DescribeInstancesInput) (*service.Request, *opsworks.DescribeInstancesOutput)
+	DescribeInstancesRequest(*opsworks.DescribeInstancesInput) (*request.Request, *opsworks.DescribeInstancesOutput)
 
 	DescribeInstances(*opsworks.DescribeInstancesInput) (*opsworks.DescribeInstancesOutput, error)
 
-	DescribeLayersRequest(*opsworks.DescribeLayersInput) (*service.Request, *opsworks.DescribeLayersOutput)
+	DescribeLayersRequest(*opsworks.DescribeLayersInput) (*request.Request, *opsworks.DescribeLayersOutput)
 
 	DescribeLayers(*opsworks.DescribeLayersInput) (*opsworks.DescribeLayersOutput, error)
 
-	DescribeLoadBasedAutoScalingRequest(*opsworks.DescribeLoadBasedAutoScalingInput) (*service.Request, *opsworks.DescribeLoadBasedAutoScalingOutput)
+	DescribeLoadBasedAutoScalingRequest(*opsworks.DescribeLoadBasedAutoScalingInput) (*request.Request, *opsworks.DescribeLoadBasedAutoScalingOutput)
 
 	DescribeLoadBasedAutoScaling(*opsworks.DescribeLoadBasedAutoScalingInput) (*opsworks.DescribeLoadBasedAutoScalingOutput, error)
 
-	DescribeMyUserProfileRequest(*opsworks.DescribeMyUserProfileInput) (*service.Request, *opsworks.DescribeMyUserProfileOutput)
+	DescribeMyUserProfileRequest(*opsworks.DescribeMyUserProfileInput) (*request.Request, *opsworks.DescribeMyUserProfileOutput)
 
 	DescribeMyUserProfile(*opsworks.DescribeMyUserProfileInput) (*opsworks.DescribeMyUserProfileOutput, error)
 
-	DescribePermissionsRequest(*opsworks.DescribePermissionsInput) (*service.Request, *opsworks.DescribePermissionsOutput)
+	DescribePermissionsRequest(*opsworks.DescribePermissionsInput) (*request.Request, *opsworks.DescribePermissionsOutput)
 
 	DescribePermissions(*opsworks.DescribePermissionsInput) (*opsworks.DescribePermissionsOutput, error)
 
-	DescribeRaidArraysRequest(*opsworks.DescribeRaidArraysInput) (*service.Request, *opsworks.DescribeRaidArraysOutput)
+	DescribeRaidArraysRequest(*opsworks.DescribeRaidArraysInput) (*request.Request, *opsworks.DescribeRaidArraysOutput)
 
 	DescribeRaidArrays(*opsworks.DescribeRaidArraysInput) (*opsworks.DescribeRaidArraysOutput, error)
 
-	DescribeRdsDbInstancesRequest(*opsworks.DescribeRdsDbInstancesInput) (*service.Request, *opsworks.DescribeRdsDbInstancesOutput)
+	DescribeRdsDbInstancesRequest(*opsworks.DescribeRdsDbInstancesInput) (*request.Request, *opsworks.DescribeRdsDbInstancesOutput)
 
 	DescribeRdsDbInstances(*opsworks.DescribeRdsDbInstancesInput) (*opsworks.DescribeRdsDbInstancesOutput, error)
 
-	DescribeServiceErrorsRequest(*opsworks.DescribeServiceErrorsInput) (*service.Request, *opsworks.DescribeServiceErrorsOutput)
+	DescribeServiceErrorsRequest(*opsworks.DescribeServiceErrorsInput) (*request.Request, *opsworks.DescribeServiceErrorsOutput)
 
 	DescribeServiceErrors(*opsworks.DescribeServiceErrorsInput) (*opsworks.DescribeServiceErrorsOutput, error)
 
-	DescribeStackProvisioningParametersRequest(*opsworks.DescribeStackProvisioningParametersInput) (*service.Request, *opsworks.DescribeStackProvisioningParametersOutput)
+	DescribeStackProvisioningParametersRequest(*opsworks.DescribeStackProvisioningParametersInput) (*request.Request, *opsworks.DescribeStackProvisioningParametersOutput)
 
 	DescribeStackProvisioningParameters(*opsworks.DescribeStackProvisioningParametersInput) (*opsworks.DescribeStackProvisioningParametersOutput, error)
 
-	DescribeStackSummaryRequest(*opsworks.DescribeStackSummaryInput) (*service.Request, *opsworks.DescribeStackSummaryOutput)
+	DescribeStackSummaryRequest(*opsworks.DescribeStackSummaryInput) (*request.Request, *opsworks.DescribeStackSummaryOutput)
 
 	DescribeStackSummary(*opsworks.DescribeStackSummaryInput) (*opsworks.DescribeStackSummaryOutput, error)
 
-	DescribeStacksRequest(*opsworks.DescribeStacksInput) (*service.Request, *opsworks.DescribeStacksOutput)
+	DescribeStacksRequest(*opsworks.DescribeStacksInput) (*request.Request, *opsworks.DescribeStacksOutput)
 
 	DescribeStacks(*opsworks.DescribeStacksInput) (*opsworks.DescribeStacksOutput, error)
 
-	DescribeTimeBasedAutoScalingRequest(*opsworks.DescribeTimeBasedAutoScalingInput) (*service.Request, *opsworks.DescribeTimeBasedAutoScalingOutput)
+	DescribeTimeBasedAutoScalingRequest(*opsworks.DescribeTimeBasedAutoScalingInput) (*request.Request, *opsworks.DescribeTimeBasedAutoScalingOutput)
 
 	DescribeTimeBasedAutoScaling(*opsworks.DescribeTimeBasedAutoScalingInput) (*opsworks.DescribeTimeBasedAutoScalingOutput, error)
 
-	DescribeUserProfilesRequest(*opsworks.DescribeUserProfilesInput) (*service.Request, *opsworks.DescribeUserProfilesOutput)
+	DescribeUserProfilesRequest(*opsworks.DescribeUserProfilesInput) (*request.Request, *opsworks.DescribeUserProfilesOutput)
 
 	DescribeUserProfiles(*opsworks.DescribeUserProfilesInput) (*opsworks.DescribeUserProfilesOutput, error)
 
-	DescribeVolumesRequest(*opsworks.DescribeVolumesInput) (*service.Request, *opsworks.DescribeVolumesOutput)
+	DescribeVolumesRequest(*opsworks.DescribeVolumesInput) (*request.Request, *opsworks.DescribeVolumesOutput)
 
 	DescribeVolumes(*opsworks.DescribeVolumesInput) (*opsworks.DescribeVolumesOutput, error)
 
-	DetachElasticLoadBalancerRequest(*opsworks.DetachElasticLoadBalancerInput) (*service.Request, *opsworks.DetachElasticLoadBalancerOutput)
+	DetachElasticLoadBalancerRequest(*opsworks.DetachElasticLoadBalancerInput) (*request.Request, *opsworks.DetachElasticLoadBalancerOutput)
 
 	DetachElasticLoadBalancer(*opsworks.DetachElasticLoadBalancerInput) (*opsworks.DetachElasticLoadBalancerOutput, error)
 
-	DisassociateElasticIpRequest(*opsworks.DisassociateElasticIpInput) (*service.Request, *opsworks.DisassociateElasticIpOutput)
+	DisassociateElasticIpRequest(*opsworks.DisassociateElasticIpInput) (*request.Request, *opsworks.DisassociateElasticIpOutput)
 
 	DisassociateElasticIp(*opsworks.DisassociateElasticIpInput) (*opsworks.DisassociateElasticIpOutput, error)
 
-	GetHostnameSuggestionRequest(*opsworks.GetHostnameSuggestionInput) (*service.Request, *opsworks.GetHostnameSuggestionOutput)
+	GetHostnameSuggestionRequest(*opsworks.GetHostnameSuggestionInput) (*request.Request, *opsworks.GetHostnameSuggestionOutput)
 
 	GetHostnameSuggestion(*opsworks.GetHostnameSuggestionInput) (*opsworks.GetHostnameSuggestionOutput, error)
 
-	GrantAccessRequest(*opsworks.GrantAccessInput) (*service.Request, *opsworks.GrantAccessOutput)
+	GrantAccessRequest(*opsworks.GrantAccessInput) (*request.Request, *opsworks.GrantAccessOutput)
 
 	GrantAccess(*opsworks.GrantAccessInput) (*opsworks.GrantAccessOutput, error)
 
-	RebootInstanceRequest(*opsworks.RebootInstanceInput) (*service.Request, *opsworks.RebootInstanceOutput)
+	RebootInstanceRequest(*opsworks.RebootInstanceInput) (*request.Request, *opsworks.RebootInstanceOutput)
 
 	RebootInstance(*opsworks.RebootInstanceInput) (*opsworks.RebootInstanceOutput, error)
 
-	RegisterEcsClusterRequest(*opsworks.RegisterEcsClusterInput) (*service.Request, *opsworks.RegisterEcsClusterOutput)
+	RegisterEcsClusterRequest(*opsworks.RegisterEcsClusterInput) (*request.Request, *opsworks.RegisterEcsClusterOutput)
 
 	RegisterEcsCluster(*opsworks.RegisterEcsClusterInput) (*opsworks.RegisterEcsClusterOutput, error)
 
-	RegisterElasticIpRequest(*opsworks.RegisterElasticIpInput) (*service.Request, *opsworks.RegisterElasticIpOutput)
+	RegisterElasticIpRequest(*opsworks.RegisterElasticIpInput) (*request.Request, *opsworks.RegisterElasticIpOutput)
 
 	RegisterElasticIp(*opsworks.RegisterElasticIpInput) (*opsworks.RegisterElasticIpOutput, error)
 
-	RegisterInstanceRequest(*opsworks.RegisterInstanceInput) (*service.Request, *opsworks.RegisterInstanceOutput)
+	RegisterInstanceRequest(*opsworks.RegisterInstanceInput) (*request.Request, *opsworks.RegisterInstanceOutput)
 
 	RegisterInstance(*opsworks.RegisterInstanceInput) (*opsworks.RegisterInstanceOutput, error)
 
-	RegisterRdsDbInstanceRequest(*opsworks.RegisterRdsDbInstanceInput) (*service.Request, *opsworks.RegisterRdsDbInstanceOutput)
+	RegisterRdsDbInstanceRequest(*opsworks.RegisterRdsDbInstanceInput) (*request.Request, *opsworks.RegisterRdsDbInstanceOutput)
 
 	RegisterRdsDbInstance(*opsworks.RegisterRdsDbInstanceInput) (*opsworks.RegisterRdsDbInstanceOutput, error)
 
-	RegisterVolumeRequest(*opsworks.RegisterVolumeInput) (*service.Request, *opsworks.RegisterVolumeOutput)
+	RegisterVolumeRequest(*opsworks.RegisterVolumeInput) (*request.Request, *opsworks.RegisterVolumeOutput)
 
 	RegisterVolume(*opsworks.RegisterVolumeInput) (*opsworks.RegisterVolumeOutput, error)
 
-	SetLoadBasedAutoScalingRequest(*opsworks.SetLoadBasedAutoScalingInput) (*service.Request, *opsworks.SetLoadBasedAutoScalingOutput)
+	SetLoadBasedAutoScalingRequest(*opsworks.SetLoadBasedAutoScalingInput) (*request.Request, *opsworks.SetLoadBasedAutoScalingOutput)
 
 	SetLoadBasedAutoScaling(*opsworks.SetLoadBasedAutoScalingInput) (*opsworks.SetLoadBasedAutoScalingOutput, error)
 
-	SetPermissionRequest(*opsworks.SetPermissionInput) (*service.Request, *opsworks.SetPermissionOutput)
+	SetPermissionRequest(*opsworks.SetPermissionInput) (*request.Request, *opsworks.SetPermissionOutput)
 
 	SetPermission(*opsworks.SetPermissionInput) (*opsworks.SetPermissionOutput, error)
 
-	SetTimeBasedAutoScalingRequest(*opsworks.SetTimeBasedAutoScalingInput) (*service.Request, *opsworks.SetTimeBasedAutoScalingOutput)
+	SetTimeBasedAutoScalingRequest(*opsworks.SetTimeBasedAutoScalingInput) (*request.Request, *opsworks.SetTimeBasedAutoScalingOutput)
 
 	SetTimeBasedAutoScaling(*opsworks.SetTimeBasedAutoScalingInput) (*opsworks.SetTimeBasedAutoScalingOutput, error)
 
-	StartInstanceRequest(*opsworks.StartInstanceInput) (*service.Request, *opsworks.StartInstanceOutput)
+	StartInstanceRequest(*opsworks.StartInstanceInput) (*request.Request, *opsworks.StartInstanceOutput)
 
 	StartInstance(*opsworks.StartInstanceInput) (*opsworks.StartInstanceOutput, error)
 
-	StartStackRequest(*opsworks.StartStackInput) (*service.Request, *opsworks.StartStackOutput)
+	StartStackRequest(*opsworks.StartStackInput) (*request.Request, *opsworks.StartStackOutput)
 
 	StartStack(*opsworks.StartStackInput) (*opsworks.StartStackOutput, error)
 
-	StopInstanceRequest(*opsworks.StopInstanceInput) (*service.Request, *opsworks.StopInstanceOutput)
+	StopInstanceRequest(*opsworks.StopInstanceInput) (*request.Request, *opsworks.StopInstanceOutput)
 
 	StopInstance(*opsworks.StopInstanceInput) (*opsworks.StopInstanceOutput, error)
 
-	StopStackRequest(*opsworks.StopStackInput) (*service.Request, *opsworks.StopStackOutput)
+	StopStackRequest(*opsworks.StopStackInput) (*request.Request, *opsworks.StopStackOutput)
 
 	StopStack(*opsworks.StopStackInput) (*opsworks.StopStackOutput, error)
 
-	UnassignInstanceRequest(*opsworks.UnassignInstanceInput) (*service.Request, *opsworks.UnassignInstanceOutput)
+	UnassignInstanceRequest(*opsworks.UnassignInstanceInput) (*request.Request, *opsworks.UnassignInstanceOutput)
 
 	UnassignInstance(*opsworks.UnassignInstanceInput) (*opsworks.UnassignInstanceOutput, error)
 
-	UnassignVolumeRequest(*opsworks.UnassignVolumeInput) (*service.Request, *opsworks.UnassignVolumeOutput)
+	UnassignVolumeRequest(*opsworks.UnassignVolumeInput) (*request.Request, *opsworks.UnassignVolumeOutput)
 
 	UnassignVolume(*opsworks.UnassignVolumeInput) (*opsworks.UnassignVolumeOutput, error)
 
-	UpdateAppRequest(*opsworks.UpdateAppInput) (*service.Request, *opsworks.UpdateAppOutput)
+	UpdateAppRequest(*opsworks.UpdateAppInput) (*request.Request, *opsworks.UpdateAppOutput)
 
 	UpdateApp(*opsworks.UpdateAppInput) (*opsworks.UpdateAppOutput, error)
 
-	UpdateElasticIpRequest(*opsworks.UpdateElasticIpInput) (*service.Request, *opsworks.UpdateElasticIpOutput)
+	UpdateElasticIpRequest(*opsworks.UpdateElasticIpInput) (*request.Request, *opsworks.UpdateElasticIpOutput)
 
 	UpdateElasticIp(*opsworks.UpdateElasticIpInput) (*opsworks.UpdateElasticIpOutput, error)
 
-	UpdateInstanceRequest(*opsworks.UpdateInstanceInput) (*service.Request, *opsworks.UpdateInstanceOutput)
+	UpdateInstanceRequest(*opsworks.UpdateInstanceInput) (*request.Request, *opsworks.UpdateInstanceOutput)
 
 	UpdateInstance(*opsworks.UpdateInstanceInput) (*opsworks.UpdateInstanceOutput, error)
 
-	UpdateLayerRequest(*opsworks.UpdateLayerInput) (*service.Request, *opsworks.UpdateLayerOutput)
+	UpdateLayerRequest(*opsworks.UpdateLayerInput) (*request.Request, *opsworks.UpdateLayerOutput)
 
 	UpdateLayer(*opsworks.UpdateLayerInput) (*opsworks.UpdateLayerOutput, error)
 
-	UpdateMyUserProfileRequest(*opsworks.UpdateMyUserProfileInput) (*service.Request, *opsworks.UpdateMyUserProfileOutput)
+	UpdateMyUserProfileRequest(*opsworks.UpdateMyUserProfileInput) (*request.Request, *opsworks.UpdateMyUserProfileOutput)
 
 	UpdateMyUserProfile(*opsworks.UpdateMyUserProfileInput) (*opsworks.UpdateMyUserProfileOutput, error)
 
-	UpdateRdsDbInstanceRequest(*opsworks.UpdateRdsDbInstanceInput) (*service.Request, *opsworks.UpdateRdsDbInstanceOutput)
+	UpdateRdsDbInstanceRequest(*opsworks.UpdateRdsDbInstanceInput) (*request.Request, *opsworks.UpdateRdsDbInstanceOutput)
 
 	UpdateRdsDbInstance(*opsworks.UpdateRdsDbInstanceInput) (*opsworks.UpdateRdsDbInstanceOutput, error)
 
-	UpdateStackRequest(*opsworks.UpdateStackInput) (*service.Request, *opsworks.UpdateStackOutput)
+	UpdateStackRequest(*opsworks.UpdateStackInput) (*request.Request, *opsworks.UpdateStackOutput)
 
 	UpdateStack(*opsworks.UpdateStackInput) (*opsworks.UpdateStackOutput, error)
 
-	UpdateUserProfileRequest(*opsworks.UpdateUserProfileInput) (*service.Request, *opsworks.UpdateUserProfileOutput)
+	UpdateUserProfileRequest(*opsworks.UpdateUserProfileInput) (*request.Request, *opsworks.UpdateUserProfileOutput)
 
 	UpdateUserProfile(*opsworks.UpdateUserProfileInput) (*opsworks.UpdateUserProfileOutput, error)
 
-	UpdateVolumeRequest(*opsworks.UpdateVolumeInput) (*service.Request, *opsworks.UpdateVolumeOutput)
+	UpdateVolumeRequest(*opsworks.UpdateVolumeInput) (*request.Request, *opsworks.UpdateVolumeOutput)
 
 	UpdateVolume(*opsworks.UpdateVolumeInput) (*opsworks.UpdateVolumeOutput, error)
 }

--- a/service/opsworks/service.go
+++ b/service/opsworks/service.go
@@ -5,7 +5,9 @@ package opsworks
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -57,16 +59,18 @@ type OpsWorks struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new OpsWorks client.
 func New(config *aws.Config) *OpsWorks {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "opsworks",
-		APIVersion:   "2013-02-18",
-		JSONVersion:  "1.1",
-		TargetPrefix: "OpsWorks_20130218",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "opsworks",
+			APIVersion:   "2013-02-18",
+			JSONVersion:  "1.1",
+			TargetPrefix: "OpsWorks_20130218",
+		},
 	}
 	service.Initialize()
 
@@ -87,8 +91,8 @@ func New(config *aws.Config) *OpsWorks {
 
 // newRequest creates a new request for a OpsWorks operation and runs any
 // custom request initialization.
-func (c *OpsWorks) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *OpsWorks) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/rds/api.go
+++ b/service/rds/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddSourceIdentifierToSubscription = "AddSourceIdentifierToSubscription"
 
 // AddSourceIdentifierToSubscriptionRequest generates a request for the AddSourceIdentifierToSubscription operation.
-func (c *RDS) AddSourceIdentifierToSubscriptionRequest(input *AddSourceIdentifierToSubscriptionInput) (req *service.Request, output *AddSourceIdentifierToSubscriptionOutput) {
-	op := &service.Operation{
+func (c *RDS) AddSourceIdentifierToSubscriptionRequest(input *AddSourceIdentifierToSubscriptionInput) (req *request.Request, output *AddSourceIdentifierToSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opAddSourceIdentifierToSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -40,8 +40,8 @@ func (c *RDS) AddSourceIdentifierToSubscription(input *AddSourceIdentifierToSubs
 const opAddTagsToResource = "AddTagsToResource"
 
 // AddTagsToResourceRequest generates a request for the AddTagsToResource operation.
-func (c *RDS) AddTagsToResourceRequest(input *AddTagsToResourceInput) (req *service.Request, output *AddTagsToResourceOutput) {
-	op := &service.Operation{
+func (c *RDS) AddTagsToResourceRequest(input *AddTagsToResourceInput) (req *request.Request, output *AddTagsToResourceOutput) {
+	op := &request.Operation{
 		Name:       opAddTagsToResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -72,8 +72,8 @@ func (c *RDS) AddTagsToResource(input *AddTagsToResourceInput) (*AddTagsToResour
 const opApplyPendingMaintenanceAction = "ApplyPendingMaintenanceAction"
 
 // ApplyPendingMaintenanceActionRequest generates a request for the ApplyPendingMaintenanceAction operation.
-func (c *RDS) ApplyPendingMaintenanceActionRequest(input *ApplyPendingMaintenanceActionInput) (req *service.Request, output *ApplyPendingMaintenanceActionOutput) {
-	op := &service.Operation{
+func (c *RDS) ApplyPendingMaintenanceActionRequest(input *ApplyPendingMaintenanceActionInput) (req *request.Request, output *ApplyPendingMaintenanceActionOutput) {
+	op := &request.Operation{
 		Name:       opApplyPendingMaintenanceAction,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -100,8 +100,8 @@ func (c *RDS) ApplyPendingMaintenanceAction(input *ApplyPendingMaintenanceAction
 const opAuthorizeDBSecurityGroupIngress = "AuthorizeDBSecurityGroupIngress"
 
 // AuthorizeDBSecurityGroupIngressRequest generates a request for the AuthorizeDBSecurityGroupIngress operation.
-func (c *RDS) AuthorizeDBSecurityGroupIngressRequest(input *AuthorizeDBSecurityGroupIngressInput) (req *service.Request, output *AuthorizeDBSecurityGroupIngressOutput) {
-	op := &service.Operation{
+func (c *RDS) AuthorizeDBSecurityGroupIngressRequest(input *AuthorizeDBSecurityGroupIngressInput) (req *request.Request, output *AuthorizeDBSecurityGroupIngressOutput) {
+	op := &request.Operation{
 		Name:       opAuthorizeDBSecurityGroupIngress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -138,8 +138,8 @@ func (c *RDS) AuthorizeDBSecurityGroupIngress(input *AuthorizeDBSecurityGroupIng
 const opCopyDBClusterSnapshot = "CopyDBClusterSnapshot"
 
 // CopyDBClusterSnapshotRequest generates a request for the CopyDBClusterSnapshot operation.
-func (c *RDS) CopyDBClusterSnapshotRequest(input *CopyDBClusterSnapshotInput) (req *service.Request, output *CopyDBClusterSnapshotOutput) {
-	op := &service.Operation{
+func (c *RDS) CopyDBClusterSnapshotRequest(input *CopyDBClusterSnapshotInput) (req *request.Request, output *CopyDBClusterSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCopyDBClusterSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -167,8 +167,8 @@ func (c *RDS) CopyDBClusterSnapshot(input *CopyDBClusterSnapshotInput) (*CopyDBC
 const opCopyDBParameterGroup = "CopyDBParameterGroup"
 
 // CopyDBParameterGroupRequest generates a request for the CopyDBParameterGroup operation.
-func (c *RDS) CopyDBParameterGroupRequest(input *CopyDBParameterGroupInput) (req *service.Request, output *CopyDBParameterGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) CopyDBParameterGroupRequest(input *CopyDBParameterGroupInput) (req *request.Request, output *CopyDBParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opCopyDBParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -194,8 +194,8 @@ func (c *RDS) CopyDBParameterGroup(input *CopyDBParameterGroupInput) (*CopyDBPar
 const opCopyDBSnapshot = "CopyDBSnapshot"
 
 // CopyDBSnapshotRequest generates a request for the CopyDBSnapshot operation.
-func (c *RDS) CopyDBSnapshotRequest(input *CopyDBSnapshotInput) (req *service.Request, output *CopyDBSnapshotOutput) {
-	op := &service.Operation{
+func (c *RDS) CopyDBSnapshotRequest(input *CopyDBSnapshotInput) (req *request.Request, output *CopyDBSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCopyDBSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -222,8 +222,8 @@ func (c *RDS) CopyDBSnapshot(input *CopyDBSnapshotInput) (*CopyDBSnapshotOutput,
 const opCopyOptionGroup = "CopyOptionGroup"
 
 // CopyOptionGroupRequest generates a request for the CopyOptionGroup operation.
-func (c *RDS) CopyOptionGroupRequest(input *CopyOptionGroupInput) (req *service.Request, output *CopyOptionGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) CopyOptionGroupRequest(input *CopyOptionGroupInput) (req *request.Request, output *CopyOptionGroupOutput) {
+	op := &request.Operation{
 		Name:       opCopyOptionGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -249,8 +249,8 @@ func (c *RDS) CopyOptionGroup(input *CopyOptionGroupInput) (*CopyOptionGroupOutp
 const opCreateDBCluster = "CreateDBCluster"
 
 // CreateDBClusterRequest generates a request for the CreateDBCluster operation.
-func (c *RDS) CreateDBClusterRequest(input *CreateDBClusterInput) (req *service.Request, output *CreateDBClusterOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBClusterRequest(input *CreateDBClusterInput) (req *request.Request, output *CreateDBClusterOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -278,8 +278,8 @@ func (c *RDS) CreateDBCluster(input *CreateDBClusterInput) (*CreateDBClusterOutp
 const opCreateDBClusterParameterGroup = "CreateDBClusterParameterGroup"
 
 // CreateDBClusterParameterGroupRequest generates a request for the CreateDBClusterParameterGroup operation.
-func (c *RDS) CreateDBClusterParameterGroupRequest(input *CreateDBClusterParameterGroupInput) (req *service.Request, output *CreateDBClusterParameterGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBClusterParameterGroupRequest(input *CreateDBClusterParameterGroupInput) (req *request.Request, output *CreateDBClusterParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBClusterParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -332,8 +332,8 @@ func (c *RDS) CreateDBClusterParameterGroup(input *CreateDBClusterParameterGroup
 const opCreateDBClusterSnapshot = "CreateDBClusterSnapshot"
 
 // CreateDBClusterSnapshotRequest generates a request for the CreateDBClusterSnapshot operation.
-func (c *RDS) CreateDBClusterSnapshotRequest(input *CreateDBClusterSnapshotInput) (req *service.Request, output *CreateDBClusterSnapshotOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBClusterSnapshotRequest(input *CreateDBClusterSnapshotInput) (req *request.Request, output *CreateDBClusterSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBClusterSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -361,8 +361,8 @@ func (c *RDS) CreateDBClusterSnapshot(input *CreateDBClusterSnapshotInput) (*Cre
 const opCreateDBInstance = "CreateDBInstance"
 
 // CreateDBInstanceRequest generates a request for the CreateDBInstance operation.
-func (c *RDS) CreateDBInstanceRequest(input *CreateDBInstanceInput) (req *service.Request, output *CreateDBInstanceOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBInstanceRequest(input *CreateDBInstanceInput) (req *request.Request, output *CreateDBInstanceOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -388,8 +388,8 @@ func (c *RDS) CreateDBInstance(input *CreateDBInstanceInput) (*CreateDBInstanceO
 const opCreateDBInstanceReadReplica = "CreateDBInstanceReadReplica"
 
 // CreateDBInstanceReadReplicaRequest generates a request for the CreateDBInstanceReadReplica operation.
-func (c *RDS) CreateDBInstanceReadReplicaRequest(input *CreateDBInstanceReadReplicaInput) (req *service.Request, output *CreateDBInstanceReadReplicaOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBInstanceReadReplicaRequest(input *CreateDBInstanceReadReplicaInput) (req *request.Request, output *CreateDBInstanceReadReplicaOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBInstanceReadReplica,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -423,8 +423,8 @@ func (c *RDS) CreateDBInstanceReadReplica(input *CreateDBInstanceReadReplicaInpu
 const opCreateDBParameterGroup = "CreateDBParameterGroup"
 
 // CreateDBParameterGroupRequest generates a request for the CreateDBParameterGroup operation.
-func (c *RDS) CreateDBParameterGroupRequest(input *CreateDBParameterGroupInput) (req *service.Request, output *CreateDBParameterGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBParameterGroupRequest(input *CreateDBParameterGroupInput) (req *request.Request, output *CreateDBParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -470,8 +470,8 @@ func (c *RDS) CreateDBParameterGroup(input *CreateDBParameterGroupInput) (*Creat
 const opCreateDBSecurityGroup = "CreateDBSecurityGroup"
 
 // CreateDBSecurityGroupRequest generates a request for the CreateDBSecurityGroup operation.
-func (c *RDS) CreateDBSecurityGroupRequest(input *CreateDBSecurityGroupInput) (req *service.Request, output *CreateDBSecurityGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBSecurityGroupRequest(input *CreateDBSecurityGroupInput) (req *request.Request, output *CreateDBSecurityGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -498,8 +498,8 @@ func (c *RDS) CreateDBSecurityGroup(input *CreateDBSecurityGroupInput) (*CreateD
 const opCreateDBSnapshot = "CreateDBSnapshot"
 
 // CreateDBSnapshotRequest generates a request for the CreateDBSnapshot operation.
-func (c *RDS) CreateDBSnapshotRequest(input *CreateDBSnapshotInput) (req *service.Request, output *CreateDBSnapshotOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBSnapshotRequest(input *CreateDBSnapshotInput) (req *request.Request, output *CreateDBSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -525,8 +525,8 @@ func (c *RDS) CreateDBSnapshot(input *CreateDBSnapshotInput) (*CreateDBSnapshotO
 const opCreateDBSubnetGroup = "CreateDBSubnetGroup"
 
 // CreateDBSubnetGroupRequest generates a request for the CreateDBSubnetGroup operation.
-func (c *RDS) CreateDBSubnetGroupRequest(input *CreateDBSubnetGroupInput) (req *service.Request, output *CreateDBSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateDBSubnetGroupRequest(input *CreateDBSubnetGroupInput) (req *request.Request, output *CreateDBSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateDBSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -553,8 +553,8 @@ func (c *RDS) CreateDBSubnetGroup(input *CreateDBSubnetGroupInput) (*CreateDBSub
 const opCreateEventSubscription = "CreateEventSubscription"
 
 // CreateEventSubscriptionRequest generates a request for the CreateEventSubscription operation.
-func (c *RDS) CreateEventSubscriptionRequest(input *CreateEventSubscriptionInput) (req *service.Request, output *CreateEventSubscriptionOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateEventSubscriptionRequest(input *CreateEventSubscriptionInput) (req *request.Request, output *CreateEventSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opCreateEventSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -598,8 +598,8 @@ func (c *RDS) CreateEventSubscription(input *CreateEventSubscriptionInput) (*Cre
 const opCreateOptionGroup = "CreateOptionGroup"
 
 // CreateOptionGroupRequest generates a request for the CreateOptionGroup operation.
-func (c *RDS) CreateOptionGroupRequest(input *CreateOptionGroupInput) (req *service.Request, output *CreateOptionGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) CreateOptionGroupRequest(input *CreateOptionGroupInput) (req *request.Request, output *CreateOptionGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateOptionGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -625,8 +625,8 @@ func (c *RDS) CreateOptionGroup(input *CreateOptionGroupInput) (*CreateOptionGro
 const opDeleteDBCluster = "DeleteDBCluster"
 
 // DeleteDBClusterRequest generates a request for the DeleteDBCluster operation.
-func (c *RDS) DeleteDBClusterRequest(input *DeleteDBClusterInput) (req *service.Request, output *DeleteDBClusterOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteDBClusterRequest(input *DeleteDBClusterInput) (req *request.Request, output *DeleteDBClusterOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDBCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -659,8 +659,8 @@ func (c *RDS) DeleteDBCluster(input *DeleteDBClusterInput) (*DeleteDBClusterOutp
 const opDeleteDBClusterParameterGroup = "DeleteDBClusterParameterGroup"
 
 // DeleteDBClusterParameterGroupRequest generates a request for the DeleteDBClusterParameterGroup operation.
-func (c *RDS) DeleteDBClusterParameterGroupRequest(input *DeleteDBClusterParameterGroupInput) (req *service.Request, output *DeleteDBClusterParameterGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteDBClusterParameterGroupRequest(input *DeleteDBClusterParameterGroupInput) (req *request.Request, output *DeleteDBClusterParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDBClusterParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -690,8 +690,8 @@ func (c *RDS) DeleteDBClusterParameterGroup(input *DeleteDBClusterParameterGroup
 const opDeleteDBClusterSnapshot = "DeleteDBClusterSnapshot"
 
 // DeleteDBClusterSnapshotRequest generates a request for the DeleteDBClusterSnapshot operation.
-func (c *RDS) DeleteDBClusterSnapshotRequest(input *DeleteDBClusterSnapshotInput) (req *service.Request, output *DeleteDBClusterSnapshotOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteDBClusterSnapshotRequest(input *DeleteDBClusterSnapshotInput) (req *request.Request, output *DeleteDBClusterSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDBClusterSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -722,8 +722,8 @@ func (c *RDS) DeleteDBClusterSnapshot(input *DeleteDBClusterSnapshotInput) (*Del
 const opDeleteDBInstance = "DeleteDBInstance"
 
 // DeleteDBInstanceRequest generates a request for the DeleteDBInstance operation.
-func (c *RDS) DeleteDBInstanceRequest(input *DeleteDBInstanceInput) (req *service.Request, output *DeleteDBInstanceOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteDBInstanceRequest(input *DeleteDBInstanceInput) (req *request.Request, output *DeleteDBInstanceOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDBInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -762,8 +762,8 @@ func (c *RDS) DeleteDBInstance(input *DeleteDBInstanceInput) (*DeleteDBInstanceO
 const opDeleteDBParameterGroup = "DeleteDBParameterGroup"
 
 // DeleteDBParameterGroupRequest generates a request for the DeleteDBParameterGroup operation.
-func (c *RDS) DeleteDBParameterGroupRequest(input *DeleteDBParameterGroupInput) (req *service.Request, output *DeleteDBParameterGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteDBParameterGroupRequest(input *DeleteDBParameterGroupInput) (req *request.Request, output *DeleteDBParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDBParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -790,8 +790,8 @@ func (c *RDS) DeleteDBParameterGroup(input *DeleteDBParameterGroupInput) (*Delet
 const opDeleteDBSecurityGroup = "DeleteDBSecurityGroup"
 
 // DeleteDBSecurityGroupRequest generates a request for the DeleteDBSecurityGroup operation.
-func (c *RDS) DeleteDBSecurityGroupRequest(input *DeleteDBSecurityGroupInput) (req *service.Request, output *DeleteDBSecurityGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteDBSecurityGroupRequest(input *DeleteDBSecurityGroupInput) (req *request.Request, output *DeleteDBSecurityGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDBSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -819,8 +819,8 @@ func (c *RDS) DeleteDBSecurityGroup(input *DeleteDBSecurityGroupInput) (*DeleteD
 const opDeleteDBSnapshot = "DeleteDBSnapshot"
 
 // DeleteDBSnapshotRequest generates a request for the DeleteDBSnapshot operation.
-func (c *RDS) DeleteDBSnapshotRequest(input *DeleteDBSnapshotInput) (req *service.Request, output *DeleteDBSnapshotOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteDBSnapshotRequest(input *DeleteDBSnapshotInput) (req *request.Request, output *DeleteDBSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDBSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -849,8 +849,8 @@ func (c *RDS) DeleteDBSnapshot(input *DeleteDBSnapshotInput) (*DeleteDBSnapshotO
 const opDeleteDBSubnetGroup = "DeleteDBSubnetGroup"
 
 // DeleteDBSubnetGroupRequest generates a request for the DeleteDBSubnetGroup operation.
-func (c *RDS) DeleteDBSubnetGroupRequest(input *DeleteDBSubnetGroupInput) (req *service.Request, output *DeleteDBSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteDBSubnetGroupRequest(input *DeleteDBSubnetGroupInput) (req *request.Request, output *DeleteDBSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDBSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -878,8 +878,8 @@ func (c *RDS) DeleteDBSubnetGroup(input *DeleteDBSubnetGroupInput) (*DeleteDBSub
 const opDeleteEventSubscription = "DeleteEventSubscription"
 
 // DeleteEventSubscriptionRequest generates a request for the DeleteEventSubscription operation.
-func (c *RDS) DeleteEventSubscriptionRequest(input *DeleteEventSubscriptionInput) (req *service.Request, output *DeleteEventSubscriptionOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteEventSubscriptionRequest(input *DeleteEventSubscriptionInput) (req *request.Request, output *DeleteEventSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteEventSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -905,8 +905,8 @@ func (c *RDS) DeleteEventSubscription(input *DeleteEventSubscriptionInput) (*Del
 const opDeleteOptionGroup = "DeleteOptionGroup"
 
 // DeleteOptionGroupRequest generates a request for the DeleteOptionGroup operation.
-func (c *RDS) DeleteOptionGroupRequest(input *DeleteOptionGroupInput) (req *service.Request, output *DeleteOptionGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) DeleteOptionGroupRequest(input *DeleteOptionGroupInput) (req *request.Request, output *DeleteOptionGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteOptionGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -932,8 +932,8 @@ func (c *RDS) DeleteOptionGroup(input *DeleteOptionGroupInput) (*DeleteOptionGro
 const opDescribeAccountAttributes = "DescribeAccountAttributes"
 
 // DescribeAccountAttributesRequest generates a request for the DescribeAccountAttributes operation.
-func (c *RDS) DescribeAccountAttributesRequest(input *DescribeAccountAttributesInput) (req *service.Request, output *DescribeAccountAttributesOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeAccountAttributesRequest(input *DescribeAccountAttributesInput) (req *request.Request, output *DescribeAccountAttributesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAccountAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -964,8 +964,8 @@ func (c *RDS) DescribeAccountAttributes(input *DescribeAccountAttributesInput) (
 const opDescribeCertificates = "DescribeCertificates"
 
 // DescribeCertificatesRequest generates a request for the DescribeCertificates operation.
-func (c *RDS) DescribeCertificatesRequest(input *DescribeCertificatesInput) (req *service.Request, output *DescribeCertificatesOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeCertificatesRequest(input *DescribeCertificatesInput) (req *request.Request, output *DescribeCertificatesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCertificates,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -991,8 +991,8 @@ func (c *RDS) DescribeCertificates(input *DescribeCertificatesInput) (*DescribeC
 const opDescribeDBClusterParameterGroups = "DescribeDBClusterParameterGroups"
 
 // DescribeDBClusterParameterGroupsRequest generates a request for the DescribeDBClusterParameterGroups operation.
-func (c *RDS) DescribeDBClusterParameterGroupsRequest(input *DescribeDBClusterParameterGroupsInput) (req *service.Request, output *DescribeDBClusterParameterGroupsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBClusterParameterGroupsRequest(input *DescribeDBClusterParameterGroupsInput) (req *request.Request, output *DescribeDBClusterParameterGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBClusterParameterGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1023,8 +1023,8 @@ func (c *RDS) DescribeDBClusterParameterGroups(input *DescribeDBClusterParameter
 const opDescribeDBClusterParameters = "DescribeDBClusterParameters"
 
 // DescribeDBClusterParametersRequest generates a request for the DescribeDBClusterParameters operation.
-func (c *RDS) DescribeDBClusterParametersRequest(input *DescribeDBClusterParametersInput) (req *service.Request, output *DescribeDBClusterParametersOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBClusterParametersRequest(input *DescribeDBClusterParametersInput) (req *request.Request, output *DescribeDBClusterParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBClusterParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1054,8 +1054,8 @@ func (c *RDS) DescribeDBClusterParameters(input *DescribeDBClusterParametersInpu
 const opDescribeDBClusterSnapshots = "DescribeDBClusterSnapshots"
 
 // DescribeDBClusterSnapshotsRequest generates a request for the DescribeDBClusterSnapshots operation.
-func (c *RDS) DescribeDBClusterSnapshotsRequest(input *DescribeDBClusterSnapshotsInput) (req *service.Request, output *DescribeDBClusterSnapshotsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBClusterSnapshotsRequest(input *DescribeDBClusterSnapshotsInput) (req *request.Request, output *DescribeDBClusterSnapshotsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBClusterSnapshots,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1084,8 +1084,8 @@ func (c *RDS) DescribeDBClusterSnapshots(input *DescribeDBClusterSnapshotsInput)
 const opDescribeDBClusters = "DescribeDBClusters"
 
 // DescribeDBClustersRequest generates a request for the DescribeDBClusters operation.
-func (c *RDS) DescribeDBClustersRequest(input *DescribeDBClustersInput) (req *service.Request, output *DescribeDBClustersOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBClustersRequest(input *DescribeDBClustersInput) (req *request.Request, output *DescribeDBClustersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBClusters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1115,12 +1115,12 @@ func (c *RDS) DescribeDBClusters(input *DescribeDBClustersInput) (*DescribeDBClu
 const opDescribeDBEngineVersions = "DescribeDBEngineVersions"
 
 // DescribeDBEngineVersionsRequest generates a request for the DescribeDBEngineVersions operation.
-func (c *RDS) DescribeDBEngineVersionsRequest(input *DescribeDBEngineVersionsInput) (req *service.Request, output *DescribeDBEngineVersionsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBEngineVersionsRequest(input *DescribeDBEngineVersionsInput) (req *request.Request, output *DescribeDBEngineVersionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBEngineVersions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1155,12 +1155,12 @@ func (c *RDS) DescribeDBEngineVersionsPages(input *DescribeDBEngineVersionsInput
 const opDescribeDBInstances = "DescribeDBInstances"
 
 // DescribeDBInstancesRequest generates a request for the DescribeDBInstances operation.
-func (c *RDS) DescribeDBInstancesRequest(input *DescribeDBInstancesInput) (req *service.Request, output *DescribeDBInstancesOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBInstancesRequest(input *DescribeDBInstancesInput) (req *request.Request, output *DescribeDBInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1195,12 +1195,12 @@ func (c *RDS) DescribeDBInstancesPages(input *DescribeDBInstancesInput, fn func(
 const opDescribeDBLogFiles = "DescribeDBLogFiles"
 
 // DescribeDBLogFilesRequest generates a request for the DescribeDBLogFiles operation.
-func (c *RDS) DescribeDBLogFilesRequest(input *DescribeDBLogFilesInput) (req *service.Request, output *DescribeDBLogFilesOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBLogFilesRequest(input *DescribeDBLogFilesInput) (req *request.Request, output *DescribeDBLogFilesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBLogFiles,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1235,12 +1235,12 @@ func (c *RDS) DescribeDBLogFilesPages(input *DescribeDBLogFilesInput, fn func(p 
 const opDescribeDBParameterGroups = "DescribeDBParameterGroups"
 
 // DescribeDBParameterGroupsRequest generates a request for the DescribeDBParameterGroups operation.
-func (c *RDS) DescribeDBParameterGroupsRequest(input *DescribeDBParameterGroupsInput) (req *service.Request, output *DescribeDBParameterGroupsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBParameterGroupsRequest(input *DescribeDBParameterGroupsInput) (req *request.Request, output *DescribeDBParameterGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBParameterGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1277,12 +1277,12 @@ func (c *RDS) DescribeDBParameterGroupsPages(input *DescribeDBParameterGroupsInp
 const opDescribeDBParameters = "DescribeDBParameters"
 
 // DescribeDBParametersRequest generates a request for the DescribeDBParameters operation.
-func (c *RDS) DescribeDBParametersRequest(input *DescribeDBParametersInput) (req *service.Request, output *DescribeDBParametersOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBParametersRequest(input *DescribeDBParametersInput) (req *request.Request, output *DescribeDBParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1317,12 +1317,12 @@ func (c *RDS) DescribeDBParametersPages(input *DescribeDBParametersInput, fn fun
 const opDescribeDBSecurityGroups = "DescribeDBSecurityGroups"
 
 // DescribeDBSecurityGroupsRequest generates a request for the DescribeDBSecurityGroups operation.
-func (c *RDS) DescribeDBSecurityGroupsRequest(input *DescribeDBSecurityGroupsInput) (req *service.Request, output *DescribeDBSecurityGroupsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBSecurityGroupsRequest(input *DescribeDBSecurityGroupsInput) (req *request.Request, output *DescribeDBSecurityGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBSecurityGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1359,12 +1359,12 @@ func (c *RDS) DescribeDBSecurityGroupsPages(input *DescribeDBSecurityGroupsInput
 const opDescribeDBSnapshots = "DescribeDBSnapshots"
 
 // DescribeDBSnapshotsRequest generates a request for the DescribeDBSnapshots operation.
-func (c *RDS) DescribeDBSnapshotsRequest(input *DescribeDBSnapshotsInput) (req *service.Request, output *DescribeDBSnapshotsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBSnapshotsRequest(input *DescribeDBSnapshotsInput) (req *request.Request, output *DescribeDBSnapshotsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBSnapshots,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1399,12 +1399,12 @@ func (c *RDS) DescribeDBSnapshotsPages(input *DescribeDBSnapshotsInput, fn func(
 const opDescribeDBSubnetGroups = "DescribeDBSubnetGroups"
 
 // DescribeDBSubnetGroupsRequest generates a request for the DescribeDBSubnetGroups operation.
-func (c *RDS) DescribeDBSubnetGroupsRequest(input *DescribeDBSubnetGroupsInput) (req *service.Request, output *DescribeDBSubnetGroupsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeDBSubnetGroupsRequest(input *DescribeDBSubnetGroupsInput) (req *request.Request, output *DescribeDBSubnetGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDBSubnetGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1442,8 +1442,8 @@ func (c *RDS) DescribeDBSubnetGroupsPages(input *DescribeDBSubnetGroupsInput, fn
 const opDescribeEngineDefaultClusterParameters = "DescribeEngineDefaultClusterParameters"
 
 // DescribeEngineDefaultClusterParametersRequest generates a request for the DescribeEngineDefaultClusterParameters operation.
-func (c *RDS) DescribeEngineDefaultClusterParametersRequest(input *DescribeEngineDefaultClusterParametersInput) (req *service.Request, output *DescribeEngineDefaultClusterParametersOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeEngineDefaultClusterParametersRequest(input *DescribeEngineDefaultClusterParametersInput) (req *request.Request, output *DescribeEngineDefaultClusterParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEngineDefaultClusterParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1473,12 +1473,12 @@ func (c *RDS) DescribeEngineDefaultClusterParameters(input *DescribeEngineDefaul
 const opDescribeEngineDefaultParameters = "DescribeEngineDefaultParameters"
 
 // DescribeEngineDefaultParametersRequest generates a request for the DescribeEngineDefaultParameters operation.
-func (c *RDS) DescribeEngineDefaultParametersRequest(input *DescribeEngineDefaultParametersInput) (req *service.Request, output *DescribeEngineDefaultParametersOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeEngineDefaultParametersRequest(input *DescribeEngineDefaultParametersInput) (req *request.Request, output *DescribeEngineDefaultParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEngineDefaultParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"EngineDefaults.Marker"},
 			LimitToken:      "MaxRecords",
@@ -1514,8 +1514,8 @@ func (c *RDS) DescribeEngineDefaultParametersPages(input *DescribeEngineDefaultP
 const opDescribeEventCategories = "DescribeEventCategories"
 
 // DescribeEventCategoriesRequest generates a request for the DescribeEventCategories operation.
-func (c *RDS) DescribeEventCategoriesRequest(input *DescribeEventCategoriesInput) (req *service.Request, output *DescribeEventCategoriesOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeEventCategoriesRequest(input *DescribeEventCategoriesInput) (req *request.Request, output *DescribeEventCategoriesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEventCategories,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1544,12 +1544,12 @@ func (c *RDS) DescribeEventCategories(input *DescribeEventCategoriesInput) (*Des
 const opDescribeEventSubscriptions = "DescribeEventSubscriptions"
 
 // DescribeEventSubscriptionsRequest generates a request for the DescribeEventSubscriptions operation.
-func (c *RDS) DescribeEventSubscriptionsRequest(input *DescribeEventSubscriptionsInput) (req *service.Request, output *DescribeEventSubscriptionsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeEventSubscriptionsRequest(input *DescribeEventSubscriptionsInput) (req *request.Request, output *DescribeEventSubscriptionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEventSubscriptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1588,12 +1588,12 @@ func (c *RDS) DescribeEventSubscriptionsPages(input *DescribeEventSubscriptionsI
 const opDescribeEvents = "DescribeEvents"
 
 // DescribeEventsRequest generates a request for the DescribeEvents operation.
-func (c *RDS) DescribeEventsRequest(input *DescribeEventsInput) (req *service.Request, output *DescribeEventsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeEventsRequest(input *DescribeEventsInput) (req *request.Request, output *DescribeEventsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1632,12 +1632,12 @@ func (c *RDS) DescribeEventsPages(input *DescribeEventsInput, fn func(p *Describ
 const opDescribeOptionGroupOptions = "DescribeOptionGroupOptions"
 
 // DescribeOptionGroupOptionsRequest generates a request for the DescribeOptionGroupOptions operation.
-func (c *RDS) DescribeOptionGroupOptionsRequest(input *DescribeOptionGroupOptionsInput) (req *service.Request, output *DescribeOptionGroupOptionsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeOptionGroupOptionsRequest(input *DescribeOptionGroupOptionsInput) (req *request.Request, output *DescribeOptionGroupOptionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeOptionGroupOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1672,12 +1672,12 @@ func (c *RDS) DescribeOptionGroupOptionsPages(input *DescribeOptionGroupOptionsI
 const opDescribeOptionGroups = "DescribeOptionGroups"
 
 // DescribeOptionGroupsRequest generates a request for the DescribeOptionGroups operation.
-func (c *RDS) DescribeOptionGroupsRequest(input *DescribeOptionGroupsInput) (req *service.Request, output *DescribeOptionGroupsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeOptionGroupsRequest(input *DescribeOptionGroupsInput) (req *request.Request, output *DescribeOptionGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeOptionGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1712,12 +1712,12 @@ func (c *RDS) DescribeOptionGroupsPages(input *DescribeOptionGroupsInput, fn fun
 const opDescribeOrderableDBInstanceOptions = "DescribeOrderableDBInstanceOptions"
 
 // DescribeOrderableDBInstanceOptionsRequest generates a request for the DescribeOrderableDBInstanceOptions operation.
-func (c *RDS) DescribeOrderableDBInstanceOptionsRequest(input *DescribeOrderableDBInstanceOptionsInput) (req *service.Request, output *DescribeOrderableDBInstanceOptionsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeOrderableDBInstanceOptionsRequest(input *DescribeOrderableDBInstanceOptionsInput) (req *request.Request, output *DescribeOrderableDBInstanceOptionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeOrderableDBInstanceOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1752,8 +1752,8 @@ func (c *RDS) DescribeOrderableDBInstanceOptionsPages(input *DescribeOrderableDB
 const opDescribePendingMaintenanceActions = "DescribePendingMaintenanceActions"
 
 // DescribePendingMaintenanceActionsRequest generates a request for the DescribePendingMaintenanceActions operation.
-func (c *RDS) DescribePendingMaintenanceActionsRequest(input *DescribePendingMaintenanceActionsInput) (req *service.Request, output *DescribePendingMaintenanceActionsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribePendingMaintenanceActionsRequest(input *DescribePendingMaintenanceActionsInput) (req *request.Request, output *DescribePendingMaintenanceActionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribePendingMaintenanceActions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1780,12 +1780,12 @@ func (c *RDS) DescribePendingMaintenanceActions(input *DescribePendingMaintenanc
 const opDescribeReservedDBInstances = "DescribeReservedDBInstances"
 
 // DescribeReservedDBInstancesRequest generates a request for the DescribeReservedDBInstances operation.
-func (c *RDS) DescribeReservedDBInstancesRequest(input *DescribeReservedDBInstancesInput) (req *service.Request, output *DescribeReservedDBInstancesOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeReservedDBInstancesRequest(input *DescribeReservedDBInstancesInput) (req *request.Request, output *DescribeReservedDBInstancesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedDBInstances,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1821,12 +1821,12 @@ func (c *RDS) DescribeReservedDBInstancesPages(input *DescribeReservedDBInstance
 const opDescribeReservedDBInstancesOfferings = "DescribeReservedDBInstancesOfferings"
 
 // DescribeReservedDBInstancesOfferingsRequest generates a request for the DescribeReservedDBInstancesOfferings operation.
-func (c *RDS) DescribeReservedDBInstancesOfferingsRequest(input *DescribeReservedDBInstancesOfferingsInput) (req *service.Request, output *DescribeReservedDBInstancesOfferingsOutput) {
-	op := &service.Operation{
+func (c *RDS) DescribeReservedDBInstancesOfferingsRequest(input *DescribeReservedDBInstancesOfferingsInput) (req *request.Request, output *DescribeReservedDBInstancesOfferingsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedDBInstancesOfferings,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1861,12 +1861,12 @@ func (c *RDS) DescribeReservedDBInstancesOfferingsPages(input *DescribeReservedD
 const opDownloadDBLogFilePortion = "DownloadDBLogFilePortion"
 
 // DownloadDBLogFilePortionRequest generates a request for the DownloadDBLogFilePortion operation.
-func (c *RDS) DownloadDBLogFilePortionRequest(input *DownloadDBLogFilePortionInput) (req *service.Request, output *DownloadDBLogFilePortionOutput) {
-	op := &service.Operation{
+func (c *RDS) DownloadDBLogFilePortionRequest(input *DownloadDBLogFilePortionInput) (req *request.Request, output *DownloadDBLogFilePortionOutput) {
+	op := &request.Operation{
 		Name:       opDownloadDBLogFilePortion,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "NumberOfLines",
@@ -1901,8 +1901,8 @@ func (c *RDS) DownloadDBLogFilePortionPages(input *DownloadDBLogFilePortionInput
 const opFailoverDBCluster = "FailoverDBCluster"
 
 // FailoverDBClusterRequest generates a request for the FailoverDBCluster operation.
-func (c *RDS) FailoverDBClusterRequest(input *FailoverDBClusterInput) (req *service.Request, output *FailoverDBClusterOutput) {
-	op := &service.Operation{
+func (c *RDS) FailoverDBClusterRequest(input *FailoverDBClusterInput) (req *request.Request, output *FailoverDBClusterOutput) {
+	op := &request.Operation{
 		Name:       opFailoverDBCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1942,8 +1942,8 @@ func (c *RDS) FailoverDBCluster(input *FailoverDBClusterInput) (*FailoverDBClust
 const opListTagsForResource = "ListTagsForResource"
 
 // ListTagsForResourceRequest generates a request for the ListTagsForResource operation.
-func (c *RDS) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *service.Request, output *ListTagsForResourceOutput) {
-	op := &service.Operation{
+func (c *RDS) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *ListTagsForResourceOutput) {
+	op := &request.Operation{
 		Name:       opListTagsForResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1972,8 +1972,8 @@ func (c *RDS) ListTagsForResource(input *ListTagsForResourceInput) (*ListTagsFor
 const opModifyDBCluster = "ModifyDBCluster"
 
 // ModifyDBClusterRequest generates a request for the ModifyDBCluster operation.
-func (c *RDS) ModifyDBClusterRequest(input *ModifyDBClusterInput) (req *service.Request, output *ModifyDBClusterOutput) {
-	op := &service.Operation{
+func (c *RDS) ModifyDBClusterRequest(input *ModifyDBClusterInput) (req *request.Request, output *ModifyDBClusterOutput) {
+	op := &request.Operation{
 		Name:       opModifyDBCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2003,8 +2003,8 @@ func (c *RDS) ModifyDBCluster(input *ModifyDBClusterInput) (*ModifyDBClusterOutp
 const opModifyDBClusterParameterGroup = "ModifyDBClusterParameterGroup"
 
 // ModifyDBClusterParameterGroupRequest generates a request for the ModifyDBClusterParameterGroup operation.
-func (c *RDS) ModifyDBClusterParameterGroupRequest(input *ModifyDBClusterParameterGroupInput) (req *service.Request, output *DBClusterParameterGroupNameMessage) {
-	op := &service.Operation{
+func (c *RDS) ModifyDBClusterParameterGroupRequest(input *ModifyDBClusterParameterGroupInput) (req *request.Request, output *DBClusterParameterGroupNameMessage) {
+	op := &request.Operation{
 		Name:       opModifyDBClusterParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2051,8 +2051,8 @@ func (c *RDS) ModifyDBClusterParameterGroup(input *ModifyDBClusterParameterGroup
 const opModifyDBInstance = "ModifyDBInstance"
 
 // ModifyDBInstanceRequest generates a request for the ModifyDBInstance operation.
-func (c *RDS) ModifyDBInstanceRequest(input *ModifyDBInstanceInput) (req *service.Request, output *ModifyDBInstanceOutput) {
-	op := &service.Operation{
+func (c *RDS) ModifyDBInstanceRequest(input *ModifyDBInstanceInput) (req *request.Request, output *ModifyDBInstanceOutput) {
+	op := &request.Operation{
 		Name:       opModifyDBInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2079,8 +2079,8 @@ func (c *RDS) ModifyDBInstance(input *ModifyDBInstanceInput) (*ModifyDBInstanceO
 const opModifyDBParameterGroup = "ModifyDBParameterGroup"
 
 // ModifyDBParameterGroupRequest generates a request for the ModifyDBParameterGroup operation.
-func (c *RDS) ModifyDBParameterGroupRequest(input *ModifyDBParameterGroupInput) (req *service.Request, output *DBParameterGroupNameMessage) {
-	op := &service.Operation{
+func (c *RDS) ModifyDBParameterGroupRequest(input *ModifyDBParameterGroupInput) (req *request.Request, output *DBParameterGroupNameMessage) {
+	op := &request.Operation{
 		Name:       opModifyDBParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2123,8 +2123,8 @@ func (c *RDS) ModifyDBParameterGroup(input *ModifyDBParameterGroupInput) (*DBPar
 const opModifyDBSubnetGroup = "ModifyDBSubnetGroup"
 
 // ModifyDBSubnetGroupRequest generates a request for the ModifyDBSubnetGroup operation.
-func (c *RDS) ModifyDBSubnetGroupRequest(input *ModifyDBSubnetGroupInput) (req *service.Request, output *ModifyDBSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) ModifyDBSubnetGroupRequest(input *ModifyDBSubnetGroupInput) (req *request.Request, output *ModifyDBSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opModifyDBSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2151,8 +2151,8 @@ func (c *RDS) ModifyDBSubnetGroup(input *ModifyDBSubnetGroupInput) (*ModifyDBSub
 const opModifyEventSubscription = "ModifyEventSubscription"
 
 // ModifyEventSubscriptionRequest generates a request for the ModifyEventSubscription operation.
-func (c *RDS) ModifyEventSubscriptionRequest(input *ModifyEventSubscriptionInput) (req *service.Request, output *ModifyEventSubscriptionOutput) {
-	op := &service.Operation{
+func (c *RDS) ModifyEventSubscriptionRequest(input *ModifyEventSubscriptionInput) (req *request.Request, output *ModifyEventSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opModifyEventSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2186,8 +2186,8 @@ func (c *RDS) ModifyEventSubscription(input *ModifyEventSubscriptionInput) (*Mod
 const opModifyOptionGroup = "ModifyOptionGroup"
 
 // ModifyOptionGroupRequest generates a request for the ModifyOptionGroup operation.
-func (c *RDS) ModifyOptionGroupRequest(input *ModifyOptionGroupInput) (req *service.Request, output *ModifyOptionGroupOutput) {
-	op := &service.Operation{
+func (c *RDS) ModifyOptionGroupRequest(input *ModifyOptionGroupInput) (req *request.Request, output *ModifyOptionGroupOutput) {
+	op := &request.Operation{
 		Name:       opModifyOptionGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2213,8 +2213,8 @@ func (c *RDS) ModifyOptionGroup(input *ModifyOptionGroupInput) (*ModifyOptionGro
 const opPromoteReadReplica = "PromoteReadReplica"
 
 // PromoteReadReplicaRequest generates a request for the PromoteReadReplica operation.
-func (c *RDS) PromoteReadReplicaRequest(input *PromoteReadReplicaInput) (req *service.Request, output *PromoteReadReplicaOutput) {
-	op := &service.Operation{
+func (c *RDS) PromoteReadReplicaRequest(input *PromoteReadReplicaInput) (req *request.Request, output *PromoteReadReplicaOutput) {
+	op := &request.Operation{
 		Name:       opPromoteReadReplica,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2245,8 +2245,8 @@ func (c *RDS) PromoteReadReplica(input *PromoteReadReplicaInput) (*PromoteReadRe
 const opPurchaseReservedDBInstancesOffering = "PurchaseReservedDBInstancesOffering"
 
 // PurchaseReservedDBInstancesOfferingRequest generates a request for the PurchaseReservedDBInstancesOffering operation.
-func (c *RDS) PurchaseReservedDBInstancesOfferingRequest(input *PurchaseReservedDBInstancesOfferingInput) (req *service.Request, output *PurchaseReservedDBInstancesOfferingOutput) {
-	op := &service.Operation{
+func (c *RDS) PurchaseReservedDBInstancesOfferingRequest(input *PurchaseReservedDBInstancesOfferingInput) (req *request.Request, output *PurchaseReservedDBInstancesOfferingOutput) {
+	op := &request.Operation{
 		Name:       opPurchaseReservedDBInstancesOffering,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2272,8 +2272,8 @@ func (c *RDS) PurchaseReservedDBInstancesOffering(input *PurchaseReservedDBInsta
 const opRebootDBInstance = "RebootDBInstance"
 
 // RebootDBInstanceRequest generates a request for the RebootDBInstance operation.
-func (c *RDS) RebootDBInstanceRequest(input *RebootDBInstanceInput) (req *service.Request, output *RebootDBInstanceOutput) {
-	op := &service.Operation{
+func (c *RDS) RebootDBInstanceRequest(input *RebootDBInstanceInput) (req *request.Request, output *RebootDBInstanceOutput) {
+	op := &request.Operation{
 		Name:       opRebootDBInstance,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2315,8 +2315,8 @@ func (c *RDS) RebootDBInstance(input *RebootDBInstanceInput) (*RebootDBInstanceO
 const opRemoveSourceIdentifierFromSubscription = "RemoveSourceIdentifierFromSubscription"
 
 // RemoveSourceIdentifierFromSubscriptionRequest generates a request for the RemoveSourceIdentifierFromSubscription operation.
-func (c *RDS) RemoveSourceIdentifierFromSubscriptionRequest(input *RemoveSourceIdentifierFromSubscriptionInput) (req *service.Request, output *RemoveSourceIdentifierFromSubscriptionOutput) {
-	op := &service.Operation{
+func (c *RDS) RemoveSourceIdentifierFromSubscriptionRequest(input *RemoveSourceIdentifierFromSubscriptionInput) (req *request.Request, output *RemoveSourceIdentifierFromSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opRemoveSourceIdentifierFromSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2342,8 +2342,8 @@ func (c *RDS) RemoveSourceIdentifierFromSubscription(input *RemoveSourceIdentifi
 const opRemoveTagsFromResource = "RemoveTagsFromResource"
 
 // RemoveTagsFromResourceRequest generates a request for the RemoveTagsFromResource operation.
-func (c *RDS) RemoveTagsFromResourceRequest(input *RemoveTagsFromResourceInput) (req *service.Request, output *RemoveTagsFromResourceOutput) {
-	op := &service.Operation{
+func (c *RDS) RemoveTagsFromResourceRequest(input *RemoveTagsFromResourceInput) (req *request.Request, output *RemoveTagsFromResourceOutput) {
+	op := &request.Operation{
 		Name:       opRemoveTagsFromResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2372,8 +2372,8 @@ func (c *RDS) RemoveTagsFromResource(input *RemoveTagsFromResourceInput) (*Remov
 const opResetDBClusterParameterGroup = "ResetDBClusterParameterGroup"
 
 // ResetDBClusterParameterGroupRequest generates a request for the ResetDBClusterParameterGroup operation.
-func (c *RDS) ResetDBClusterParameterGroupRequest(input *ResetDBClusterParameterGroupInput) (req *service.Request, output *DBClusterParameterGroupNameMessage) {
-	op := &service.Operation{
+func (c *RDS) ResetDBClusterParameterGroupRequest(input *ResetDBClusterParameterGroupInput) (req *request.Request, output *DBClusterParameterGroupNameMessage) {
+	op := &request.Operation{
 		Name:       opResetDBClusterParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2411,8 +2411,8 @@ func (c *RDS) ResetDBClusterParameterGroup(input *ResetDBClusterParameterGroupIn
 const opResetDBParameterGroup = "ResetDBParameterGroup"
 
 // ResetDBParameterGroupRequest generates a request for the ResetDBParameterGroup operation.
-func (c *RDS) ResetDBParameterGroupRequest(input *ResetDBParameterGroupInput) (req *service.Request, output *DBParameterGroupNameMessage) {
-	op := &service.Operation{
+func (c *RDS) ResetDBParameterGroupRequest(input *ResetDBParameterGroupInput) (req *request.Request, output *DBParameterGroupNameMessage) {
+	op := &request.Operation{
 		Name:       opResetDBParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2444,8 +2444,8 @@ func (c *RDS) ResetDBParameterGroup(input *ResetDBParameterGroupInput) (*DBParam
 const opRestoreDBClusterFromSnapshot = "RestoreDBClusterFromSnapshot"
 
 // RestoreDBClusterFromSnapshotRequest generates a request for the RestoreDBClusterFromSnapshot operation.
-func (c *RDS) RestoreDBClusterFromSnapshotRequest(input *RestoreDBClusterFromSnapshotInput) (req *service.Request, output *RestoreDBClusterFromSnapshotOutput) {
-	op := &service.Operation{
+func (c *RDS) RestoreDBClusterFromSnapshotRequest(input *RestoreDBClusterFromSnapshotInput) (req *request.Request, output *RestoreDBClusterFromSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opRestoreDBClusterFromSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2477,8 +2477,8 @@ func (c *RDS) RestoreDBClusterFromSnapshot(input *RestoreDBClusterFromSnapshotIn
 const opRestoreDBClusterToPointInTime = "RestoreDBClusterToPointInTime"
 
 // RestoreDBClusterToPointInTimeRequest generates a request for the RestoreDBClusterToPointInTime operation.
-func (c *RDS) RestoreDBClusterToPointInTimeRequest(input *RestoreDBClusterToPointInTimeInput) (req *service.Request, output *RestoreDBClusterToPointInTimeOutput) {
-	op := &service.Operation{
+func (c *RDS) RestoreDBClusterToPointInTimeRequest(input *RestoreDBClusterToPointInTimeInput) (req *request.Request, output *RestoreDBClusterToPointInTimeOutput) {
+	op := &request.Operation{
 		Name:       opRestoreDBClusterToPointInTime,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2511,8 +2511,8 @@ func (c *RDS) RestoreDBClusterToPointInTime(input *RestoreDBClusterToPointInTime
 const opRestoreDBInstanceFromDBSnapshot = "RestoreDBInstanceFromDBSnapshot"
 
 // RestoreDBInstanceFromDBSnapshotRequest generates a request for the RestoreDBInstanceFromDBSnapshot operation.
-func (c *RDS) RestoreDBInstanceFromDBSnapshotRequest(input *RestoreDBInstanceFromDBSnapshotInput) (req *service.Request, output *RestoreDBInstanceFromDBSnapshotOutput) {
-	op := &service.Operation{
+func (c *RDS) RestoreDBInstanceFromDBSnapshotRequest(input *RestoreDBInstanceFromDBSnapshotInput) (req *request.Request, output *RestoreDBInstanceFromDBSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opRestoreDBInstanceFromDBSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2554,8 +2554,8 @@ func (c *RDS) RestoreDBInstanceFromDBSnapshot(input *RestoreDBInstanceFromDBSnap
 const opRestoreDBInstanceToPointInTime = "RestoreDBInstanceToPointInTime"
 
 // RestoreDBInstanceToPointInTimeRequest generates a request for the RestoreDBInstanceToPointInTime operation.
-func (c *RDS) RestoreDBInstanceToPointInTimeRequest(input *RestoreDBInstanceToPointInTimeInput) (req *service.Request, output *RestoreDBInstanceToPointInTimeOutput) {
-	op := &service.Operation{
+func (c *RDS) RestoreDBInstanceToPointInTimeRequest(input *RestoreDBInstanceToPointInTimeInput) (req *request.Request, output *RestoreDBInstanceToPointInTimeOutput) {
+	op := &request.Operation{
 		Name:       opRestoreDBInstanceToPointInTime,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2589,8 +2589,8 @@ func (c *RDS) RestoreDBInstanceToPointInTime(input *RestoreDBInstanceToPointInTi
 const opRevokeDBSecurityGroupIngress = "RevokeDBSecurityGroupIngress"
 
 // RevokeDBSecurityGroupIngressRequest generates a request for the RevokeDBSecurityGroupIngress operation.
-func (c *RDS) RevokeDBSecurityGroupIngressRequest(input *RevokeDBSecurityGroupIngressInput) (req *service.Request, output *RevokeDBSecurityGroupIngressOutput) {
-	op := &service.Operation{
+func (c *RDS) RevokeDBSecurityGroupIngressRequest(input *RevokeDBSecurityGroupIngressInput) (req *request.Request, output *RevokeDBSecurityGroupIngressOutput) {
+	op := &request.Operation{
 		Name:       opRevokeDBSecurityGroupIngress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/rds/rdsiface/interface.go
+++ b/service/rds/rdsiface/interface.go
@@ -4,347 +4,347 @@
 package rdsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/rds"
 )
 
 // RDSAPI is the interface type for rds.RDS.
 type RDSAPI interface {
-	AddSourceIdentifierToSubscriptionRequest(*rds.AddSourceIdentifierToSubscriptionInput) (*service.Request, *rds.AddSourceIdentifierToSubscriptionOutput)
+	AddSourceIdentifierToSubscriptionRequest(*rds.AddSourceIdentifierToSubscriptionInput) (*request.Request, *rds.AddSourceIdentifierToSubscriptionOutput)
 
 	AddSourceIdentifierToSubscription(*rds.AddSourceIdentifierToSubscriptionInput) (*rds.AddSourceIdentifierToSubscriptionOutput, error)
 
-	AddTagsToResourceRequest(*rds.AddTagsToResourceInput) (*service.Request, *rds.AddTagsToResourceOutput)
+	AddTagsToResourceRequest(*rds.AddTagsToResourceInput) (*request.Request, *rds.AddTagsToResourceOutput)
 
 	AddTagsToResource(*rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error)
 
-	ApplyPendingMaintenanceActionRequest(*rds.ApplyPendingMaintenanceActionInput) (*service.Request, *rds.ApplyPendingMaintenanceActionOutput)
+	ApplyPendingMaintenanceActionRequest(*rds.ApplyPendingMaintenanceActionInput) (*request.Request, *rds.ApplyPendingMaintenanceActionOutput)
 
 	ApplyPendingMaintenanceAction(*rds.ApplyPendingMaintenanceActionInput) (*rds.ApplyPendingMaintenanceActionOutput, error)
 
-	AuthorizeDBSecurityGroupIngressRequest(*rds.AuthorizeDBSecurityGroupIngressInput) (*service.Request, *rds.AuthorizeDBSecurityGroupIngressOutput)
+	AuthorizeDBSecurityGroupIngressRequest(*rds.AuthorizeDBSecurityGroupIngressInput) (*request.Request, *rds.AuthorizeDBSecurityGroupIngressOutput)
 
 	AuthorizeDBSecurityGroupIngress(*rds.AuthorizeDBSecurityGroupIngressInput) (*rds.AuthorizeDBSecurityGroupIngressOutput, error)
 
-	CopyDBClusterSnapshotRequest(*rds.CopyDBClusterSnapshotInput) (*service.Request, *rds.CopyDBClusterSnapshotOutput)
+	CopyDBClusterSnapshotRequest(*rds.CopyDBClusterSnapshotInput) (*request.Request, *rds.CopyDBClusterSnapshotOutput)
 
 	CopyDBClusterSnapshot(*rds.CopyDBClusterSnapshotInput) (*rds.CopyDBClusterSnapshotOutput, error)
 
-	CopyDBParameterGroupRequest(*rds.CopyDBParameterGroupInput) (*service.Request, *rds.CopyDBParameterGroupOutput)
+	CopyDBParameterGroupRequest(*rds.CopyDBParameterGroupInput) (*request.Request, *rds.CopyDBParameterGroupOutput)
 
 	CopyDBParameterGroup(*rds.CopyDBParameterGroupInput) (*rds.CopyDBParameterGroupOutput, error)
 
-	CopyDBSnapshotRequest(*rds.CopyDBSnapshotInput) (*service.Request, *rds.CopyDBSnapshotOutput)
+	CopyDBSnapshotRequest(*rds.CopyDBSnapshotInput) (*request.Request, *rds.CopyDBSnapshotOutput)
 
 	CopyDBSnapshot(*rds.CopyDBSnapshotInput) (*rds.CopyDBSnapshotOutput, error)
 
-	CopyOptionGroupRequest(*rds.CopyOptionGroupInput) (*service.Request, *rds.CopyOptionGroupOutput)
+	CopyOptionGroupRequest(*rds.CopyOptionGroupInput) (*request.Request, *rds.CopyOptionGroupOutput)
 
 	CopyOptionGroup(*rds.CopyOptionGroupInput) (*rds.CopyOptionGroupOutput, error)
 
-	CreateDBClusterRequest(*rds.CreateDBClusterInput) (*service.Request, *rds.CreateDBClusterOutput)
+	CreateDBClusterRequest(*rds.CreateDBClusterInput) (*request.Request, *rds.CreateDBClusterOutput)
 
 	CreateDBCluster(*rds.CreateDBClusterInput) (*rds.CreateDBClusterOutput, error)
 
-	CreateDBClusterParameterGroupRequest(*rds.CreateDBClusterParameterGroupInput) (*service.Request, *rds.CreateDBClusterParameterGroupOutput)
+	CreateDBClusterParameterGroupRequest(*rds.CreateDBClusterParameterGroupInput) (*request.Request, *rds.CreateDBClusterParameterGroupOutput)
 
 	CreateDBClusterParameterGroup(*rds.CreateDBClusterParameterGroupInput) (*rds.CreateDBClusterParameterGroupOutput, error)
 
-	CreateDBClusterSnapshotRequest(*rds.CreateDBClusterSnapshotInput) (*service.Request, *rds.CreateDBClusterSnapshotOutput)
+	CreateDBClusterSnapshotRequest(*rds.CreateDBClusterSnapshotInput) (*request.Request, *rds.CreateDBClusterSnapshotOutput)
 
 	CreateDBClusterSnapshot(*rds.CreateDBClusterSnapshotInput) (*rds.CreateDBClusterSnapshotOutput, error)
 
-	CreateDBInstanceRequest(*rds.CreateDBInstanceInput) (*service.Request, *rds.CreateDBInstanceOutput)
+	CreateDBInstanceRequest(*rds.CreateDBInstanceInput) (*request.Request, *rds.CreateDBInstanceOutput)
 
 	CreateDBInstance(*rds.CreateDBInstanceInput) (*rds.CreateDBInstanceOutput, error)
 
-	CreateDBInstanceReadReplicaRequest(*rds.CreateDBInstanceReadReplicaInput) (*service.Request, *rds.CreateDBInstanceReadReplicaOutput)
+	CreateDBInstanceReadReplicaRequest(*rds.CreateDBInstanceReadReplicaInput) (*request.Request, *rds.CreateDBInstanceReadReplicaOutput)
 
 	CreateDBInstanceReadReplica(*rds.CreateDBInstanceReadReplicaInput) (*rds.CreateDBInstanceReadReplicaOutput, error)
 
-	CreateDBParameterGroupRequest(*rds.CreateDBParameterGroupInput) (*service.Request, *rds.CreateDBParameterGroupOutput)
+	CreateDBParameterGroupRequest(*rds.CreateDBParameterGroupInput) (*request.Request, *rds.CreateDBParameterGroupOutput)
 
 	CreateDBParameterGroup(*rds.CreateDBParameterGroupInput) (*rds.CreateDBParameterGroupOutput, error)
 
-	CreateDBSecurityGroupRequest(*rds.CreateDBSecurityGroupInput) (*service.Request, *rds.CreateDBSecurityGroupOutput)
+	CreateDBSecurityGroupRequest(*rds.CreateDBSecurityGroupInput) (*request.Request, *rds.CreateDBSecurityGroupOutput)
 
 	CreateDBSecurityGroup(*rds.CreateDBSecurityGroupInput) (*rds.CreateDBSecurityGroupOutput, error)
 
-	CreateDBSnapshotRequest(*rds.CreateDBSnapshotInput) (*service.Request, *rds.CreateDBSnapshotOutput)
+	CreateDBSnapshotRequest(*rds.CreateDBSnapshotInput) (*request.Request, *rds.CreateDBSnapshotOutput)
 
 	CreateDBSnapshot(*rds.CreateDBSnapshotInput) (*rds.CreateDBSnapshotOutput, error)
 
-	CreateDBSubnetGroupRequest(*rds.CreateDBSubnetGroupInput) (*service.Request, *rds.CreateDBSubnetGroupOutput)
+	CreateDBSubnetGroupRequest(*rds.CreateDBSubnetGroupInput) (*request.Request, *rds.CreateDBSubnetGroupOutput)
 
 	CreateDBSubnetGroup(*rds.CreateDBSubnetGroupInput) (*rds.CreateDBSubnetGroupOutput, error)
 
-	CreateEventSubscriptionRequest(*rds.CreateEventSubscriptionInput) (*service.Request, *rds.CreateEventSubscriptionOutput)
+	CreateEventSubscriptionRequest(*rds.CreateEventSubscriptionInput) (*request.Request, *rds.CreateEventSubscriptionOutput)
 
 	CreateEventSubscription(*rds.CreateEventSubscriptionInput) (*rds.CreateEventSubscriptionOutput, error)
 
-	CreateOptionGroupRequest(*rds.CreateOptionGroupInput) (*service.Request, *rds.CreateOptionGroupOutput)
+	CreateOptionGroupRequest(*rds.CreateOptionGroupInput) (*request.Request, *rds.CreateOptionGroupOutput)
 
 	CreateOptionGroup(*rds.CreateOptionGroupInput) (*rds.CreateOptionGroupOutput, error)
 
-	DeleteDBClusterRequest(*rds.DeleteDBClusterInput) (*service.Request, *rds.DeleteDBClusterOutput)
+	DeleteDBClusterRequest(*rds.DeleteDBClusterInput) (*request.Request, *rds.DeleteDBClusterOutput)
 
 	DeleteDBCluster(*rds.DeleteDBClusterInput) (*rds.DeleteDBClusterOutput, error)
 
-	DeleteDBClusterParameterGroupRequest(*rds.DeleteDBClusterParameterGroupInput) (*service.Request, *rds.DeleteDBClusterParameterGroupOutput)
+	DeleteDBClusterParameterGroupRequest(*rds.DeleteDBClusterParameterGroupInput) (*request.Request, *rds.DeleteDBClusterParameterGroupOutput)
 
 	DeleteDBClusterParameterGroup(*rds.DeleteDBClusterParameterGroupInput) (*rds.DeleteDBClusterParameterGroupOutput, error)
 
-	DeleteDBClusterSnapshotRequest(*rds.DeleteDBClusterSnapshotInput) (*service.Request, *rds.DeleteDBClusterSnapshotOutput)
+	DeleteDBClusterSnapshotRequest(*rds.DeleteDBClusterSnapshotInput) (*request.Request, *rds.DeleteDBClusterSnapshotOutput)
 
 	DeleteDBClusterSnapshot(*rds.DeleteDBClusterSnapshotInput) (*rds.DeleteDBClusterSnapshotOutput, error)
 
-	DeleteDBInstanceRequest(*rds.DeleteDBInstanceInput) (*service.Request, *rds.DeleteDBInstanceOutput)
+	DeleteDBInstanceRequest(*rds.DeleteDBInstanceInput) (*request.Request, *rds.DeleteDBInstanceOutput)
 
 	DeleteDBInstance(*rds.DeleteDBInstanceInput) (*rds.DeleteDBInstanceOutput, error)
 
-	DeleteDBParameterGroupRequest(*rds.DeleteDBParameterGroupInput) (*service.Request, *rds.DeleteDBParameterGroupOutput)
+	DeleteDBParameterGroupRequest(*rds.DeleteDBParameterGroupInput) (*request.Request, *rds.DeleteDBParameterGroupOutput)
 
 	DeleteDBParameterGroup(*rds.DeleteDBParameterGroupInput) (*rds.DeleteDBParameterGroupOutput, error)
 
-	DeleteDBSecurityGroupRequest(*rds.DeleteDBSecurityGroupInput) (*service.Request, *rds.DeleteDBSecurityGroupOutput)
+	DeleteDBSecurityGroupRequest(*rds.DeleteDBSecurityGroupInput) (*request.Request, *rds.DeleteDBSecurityGroupOutput)
 
 	DeleteDBSecurityGroup(*rds.DeleteDBSecurityGroupInput) (*rds.DeleteDBSecurityGroupOutput, error)
 
-	DeleteDBSnapshotRequest(*rds.DeleteDBSnapshotInput) (*service.Request, *rds.DeleteDBSnapshotOutput)
+	DeleteDBSnapshotRequest(*rds.DeleteDBSnapshotInput) (*request.Request, *rds.DeleteDBSnapshotOutput)
 
 	DeleteDBSnapshot(*rds.DeleteDBSnapshotInput) (*rds.DeleteDBSnapshotOutput, error)
 
-	DeleteDBSubnetGroupRequest(*rds.DeleteDBSubnetGroupInput) (*service.Request, *rds.DeleteDBSubnetGroupOutput)
+	DeleteDBSubnetGroupRequest(*rds.DeleteDBSubnetGroupInput) (*request.Request, *rds.DeleteDBSubnetGroupOutput)
 
 	DeleteDBSubnetGroup(*rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error)
 
-	DeleteEventSubscriptionRequest(*rds.DeleteEventSubscriptionInput) (*service.Request, *rds.DeleteEventSubscriptionOutput)
+	DeleteEventSubscriptionRequest(*rds.DeleteEventSubscriptionInput) (*request.Request, *rds.DeleteEventSubscriptionOutput)
 
 	DeleteEventSubscription(*rds.DeleteEventSubscriptionInput) (*rds.DeleteEventSubscriptionOutput, error)
 
-	DeleteOptionGroupRequest(*rds.DeleteOptionGroupInput) (*service.Request, *rds.DeleteOptionGroupOutput)
+	DeleteOptionGroupRequest(*rds.DeleteOptionGroupInput) (*request.Request, *rds.DeleteOptionGroupOutput)
 
 	DeleteOptionGroup(*rds.DeleteOptionGroupInput) (*rds.DeleteOptionGroupOutput, error)
 
-	DescribeAccountAttributesRequest(*rds.DescribeAccountAttributesInput) (*service.Request, *rds.DescribeAccountAttributesOutput)
+	DescribeAccountAttributesRequest(*rds.DescribeAccountAttributesInput) (*request.Request, *rds.DescribeAccountAttributesOutput)
 
 	DescribeAccountAttributes(*rds.DescribeAccountAttributesInput) (*rds.DescribeAccountAttributesOutput, error)
 
-	DescribeCertificatesRequest(*rds.DescribeCertificatesInput) (*service.Request, *rds.DescribeCertificatesOutput)
+	DescribeCertificatesRequest(*rds.DescribeCertificatesInput) (*request.Request, *rds.DescribeCertificatesOutput)
 
 	DescribeCertificates(*rds.DescribeCertificatesInput) (*rds.DescribeCertificatesOutput, error)
 
-	DescribeDBClusterParameterGroupsRequest(*rds.DescribeDBClusterParameterGroupsInput) (*service.Request, *rds.DescribeDBClusterParameterGroupsOutput)
+	DescribeDBClusterParameterGroupsRequest(*rds.DescribeDBClusterParameterGroupsInput) (*request.Request, *rds.DescribeDBClusterParameterGroupsOutput)
 
 	DescribeDBClusterParameterGroups(*rds.DescribeDBClusterParameterGroupsInput) (*rds.DescribeDBClusterParameterGroupsOutput, error)
 
-	DescribeDBClusterParametersRequest(*rds.DescribeDBClusterParametersInput) (*service.Request, *rds.DescribeDBClusterParametersOutput)
+	DescribeDBClusterParametersRequest(*rds.DescribeDBClusterParametersInput) (*request.Request, *rds.DescribeDBClusterParametersOutput)
 
 	DescribeDBClusterParameters(*rds.DescribeDBClusterParametersInput) (*rds.DescribeDBClusterParametersOutput, error)
 
-	DescribeDBClusterSnapshotsRequest(*rds.DescribeDBClusterSnapshotsInput) (*service.Request, *rds.DescribeDBClusterSnapshotsOutput)
+	DescribeDBClusterSnapshotsRequest(*rds.DescribeDBClusterSnapshotsInput) (*request.Request, *rds.DescribeDBClusterSnapshotsOutput)
 
 	DescribeDBClusterSnapshots(*rds.DescribeDBClusterSnapshotsInput) (*rds.DescribeDBClusterSnapshotsOutput, error)
 
-	DescribeDBClustersRequest(*rds.DescribeDBClustersInput) (*service.Request, *rds.DescribeDBClustersOutput)
+	DescribeDBClustersRequest(*rds.DescribeDBClustersInput) (*request.Request, *rds.DescribeDBClustersOutput)
 
 	DescribeDBClusters(*rds.DescribeDBClustersInput) (*rds.DescribeDBClustersOutput, error)
 
-	DescribeDBEngineVersionsRequest(*rds.DescribeDBEngineVersionsInput) (*service.Request, *rds.DescribeDBEngineVersionsOutput)
+	DescribeDBEngineVersionsRequest(*rds.DescribeDBEngineVersionsInput) (*request.Request, *rds.DescribeDBEngineVersionsOutput)
 
 	DescribeDBEngineVersions(*rds.DescribeDBEngineVersionsInput) (*rds.DescribeDBEngineVersionsOutput, error)
 
 	DescribeDBEngineVersionsPages(*rds.DescribeDBEngineVersionsInput, func(*rds.DescribeDBEngineVersionsOutput, bool) bool) error
 
-	DescribeDBInstancesRequest(*rds.DescribeDBInstancesInput) (*service.Request, *rds.DescribeDBInstancesOutput)
+	DescribeDBInstancesRequest(*rds.DescribeDBInstancesInput) (*request.Request, *rds.DescribeDBInstancesOutput)
 
 	DescribeDBInstances(*rds.DescribeDBInstancesInput) (*rds.DescribeDBInstancesOutput, error)
 
 	DescribeDBInstancesPages(*rds.DescribeDBInstancesInput, func(*rds.DescribeDBInstancesOutput, bool) bool) error
 
-	DescribeDBLogFilesRequest(*rds.DescribeDBLogFilesInput) (*service.Request, *rds.DescribeDBLogFilesOutput)
+	DescribeDBLogFilesRequest(*rds.DescribeDBLogFilesInput) (*request.Request, *rds.DescribeDBLogFilesOutput)
 
 	DescribeDBLogFiles(*rds.DescribeDBLogFilesInput) (*rds.DescribeDBLogFilesOutput, error)
 
 	DescribeDBLogFilesPages(*rds.DescribeDBLogFilesInput, func(*rds.DescribeDBLogFilesOutput, bool) bool) error
 
-	DescribeDBParameterGroupsRequest(*rds.DescribeDBParameterGroupsInput) (*service.Request, *rds.DescribeDBParameterGroupsOutput)
+	DescribeDBParameterGroupsRequest(*rds.DescribeDBParameterGroupsInput) (*request.Request, *rds.DescribeDBParameterGroupsOutput)
 
 	DescribeDBParameterGroups(*rds.DescribeDBParameterGroupsInput) (*rds.DescribeDBParameterGroupsOutput, error)
 
 	DescribeDBParameterGroupsPages(*rds.DescribeDBParameterGroupsInput, func(*rds.DescribeDBParameterGroupsOutput, bool) bool) error
 
-	DescribeDBParametersRequest(*rds.DescribeDBParametersInput) (*service.Request, *rds.DescribeDBParametersOutput)
+	DescribeDBParametersRequest(*rds.DescribeDBParametersInput) (*request.Request, *rds.DescribeDBParametersOutput)
 
 	DescribeDBParameters(*rds.DescribeDBParametersInput) (*rds.DescribeDBParametersOutput, error)
 
 	DescribeDBParametersPages(*rds.DescribeDBParametersInput, func(*rds.DescribeDBParametersOutput, bool) bool) error
 
-	DescribeDBSecurityGroupsRequest(*rds.DescribeDBSecurityGroupsInput) (*service.Request, *rds.DescribeDBSecurityGroupsOutput)
+	DescribeDBSecurityGroupsRequest(*rds.DescribeDBSecurityGroupsInput) (*request.Request, *rds.DescribeDBSecurityGroupsOutput)
 
 	DescribeDBSecurityGroups(*rds.DescribeDBSecurityGroupsInput) (*rds.DescribeDBSecurityGroupsOutput, error)
 
 	DescribeDBSecurityGroupsPages(*rds.DescribeDBSecurityGroupsInput, func(*rds.DescribeDBSecurityGroupsOutput, bool) bool) error
 
-	DescribeDBSnapshotsRequest(*rds.DescribeDBSnapshotsInput) (*service.Request, *rds.DescribeDBSnapshotsOutput)
+	DescribeDBSnapshotsRequest(*rds.DescribeDBSnapshotsInput) (*request.Request, *rds.DescribeDBSnapshotsOutput)
 
 	DescribeDBSnapshots(*rds.DescribeDBSnapshotsInput) (*rds.DescribeDBSnapshotsOutput, error)
 
 	DescribeDBSnapshotsPages(*rds.DescribeDBSnapshotsInput, func(*rds.DescribeDBSnapshotsOutput, bool) bool) error
 
-	DescribeDBSubnetGroupsRequest(*rds.DescribeDBSubnetGroupsInput) (*service.Request, *rds.DescribeDBSubnetGroupsOutput)
+	DescribeDBSubnetGroupsRequest(*rds.DescribeDBSubnetGroupsInput) (*request.Request, *rds.DescribeDBSubnetGroupsOutput)
 
 	DescribeDBSubnetGroups(*rds.DescribeDBSubnetGroupsInput) (*rds.DescribeDBSubnetGroupsOutput, error)
 
 	DescribeDBSubnetGroupsPages(*rds.DescribeDBSubnetGroupsInput, func(*rds.DescribeDBSubnetGroupsOutput, bool) bool) error
 
-	DescribeEngineDefaultClusterParametersRequest(*rds.DescribeEngineDefaultClusterParametersInput) (*service.Request, *rds.DescribeEngineDefaultClusterParametersOutput)
+	DescribeEngineDefaultClusterParametersRequest(*rds.DescribeEngineDefaultClusterParametersInput) (*request.Request, *rds.DescribeEngineDefaultClusterParametersOutput)
 
 	DescribeEngineDefaultClusterParameters(*rds.DescribeEngineDefaultClusterParametersInput) (*rds.DescribeEngineDefaultClusterParametersOutput, error)
 
-	DescribeEngineDefaultParametersRequest(*rds.DescribeEngineDefaultParametersInput) (*service.Request, *rds.DescribeEngineDefaultParametersOutput)
+	DescribeEngineDefaultParametersRequest(*rds.DescribeEngineDefaultParametersInput) (*request.Request, *rds.DescribeEngineDefaultParametersOutput)
 
 	DescribeEngineDefaultParameters(*rds.DescribeEngineDefaultParametersInput) (*rds.DescribeEngineDefaultParametersOutput, error)
 
 	DescribeEngineDefaultParametersPages(*rds.DescribeEngineDefaultParametersInput, func(*rds.DescribeEngineDefaultParametersOutput, bool) bool) error
 
-	DescribeEventCategoriesRequest(*rds.DescribeEventCategoriesInput) (*service.Request, *rds.DescribeEventCategoriesOutput)
+	DescribeEventCategoriesRequest(*rds.DescribeEventCategoriesInput) (*request.Request, *rds.DescribeEventCategoriesOutput)
 
 	DescribeEventCategories(*rds.DescribeEventCategoriesInput) (*rds.DescribeEventCategoriesOutput, error)
 
-	DescribeEventSubscriptionsRequest(*rds.DescribeEventSubscriptionsInput) (*service.Request, *rds.DescribeEventSubscriptionsOutput)
+	DescribeEventSubscriptionsRequest(*rds.DescribeEventSubscriptionsInput) (*request.Request, *rds.DescribeEventSubscriptionsOutput)
 
 	DescribeEventSubscriptions(*rds.DescribeEventSubscriptionsInput) (*rds.DescribeEventSubscriptionsOutput, error)
 
 	DescribeEventSubscriptionsPages(*rds.DescribeEventSubscriptionsInput, func(*rds.DescribeEventSubscriptionsOutput, bool) bool) error
 
-	DescribeEventsRequest(*rds.DescribeEventsInput) (*service.Request, *rds.DescribeEventsOutput)
+	DescribeEventsRequest(*rds.DescribeEventsInput) (*request.Request, *rds.DescribeEventsOutput)
 
 	DescribeEvents(*rds.DescribeEventsInput) (*rds.DescribeEventsOutput, error)
 
 	DescribeEventsPages(*rds.DescribeEventsInput, func(*rds.DescribeEventsOutput, bool) bool) error
 
-	DescribeOptionGroupOptionsRequest(*rds.DescribeOptionGroupOptionsInput) (*service.Request, *rds.DescribeOptionGroupOptionsOutput)
+	DescribeOptionGroupOptionsRequest(*rds.DescribeOptionGroupOptionsInput) (*request.Request, *rds.DescribeOptionGroupOptionsOutput)
 
 	DescribeOptionGroupOptions(*rds.DescribeOptionGroupOptionsInput) (*rds.DescribeOptionGroupOptionsOutput, error)
 
 	DescribeOptionGroupOptionsPages(*rds.DescribeOptionGroupOptionsInput, func(*rds.DescribeOptionGroupOptionsOutput, bool) bool) error
 
-	DescribeOptionGroupsRequest(*rds.DescribeOptionGroupsInput) (*service.Request, *rds.DescribeOptionGroupsOutput)
+	DescribeOptionGroupsRequest(*rds.DescribeOptionGroupsInput) (*request.Request, *rds.DescribeOptionGroupsOutput)
 
 	DescribeOptionGroups(*rds.DescribeOptionGroupsInput) (*rds.DescribeOptionGroupsOutput, error)
 
 	DescribeOptionGroupsPages(*rds.DescribeOptionGroupsInput, func(*rds.DescribeOptionGroupsOutput, bool) bool) error
 
-	DescribeOrderableDBInstanceOptionsRequest(*rds.DescribeOrderableDBInstanceOptionsInput) (*service.Request, *rds.DescribeOrderableDBInstanceOptionsOutput)
+	DescribeOrderableDBInstanceOptionsRequest(*rds.DescribeOrderableDBInstanceOptionsInput) (*request.Request, *rds.DescribeOrderableDBInstanceOptionsOutput)
 
 	DescribeOrderableDBInstanceOptions(*rds.DescribeOrderableDBInstanceOptionsInput) (*rds.DescribeOrderableDBInstanceOptionsOutput, error)
 
 	DescribeOrderableDBInstanceOptionsPages(*rds.DescribeOrderableDBInstanceOptionsInput, func(*rds.DescribeOrderableDBInstanceOptionsOutput, bool) bool) error
 
-	DescribePendingMaintenanceActionsRequest(*rds.DescribePendingMaintenanceActionsInput) (*service.Request, *rds.DescribePendingMaintenanceActionsOutput)
+	DescribePendingMaintenanceActionsRequest(*rds.DescribePendingMaintenanceActionsInput) (*request.Request, *rds.DescribePendingMaintenanceActionsOutput)
 
 	DescribePendingMaintenanceActions(*rds.DescribePendingMaintenanceActionsInput) (*rds.DescribePendingMaintenanceActionsOutput, error)
 
-	DescribeReservedDBInstancesRequest(*rds.DescribeReservedDBInstancesInput) (*service.Request, *rds.DescribeReservedDBInstancesOutput)
+	DescribeReservedDBInstancesRequest(*rds.DescribeReservedDBInstancesInput) (*request.Request, *rds.DescribeReservedDBInstancesOutput)
 
 	DescribeReservedDBInstances(*rds.DescribeReservedDBInstancesInput) (*rds.DescribeReservedDBInstancesOutput, error)
 
 	DescribeReservedDBInstancesPages(*rds.DescribeReservedDBInstancesInput, func(*rds.DescribeReservedDBInstancesOutput, bool) bool) error
 
-	DescribeReservedDBInstancesOfferingsRequest(*rds.DescribeReservedDBInstancesOfferingsInput) (*service.Request, *rds.DescribeReservedDBInstancesOfferingsOutput)
+	DescribeReservedDBInstancesOfferingsRequest(*rds.DescribeReservedDBInstancesOfferingsInput) (*request.Request, *rds.DescribeReservedDBInstancesOfferingsOutput)
 
 	DescribeReservedDBInstancesOfferings(*rds.DescribeReservedDBInstancesOfferingsInput) (*rds.DescribeReservedDBInstancesOfferingsOutput, error)
 
 	DescribeReservedDBInstancesOfferingsPages(*rds.DescribeReservedDBInstancesOfferingsInput, func(*rds.DescribeReservedDBInstancesOfferingsOutput, bool) bool) error
 
-	DownloadDBLogFilePortionRequest(*rds.DownloadDBLogFilePortionInput) (*service.Request, *rds.DownloadDBLogFilePortionOutput)
+	DownloadDBLogFilePortionRequest(*rds.DownloadDBLogFilePortionInput) (*request.Request, *rds.DownloadDBLogFilePortionOutput)
 
 	DownloadDBLogFilePortion(*rds.DownloadDBLogFilePortionInput) (*rds.DownloadDBLogFilePortionOutput, error)
 
 	DownloadDBLogFilePortionPages(*rds.DownloadDBLogFilePortionInput, func(*rds.DownloadDBLogFilePortionOutput, bool) bool) error
 
-	FailoverDBClusterRequest(*rds.FailoverDBClusterInput) (*service.Request, *rds.FailoverDBClusterOutput)
+	FailoverDBClusterRequest(*rds.FailoverDBClusterInput) (*request.Request, *rds.FailoverDBClusterOutput)
 
 	FailoverDBCluster(*rds.FailoverDBClusterInput) (*rds.FailoverDBClusterOutput, error)
 
-	ListTagsForResourceRequest(*rds.ListTagsForResourceInput) (*service.Request, *rds.ListTagsForResourceOutput)
+	ListTagsForResourceRequest(*rds.ListTagsForResourceInput) (*request.Request, *rds.ListTagsForResourceOutput)
 
 	ListTagsForResource(*rds.ListTagsForResourceInput) (*rds.ListTagsForResourceOutput, error)
 
-	ModifyDBClusterRequest(*rds.ModifyDBClusterInput) (*service.Request, *rds.ModifyDBClusterOutput)
+	ModifyDBClusterRequest(*rds.ModifyDBClusterInput) (*request.Request, *rds.ModifyDBClusterOutput)
 
 	ModifyDBCluster(*rds.ModifyDBClusterInput) (*rds.ModifyDBClusterOutput, error)
 
-	ModifyDBClusterParameterGroupRequest(*rds.ModifyDBClusterParameterGroupInput) (*service.Request, *rds.DBClusterParameterGroupNameMessage)
+	ModifyDBClusterParameterGroupRequest(*rds.ModifyDBClusterParameterGroupInput) (*request.Request, *rds.DBClusterParameterGroupNameMessage)
 
 	ModifyDBClusterParameterGroup(*rds.ModifyDBClusterParameterGroupInput) (*rds.DBClusterParameterGroupNameMessage, error)
 
-	ModifyDBInstanceRequest(*rds.ModifyDBInstanceInput) (*service.Request, *rds.ModifyDBInstanceOutput)
+	ModifyDBInstanceRequest(*rds.ModifyDBInstanceInput) (*request.Request, *rds.ModifyDBInstanceOutput)
 
 	ModifyDBInstance(*rds.ModifyDBInstanceInput) (*rds.ModifyDBInstanceOutput, error)
 
-	ModifyDBParameterGroupRequest(*rds.ModifyDBParameterGroupInput) (*service.Request, *rds.DBParameterGroupNameMessage)
+	ModifyDBParameterGroupRequest(*rds.ModifyDBParameterGroupInput) (*request.Request, *rds.DBParameterGroupNameMessage)
 
 	ModifyDBParameterGroup(*rds.ModifyDBParameterGroupInput) (*rds.DBParameterGroupNameMessage, error)
 
-	ModifyDBSubnetGroupRequest(*rds.ModifyDBSubnetGroupInput) (*service.Request, *rds.ModifyDBSubnetGroupOutput)
+	ModifyDBSubnetGroupRequest(*rds.ModifyDBSubnetGroupInput) (*request.Request, *rds.ModifyDBSubnetGroupOutput)
 
 	ModifyDBSubnetGroup(*rds.ModifyDBSubnetGroupInput) (*rds.ModifyDBSubnetGroupOutput, error)
 
-	ModifyEventSubscriptionRequest(*rds.ModifyEventSubscriptionInput) (*service.Request, *rds.ModifyEventSubscriptionOutput)
+	ModifyEventSubscriptionRequest(*rds.ModifyEventSubscriptionInput) (*request.Request, *rds.ModifyEventSubscriptionOutput)
 
 	ModifyEventSubscription(*rds.ModifyEventSubscriptionInput) (*rds.ModifyEventSubscriptionOutput, error)
 
-	ModifyOptionGroupRequest(*rds.ModifyOptionGroupInput) (*service.Request, *rds.ModifyOptionGroupOutput)
+	ModifyOptionGroupRequest(*rds.ModifyOptionGroupInput) (*request.Request, *rds.ModifyOptionGroupOutput)
 
 	ModifyOptionGroup(*rds.ModifyOptionGroupInput) (*rds.ModifyOptionGroupOutput, error)
 
-	PromoteReadReplicaRequest(*rds.PromoteReadReplicaInput) (*service.Request, *rds.PromoteReadReplicaOutput)
+	PromoteReadReplicaRequest(*rds.PromoteReadReplicaInput) (*request.Request, *rds.PromoteReadReplicaOutput)
 
 	PromoteReadReplica(*rds.PromoteReadReplicaInput) (*rds.PromoteReadReplicaOutput, error)
 
-	PurchaseReservedDBInstancesOfferingRequest(*rds.PurchaseReservedDBInstancesOfferingInput) (*service.Request, *rds.PurchaseReservedDBInstancesOfferingOutput)
+	PurchaseReservedDBInstancesOfferingRequest(*rds.PurchaseReservedDBInstancesOfferingInput) (*request.Request, *rds.PurchaseReservedDBInstancesOfferingOutput)
 
 	PurchaseReservedDBInstancesOffering(*rds.PurchaseReservedDBInstancesOfferingInput) (*rds.PurchaseReservedDBInstancesOfferingOutput, error)
 
-	RebootDBInstanceRequest(*rds.RebootDBInstanceInput) (*service.Request, *rds.RebootDBInstanceOutput)
+	RebootDBInstanceRequest(*rds.RebootDBInstanceInput) (*request.Request, *rds.RebootDBInstanceOutput)
 
 	RebootDBInstance(*rds.RebootDBInstanceInput) (*rds.RebootDBInstanceOutput, error)
 
-	RemoveSourceIdentifierFromSubscriptionRequest(*rds.RemoveSourceIdentifierFromSubscriptionInput) (*service.Request, *rds.RemoveSourceIdentifierFromSubscriptionOutput)
+	RemoveSourceIdentifierFromSubscriptionRequest(*rds.RemoveSourceIdentifierFromSubscriptionInput) (*request.Request, *rds.RemoveSourceIdentifierFromSubscriptionOutput)
 
 	RemoveSourceIdentifierFromSubscription(*rds.RemoveSourceIdentifierFromSubscriptionInput) (*rds.RemoveSourceIdentifierFromSubscriptionOutput, error)
 
-	RemoveTagsFromResourceRequest(*rds.RemoveTagsFromResourceInput) (*service.Request, *rds.RemoveTagsFromResourceOutput)
+	RemoveTagsFromResourceRequest(*rds.RemoveTagsFromResourceInput) (*request.Request, *rds.RemoveTagsFromResourceOutput)
 
 	RemoveTagsFromResource(*rds.RemoveTagsFromResourceInput) (*rds.RemoveTagsFromResourceOutput, error)
 
-	ResetDBClusterParameterGroupRequest(*rds.ResetDBClusterParameterGroupInput) (*service.Request, *rds.DBClusterParameterGroupNameMessage)
+	ResetDBClusterParameterGroupRequest(*rds.ResetDBClusterParameterGroupInput) (*request.Request, *rds.DBClusterParameterGroupNameMessage)
 
 	ResetDBClusterParameterGroup(*rds.ResetDBClusterParameterGroupInput) (*rds.DBClusterParameterGroupNameMessage, error)
 
-	ResetDBParameterGroupRequest(*rds.ResetDBParameterGroupInput) (*service.Request, *rds.DBParameterGroupNameMessage)
+	ResetDBParameterGroupRequest(*rds.ResetDBParameterGroupInput) (*request.Request, *rds.DBParameterGroupNameMessage)
 
 	ResetDBParameterGroup(*rds.ResetDBParameterGroupInput) (*rds.DBParameterGroupNameMessage, error)
 
-	RestoreDBClusterFromSnapshotRequest(*rds.RestoreDBClusterFromSnapshotInput) (*service.Request, *rds.RestoreDBClusterFromSnapshotOutput)
+	RestoreDBClusterFromSnapshotRequest(*rds.RestoreDBClusterFromSnapshotInput) (*request.Request, *rds.RestoreDBClusterFromSnapshotOutput)
 
 	RestoreDBClusterFromSnapshot(*rds.RestoreDBClusterFromSnapshotInput) (*rds.RestoreDBClusterFromSnapshotOutput, error)
 
-	RestoreDBClusterToPointInTimeRequest(*rds.RestoreDBClusterToPointInTimeInput) (*service.Request, *rds.RestoreDBClusterToPointInTimeOutput)
+	RestoreDBClusterToPointInTimeRequest(*rds.RestoreDBClusterToPointInTimeInput) (*request.Request, *rds.RestoreDBClusterToPointInTimeOutput)
 
 	RestoreDBClusterToPointInTime(*rds.RestoreDBClusterToPointInTimeInput) (*rds.RestoreDBClusterToPointInTimeOutput, error)
 
-	RestoreDBInstanceFromDBSnapshotRequest(*rds.RestoreDBInstanceFromDBSnapshotInput) (*service.Request, *rds.RestoreDBInstanceFromDBSnapshotOutput)
+	RestoreDBInstanceFromDBSnapshotRequest(*rds.RestoreDBInstanceFromDBSnapshotInput) (*request.Request, *rds.RestoreDBInstanceFromDBSnapshotOutput)
 
 	RestoreDBInstanceFromDBSnapshot(*rds.RestoreDBInstanceFromDBSnapshotInput) (*rds.RestoreDBInstanceFromDBSnapshotOutput, error)
 
-	RestoreDBInstanceToPointInTimeRequest(*rds.RestoreDBInstanceToPointInTimeInput) (*service.Request, *rds.RestoreDBInstanceToPointInTimeOutput)
+	RestoreDBInstanceToPointInTimeRequest(*rds.RestoreDBInstanceToPointInTimeInput) (*request.Request, *rds.RestoreDBInstanceToPointInTimeOutput)
 
 	RestoreDBInstanceToPointInTime(*rds.RestoreDBInstanceToPointInTimeInput) (*rds.RestoreDBInstanceToPointInTimeOutput, error)
 
-	RevokeDBSecurityGroupIngressRequest(*rds.RevokeDBSecurityGroupIngressInput) (*service.Request, *rds.RevokeDBSecurityGroupIngressOutput)
+	RevokeDBSecurityGroupIngressRequest(*rds.RevokeDBSecurityGroupIngressInput) (*request.Request, *rds.RevokeDBSecurityGroupIngressOutput)
 
 	RevokeDBSecurityGroupIngress(*rds.RevokeDBSecurityGroupIngressInput) (*rds.RevokeDBSecurityGroupIngressOutput, error)
 }

--- a/service/rds/service.go
+++ b/service/rds/service.go
@@ -5,7 +5,9 @@ package rds
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -42,14 +44,16 @@ type RDS struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new RDS client.
 func New(config *aws.Config) *RDS {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "rds",
-		APIVersion:  "2014-10-31",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "rds",
+			APIVersion:  "2014-10-31",
+		},
 	}
 	service.Initialize()
 
@@ -70,8 +74,8 @@ func New(config *aws.Config) *RDS {
 
 // newRequest creates a new request for a RDS operation and runs any
 // custom request initialization.
-func (c *RDS) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *RDS) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/redshift/api.go
+++ b/service/redshift/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAuthorizeClusterSecurityGroupIngress = "AuthorizeClusterSecurityGroupIngress"
 
 // AuthorizeClusterSecurityGroupIngressRequest generates a request for the AuthorizeClusterSecurityGroupIngress operation.
-func (c *Redshift) AuthorizeClusterSecurityGroupIngressRequest(input *AuthorizeClusterSecurityGroupIngressInput) (req *service.Request, output *AuthorizeClusterSecurityGroupIngressOutput) {
-	op := &service.Operation{
+func (c *Redshift) AuthorizeClusterSecurityGroupIngressRequest(input *AuthorizeClusterSecurityGroupIngressInput) (req *request.Request, output *AuthorizeClusterSecurityGroupIngressOutput) {
+	op := &request.Operation{
 		Name:       opAuthorizeClusterSecurityGroupIngress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -54,8 +54,8 @@ func (c *Redshift) AuthorizeClusterSecurityGroupIngress(input *AuthorizeClusterS
 const opAuthorizeSnapshotAccess = "AuthorizeSnapshotAccess"
 
 // AuthorizeSnapshotAccessRequest generates a request for the AuthorizeSnapshotAccess operation.
-func (c *Redshift) AuthorizeSnapshotAccessRequest(input *AuthorizeSnapshotAccessInput) (req *service.Request, output *AuthorizeSnapshotAccessOutput) {
-	op := &service.Operation{
+func (c *Redshift) AuthorizeSnapshotAccessRequest(input *AuthorizeSnapshotAccessInput) (req *request.Request, output *AuthorizeSnapshotAccessOutput) {
+	op := &request.Operation{
 		Name:       opAuthorizeSnapshotAccess,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -85,8 +85,8 @@ func (c *Redshift) AuthorizeSnapshotAccess(input *AuthorizeSnapshotAccessInput) 
 const opCopyClusterSnapshot = "CopyClusterSnapshot"
 
 // CopyClusterSnapshotRequest generates a request for the CopyClusterSnapshot operation.
-func (c *Redshift) CopyClusterSnapshotRequest(input *CopyClusterSnapshotInput) (req *service.Request, output *CopyClusterSnapshotOutput) {
-	op := &service.Operation{
+func (c *Redshift) CopyClusterSnapshotRequest(input *CopyClusterSnapshotInput) (req *request.Request, output *CopyClusterSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCopyClusterSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -124,8 +124,8 @@ func (c *Redshift) CopyClusterSnapshot(input *CopyClusterSnapshotInput) (*CopyCl
 const opCreateCluster = "CreateCluster"
 
 // CreateClusterRequest generates a request for the CreateCluster operation.
-func (c *Redshift) CreateClusterRequest(input *CreateClusterInput) (req *service.Request, output *CreateClusterOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateClusterRequest(input *CreateClusterInput) (req *request.Request, output *CreateClusterOutput) {
+	op := &request.Operation{
 		Name:       opCreateCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -157,8 +157,8 @@ func (c *Redshift) CreateCluster(input *CreateClusterInput) (*CreateClusterOutpu
 const opCreateClusterParameterGroup = "CreateClusterParameterGroup"
 
 // CreateClusterParameterGroupRequest generates a request for the CreateClusterParameterGroup operation.
-func (c *Redshift) CreateClusterParameterGroupRequest(input *CreateClusterParameterGroupInput) (req *service.Request, output *CreateClusterParameterGroupOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateClusterParameterGroupRequest(input *CreateClusterParameterGroupInput) (req *request.Request, output *CreateClusterParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateClusterParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -194,8 +194,8 @@ func (c *Redshift) CreateClusterParameterGroup(input *CreateClusterParameterGrou
 const opCreateClusterSecurityGroup = "CreateClusterSecurityGroup"
 
 // CreateClusterSecurityGroupRequest generates a request for the CreateClusterSecurityGroup operation.
-func (c *Redshift) CreateClusterSecurityGroupRequest(input *CreateClusterSecurityGroupInput) (req *service.Request, output *CreateClusterSecurityGroupOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateClusterSecurityGroupRequest(input *CreateClusterSecurityGroupInput) (req *request.Request, output *CreateClusterSecurityGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateClusterSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -226,8 +226,8 @@ func (c *Redshift) CreateClusterSecurityGroup(input *CreateClusterSecurityGroupI
 const opCreateClusterSnapshot = "CreateClusterSnapshot"
 
 // CreateClusterSnapshotRequest generates a request for the CreateClusterSnapshot operation.
-func (c *Redshift) CreateClusterSnapshotRequest(input *CreateClusterSnapshotInput) (req *service.Request, output *CreateClusterSnapshotOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateClusterSnapshotRequest(input *CreateClusterSnapshotInput) (req *request.Request, output *CreateClusterSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCreateClusterSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -258,8 +258,8 @@ func (c *Redshift) CreateClusterSnapshot(input *CreateClusterSnapshotInput) (*Cr
 const opCreateClusterSubnetGroup = "CreateClusterSubnetGroup"
 
 // CreateClusterSubnetGroupRequest generates a request for the CreateClusterSubnetGroup operation.
-func (c *Redshift) CreateClusterSubnetGroupRequest(input *CreateClusterSubnetGroupInput) (req *service.Request, output *CreateClusterSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateClusterSubnetGroupRequest(input *CreateClusterSubnetGroupInput) (req *request.Request, output *CreateClusterSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opCreateClusterSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -291,8 +291,8 @@ func (c *Redshift) CreateClusterSubnetGroup(input *CreateClusterSubnetGroupInput
 const opCreateEventSubscription = "CreateEventSubscription"
 
 // CreateEventSubscriptionRequest generates a request for the CreateEventSubscription operation.
-func (c *Redshift) CreateEventSubscriptionRequest(input *CreateEventSubscriptionInput) (req *service.Request, output *CreateEventSubscriptionOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateEventSubscriptionRequest(input *CreateEventSubscriptionInput) (req *request.Request, output *CreateEventSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opCreateEventSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -339,8 +339,8 @@ func (c *Redshift) CreateEventSubscription(input *CreateEventSubscriptionInput) 
 const opCreateHsmClientCertificate = "CreateHsmClientCertificate"
 
 // CreateHsmClientCertificateRequest generates a request for the CreateHsmClientCertificate operation.
-func (c *Redshift) CreateHsmClientCertificateRequest(input *CreateHsmClientCertificateInput) (req *service.Request, output *CreateHsmClientCertificateOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateHsmClientCertificateRequest(input *CreateHsmClientCertificateInput) (req *request.Request, output *CreateHsmClientCertificateOutput) {
+	op := &request.Operation{
 		Name:       opCreateHsmClientCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -374,8 +374,8 @@ func (c *Redshift) CreateHsmClientCertificate(input *CreateHsmClientCertificateI
 const opCreateHsmConfiguration = "CreateHsmConfiguration"
 
 // CreateHsmConfigurationRequest generates a request for the CreateHsmConfiguration operation.
-func (c *Redshift) CreateHsmConfigurationRequest(input *CreateHsmConfigurationInput) (req *service.Request, output *CreateHsmConfigurationOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateHsmConfigurationRequest(input *CreateHsmConfigurationInput) (req *request.Request, output *CreateHsmConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opCreateHsmConfiguration,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -410,8 +410,8 @@ func (c *Redshift) CreateHsmConfiguration(input *CreateHsmConfigurationInput) (*
 const opCreateSnapshotCopyGrant = "CreateSnapshotCopyGrant"
 
 // CreateSnapshotCopyGrantRequest generates a request for the CreateSnapshotCopyGrant operation.
-func (c *Redshift) CreateSnapshotCopyGrantRequest(input *CreateSnapshotCopyGrantInput) (req *service.Request, output *CreateSnapshotCopyGrantOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateSnapshotCopyGrantRequest(input *CreateSnapshotCopyGrantInput) (req *request.Request, output *CreateSnapshotCopyGrantOutput) {
+	op := &request.Operation{
 		Name:       opCreateSnapshotCopyGrant,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -443,8 +443,8 @@ func (c *Redshift) CreateSnapshotCopyGrant(input *CreateSnapshotCopyGrantInput) 
 const opCreateTags = "CreateTags"
 
 // CreateTagsRequest generates a request for the CreateTags operation.
-func (c *Redshift) CreateTagsRequest(input *CreateTagsInput) (req *service.Request, output *CreateTagsOutput) {
-	op := &service.Operation{
+func (c *Redshift) CreateTagsRequest(input *CreateTagsInput) (req *request.Request, output *CreateTagsOutput) {
+	op := &request.Operation{
 		Name:       opCreateTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -476,8 +476,8 @@ func (c *Redshift) CreateTags(input *CreateTagsInput) (*CreateTagsOutput, error)
 const opDeleteCluster = "DeleteCluster"
 
 // DeleteClusterRequest generates a request for the DeleteCluster operation.
-func (c *Redshift) DeleteClusterRequest(input *DeleteClusterInput) (req *service.Request, output *DeleteClusterOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteClusterRequest(input *DeleteClusterInput) (req *request.Request, output *DeleteClusterOutput) {
+	op := &request.Operation{
 		Name:       opDeleteCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -519,8 +519,8 @@ func (c *Redshift) DeleteCluster(input *DeleteClusterInput) (*DeleteClusterOutpu
 const opDeleteClusterParameterGroup = "DeleteClusterParameterGroup"
 
 // DeleteClusterParameterGroupRequest generates a request for the DeleteClusterParameterGroup operation.
-func (c *Redshift) DeleteClusterParameterGroupRequest(input *DeleteClusterParameterGroupInput) (req *service.Request, output *DeleteClusterParameterGroupOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteClusterParameterGroupRequest(input *DeleteClusterParameterGroupInput) (req *request.Request, output *DeleteClusterParameterGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteClusterParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -547,8 +547,8 @@ func (c *Redshift) DeleteClusterParameterGroup(input *DeleteClusterParameterGrou
 const opDeleteClusterSecurityGroup = "DeleteClusterSecurityGroup"
 
 // DeleteClusterSecurityGroupRequest generates a request for the DeleteClusterSecurityGroup operation.
-func (c *Redshift) DeleteClusterSecurityGroupRequest(input *DeleteClusterSecurityGroupInput) (req *service.Request, output *DeleteClusterSecurityGroupOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteClusterSecurityGroupRequest(input *DeleteClusterSecurityGroupInput) (req *request.Request, output *DeleteClusterSecurityGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteClusterSecurityGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -579,8 +579,8 @@ func (c *Redshift) DeleteClusterSecurityGroup(input *DeleteClusterSecurityGroupI
 const opDeleteClusterSnapshot = "DeleteClusterSnapshot"
 
 // DeleteClusterSnapshotRequest generates a request for the DeleteClusterSnapshot operation.
-func (c *Redshift) DeleteClusterSnapshotRequest(input *DeleteClusterSnapshotInput) (req *service.Request, output *DeleteClusterSnapshotOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteClusterSnapshotRequest(input *DeleteClusterSnapshotInput) (req *request.Request, output *DeleteClusterSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opDeleteClusterSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -613,8 +613,8 @@ func (c *Redshift) DeleteClusterSnapshot(input *DeleteClusterSnapshotInput) (*De
 const opDeleteClusterSubnetGroup = "DeleteClusterSubnetGroup"
 
 // DeleteClusterSubnetGroupRequest generates a request for the DeleteClusterSubnetGroup operation.
-func (c *Redshift) DeleteClusterSubnetGroupRequest(input *DeleteClusterSubnetGroupInput) (req *service.Request, output *DeleteClusterSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteClusterSubnetGroupRequest(input *DeleteClusterSubnetGroupInput) (req *request.Request, output *DeleteClusterSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opDeleteClusterSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -640,8 +640,8 @@ func (c *Redshift) DeleteClusterSubnetGroup(input *DeleteClusterSubnetGroupInput
 const opDeleteEventSubscription = "DeleteEventSubscription"
 
 // DeleteEventSubscriptionRequest generates a request for the DeleteEventSubscription operation.
-func (c *Redshift) DeleteEventSubscriptionRequest(input *DeleteEventSubscriptionInput) (req *service.Request, output *DeleteEventSubscriptionOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteEventSubscriptionRequest(input *DeleteEventSubscriptionInput) (req *request.Request, output *DeleteEventSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opDeleteEventSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -667,8 +667,8 @@ func (c *Redshift) DeleteEventSubscription(input *DeleteEventSubscriptionInput) 
 const opDeleteHsmClientCertificate = "DeleteHsmClientCertificate"
 
 // DeleteHsmClientCertificateRequest generates a request for the DeleteHsmClientCertificate operation.
-func (c *Redshift) DeleteHsmClientCertificateRequest(input *DeleteHsmClientCertificateInput) (req *service.Request, output *DeleteHsmClientCertificateOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteHsmClientCertificateRequest(input *DeleteHsmClientCertificateInput) (req *request.Request, output *DeleteHsmClientCertificateOutput) {
+	op := &request.Operation{
 		Name:       opDeleteHsmClientCertificate,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -694,8 +694,8 @@ func (c *Redshift) DeleteHsmClientCertificate(input *DeleteHsmClientCertificateI
 const opDeleteHsmConfiguration = "DeleteHsmConfiguration"
 
 // DeleteHsmConfigurationRequest generates a request for the DeleteHsmConfiguration operation.
-func (c *Redshift) DeleteHsmConfigurationRequest(input *DeleteHsmConfigurationInput) (req *service.Request, output *DeleteHsmConfigurationOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteHsmConfigurationRequest(input *DeleteHsmConfigurationInput) (req *request.Request, output *DeleteHsmConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteHsmConfiguration,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -721,8 +721,8 @@ func (c *Redshift) DeleteHsmConfiguration(input *DeleteHsmConfigurationInput) (*
 const opDeleteSnapshotCopyGrant = "DeleteSnapshotCopyGrant"
 
 // DeleteSnapshotCopyGrantRequest generates a request for the DeleteSnapshotCopyGrant operation.
-func (c *Redshift) DeleteSnapshotCopyGrantRequest(input *DeleteSnapshotCopyGrantInput) (req *service.Request, output *DeleteSnapshotCopyGrantOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteSnapshotCopyGrantRequest(input *DeleteSnapshotCopyGrantInput) (req *request.Request, output *DeleteSnapshotCopyGrantOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSnapshotCopyGrant,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -748,8 +748,8 @@ func (c *Redshift) DeleteSnapshotCopyGrant(input *DeleteSnapshotCopyGrantInput) 
 const opDeleteTags = "DeleteTags"
 
 // DeleteTagsRequest generates a request for the DeleteTags operation.
-func (c *Redshift) DeleteTagsRequest(input *DeleteTagsInput) (req *service.Request, output *DeleteTagsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DeleteTagsRequest(input *DeleteTagsInput) (req *request.Request, output *DeleteTagsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -776,12 +776,12 @@ func (c *Redshift) DeleteTags(input *DeleteTagsInput) (*DeleteTagsOutput, error)
 const opDescribeClusterParameterGroups = "DescribeClusterParameterGroups"
 
 // DescribeClusterParameterGroupsRequest generates a request for the DescribeClusterParameterGroups operation.
-func (c *Redshift) DescribeClusterParameterGroupsRequest(input *DescribeClusterParameterGroupsInput) (req *service.Request, output *DescribeClusterParameterGroupsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeClusterParameterGroupsRequest(input *DescribeClusterParameterGroupsInput) (req *request.Request, output *DescribeClusterParameterGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClusterParameterGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -834,12 +834,12 @@ func (c *Redshift) DescribeClusterParameterGroupsPages(input *DescribeClusterPar
 const opDescribeClusterParameters = "DescribeClusterParameters"
 
 // DescribeClusterParametersRequest generates a request for the DescribeClusterParameters operation.
-func (c *Redshift) DescribeClusterParametersRequest(input *DescribeClusterParametersInput) (req *service.Request, output *DescribeClusterParametersOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeClusterParametersRequest(input *DescribeClusterParametersInput) (req *request.Request, output *DescribeClusterParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClusterParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -885,12 +885,12 @@ func (c *Redshift) DescribeClusterParametersPages(input *DescribeClusterParamete
 const opDescribeClusterSecurityGroups = "DescribeClusterSecurityGroups"
 
 // DescribeClusterSecurityGroupsRequest generates a request for the DescribeClusterSecurityGroups operation.
-func (c *Redshift) DescribeClusterSecurityGroupsRequest(input *DescribeClusterSecurityGroupsInput) (req *service.Request, output *DescribeClusterSecurityGroupsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeClusterSecurityGroupsRequest(input *DescribeClusterSecurityGroupsInput) (req *request.Request, output *DescribeClusterSecurityGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClusterSecurityGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -941,12 +941,12 @@ func (c *Redshift) DescribeClusterSecurityGroupsPages(input *DescribeClusterSecu
 const opDescribeClusterSnapshots = "DescribeClusterSnapshots"
 
 // DescribeClusterSnapshotsRequest generates a request for the DescribeClusterSnapshots operation.
-func (c *Redshift) DescribeClusterSnapshotsRequest(input *DescribeClusterSnapshotsInput) (req *service.Request, output *DescribeClusterSnapshotsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeClusterSnapshotsRequest(input *DescribeClusterSnapshotsInput) (req *request.Request, output *DescribeClusterSnapshotsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClusterSnapshots,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -996,12 +996,12 @@ func (c *Redshift) DescribeClusterSnapshotsPages(input *DescribeClusterSnapshots
 const opDescribeClusterSubnetGroups = "DescribeClusterSubnetGroups"
 
 // DescribeClusterSubnetGroupsRequest generates a request for the DescribeClusterSubnetGroups operation.
-func (c *Redshift) DescribeClusterSubnetGroupsRequest(input *DescribeClusterSubnetGroupsInput) (req *service.Request, output *DescribeClusterSubnetGroupsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeClusterSubnetGroupsRequest(input *DescribeClusterSubnetGroupsInput) (req *request.Request, output *DescribeClusterSubnetGroupsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClusterSubnetGroups,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1048,12 +1048,12 @@ func (c *Redshift) DescribeClusterSubnetGroupsPages(input *DescribeClusterSubnet
 const opDescribeClusterVersions = "DescribeClusterVersions"
 
 // DescribeClusterVersionsRequest generates a request for the DescribeClusterVersions operation.
-func (c *Redshift) DescribeClusterVersionsRequest(input *DescribeClusterVersionsInput) (req *service.Request, output *DescribeClusterVersionsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeClusterVersionsRequest(input *DescribeClusterVersionsInput) (req *request.Request, output *DescribeClusterVersionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClusterVersions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1092,12 +1092,12 @@ func (c *Redshift) DescribeClusterVersionsPages(input *DescribeClusterVersionsIn
 const opDescribeClusters = "DescribeClusters"
 
 // DescribeClustersRequest generates a request for the DescribeClusters operation.
-func (c *Redshift) DescribeClustersRequest(input *DescribeClustersInput) (req *service.Request, output *DescribeClustersOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeClustersRequest(input *DescribeClustersInput) (req *request.Request, output *DescribeClustersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeClusters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1145,12 +1145,12 @@ func (c *Redshift) DescribeClustersPages(input *DescribeClustersInput, fn func(p
 const opDescribeDefaultClusterParameters = "DescribeDefaultClusterParameters"
 
 // DescribeDefaultClusterParametersRequest generates a request for the DescribeDefaultClusterParameters operation.
-func (c *Redshift) DescribeDefaultClusterParametersRequest(input *DescribeDefaultClusterParametersInput) (req *service.Request, output *DescribeDefaultClusterParametersOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeDefaultClusterParametersRequest(input *DescribeDefaultClusterParametersInput) (req *request.Request, output *DescribeDefaultClusterParametersOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDefaultClusterParameters,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"DefaultClusterParameters.Marker"},
 			LimitToken:      "MaxRecords",
@@ -1189,8 +1189,8 @@ func (c *Redshift) DescribeDefaultClusterParametersPages(input *DescribeDefaultC
 const opDescribeEventCategories = "DescribeEventCategories"
 
 // DescribeEventCategoriesRequest generates a request for the DescribeEventCategories operation.
-func (c *Redshift) DescribeEventCategoriesRequest(input *DescribeEventCategoriesInput) (req *service.Request, output *DescribeEventCategoriesOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeEventCategoriesRequest(input *DescribeEventCategoriesInput) (req *request.Request, output *DescribeEventCategoriesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEventCategories,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1218,12 +1218,12 @@ func (c *Redshift) DescribeEventCategories(input *DescribeEventCategoriesInput) 
 const opDescribeEventSubscriptions = "DescribeEventSubscriptions"
 
 // DescribeEventSubscriptionsRequest generates a request for the DescribeEventSubscriptions operation.
-func (c *Redshift) DescribeEventSubscriptionsRequest(input *DescribeEventSubscriptionsInput) (req *service.Request, output *DescribeEventSubscriptionsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeEventSubscriptionsRequest(input *DescribeEventSubscriptionsInput) (req *request.Request, output *DescribeEventSubscriptionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEventSubscriptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1260,12 +1260,12 @@ func (c *Redshift) DescribeEventSubscriptionsPages(input *DescribeEventSubscript
 const opDescribeEvents = "DescribeEvents"
 
 // DescribeEventsRequest generates a request for the DescribeEvents operation.
-func (c *Redshift) DescribeEventsRequest(input *DescribeEventsInput) (req *service.Request, output *DescribeEventsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeEventsRequest(input *DescribeEventsInput) (req *request.Request, output *DescribeEventsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeEvents,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1303,12 +1303,12 @@ func (c *Redshift) DescribeEventsPages(input *DescribeEventsInput, fn func(p *De
 const opDescribeHsmClientCertificates = "DescribeHsmClientCertificates"
 
 // DescribeHsmClientCertificatesRequest generates a request for the DescribeHsmClientCertificates operation.
-func (c *Redshift) DescribeHsmClientCertificatesRequest(input *DescribeHsmClientCertificatesInput) (req *service.Request, output *DescribeHsmClientCertificatesOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeHsmClientCertificatesRequest(input *DescribeHsmClientCertificatesInput) (req *request.Request, output *DescribeHsmClientCertificatesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeHsmClientCertificates,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1355,12 +1355,12 @@ func (c *Redshift) DescribeHsmClientCertificatesPages(input *DescribeHsmClientCe
 const opDescribeHsmConfigurations = "DescribeHsmConfigurations"
 
 // DescribeHsmConfigurationsRequest generates a request for the DescribeHsmConfigurations operation.
-func (c *Redshift) DescribeHsmConfigurationsRequest(input *DescribeHsmConfigurationsInput) (req *service.Request, output *DescribeHsmConfigurationsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeHsmConfigurationsRequest(input *DescribeHsmConfigurationsInput) (req *request.Request, output *DescribeHsmConfigurationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeHsmConfigurations,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1407,8 +1407,8 @@ func (c *Redshift) DescribeHsmConfigurationsPages(input *DescribeHsmConfiguratio
 const opDescribeLoggingStatus = "DescribeLoggingStatus"
 
 // DescribeLoggingStatusRequest generates a request for the DescribeLoggingStatus operation.
-func (c *Redshift) DescribeLoggingStatusRequest(input *DescribeLoggingStatusInput) (req *service.Request, output *LoggingStatus) {
-	op := &service.Operation{
+func (c *Redshift) DescribeLoggingStatusRequest(input *DescribeLoggingStatusInput) (req *request.Request, output *LoggingStatus) {
+	op := &request.Operation{
 		Name:       opDescribeLoggingStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1435,12 +1435,12 @@ func (c *Redshift) DescribeLoggingStatus(input *DescribeLoggingStatusInput) (*Lo
 const opDescribeOrderableClusterOptions = "DescribeOrderableClusterOptions"
 
 // DescribeOrderableClusterOptionsRequest generates a request for the DescribeOrderableClusterOptions operation.
-func (c *Redshift) DescribeOrderableClusterOptionsRequest(input *DescribeOrderableClusterOptionsInput) (req *service.Request, output *DescribeOrderableClusterOptionsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeOrderableClusterOptionsRequest(input *DescribeOrderableClusterOptionsInput) (req *request.Request, output *DescribeOrderableClusterOptionsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeOrderableClusterOptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1483,12 +1483,12 @@ func (c *Redshift) DescribeOrderableClusterOptionsPages(input *DescribeOrderable
 const opDescribeReservedNodeOfferings = "DescribeReservedNodeOfferings"
 
 // DescribeReservedNodeOfferingsRequest generates a request for the DescribeReservedNodeOfferings operation.
-func (c *Redshift) DescribeReservedNodeOfferingsRequest(input *DescribeReservedNodeOfferingsInput) (req *service.Request, output *DescribeReservedNodeOfferingsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeReservedNodeOfferingsRequest(input *DescribeReservedNodeOfferingsInput) (req *request.Request, output *DescribeReservedNodeOfferingsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedNodeOfferings,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1532,12 +1532,12 @@ func (c *Redshift) DescribeReservedNodeOfferingsPages(input *DescribeReservedNod
 const opDescribeReservedNodes = "DescribeReservedNodes"
 
 // DescribeReservedNodesRequest generates a request for the DescribeReservedNodes operation.
-func (c *Redshift) DescribeReservedNodesRequest(input *DescribeReservedNodesInput) (req *service.Request, output *DescribeReservedNodesOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeReservedNodesRequest(input *DescribeReservedNodesInput) (req *request.Request, output *DescribeReservedNodesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeReservedNodes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "MaxRecords",
@@ -1572,8 +1572,8 @@ func (c *Redshift) DescribeReservedNodesPages(input *DescribeReservedNodesInput,
 const opDescribeResize = "DescribeResize"
 
 // DescribeResizeRequest generates a request for the DescribeResize operation.
-func (c *Redshift) DescribeResizeRequest(input *DescribeResizeInput) (req *service.Request, output *DescribeResizeOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeResizeRequest(input *DescribeResizeInput) (req *request.Request, output *DescribeResizeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeResize,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1605,8 +1605,8 @@ func (c *Redshift) DescribeResize(input *DescribeResizeInput) (*DescribeResizeOu
 const opDescribeSnapshotCopyGrants = "DescribeSnapshotCopyGrants"
 
 // DescribeSnapshotCopyGrantsRequest generates a request for the DescribeSnapshotCopyGrants operation.
-func (c *Redshift) DescribeSnapshotCopyGrantsRequest(input *DescribeSnapshotCopyGrantsInput) (req *service.Request, output *DescribeSnapshotCopyGrantsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeSnapshotCopyGrantsRequest(input *DescribeSnapshotCopyGrantsInput) (req *request.Request, output *DescribeSnapshotCopyGrantsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSnapshotCopyGrants,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1637,8 +1637,8 @@ func (c *Redshift) DescribeSnapshotCopyGrants(input *DescribeSnapshotCopyGrantsI
 const opDescribeTags = "DescribeTags"
 
 // DescribeTagsRequest generates a request for the DescribeTags operation.
-func (c *Redshift) DescribeTagsRequest(input *DescribeTagsInput) (req *service.Request, output *DescribeTagsOutput) {
-	op := &service.Operation{
+func (c *Redshift) DescribeTagsRequest(input *DescribeTagsInput) (req *request.Request, output *DescribeTagsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTags,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1682,8 +1682,8 @@ func (c *Redshift) DescribeTags(input *DescribeTagsInput) (*DescribeTagsOutput, 
 const opDisableLogging = "DisableLogging"
 
 // DisableLoggingRequest generates a request for the DisableLogging operation.
-func (c *Redshift) DisableLoggingRequest(input *DisableLoggingInput) (req *service.Request, output *LoggingStatus) {
-	op := &service.Operation{
+func (c *Redshift) DisableLoggingRequest(input *DisableLoggingInput) (req *request.Request, output *LoggingStatus) {
+	op := &request.Operation{
 		Name:       opDisableLogging,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1710,8 +1710,8 @@ func (c *Redshift) DisableLogging(input *DisableLoggingInput) (*LoggingStatus, e
 const opDisableSnapshotCopy = "DisableSnapshotCopy"
 
 // DisableSnapshotCopyRequest generates a request for the DisableSnapshotCopy operation.
-func (c *Redshift) DisableSnapshotCopyRequest(input *DisableSnapshotCopyInput) (req *service.Request, output *DisableSnapshotCopyOutput) {
-	op := &service.Operation{
+func (c *Redshift) DisableSnapshotCopyRequest(input *DisableSnapshotCopyInput) (req *request.Request, output *DisableSnapshotCopyOutput) {
+	op := &request.Operation{
 		Name:       opDisableSnapshotCopy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1742,8 +1742,8 @@ func (c *Redshift) DisableSnapshotCopy(input *DisableSnapshotCopyInput) (*Disabl
 const opEnableLogging = "EnableLogging"
 
 // EnableLoggingRequest generates a request for the EnableLogging operation.
-func (c *Redshift) EnableLoggingRequest(input *EnableLoggingInput) (req *service.Request, output *LoggingStatus) {
-	op := &service.Operation{
+func (c *Redshift) EnableLoggingRequest(input *EnableLoggingInput) (req *request.Request, output *LoggingStatus) {
+	op := &request.Operation{
 		Name:       opEnableLogging,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1770,8 +1770,8 @@ func (c *Redshift) EnableLogging(input *EnableLoggingInput) (*LoggingStatus, err
 const opEnableSnapshotCopy = "EnableSnapshotCopy"
 
 // EnableSnapshotCopyRequest generates a request for the EnableSnapshotCopy operation.
-func (c *Redshift) EnableSnapshotCopyRequest(input *EnableSnapshotCopyInput) (req *service.Request, output *EnableSnapshotCopyOutput) {
-	op := &service.Operation{
+func (c *Redshift) EnableSnapshotCopyRequest(input *EnableSnapshotCopyInput) (req *request.Request, output *EnableSnapshotCopyOutput) {
+	op := &request.Operation{
 		Name:       opEnableSnapshotCopy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1798,8 +1798,8 @@ func (c *Redshift) EnableSnapshotCopy(input *EnableSnapshotCopyInput) (*EnableSn
 const opModifyCluster = "ModifyCluster"
 
 // ModifyClusterRequest generates a request for the ModifyCluster operation.
-func (c *Redshift) ModifyClusterRequest(input *ModifyClusterInput) (req *service.Request, output *ModifyClusterOutput) {
-	op := &service.Operation{
+func (c *Redshift) ModifyClusterRequest(input *ModifyClusterInput) (req *request.Request, output *ModifyClusterOutput) {
+	op := &request.Operation{
 		Name:       opModifyCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1835,8 +1835,8 @@ func (c *Redshift) ModifyCluster(input *ModifyClusterInput) (*ModifyClusterOutpu
 const opModifyClusterParameterGroup = "ModifyClusterParameterGroup"
 
 // ModifyClusterParameterGroupRequest generates a request for the ModifyClusterParameterGroup operation.
-func (c *Redshift) ModifyClusterParameterGroupRequest(input *ModifyClusterParameterGroupInput) (req *service.Request, output *ClusterParameterGroupNameMessage) {
-	op := &service.Operation{
+func (c *Redshift) ModifyClusterParameterGroupRequest(input *ModifyClusterParameterGroupInput) (req *request.Request, output *ClusterParameterGroupNameMessage) {
+	op := &request.Operation{
 		Name:       opModifyClusterParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1866,8 +1866,8 @@ func (c *Redshift) ModifyClusterParameterGroup(input *ModifyClusterParameterGrou
 const opModifyClusterSubnetGroup = "ModifyClusterSubnetGroup"
 
 // ModifyClusterSubnetGroupRequest generates a request for the ModifyClusterSubnetGroup operation.
-func (c *Redshift) ModifyClusterSubnetGroupRequest(input *ModifyClusterSubnetGroupInput) (req *service.Request, output *ModifyClusterSubnetGroupOutput) {
-	op := &service.Operation{
+func (c *Redshift) ModifyClusterSubnetGroupRequest(input *ModifyClusterSubnetGroupInput) (req *request.Request, output *ModifyClusterSubnetGroupOutput) {
+	op := &request.Operation{
 		Name:       opModifyClusterSubnetGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1895,8 +1895,8 @@ func (c *Redshift) ModifyClusterSubnetGroup(input *ModifyClusterSubnetGroupInput
 const opModifyEventSubscription = "ModifyEventSubscription"
 
 // ModifyEventSubscriptionRequest generates a request for the ModifyEventSubscription operation.
-func (c *Redshift) ModifyEventSubscriptionRequest(input *ModifyEventSubscriptionInput) (req *service.Request, output *ModifyEventSubscriptionOutput) {
-	op := &service.Operation{
+func (c *Redshift) ModifyEventSubscriptionRequest(input *ModifyEventSubscriptionInput) (req *request.Request, output *ModifyEventSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opModifyEventSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1922,8 +1922,8 @@ func (c *Redshift) ModifyEventSubscription(input *ModifyEventSubscriptionInput) 
 const opModifySnapshotCopyRetentionPeriod = "ModifySnapshotCopyRetentionPeriod"
 
 // ModifySnapshotCopyRetentionPeriodRequest generates a request for the ModifySnapshotCopyRetentionPeriod operation.
-func (c *Redshift) ModifySnapshotCopyRetentionPeriodRequest(input *ModifySnapshotCopyRetentionPeriodInput) (req *service.Request, output *ModifySnapshotCopyRetentionPeriodOutput) {
-	op := &service.Operation{
+func (c *Redshift) ModifySnapshotCopyRetentionPeriodRequest(input *ModifySnapshotCopyRetentionPeriodInput) (req *request.Request, output *ModifySnapshotCopyRetentionPeriodOutput) {
+	op := &request.Operation{
 		Name:       opModifySnapshotCopyRetentionPeriod,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1950,8 +1950,8 @@ func (c *Redshift) ModifySnapshotCopyRetentionPeriod(input *ModifySnapshotCopyRe
 const opPurchaseReservedNodeOffering = "PurchaseReservedNodeOffering"
 
 // PurchaseReservedNodeOfferingRequest generates a request for the PurchaseReservedNodeOffering operation.
-func (c *Redshift) PurchaseReservedNodeOfferingRequest(input *PurchaseReservedNodeOfferingInput) (req *service.Request, output *PurchaseReservedNodeOfferingOutput) {
-	op := &service.Operation{
+func (c *Redshift) PurchaseReservedNodeOfferingRequest(input *PurchaseReservedNodeOfferingInput) (req *request.Request, output *PurchaseReservedNodeOfferingOutput) {
+	op := &request.Operation{
 		Name:       opPurchaseReservedNodeOffering,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1985,8 +1985,8 @@ func (c *Redshift) PurchaseReservedNodeOffering(input *PurchaseReservedNodeOffer
 const opRebootCluster = "RebootCluster"
 
 // RebootClusterRequest generates a request for the RebootCluster operation.
-func (c *Redshift) RebootClusterRequest(input *RebootClusterInput) (req *service.Request, output *RebootClusterOutput) {
-	op := &service.Operation{
+func (c *Redshift) RebootClusterRequest(input *RebootClusterInput) (req *request.Request, output *RebootClusterOutput) {
+	op := &request.Operation{
 		Name:       opRebootCluster,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2018,8 +2018,8 @@ func (c *Redshift) RebootCluster(input *RebootClusterInput) (*RebootClusterOutpu
 const opResetClusterParameterGroup = "ResetClusterParameterGroup"
 
 // ResetClusterParameterGroupRequest generates a request for the ResetClusterParameterGroup operation.
-func (c *Redshift) ResetClusterParameterGroupRequest(input *ResetClusterParameterGroupInput) (req *service.Request, output *ClusterParameterGroupNameMessage) {
-	op := &service.Operation{
+func (c *Redshift) ResetClusterParameterGroupRequest(input *ResetClusterParameterGroupInput) (req *request.Request, output *ClusterParameterGroupNameMessage) {
+	op := &request.Operation{
 		Name:       opResetClusterParameterGroup,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2048,8 +2048,8 @@ func (c *Redshift) ResetClusterParameterGroup(input *ResetClusterParameterGroupI
 const opRestoreFromClusterSnapshot = "RestoreFromClusterSnapshot"
 
 // RestoreFromClusterSnapshotRequest generates a request for the RestoreFromClusterSnapshot operation.
-func (c *Redshift) RestoreFromClusterSnapshotRequest(input *RestoreFromClusterSnapshotInput) (req *service.Request, output *RestoreFromClusterSnapshotOutput) {
-	op := &service.Operation{
+func (c *Redshift) RestoreFromClusterSnapshotRequest(input *RestoreFromClusterSnapshotInput) (req *request.Request, output *RestoreFromClusterSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opRestoreFromClusterSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2089,8 +2089,8 @@ func (c *Redshift) RestoreFromClusterSnapshot(input *RestoreFromClusterSnapshotI
 const opRevokeClusterSecurityGroupIngress = "RevokeClusterSecurityGroupIngress"
 
 // RevokeClusterSecurityGroupIngressRequest generates a request for the RevokeClusterSecurityGroupIngress operation.
-func (c *Redshift) RevokeClusterSecurityGroupIngressRequest(input *RevokeClusterSecurityGroupIngressInput) (req *service.Request, output *RevokeClusterSecurityGroupIngressOutput) {
-	op := &service.Operation{
+func (c *Redshift) RevokeClusterSecurityGroupIngressRequest(input *RevokeClusterSecurityGroupIngressInput) (req *request.Request, output *RevokeClusterSecurityGroupIngressOutput) {
+	op := &request.Operation{
 		Name:       opRevokeClusterSecurityGroupIngress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2120,8 +2120,8 @@ func (c *Redshift) RevokeClusterSecurityGroupIngress(input *RevokeClusterSecurit
 const opRevokeSnapshotAccess = "RevokeSnapshotAccess"
 
 // RevokeSnapshotAccessRequest generates a request for the RevokeSnapshotAccess operation.
-func (c *Redshift) RevokeSnapshotAccessRequest(input *RevokeSnapshotAccessInput) (req *service.Request, output *RevokeSnapshotAccessOutput) {
-	op := &service.Operation{
+func (c *Redshift) RevokeSnapshotAccessRequest(input *RevokeSnapshotAccessInput) (req *request.Request, output *RevokeSnapshotAccessOutput) {
+	op := &request.Operation{
 		Name:       opRevokeSnapshotAccess,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -2153,8 +2153,8 @@ func (c *Redshift) RevokeSnapshotAccess(input *RevokeSnapshotAccessInput) (*Revo
 const opRotateEncryptionKey = "RotateEncryptionKey"
 
 // RotateEncryptionKeyRequest generates a request for the RotateEncryptionKey operation.
-func (c *Redshift) RotateEncryptionKeyRequest(input *RotateEncryptionKeyInput) (req *service.Request, output *RotateEncryptionKeyOutput) {
-	op := &service.Operation{
+func (c *Redshift) RotateEncryptionKeyRequest(input *RotateEncryptionKeyInput) (req *request.Request, output *RotateEncryptionKeyOutput) {
+	op := &request.Operation{
 		Name:       opRotateEncryptionKey,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/redshift/redshiftiface/interface.go
+++ b/service/redshift/redshiftiface/interface.go
@@ -4,275 +4,275 @@
 package redshiftiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/redshift"
 )
 
 // RedshiftAPI is the interface type for redshift.Redshift.
 type RedshiftAPI interface {
-	AuthorizeClusterSecurityGroupIngressRequest(*redshift.AuthorizeClusterSecurityGroupIngressInput) (*service.Request, *redshift.AuthorizeClusterSecurityGroupIngressOutput)
+	AuthorizeClusterSecurityGroupIngressRequest(*redshift.AuthorizeClusterSecurityGroupIngressInput) (*request.Request, *redshift.AuthorizeClusterSecurityGroupIngressOutput)
 
 	AuthorizeClusterSecurityGroupIngress(*redshift.AuthorizeClusterSecurityGroupIngressInput) (*redshift.AuthorizeClusterSecurityGroupIngressOutput, error)
 
-	AuthorizeSnapshotAccessRequest(*redshift.AuthorizeSnapshotAccessInput) (*service.Request, *redshift.AuthorizeSnapshotAccessOutput)
+	AuthorizeSnapshotAccessRequest(*redshift.AuthorizeSnapshotAccessInput) (*request.Request, *redshift.AuthorizeSnapshotAccessOutput)
 
 	AuthorizeSnapshotAccess(*redshift.AuthorizeSnapshotAccessInput) (*redshift.AuthorizeSnapshotAccessOutput, error)
 
-	CopyClusterSnapshotRequest(*redshift.CopyClusterSnapshotInput) (*service.Request, *redshift.CopyClusterSnapshotOutput)
+	CopyClusterSnapshotRequest(*redshift.CopyClusterSnapshotInput) (*request.Request, *redshift.CopyClusterSnapshotOutput)
 
 	CopyClusterSnapshot(*redshift.CopyClusterSnapshotInput) (*redshift.CopyClusterSnapshotOutput, error)
 
-	CreateClusterRequest(*redshift.CreateClusterInput) (*service.Request, *redshift.CreateClusterOutput)
+	CreateClusterRequest(*redshift.CreateClusterInput) (*request.Request, *redshift.CreateClusterOutput)
 
 	CreateCluster(*redshift.CreateClusterInput) (*redshift.CreateClusterOutput, error)
 
-	CreateClusterParameterGroupRequest(*redshift.CreateClusterParameterGroupInput) (*service.Request, *redshift.CreateClusterParameterGroupOutput)
+	CreateClusterParameterGroupRequest(*redshift.CreateClusterParameterGroupInput) (*request.Request, *redshift.CreateClusterParameterGroupOutput)
 
 	CreateClusterParameterGroup(*redshift.CreateClusterParameterGroupInput) (*redshift.CreateClusterParameterGroupOutput, error)
 
-	CreateClusterSecurityGroupRequest(*redshift.CreateClusterSecurityGroupInput) (*service.Request, *redshift.CreateClusterSecurityGroupOutput)
+	CreateClusterSecurityGroupRequest(*redshift.CreateClusterSecurityGroupInput) (*request.Request, *redshift.CreateClusterSecurityGroupOutput)
 
 	CreateClusterSecurityGroup(*redshift.CreateClusterSecurityGroupInput) (*redshift.CreateClusterSecurityGroupOutput, error)
 
-	CreateClusterSnapshotRequest(*redshift.CreateClusterSnapshotInput) (*service.Request, *redshift.CreateClusterSnapshotOutput)
+	CreateClusterSnapshotRequest(*redshift.CreateClusterSnapshotInput) (*request.Request, *redshift.CreateClusterSnapshotOutput)
 
 	CreateClusterSnapshot(*redshift.CreateClusterSnapshotInput) (*redshift.CreateClusterSnapshotOutput, error)
 
-	CreateClusterSubnetGroupRequest(*redshift.CreateClusterSubnetGroupInput) (*service.Request, *redshift.CreateClusterSubnetGroupOutput)
+	CreateClusterSubnetGroupRequest(*redshift.CreateClusterSubnetGroupInput) (*request.Request, *redshift.CreateClusterSubnetGroupOutput)
 
 	CreateClusterSubnetGroup(*redshift.CreateClusterSubnetGroupInput) (*redshift.CreateClusterSubnetGroupOutput, error)
 
-	CreateEventSubscriptionRequest(*redshift.CreateEventSubscriptionInput) (*service.Request, *redshift.CreateEventSubscriptionOutput)
+	CreateEventSubscriptionRequest(*redshift.CreateEventSubscriptionInput) (*request.Request, *redshift.CreateEventSubscriptionOutput)
 
 	CreateEventSubscription(*redshift.CreateEventSubscriptionInput) (*redshift.CreateEventSubscriptionOutput, error)
 
-	CreateHsmClientCertificateRequest(*redshift.CreateHsmClientCertificateInput) (*service.Request, *redshift.CreateHsmClientCertificateOutput)
+	CreateHsmClientCertificateRequest(*redshift.CreateHsmClientCertificateInput) (*request.Request, *redshift.CreateHsmClientCertificateOutput)
 
 	CreateHsmClientCertificate(*redshift.CreateHsmClientCertificateInput) (*redshift.CreateHsmClientCertificateOutput, error)
 
-	CreateHsmConfigurationRequest(*redshift.CreateHsmConfigurationInput) (*service.Request, *redshift.CreateHsmConfigurationOutput)
+	CreateHsmConfigurationRequest(*redshift.CreateHsmConfigurationInput) (*request.Request, *redshift.CreateHsmConfigurationOutput)
 
 	CreateHsmConfiguration(*redshift.CreateHsmConfigurationInput) (*redshift.CreateHsmConfigurationOutput, error)
 
-	CreateSnapshotCopyGrantRequest(*redshift.CreateSnapshotCopyGrantInput) (*service.Request, *redshift.CreateSnapshotCopyGrantOutput)
+	CreateSnapshotCopyGrantRequest(*redshift.CreateSnapshotCopyGrantInput) (*request.Request, *redshift.CreateSnapshotCopyGrantOutput)
 
 	CreateSnapshotCopyGrant(*redshift.CreateSnapshotCopyGrantInput) (*redshift.CreateSnapshotCopyGrantOutput, error)
 
-	CreateTagsRequest(*redshift.CreateTagsInput) (*service.Request, *redshift.CreateTagsOutput)
+	CreateTagsRequest(*redshift.CreateTagsInput) (*request.Request, *redshift.CreateTagsOutput)
 
 	CreateTags(*redshift.CreateTagsInput) (*redshift.CreateTagsOutput, error)
 
-	DeleteClusterRequest(*redshift.DeleteClusterInput) (*service.Request, *redshift.DeleteClusterOutput)
+	DeleteClusterRequest(*redshift.DeleteClusterInput) (*request.Request, *redshift.DeleteClusterOutput)
 
 	DeleteCluster(*redshift.DeleteClusterInput) (*redshift.DeleteClusterOutput, error)
 
-	DeleteClusterParameterGroupRequest(*redshift.DeleteClusterParameterGroupInput) (*service.Request, *redshift.DeleteClusterParameterGroupOutput)
+	DeleteClusterParameterGroupRequest(*redshift.DeleteClusterParameterGroupInput) (*request.Request, *redshift.DeleteClusterParameterGroupOutput)
 
 	DeleteClusterParameterGroup(*redshift.DeleteClusterParameterGroupInput) (*redshift.DeleteClusterParameterGroupOutput, error)
 
-	DeleteClusterSecurityGroupRequest(*redshift.DeleteClusterSecurityGroupInput) (*service.Request, *redshift.DeleteClusterSecurityGroupOutput)
+	DeleteClusterSecurityGroupRequest(*redshift.DeleteClusterSecurityGroupInput) (*request.Request, *redshift.DeleteClusterSecurityGroupOutput)
 
 	DeleteClusterSecurityGroup(*redshift.DeleteClusterSecurityGroupInput) (*redshift.DeleteClusterSecurityGroupOutput, error)
 
-	DeleteClusterSnapshotRequest(*redshift.DeleteClusterSnapshotInput) (*service.Request, *redshift.DeleteClusterSnapshotOutput)
+	DeleteClusterSnapshotRequest(*redshift.DeleteClusterSnapshotInput) (*request.Request, *redshift.DeleteClusterSnapshotOutput)
 
 	DeleteClusterSnapshot(*redshift.DeleteClusterSnapshotInput) (*redshift.DeleteClusterSnapshotOutput, error)
 
-	DeleteClusterSubnetGroupRequest(*redshift.DeleteClusterSubnetGroupInput) (*service.Request, *redshift.DeleteClusterSubnetGroupOutput)
+	DeleteClusterSubnetGroupRequest(*redshift.DeleteClusterSubnetGroupInput) (*request.Request, *redshift.DeleteClusterSubnetGroupOutput)
 
 	DeleteClusterSubnetGroup(*redshift.DeleteClusterSubnetGroupInput) (*redshift.DeleteClusterSubnetGroupOutput, error)
 
-	DeleteEventSubscriptionRequest(*redshift.DeleteEventSubscriptionInput) (*service.Request, *redshift.DeleteEventSubscriptionOutput)
+	DeleteEventSubscriptionRequest(*redshift.DeleteEventSubscriptionInput) (*request.Request, *redshift.DeleteEventSubscriptionOutput)
 
 	DeleteEventSubscription(*redshift.DeleteEventSubscriptionInput) (*redshift.DeleteEventSubscriptionOutput, error)
 
-	DeleteHsmClientCertificateRequest(*redshift.DeleteHsmClientCertificateInput) (*service.Request, *redshift.DeleteHsmClientCertificateOutput)
+	DeleteHsmClientCertificateRequest(*redshift.DeleteHsmClientCertificateInput) (*request.Request, *redshift.DeleteHsmClientCertificateOutput)
 
 	DeleteHsmClientCertificate(*redshift.DeleteHsmClientCertificateInput) (*redshift.DeleteHsmClientCertificateOutput, error)
 
-	DeleteHsmConfigurationRequest(*redshift.DeleteHsmConfigurationInput) (*service.Request, *redshift.DeleteHsmConfigurationOutput)
+	DeleteHsmConfigurationRequest(*redshift.DeleteHsmConfigurationInput) (*request.Request, *redshift.DeleteHsmConfigurationOutput)
 
 	DeleteHsmConfiguration(*redshift.DeleteHsmConfigurationInput) (*redshift.DeleteHsmConfigurationOutput, error)
 
-	DeleteSnapshotCopyGrantRequest(*redshift.DeleteSnapshotCopyGrantInput) (*service.Request, *redshift.DeleteSnapshotCopyGrantOutput)
+	DeleteSnapshotCopyGrantRequest(*redshift.DeleteSnapshotCopyGrantInput) (*request.Request, *redshift.DeleteSnapshotCopyGrantOutput)
 
 	DeleteSnapshotCopyGrant(*redshift.DeleteSnapshotCopyGrantInput) (*redshift.DeleteSnapshotCopyGrantOutput, error)
 
-	DeleteTagsRequest(*redshift.DeleteTagsInput) (*service.Request, *redshift.DeleteTagsOutput)
+	DeleteTagsRequest(*redshift.DeleteTagsInput) (*request.Request, *redshift.DeleteTagsOutput)
 
 	DeleteTags(*redshift.DeleteTagsInput) (*redshift.DeleteTagsOutput, error)
 
-	DescribeClusterParameterGroupsRequest(*redshift.DescribeClusterParameterGroupsInput) (*service.Request, *redshift.DescribeClusterParameterGroupsOutput)
+	DescribeClusterParameterGroupsRequest(*redshift.DescribeClusterParameterGroupsInput) (*request.Request, *redshift.DescribeClusterParameterGroupsOutput)
 
 	DescribeClusterParameterGroups(*redshift.DescribeClusterParameterGroupsInput) (*redshift.DescribeClusterParameterGroupsOutput, error)
 
 	DescribeClusterParameterGroupsPages(*redshift.DescribeClusterParameterGroupsInput, func(*redshift.DescribeClusterParameterGroupsOutput, bool) bool) error
 
-	DescribeClusterParametersRequest(*redshift.DescribeClusterParametersInput) (*service.Request, *redshift.DescribeClusterParametersOutput)
+	DescribeClusterParametersRequest(*redshift.DescribeClusterParametersInput) (*request.Request, *redshift.DescribeClusterParametersOutput)
 
 	DescribeClusterParameters(*redshift.DescribeClusterParametersInput) (*redshift.DescribeClusterParametersOutput, error)
 
 	DescribeClusterParametersPages(*redshift.DescribeClusterParametersInput, func(*redshift.DescribeClusterParametersOutput, bool) bool) error
 
-	DescribeClusterSecurityGroupsRequest(*redshift.DescribeClusterSecurityGroupsInput) (*service.Request, *redshift.DescribeClusterSecurityGroupsOutput)
+	DescribeClusterSecurityGroupsRequest(*redshift.DescribeClusterSecurityGroupsInput) (*request.Request, *redshift.DescribeClusterSecurityGroupsOutput)
 
 	DescribeClusterSecurityGroups(*redshift.DescribeClusterSecurityGroupsInput) (*redshift.DescribeClusterSecurityGroupsOutput, error)
 
 	DescribeClusterSecurityGroupsPages(*redshift.DescribeClusterSecurityGroupsInput, func(*redshift.DescribeClusterSecurityGroupsOutput, bool) bool) error
 
-	DescribeClusterSnapshotsRequest(*redshift.DescribeClusterSnapshotsInput) (*service.Request, *redshift.DescribeClusterSnapshotsOutput)
+	DescribeClusterSnapshotsRequest(*redshift.DescribeClusterSnapshotsInput) (*request.Request, *redshift.DescribeClusterSnapshotsOutput)
 
 	DescribeClusterSnapshots(*redshift.DescribeClusterSnapshotsInput) (*redshift.DescribeClusterSnapshotsOutput, error)
 
 	DescribeClusterSnapshotsPages(*redshift.DescribeClusterSnapshotsInput, func(*redshift.DescribeClusterSnapshotsOutput, bool) bool) error
 
-	DescribeClusterSubnetGroupsRequest(*redshift.DescribeClusterSubnetGroupsInput) (*service.Request, *redshift.DescribeClusterSubnetGroupsOutput)
+	DescribeClusterSubnetGroupsRequest(*redshift.DescribeClusterSubnetGroupsInput) (*request.Request, *redshift.DescribeClusterSubnetGroupsOutput)
 
 	DescribeClusterSubnetGroups(*redshift.DescribeClusterSubnetGroupsInput) (*redshift.DescribeClusterSubnetGroupsOutput, error)
 
 	DescribeClusterSubnetGroupsPages(*redshift.DescribeClusterSubnetGroupsInput, func(*redshift.DescribeClusterSubnetGroupsOutput, bool) bool) error
 
-	DescribeClusterVersionsRequest(*redshift.DescribeClusterVersionsInput) (*service.Request, *redshift.DescribeClusterVersionsOutput)
+	DescribeClusterVersionsRequest(*redshift.DescribeClusterVersionsInput) (*request.Request, *redshift.DescribeClusterVersionsOutput)
 
 	DescribeClusterVersions(*redshift.DescribeClusterVersionsInput) (*redshift.DescribeClusterVersionsOutput, error)
 
 	DescribeClusterVersionsPages(*redshift.DescribeClusterVersionsInput, func(*redshift.DescribeClusterVersionsOutput, bool) bool) error
 
-	DescribeClustersRequest(*redshift.DescribeClustersInput) (*service.Request, *redshift.DescribeClustersOutput)
+	DescribeClustersRequest(*redshift.DescribeClustersInput) (*request.Request, *redshift.DescribeClustersOutput)
 
 	DescribeClusters(*redshift.DescribeClustersInput) (*redshift.DescribeClustersOutput, error)
 
 	DescribeClustersPages(*redshift.DescribeClustersInput, func(*redshift.DescribeClustersOutput, bool) bool) error
 
-	DescribeDefaultClusterParametersRequest(*redshift.DescribeDefaultClusterParametersInput) (*service.Request, *redshift.DescribeDefaultClusterParametersOutput)
+	DescribeDefaultClusterParametersRequest(*redshift.DescribeDefaultClusterParametersInput) (*request.Request, *redshift.DescribeDefaultClusterParametersOutput)
 
 	DescribeDefaultClusterParameters(*redshift.DescribeDefaultClusterParametersInput) (*redshift.DescribeDefaultClusterParametersOutput, error)
 
 	DescribeDefaultClusterParametersPages(*redshift.DescribeDefaultClusterParametersInput, func(*redshift.DescribeDefaultClusterParametersOutput, bool) bool) error
 
-	DescribeEventCategoriesRequest(*redshift.DescribeEventCategoriesInput) (*service.Request, *redshift.DescribeEventCategoriesOutput)
+	DescribeEventCategoriesRequest(*redshift.DescribeEventCategoriesInput) (*request.Request, *redshift.DescribeEventCategoriesOutput)
 
 	DescribeEventCategories(*redshift.DescribeEventCategoriesInput) (*redshift.DescribeEventCategoriesOutput, error)
 
-	DescribeEventSubscriptionsRequest(*redshift.DescribeEventSubscriptionsInput) (*service.Request, *redshift.DescribeEventSubscriptionsOutput)
+	DescribeEventSubscriptionsRequest(*redshift.DescribeEventSubscriptionsInput) (*request.Request, *redshift.DescribeEventSubscriptionsOutput)
 
 	DescribeEventSubscriptions(*redshift.DescribeEventSubscriptionsInput) (*redshift.DescribeEventSubscriptionsOutput, error)
 
 	DescribeEventSubscriptionsPages(*redshift.DescribeEventSubscriptionsInput, func(*redshift.DescribeEventSubscriptionsOutput, bool) bool) error
 
-	DescribeEventsRequest(*redshift.DescribeEventsInput) (*service.Request, *redshift.DescribeEventsOutput)
+	DescribeEventsRequest(*redshift.DescribeEventsInput) (*request.Request, *redshift.DescribeEventsOutput)
 
 	DescribeEvents(*redshift.DescribeEventsInput) (*redshift.DescribeEventsOutput, error)
 
 	DescribeEventsPages(*redshift.DescribeEventsInput, func(*redshift.DescribeEventsOutput, bool) bool) error
 
-	DescribeHsmClientCertificatesRequest(*redshift.DescribeHsmClientCertificatesInput) (*service.Request, *redshift.DescribeHsmClientCertificatesOutput)
+	DescribeHsmClientCertificatesRequest(*redshift.DescribeHsmClientCertificatesInput) (*request.Request, *redshift.DescribeHsmClientCertificatesOutput)
 
 	DescribeHsmClientCertificates(*redshift.DescribeHsmClientCertificatesInput) (*redshift.DescribeHsmClientCertificatesOutput, error)
 
 	DescribeHsmClientCertificatesPages(*redshift.DescribeHsmClientCertificatesInput, func(*redshift.DescribeHsmClientCertificatesOutput, bool) bool) error
 
-	DescribeHsmConfigurationsRequest(*redshift.DescribeHsmConfigurationsInput) (*service.Request, *redshift.DescribeHsmConfigurationsOutput)
+	DescribeHsmConfigurationsRequest(*redshift.DescribeHsmConfigurationsInput) (*request.Request, *redshift.DescribeHsmConfigurationsOutput)
 
 	DescribeHsmConfigurations(*redshift.DescribeHsmConfigurationsInput) (*redshift.DescribeHsmConfigurationsOutput, error)
 
 	DescribeHsmConfigurationsPages(*redshift.DescribeHsmConfigurationsInput, func(*redshift.DescribeHsmConfigurationsOutput, bool) bool) error
 
-	DescribeLoggingStatusRequest(*redshift.DescribeLoggingStatusInput) (*service.Request, *redshift.LoggingStatus)
+	DescribeLoggingStatusRequest(*redshift.DescribeLoggingStatusInput) (*request.Request, *redshift.LoggingStatus)
 
 	DescribeLoggingStatus(*redshift.DescribeLoggingStatusInput) (*redshift.LoggingStatus, error)
 
-	DescribeOrderableClusterOptionsRequest(*redshift.DescribeOrderableClusterOptionsInput) (*service.Request, *redshift.DescribeOrderableClusterOptionsOutput)
+	DescribeOrderableClusterOptionsRequest(*redshift.DescribeOrderableClusterOptionsInput) (*request.Request, *redshift.DescribeOrderableClusterOptionsOutput)
 
 	DescribeOrderableClusterOptions(*redshift.DescribeOrderableClusterOptionsInput) (*redshift.DescribeOrderableClusterOptionsOutput, error)
 
 	DescribeOrderableClusterOptionsPages(*redshift.DescribeOrderableClusterOptionsInput, func(*redshift.DescribeOrderableClusterOptionsOutput, bool) bool) error
 
-	DescribeReservedNodeOfferingsRequest(*redshift.DescribeReservedNodeOfferingsInput) (*service.Request, *redshift.DescribeReservedNodeOfferingsOutput)
+	DescribeReservedNodeOfferingsRequest(*redshift.DescribeReservedNodeOfferingsInput) (*request.Request, *redshift.DescribeReservedNodeOfferingsOutput)
 
 	DescribeReservedNodeOfferings(*redshift.DescribeReservedNodeOfferingsInput) (*redshift.DescribeReservedNodeOfferingsOutput, error)
 
 	DescribeReservedNodeOfferingsPages(*redshift.DescribeReservedNodeOfferingsInput, func(*redshift.DescribeReservedNodeOfferingsOutput, bool) bool) error
 
-	DescribeReservedNodesRequest(*redshift.DescribeReservedNodesInput) (*service.Request, *redshift.DescribeReservedNodesOutput)
+	DescribeReservedNodesRequest(*redshift.DescribeReservedNodesInput) (*request.Request, *redshift.DescribeReservedNodesOutput)
 
 	DescribeReservedNodes(*redshift.DescribeReservedNodesInput) (*redshift.DescribeReservedNodesOutput, error)
 
 	DescribeReservedNodesPages(*redshift.DescribeReservedNodesInput, func(*redshift.DescribeReservedNodesOutput, bool) bool) error
 
-	DescribeResizeRequest(*redshift.DescribeResizeInput) (*service.Request, *redshift.DescribeResizeOutput)
+	DescribeResizeRequest(*redshift.DescribeResizeInput) (*request.Request, *redshift.DescribeResizeOutput)
 
 	DescribeResize(*redshift.DescribeResizeInput) (*redshift.DescribeResizeOutput, error)
 
-	DescribeSnapshotCopyGrantsRequest(*redshift.DescribeSnapshotCopyGrantsInput) (*service.Request, *redshift.DescribeSnapshotCopyGrantsOutput)
+	DescribeSnapshotCopyGrantsRequest(*redshift.DescribeSnapshotCopyGrantsInput) (*request.Request, *redshift.DescribeSnapshotCopyGrantsOutput)
 
 	DescribeSnapshotCopyGrants(*redshift.DescribeSnapshotCopyGrantsInput) (*redshift.DescribeSnapshotCopyGrantsOutput, error)
 
-	DescribeTagsRequest(*redshift.DescribeTagsInput) (*service.Request, *redshift.DescribeTagsOutput)
+	DescribeTagsRequest(*redshift.DescribeTagsInput) (*request.Request, *redshift.DescribeTagsOutput)
 
 	DescribeTags(*redshift.DescribeTagsInput) (*redshift.DescribeTagsOutput, error)
 
-	DisableLoggingRequest(*redshift.DisableLoggingInput) (*service.Request, *redshift.LoggingStatus)
+	DisableLoggingRequest(*redshift.DisableLoggingInput) (*request.Request, *redshift.LoggingStatus)
 
 	DisableLogging(*redshift.DisableLoggingInput) (*redshift.LoggingStatus, error)
 
-	DisableSnapshotCopyRequest(*redshift.DisableSnapshotCopyInput) (*service.Request, *redshift.DisableSnapshotCopyOutput)
+	DisableSnapshotCopyRequest(*redshift.DisableSnapshotCopyInput) (*request.Request, *redshift.DisableSnapshotCopyOutput)
 
 	DisableSnapshotCopy(*redshift.DisableSnapshotCopyInput) (*redshift.DisableSnapshotCopyOutput, error)
 
-	EnableLoggingRequest(*redshift.EnableLoggingInput) (*service.Request, *redshift.LoggingStatus)
+	EnableLoggingRequest(*redshift.EnableLoggingInput) (*request.Request, *redshift.LoggingStatus)
 
 	EnableLogging(*redshift.EnableLoggingInput) (*redshift.LoggingStatus, error)
 
-	EnableSnapshotCopyRequest(*redshift.EnableSnapshotCopyInput) (*service.Request, *redshift.EnableSnapshotCopyOutput)
+	EnableSnapshotCopyRequest(*redshift.EnableSnapshotCopyInput) (*request.Request, *redshift.EnableSnapshotCopyOutput)
 
 	EnableSnapshotCopy(*redshift.EnableSnapshotCopyInput) (*redshift.EnableSnapshotCopyOutput, error)
 
-	ModifyClusterRequest(*redshift.ModifyClusterInput) (*service.Request, *redshift.ModifyClusterOutput)
+	ModifyClusterRequest(*redshift.ModifyClusterInput) (*request.Request, *redshift.ModifyClusterOutput)
 
 	ModifyCluster(*redshift.ModifyClusterInput) (*redshift.ModifyClusterOutput, error)
 
-	ModifyClusterParameterGroupRequest(*redshift.ModifyClusterParameterGroupInput) (*service.Request, *redshift.ClusterParameterGroupNameMessage)
+	ModifyClusterParameterGroupRequest(*redshift.ModifyClusterParameterGroupInput) (*request.Request, *redshift.ClusterParameterGroupNameMessage)
 
 	ModifyClusterParameterGroup(*redshift.ModifyClusterParameterGroupInput) (*redshift.ClusterParameterGroupNameMessage, error)
 
-	ModifyClusterSubnetGroupRequest(*redshift.ModifyClusterSubnetGroupInput) (*service.Request, *redshift.ModifyClusterSubnetGroupOutput)
+	ModifyClusterSubnetGroupRequest(*redshift.ModifyClusterSubnetGroupInput) (*request.Request, *redshift.ModifyClusterSubnetGroupOutput)
 
 	ModifyClusterSubnetGroup(*redshift.ModifyClusterSubnetGroupInput) (*redshift.ModifyClusterSubnetGroupOutput, error)
 
-	ModifyEventSubscriptionRequest(*redshift.ModifyEventSubscriptionInput) (*service.Request, *redshift.ModifyEventSubscriptionOutput)
+	ModifyEventSubscriptionRequest(*redshift.ModifyEventSubscriptionInput) (*request.Request, *redshift.ModifyEventSubscriptionOutput)
 
 	ModifyEventSubscription(*redshift.ModifyEventSubscriptionInput) (*redshift.ModifyEventSubscriptionOutput, error)
 
-	ModifySnapshotCopyRetentionPeriodRequest(*redshift.ModifySnapshotCopyRetentionPeriodInput) (*service.Request, *redshift.ModifySnapshotCopyRetentionPeriodOutput)
+	ModifySnapshotCopyRetentionPeriodRequest(*redshift.ModifySnapshotCopyRetentionPeriodInput) (*request.Request, *redshift.ModifySnapshotCopyRetentionPeriodOutput)
 
 	ModifySnapshotCopyRetentionPeriod(*redshift.ModifySnapshotCopyRetentionPeriodInput) (*redshift.ModifySnapshotCopyRetentionPeriodOutput, error)
 
-	PurchaseReservedNodeOfferingRequest(*redshift.PurchaseReservedNodeOfferingInput) (*service.Request, *redshift.PurchaseReservedNodeOfferingOutput)
+	PurchaseReservedNodeOfferingRequest(*redshift.PurchaseReservedNodeOfferingInput) (*request.Request, *redshift.PurchaseReservedNodeOfferingOutput)
 
 	PurchaseReservedNodeOffering(*redshift.PurchaseReservedNodeOfferingInput) (*redshift.PurchaseReservedNodeOfferingOutput, error)
 
-	RebootClusterRequest(*redshift.RebootClusterInput) (*service.Request, *redshift.RebootClusterOutput)
+	RebootClusterRequest(*redshift.RebootClusterInput) (*request.Request, *redshift.RebootClusterOutput)
 
 	RebootCluster(*redshift.RebootClusterInput) (*redshift.RebootClusterOutput, error)
 
-	ResetClusterParameterGroupRequest(*redshift.ResetClusterParameterGroupInput) (*service.Request, *redshift.ClusterParameterGroupNameMessage)
+	ResetClusterParameterGroupRequest(*redshift.ResetClusterParameterGroupInput) (*request.Request, *redshift.ClusterParameterGroupNameMessage)
 
 	ResetClusterParameterGroup(*redshift.ResetClusterParameterGroupInput) (*redshift.ClusterParameterGroupNameMessage, error)
 
-	RestoreFromClusterSnapshotRequest(*redshift.RestoreFromClusterSnapshotInput) (*service.Request, *redshift.RestoreFromClusterSnapshotOutput)
+	RestoreFromClusterSnapshotRequest(*redshift.RestoreFromClusterSnapshotInput) (*request.Request, *redshift.RestoreFromClusterSnapshotOutput)
 
 	RestoreFromClusterSnapshot(*redshift.RestoreFromClusterSnapshotInput) (*redshift.RestoreFromClusterSnapshotOutput, error)
 
-	RevokeClusterSecurityGroupIngressRequest(*redshift.RevokeClusterSecurityGroupIngressInput) (*service.Request, *redshift.RevokeClusterSecurityGroupIngressOutput)
+	RevokeClusterSecurityGroupIngressRequest(*redshift.RevokeClusterSecurityGroupIngressInput) (*request.Request, *redshift.RevokeClusterSecurityGroupIngressOutput)
 
 	RevokeClusterSecurityGroupIngress(*redshift.RevokeClusterSecurityGroupIngressInput) (*redshift.RevokeClusterSecurityGroupIngressOutput, error)
 
-	RevokeSnapshotAccessRequest(*redshift.RevokeSnapshotAccessInput) (*service.Request, *redshift.RevokeSnapshotAccessOutput)
+	RevokeSnapshotAccessRequest(*redshift.RevokeSnapshotAccessInput) (*request.Request, *redshift.RevokeSnapshotAccessOutput)
 
 	RevokeSnapshotAccess(*redshift.RevokeSnapshotAccessInput) (*redshift.RevokeSnapshotAccessOutput, error)
 
-	RotateEncryptionKeyRequest(*redshift.RotateEncryptionKeyInput) (*service.Request, *redshift.RotateEncryptionKeyOutput)
+	RotateEncryptionKeyRequest(*redshift.RotateEncryptionKeyInput) (*request.Request, *redshift.RotateEncryptionKeyOutput)
 
 	RotateEncryptionKey(*redshift.RotateEncryptionKeyInput) (*redshift.RotateEncryptionKeyOutput, error)
 }

--- a/service/redshift/service.go
+++ b/service/redshift/service.go
@@ -5,7 +5,9 @@ package redshift
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -40,14 +42,16 @@ type Redshift struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new Redshift client.
 func New(config *aws.Config) *Redshift {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "redshift",
-		APIVersion:  "2012-12-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "redshift",
+			APIVersion:  "2012-12-01",
+		},
 	}
 	service.Initialize()
 
@@ -68,8 +72,8 @@ func New(config *aws.Config) *Redshift {
 
 // newRequest creates a new request for a Redshift operation and runs any
 // custom request initialization.
-func (c *Redshift) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *Redshift) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/route53/api.go
+++ b/service/route53/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAssociateVPCWithHostedZone = "AssociateVPCWithHostedZone"
 
 // AssociateVPCWithHostedZoneRequest generates a request for the AssociateVPCWithHostedZone operation.
-func (c *Route53) AssociateVPCWithHostedZoneRequest(input *AssociateVPCWithHostedZoneInput) (req *service.Request, output *AssociateVPCWithHostedZoneOutput) {
-	op := &service.Operation{
+func (c *Route53) AssociateVPCWithHostedZoneRequest(input *AssociateVPCWithHostedZoneInput) (req *request.Request, output *AssociateVPCWithHostedZoneOutput) {
+	op := &request.Operation{
 		Name:       opAssociateVPCWithHostedZone,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/hostedzone/{Id}/associatevpc",
@@ -47,8 +47,8 @@ func (c *Route53) AssociateVPCWithHostedZone(input *AssociateVPCWithHostedZoneIn
 const opChangeResourceRecordSets = "ChangeResourceRecordSets"
 
 // ChangeResourceRecordSetsRequest generates a request for the ChangeResourceRecordSets operation.
-func (c *Route53) ChangeResourceRecordSetsRequest(input *ChangeResourceRecordSetsInput) (req *service.Request, output *ChangeResourceRecordSetsOutput) {
-	op := &service.Operation{
+func (c *Route53) ChangeResourceRecordSetsRequest(input *ChangeResourceRecordSetsInput) (req *request.Request, output *ChangeResourceRecordSetsOutput) {
+	op := &request.Operation{
 		Name:       opChangeResourceRecordSets,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/hostedzone/{Id}/rrset/",
@@ -101,8 +101,8 @@ func (c *Route53) ChangeResourceRecordSets(input *ChangeResourceRecordSetsInput)
 const opChangeTagsForResource = "ChangeTagsForResource"
 
 // ChangeTagsForResourceRequest generates a request for the ChangeTagsForResource operation.
-func (c *Route53) ChangeTagsForResourceRequest(input *ChangeTagsForResourceInput) (req *service.Request, output *ChangeTagsForResourceOutput) {
-	op := &service.Operation{
+func (c *Route53) ChangeTagsForResourceRequest(input *ChangeTagsForResourceInput) (req *request.Request, output *ChangeTagsForResourceOutput) {
+	op := &request.Operation{
 		Name:       opChangeTagsForResource,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/tags/{ResourceType}/{ResourceId}",
@@ -127,8 +127,8 @@ func (c *Route53) ChangeTagsForResource(input *ChangeTagsForResourceInput) (*Cha
 const opCreateHealthCheck = "CreateHealthCheck"
 
 // CreateHealthCheckRequest generates a request for the CreateHealthCheck operation.
-func (c *Route53) CreateHealthCheckRequest(input *CreateHealthCheckInput) (req *service.Request, output *CreateHealthCheckOutput) {
-	op := &service.Operation{
+func (c *Route53) CreateHealthCheckRequest(input *CreateHealthCheckInput) (req *request.Request, output *CreateHealthCheckOutput) {
+	op := &request.Operation{
 		Name:       opCreateHealthCheck,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/healthcheck",
@@ -159,8 +159,8 @@ func (c *Route53) CreateHealthCheck(input *CreateHealthCheckInput) (*CreateHealt
 const opCreateHostedZone = "CreateHostedZone"
 
 // CreateHostedZoneRequest generates a request for the CreateHostedZone operation.
-func (c *Route53) CreateHostedZoneRequest(input *CreateHostedZoneInput) (req *service.Request, output *CreateHostedZoneOutput) {
-	op := &service.Operation{
+func (c *Route53) CreateHostedZoneRequest(input *CreateHostedZoneInput) (req *request.Request, output *CreateHostedZoneOutput) {
+	op := &request.Operation{
 		Name:       opCreateHostedZone,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/hostedzone",
@@ -206,8 +206,8 @@ func (c *Route53) CreateHostedZone(input *CreateHostedZoneInput) (*CreateHostedZ
 const opCreateReusableDelegationSet = "CreateReusableDelegationSet"
 
 // CreateReusableDelegationSetRequest generates a request for the CreateReusableDelegationSet operation.
-func (c *Route53) CreateReusableDelegationSetRequest(input *CreateReusableDelegationSetInput) (req *service.Request, output *CreateReusableDelegationSetOutput) {
-	op := &service.Operation{
+func (c *Route53) CreateReusableDelegationSetRequest(input *CreateReusableDelegationSetInput) (req *request.Request, output *CreateReusableDelegationSetOutput) {
+	op := &request.Operation{
 		Name:       opCreateReusableDelegationSet,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/delegationset",
@@ -241,8 +241,8 @@ func (c *Route53) CreateReusableDelegationSet(input *CreateReusableDelegationSet
 const opDeleteHealthCheck = "DeleteHealthCheck"
 
 // DeleteHealthCheckRequest generates a request for the DeleteHealthCheck operation.
-func (c *Route53) DeleteHealthCheckRequest(input *DeleteHealthCheckInput) (req *service.Request, output *DeleteHealthCheckOutput) {
-	op := &service.Operation{
+func (c *Route53) DeleteHealthCheckRequest(input *DeleteHealthCheckInput) (req *request.Request, output *DeleteHealthCheckOutput) {
+	op := &request.Operation{
 		Name:       opDeleteHealthCheck,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2013-04-01/healthcheck/{HealthCheckId}",
@@ -277,8 +277,8 @@ func (c *Route53) DeleteHealthCheck(input *DeleteHealthCheckInput) (*DeleteHealt
 const opDeleteHostedZone = "DeleteHostedZone"
 
 // DeleteHostedZoneRequest generates a request for the DeleteHostedZone operation.
-func (c *Route53) DeleteHostedZoneRequest(input *DeleteHostedZoneInput) (req *service.Request, output *DeleteHostedZoneOutput) {
-	op := &service.Operation{
+func (c *Route53) DeleteHostedZoneRequest(input *DeleteHostedZoneInput) (req *request.Request, output *DeleteHostedZoneOutput) {
+	op := &request.Operation{
 		Name:       opDeleteHostedZone,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2013-04-01/hostedzone/{Id}",
@@ -317,8 +317,8 @@ func (c *Route53) DeleteHostedZone(input *DeleteHostedZoneInput) (*DeleteHostedZ
 const opDeleteReusableDelegationSet = "DeleteReusableDelegationSet"
 
 // DeleteReusableDelegationSetRequest generates a request for the DeleteReusableDelegationSet operation.
-func (c *Route53) DeleteReusableDelegationSetRequest(input *DeleteReusableDelegationSetInput) (req *service.Request, output *DeleteReusableDelegationSetOutput) {
-	op := &service.Operation{
+func (c *Route53) DeleteReusableDelegationSetRequest(input *DeleteReusableDelegationSetInput) (req *request.Request, output *DeleteReusableDelegationSetOutput) {
+	op := &request.Operation{
 		Name:       opDeleteReusableDelegationSet,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/2013-04-01/delegationset/{Id}",
@@ -352,8 +352,8 @@ func (c *Route53) DeleteReusableDelegationSet(input *DeleteReusableDelegationSet
 const opDisassociateVPCFromHostedZone = "DisassociateVPCFromHostedZone"
 
 // DisassociateVPCFromHostedZoneRequest generates a request for the DisassociateVPCFromHostedZone operation.
-func (c *Route53) DisassociateVPCFromHostedZoneRequest(input *DisassociateVPCFromHostedZoneInput) (req *service.Request, output *DisassociateVPCFromHostedZoneOutput) {
-	op := &service.Operation{
+func (c *Route53) DisassociateVPCFromHostedZoneRequest(input *DisassociateVPCFromHostedZoneInput) (req *request.Request, output *DisassociateVPCFromHostedZoneOutput) {
+	op := &request.Operation{
 		Name:       opDisassociateVPCFromHostedZone,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/hostedzone/{Id}/disassociatevpc",
@@ -386,8 +386,8 @@ func (c *Route53) DisassociateVPCFromHostedZone(input *DisassociateVPCFromHosted
 const opGetChange = "GetChange"
 
 // GetChangeRequest generates a request for the GetChange operation.
-func (c *Route53) GetChangeRequest(input *GetChangeInput) (req *service.Request, output *GetChangeOutput) {
-	op := &service.Operation{
+func (c *Route53) GetChangeRequest(input *GetChangeInput) (req *request.Request, output *GetChangeOutput) {
+	op := &request.Operation{
 		Name:       opGetChange,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/change/{Id}",
@@ -421,8 +421,8 @@ func (c *Route53) GetChange(input *GetChangeInput) (*GetChangeOutput, error) {
 const opGetCheckerIpRanges = "GetCheckerIpRanges"
 
 // GetCheckerIpRangesRequest generates a request for the GetCheckerIpRanges operation.
-func (c *Route53) GetCheckerIpRangesRequest(input *GetCheckerIpRangesInput) (req *service.Request, output *GetCheckerIpRangesOutput) {
-	op := &service.Operation{
+func (c *Route53) GetCheckerIpRangesRequest(input *GetCheckerIpRangesInput) (req *request.Request, output *GetCheckerIpRangesOutput) {
+	op := &request.Operation{
 		Name:       opGetCheckerIpRanges,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/checkeripranges",
@@ -451,8 +451,8 @@ func (c *Route53) GetCheckerIpRanges(input *GetCheckerIpRangesInput) (*GetChecke
 const opGetGeoLocation = "GetGeoLocation"
 
 // GetGeoLocationRequest generates a request for the GetGeoLocation operation.
-func (c *Route53) GetGeoLocationRequest(input *GetGeoLocationInput) (req *service.Request, output *GetGeoLocationOutput) {
-	op := &service.Operation{
+func (c *Route53) GetGeoLocationRequest(input *GetGeoLocationInput) (req *request.Request, output *GetGeoLocationOutput) {
+	op := &request.Operation{
 		Name:       opGetGeoLocation,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/geolocation",
@@ -480,8 +480,8 @@ func (c *Route53) GetGeoLocation(input *GetGeoLocationInput) (*GetGeoLocationOut
 const opGetHealthCheck = "GetHealthCheck"
 
 // GetHealthCheckRequest generates a request for the GetHealthCheck operation.
-func (c *Route53) GetHealthCheckRequest(input *GetHealthCheckInput) (req *service.Request, output *GetHealthCheckOutput) {
-	op := &service.Operation{
+func (c *Route53) GetHealthCheckRequest(input *GetHealthCheckInput) (req *request.Request, output *GetHealthCheckOutput) {
+	op := &request.Operation{
 		Name:       opGetHealthCheck,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/healthcheck/{HealthCheckId}",
@@ -508,8 +508,8 @@ func (c *Route53) GetHealthCheck(input *GetHealthCheckInput) (*GetHealthCheckOut
 const opGetHealthCheckCount = "GetHealthCheckCount"
 
 // GetHealthCheckCountRequest generates a request for the GetHealthCheckCount operation.
-func (c *Route53) GetHealthCheckCountRequest(input *GetHealthCheckCountInput) (req *service.Request, output *GetHealthCheckCountOutput) {
-	op := &service.Operation{
+func (c *Route53) GetHealthCheckCountRequest(input *GetHealthCheckCountInput) (req *request.Request, output *GetHealthCheckCountOutput) {
+	op := &request.Operation{
 		Name:       opGetHealthCheckCount,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/healthcheckcount",
@@ -536,8 +536,8 @@ func (c *Route53) GetHealthCheckCount(input *GetHealthCheckCountInput) (*GetHeal
 const opGetHealthCheckLastFailureReason = "GetHealthCheckLastFailureReason"
 
 // GetHealthCheckLastFailureReasonRequest generates a request for the GetHealthCheckLastFailureReason operation.
-func (c *Route53) GetHealthCheckLastFailureReasonRequest(input *GetHealthCheckLastFailureReasonInput) (req *service.Request, output *GetHealthCheckLastFailureReasonOutput) {
-	op := &service.Operation{
+func (c *Route53) GetHealthCheckLastFailureReasonRequest(input *GetHealthCheckLastFailureReasonInput) (req *request.Request, output *GetHealthCheckLastFailureReasonOutput) {
+	op := &request.Operation{
 		Name:       opGetHealthCheckLastFailureReason,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/healthcheck/{HealthCheckId}/lastfailurereason",
@@ -566,8 +566,8 @@ func (c *Route53) GetHealthCheckLastFailureReason(input *GetHealthCheckLastFailu
 const opGetHealthCheckStatus = "GetHealthCheckStatus"
 
 // GetHealthCheckStatusRequest generates a request for the GetHealthCheckStatus operation.
-func (c *Route53) GetHealthCheckStatusRequest(input *GetHealthCheckStatusInput) (req *service.Request, output *GetHealthCheckStatusOutput) {
-	op := &service.Operation{
+func (c *Route53) GetHealthCheckStatusRequest(input *GetHealthCheckStatusInput) (req *request.Request, output *GetHealthCheckStatusOutput) {
+	op := &request.Operation{
 		Name:       opGetHealthCheckStatus,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/healthcheck/{HealthCheckId}/status",
@@ -595,8 +595,8 @@ func (c *Route53) GetHealthCheckStatus(input *GetHealthCheckStatusInput) (*GetHe
 const opGetHostedZone = "GetHostedZone"
 
 // GetHostedZoneRequest generates a request for the GetHostedZone operation.
-func (c *Route53) GetHostedZoneRequest(input *GetHostedZoneInput) (req *service.Request, output *GetHostedZoneOutput) {
-	op := &service.Operation{
+func (c *Route53) GetHostedZoneRequest(input *GetHostedZoneInput) (req *request.Request, output *GetHostedZoneOutput) {
+	op := &request.Operation{
 		Name:       opGetHostedZone,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/hostedzone/{Id}",
@@ -625,8 +625,8 @@ func (c *Route53) GetHostedZone(input *GetHostedZoneInput) (*GetHostedZoneOutput
 const opGetHostedZoneCount = "GetHostedZoneCount"
 
 // GetHostedZoneCountRequest generates a request for the GetHostedZoneCount operation.
-func (c *Route53) GetHostedZoneCountRequest(input *GetHostedZoneCountInput) (req *service.Request, output *GetHostedZoneCountOutput) {
-	op := &service.Operation{
+func (c *Route53) GetHostedZoneCountRequest(input *GetHostedZoneCountInput) (req *request.Request, output *GetHostedZoneCountOutput) {
+	op := &request.Operation{
 		Name:       opGetHostedZoneCount,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/hostedzonecount",
@@ -653,8 +653,8 @@ func (c *Route53) GetHostedZoneCount(input *GetHostedZoneCountInput) (*GetHosted
 const opGetReusableDelegationSet = "GetReusableDelegationSet"
 
 // GetReusableDelegationSetRequest generates a request for the GetReusableDelegationSet operation.
-func (c *Route53) GetReusableDelegationSetRequest(input *GetReusableDelegationSetInput) (req *service.Request, output *GetReusableDelegationSetOutput) {
-	op := &service.Operation{
+func (c *Route53) GetReusableDelegationSetRequest(input *GetReusableDelegationSetInput) (req *request.Request, output *GetReusableDelegationSetOutput) {
+	op := &request.Operation{
 		Name:       opGetReusableDelegationSet,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/delegationset/{Id}",
@@ -681,8 +681,8 @@ func (c *Route53) GetReusableDelegationSet(input *GetReusableDelegationSetInput)
 const opListGeoLocations = "ListGeoLocations"
 
 // ListGeoLocationsRequest generates a request for the ListGeoLocations operation.
-func (c *Route53) ListGeoLocationsRequest(input *ListGeoLocationsInput) (req *service.Request, output *ListGeoLocationsOutput) {
-	op := &service.Operation{
+func (c *Route53) ListGeoLocationsRequest(input *ListGeoLocationsInput) (req *request.Request, output *ListGeoLocationsOutput) {
+	op := &request.Operation{
 		Name:       opListGeoLocations,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/geolocations",
@@ -720,12 +720,12 @@ func (c *Route53) ListGeoLocations(input *ListGeoLocationsInput) (*ListGeoLocati
 const opListHealthChecks = "ListHealthChecks"
 
 // ListHealthChecksRequest generates a request for the ListHealthChecks operation.
-func (c *Route53) ListHealthChecksRequest(input *ListHealthChecksInput) (req *service.Request, output *ListHealthChecksOutput) {
-	op := &service.Operation{
+func (c *Route53) ListHealthChecksRequest(input *ListHealthChecksInput) (req *request.Request, output *ListHealthChecksOutput) {
+	op := &request.Operation{
 		Name:       opListHealthChecks,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/healthcheck",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "MaxItems",
@@ -768,12 +768,12 @@ func (c *Route53) ListHealthChecksPages(input *ListHealthChecksInput, fn func(p 
 const opListHostedZones = "ListHostedZones"
 
 // ListHostedZonesRequest generates a request for the ListHostedZones operation.
-func (c *Route53) ListHostedZonesRequest(input *ListHostedZonesInput) (req *service.Request, output *ListHostedZonesOutput) {
-	op := &service.Operation{
+func (c *Route53) ListHostedZonesRequest(input *ListHostedZonesInput) (req *request.Request, output *ListHostedZonesOutput) {
+	op := &request.Operation{
 		Name:       opListHostedZones,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/hostedzone",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker"},
 			LimitToken:      "MaxItems",
@@ -816,8 +816,8 @@ func (c *Route53) ListHostedZonesPages(input *ListHostedZonesInput, fn func(p *L
 const opListHostedZonesByName = "ListHostedZonesByName"
 
 // ListHostedZonesByNameRequest generates a request for the ListHostedZonesByName operation.
-func (c *Route53) ListHostedZonesByNameRequest(input *ListHostedZonesByNameInput) (req *service.Request, output *ListHostedZonesByNameOutput) {
-	op := &service.Operation{
+func (c *Route53) ListHostedZonesByNameRequest(input *ListHostedZonesByNameInput) (req *request.Request, output *ListHostedZonesByNameOutput) {
+	op := &request.Operation{
 		Name:       opListHostedZonesByName,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/hostedzonesbyname",
@@ -853,12 +853,12 @@ func (c *Route53) ListHostedZonesByName(input *ListHostedZonesByNameInput) (*Lis
 const opListResourceRecordSets = "ListResourceRecordSets"
 
 // ListResourceRecordSetsRequest generates a request for the ListResourceRecordSets operation.
-func (c *Route53) ListResourceRecordSetsRequest(input *ListResourceRecordSetsInput) (req *service.Request, output *ListResourceRecordSetsOutput) {
-	op := &service.Operation{
+func (c *Route53) ListResourceRecordSetsRequest(input *ListResourceRecordSetsInput) (req *request.Request, output *ListResourceRecordSetsOutput) {
+	op := &request.Operation{
 		Name:       opListResourceRecordSets,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/hostedzone/{Id}/rrset",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"StartRecordName", "StartRecordType", "StartRecordIdentifier"},
 			OutputTokens:    []string{"NextRecordName", "NextRecordType", "NextRecordIdentifier"},
 			LimitToken:      "MaxItems",
@@ -930,8 +930,8 @@ func (c *Route53) ListResourceRecordSetsPages(input *ListResourceRecordSetsInput
 const opListReusableDelegationSets = "ListReusableDelegationSets"
 
 // ListReusableDelegationSetsRequest generates a request for the ListReusableDelegationSets operation.
-func (c *Route53) ListReusableDelegationSetsRequest(input *ListReusableDelegationSetsInput) (req *service.Request, output *ListReusableDelegationSetsOutput) {
-	op := &service.Operation{
+func (c *Route53) ListReusableDelegationSetsRequest(input *ListReusableDelegationSetsInput) (req *request.Request, output *ListReusableDelegationSetsOutput) {
+	op := &request.Operation{
 		Name:       opListReusableDelegationSets,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/delegationset",
@@ -966,8 +966,8 @@ func (c *Route53) ListReusableDelegationSets(input *ListReusableDelegationSetsIn
 const opListTagsForResource = "ListTagsForResource"
 
 // ListTagsForResourceRequest generates a request for the ListTagsForResource operation.
-func (c *Route53) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *service.Request, output *ListTagsForResourceOutput) {
-	op := &service.Operation{
+func (c *Route53) ListTagsForResourceRequest(input *ListTagsForResourceInput) (req *request.Request, output *ListTagsForResourceOutput) {
+	op := &request.Operation{
 		Name:       opListTagsForResource,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/tags/{ResourceType}/{ResourceId}",
@@ -992,8 +992,8 @@ func (c *Route53) ListTagsForResource(input *ListTagsForResourceInput) (*ListTag
 const opListTagsForResources = "ListTagsForResources"
 
 // ListTagsForResourcesRequest generates a request for the ListTagsForResources operation.
-func (c *Route53) ListTagsForResourcesRequest(input *ListTagsForResourcesInput) (req *service.Request, output *ListTagsForResourcesOutput) {
-	op := &service.Operation{
+func (c *Route53) ListTagsForResourcesRequest(input *ListTagsForResourcesInput) (req *request.Request, output *ListTagsForResourcesOutput) {
+	op := &request.Operation{
 		Name:       opListTagsForResources,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/tags/{ResourceType}",
@@ -1018,8 +1018,8 @@ func (c *Route53) ListTagsForResources(input *ListTagsForResourcesInput) (*ListT
 const opUpdateHealthCheck = "UpdateHealthCheck"
 
 // UpdateHealthCheckRequest generates a request for the UpdateHealthCheck operation.
-func (c *Route53) UpdateHealthCheckRequest(input *UpdateHealthCheckInput) (req *service.Request, output *UpdateHealthCheckOutput) {
-	op := &service.Operation{
+func (c *Route53) UpdateHealthCheckRequest(input *UpdateHealthCheckInput) (req *request.Request, output *UpdateHealthCheckOutput) {
+	op := &request.Operation{
 		Name:       opUpdateHealthCheck,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/healthcheck/{HealthCheckId}",
@@ -1050,8 +1050,8 @@ func (c *Route53) UpdateHealthCheck(input *UpdateHealthCheckInput) (*UpdateHealt
 const opUpdateHostedZoneComment = "UpdateHostedZoneComment"
 
 // UpdateHostedZoneCommentRequest generates a request for the UpdateHostedZoneComment operation.
-func (c *Route53) UpdateHostedZoneCommentRequest(input *UpdateHostedZoneCommentInput) (req *service.Request, output *UpdateHostedZoneCommentOutput) {
-	op := &service.Operation{
+func (c *Route53) UpdateHostedZoneCommentRequest(input *UpdateHostedZoneCommentInput) (req *request.Request, output *UpdateHostedZoneCommentOutput) {
+	op := &request.Operation{
 		Name:       opUpdateHostedZoneComment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/2013-04-01/hostedzone/{Id}",

--- a/service/route53/customizations.go
+++ b/service/route53/customizations.go
@@ -3,6 +3,7 @@ package route53
 import (
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
 )
 
@@ -14,7 +15,7 @@ func init() {
 
 var reSanitizeURL = regexp.MustCompile(`\/%2F\w+%2F`)
 
-func sanitizeURL(r *service.Request) {
+func sanitizeURL(r *request.Request) {
 	r.HTTPRequest.URL.Opaque =
 		reSanitizeURL.ReplaceAllString(r.HTTPRequest.URL.Opaque, "/")
 }

--- a/service/route53/route53iface/interface.go
+++ b/service/route53/route53iface/interface.go
@@ -4,135 +4,135 @@
 package route53iface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
 // Route53API is the interface type for route53.Route53.
 type Route53API interface {
-	AssociateVPCWithHostedZoneRequest(*route53.AssociateVPCWithHostedZoneInput) (*service.Request, *route53.AssociateVPCWithHostedZoneOutput)
+	AssociateVPCWithHostedZoneRequest(*route53.AssociateVPCWithHostedZoneInput) (*request.Request, *route53.AssociateVPCWithHostedZoneOutput)
 
 	AssociateVPCWithHostedZone(*route53.AssociateVPCWithHostedZoneInput) (*route53.AssociateVPCWithHostedZoneOutput, error)
 
-	ChangeResourceRecordSetsRequest(*route53.ChangeResourceRecordSetsInput) (*service.Request, *route53.ChangeResourceRecordSetsOutput)
+	ChangeResourceRecordSetsRequest(*route53.ChangeResourceRecordSetsInput) (*request.Request, *route53.ChangeResourceRecordSetsOutput)
 
 	ChangeResourceRecordSets(*route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error)
 
-	ChangeTagsForResourceRequest(*route53.ChangeTagsForResourceInput) (*service.Request, *route53.ChangeTagsForResourceOutput)
+	ChangeTagsForResourceRequest(*route53.ChangeTagsForResourceInput) (*request.Request, *route53.ChangeTagsForResourceOutput)
 
 	ChangeTagsForResource(*route53.ChangeTagsForResourceInput) (*route53.ChangeTagsForResourceOutput, error)
 
-	CreateHealthCheckRequest(*route53.CreateHealthCheckInput) (*service.Request, *route53.CreateHealthCheckOutput)
+	CreateHealthCheckRequest(*route53.CreateHealthCheckInput) (*request.Request, *route53.CreateHealthCheckOutput)
 
 	CreateHealthCheck(*route53.CreateHealthCheckInput) (*route53.CreateHealthCheckOutput, error)
 
-	CreateHostedZoneRequest(*route53.CreateHostedZoneInput) (*service.Request, *route53.CreateHostedZoneOutput)
+	CreateHostedZoneRequest(*route53.CreateHostedZoneInput) (*request.Request, *route53.CreateHostedZoneOutput)
 
 	CreateHostedZone(*route53.CreateHostedZoneInput) (*route53.CreateHostedZoneOutput, error)
 
-	CreateReusableDelegationSetRequest(*route53.CreateReusableDelegationSetInput) (*service.Request, *route53.CreateReusableDelegationSetOutput)
+	CreateReusableDelegationSetRequest(*route53.CreateReusableDelegationSetInput) (*request.Request, *route53.CreateReusableDelegationSetOutput)
 
 	CreateReusableDelegationSet(*route53.CreateReusableDelegationSetInput) (*route53.CreateReusableDelegationSetOutput, error)
 
-	DeleteHealthCheckRequest(*route53.DeleteHealthCheckInput) (*service.Request, *route53.DeleteHealthCheckOutput)
+	DeleteHealthCheckRequest(*route53.DeleteHealthCheckInput) (*request.Request, *route53.DeleteHealthCheckOutput)
 
 	DeleteHealthCheck(*route53.DeleteHealthCheckInput) (*route53.DeleteHealthCheckOutput, error)
 
-	DeleteHostedZoneRequest(*route53.DeleteHostedZoneInput) (*service.Request, *route53.DeleteHostedZoneOutput)
+	DeleteHostedZoneRequest(*route53.DeleteHostedZoneInput) (*request.Request, *route53.DeleteHostedZoneOutput)
 
 	DeleteHostedZone(*route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error)
 
-	DeleteReusableDelegationSetRequest(*route53.DeleteReusableDelegationSetInput) (*service.Request, *route53.DeleteReusableDelegationSetOutput)
+	DeleteReusableDelegationSetRequest(*route53.DeleteReusableDelegationSetInput) (*request.Request, *route53.DeleteReusableDelegationSetOutput)
 
 	DeleteReusableDelegationSet(*route53.DeleteReusableDelegationSetInput) (*route53.DeleteReusableDelegationSetOutput, error)
 
-	DisassociateVPCFromHostedZoneRequest(*route53.DisassociateVPCFromHostedZoneInput) (*service.Request, *route53.DisassociateVPCFromHostedZoneOutput)
+	DisassociateVPCFromHostedZoneRequest(*route53.DisassociateVPCFromHostedZoneInput) (*request.Request, *route53.DisassociateVPCFromHostedZoneOutput)
 
 	DisassociateVPCFromHostedZone(*route53.DisassociateVPCFromHostedZoneInput) (*route53.DisassociateVPCFromHostedZoneOutput, error)
 
-	GetChangeRequest(*route53.GetChangeInput) (*service.Request, *route53.GetChangeOutput)
+	GetChangeRequest(*route53.GetChangeInput) (*request.Request, *route53.GetChangeOutput)
 
 	GetChange(*route53.GetChangeInput) (*route53.GetChangeOutput, error)
 
-	GetCheckerIpRangesRequest(*route53.GetCheckerIpRangesInput) (*service.Request, *route53.GetCheckerIpRangesOutput)
+	GetCheckerIpRangesRequest(*route53.GetCheckerIpRangesInput) (*request.Request, *route53.GetCheckerIpRangesOutput)
 
 	GetCheckerIpRanges(*route53.GetCheckerIpRangesInput) (*route53.GetCheckerIpRangesOutput, error)
 
-	GetGeoLocationRequest(*route53.GetGeoLocationInput) (*service.Request, *route53.GetGeoLocationOutput)
+	GetGeoLocationRequest(*route53.GetGeoLocationInput) (*request.Request, *route53.GetGeoLocationOutput)
 
 	GetGeoLocation(*route53.GetGeoLocationInput) (*route53.GetGeoLocationOutput, error)
 
-	GetHealthCheckRequest(*route53.GetHealthCheckInput) (*service.Request, *route53.GetHealthCheckOutput)
+	GetHealthCheckRequest(*route53.GetHealthCheckInput) (*request.Request, *route53.GetHealthCheckOutput)
 
 	GetHealthCheck(*route53.GetHealthCheckInput) (*route53.GetHealthCheckOutput, error)
 
-	GetHealthCheckCountRequest(*route53.GetHealthCheckCountInput) (*service.Request, *route53.GetHealthCheckCountOutput)
+	GetHealthCheckCountRequest(*route53.GetHealthCheckCountInput) (*request.Request, *route53.GetHealthCheckCountOutput)
 
 	GetHealthCheckCount(*route53.GetHealthCheckCountInput) (*route53.GetHealthCheckCountOutput, error)
 
-	GetHealthCheckLastFailureReasonRequest(*route53.GetHealthCheckLastFailureReasonInput) (*service.Request, *route53.GetHealthCheckLastFailureReasonOutput)
+	GetHealthCheckLastFailureReasonRequest(*route53.GetHealthCheckLastFailureReasonInput) (*request.Request, *route53.GetHealthCheckLastFailureReasonOutput)
 
 	GetHealthCheckLastFailureReason(*route53.GetHealthCheckLastFailureReasonInput) (*route53.GetHealthCheckLastFailureReasonOutput, error)
 
-	GetHealthCheckStatusRequest(*route53.GetHealthCheckStatusInput) (*service.Request, *route53.GetHealthCheckStatusOutput)
+	GetHealthCheckStatusRequest(*route53.GetHealthCheckStatusInput) (*request.Request, *route53.GetHealthCheckStatusOutput)
 
 	GetHealthCheckStatus(*route53.GetHealthCheckStatusInput) (*route53.GetHealthCheckStatusOutput, error)
 
-	GetHostedZoneRequest(*route53.GetHostedZoneInput) (*service.Request, *route53.GetHostedZoneOutput)
+	GetHostedZoneRequest(*route53.GetHostedZoneInput) (*request.Request, *route53.GetHostedZoneOutput)
 
 	GetHostedZone(*route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error)
 
-	GetHostedZoneCountRequest(*route53.GetHostedZoneCountInput) (*service.Request, *route53.GetHostedZoneCountOutput)
+	GetHostedZoneCountRequest(*route53.GetHostedZoneCountInput) (*request.Request, *route53.GetHostedZoneCountOutput)
 
 	GetHostedZoneCount(*route53.GetHostedZoneCountInput) (*route53.GetHostedZoneCountOutput, error)
 
-	GetReusableDelegationSetRequest(*route53.GetReusableDelegationSetInput) (*service.Request, *route53.GetReusableDelegationSetOutput)
+	GetReusableDelegationSetRequest(*route53.GetReusableDelegationSetInput) (*request.Request, *route53.GetReusableDelegationSetOutput)
 
 	GetReusableDelegationSet(*route53.GetReusableDelegationSetInput) (*route53.GetReusableDelegationSetOutput, error)
 
-	ListGeoLocationsRequest(*route53.ListGeoLocationsInput) (*service.Request, *route53.ListGeoLocationsOutput)
+	ListGeoLocationsRequest(*route53.ListGeoLocationsInput) (*request.Request, *route53.ListGeoLocationsOutput)
 
 	ListGeoLocations(*route53.ListGeoLocationsInput) (*route53.ListGeoLocationsOutput, error)
 
-	ListHealthChecksRequest(*route53.ListHealthChecksInput) (*service.Request, *route53.ListHealthChecksOutput)
+	ListHealthChecksRequest(*route53.ListHealthChecksInput) (*request.Request, *route53.ListHealthChecksOutput)
 
 	ListHealthChecks(*route53.ListHealthChecksInput) (*route53.ListHealthChecksOutput, error)
 
 	ListHealthChecksPages(*route53.ListHealthChecksInput, func(*route53.ListHealthChecksOutput, bool) bool) error
 
-	ListHostedZonesRequest(*route53.ListHostedZonesInput) (*service.Request, *route53.ListHostedZonesOutput)
+	ListHostedZonesRequest(*route53.ListHostedZonesInput) (*request.Request, *route53.ListHostedZonesOutput)
 
 	ListHostedZones(*route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error)
 
 	ListHostedZonesPages(*route53.ListHostedZonesInput, func(*route53.ListHostedZonesOutput, bool) bool) error
 
-	ListHostedZonesByNameRequest(*route53.ListHostedZonesByNameInput) (*service.Request, *route53.ListHostedZonesByNameOutput)
+	ListHostedZonesByNameRequest(*route53.ListHostedZonesByNameInput) (*request.Request, *route53.ListHostedZonesByNameOutput)
 
 	ListHostedZonesByName(*route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesByNameOutput, error)
 
-	ListResourceRecordSetsRequest(*route53.ListResourceRecordSetsInput) (*service.Request, *route53.ListResourceRecordSetsOutput)
+	ListResourceRecordSetsRequest(*route53.ListResourceRecordSetsInput) (*request.Request, *route53.ListResourceRecordSetsOutput)
 
 	ListResourceRecordSets(*route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error)
 
 	ListResourceRecordSetsPages(*route53.ListResourceRecordSetsInput, func(*route53.ListResourceRecordSetsOutput, bool) bool) error
 
-	ListReusableDelegationSetsRequest(*route53.ListReusableDelegationSetsInput) (*service.Request, *route53.ListReusableDelegationSetsOutput)
+	ListReusableDelegationSetsRequest(*route53.ListReusableDelegationSetsInput) (*request.Request, *route53.ListReusableDelegationSetsOutput)
 
 	ListReusableDelegationSets(*route53.ListReusableDelegationSetsInput) (*route53.ListReusableDelegationSetsOutput, error)
 
-	ListTagsForResourceRequest(*route53.ListTagsForResourceInput) (*service.Request, *route53.ListTagsForResourceOutput)
+	ListTagsForResourceRequest(*route53.ListTagsForResourceInput) (*request.Request, *route53.ListTagsForResourceOutput)
 
 	ListTagsForResource(*route53.ListTagsForResourceInput) (*route53.ListTagsForResourceOutput, error)
 
-	ListTagsForResourcesRequest(*route53.ListTagsForResourcesInput) (*service.Request, *route53.ListTagsForResourcesOutput)
+	ListTagsForResourcesRequest(*route53.ListTagsForResourcesInput) (*request.Request, *route53.ListTagsForResourcesOutput)
 
 	ListTagsForResources(*route53.ListTagsForResourcesInput) (*route53.ListTagsForResourcesOutput, error)
 
-	UpdateHealthCheckRequest(*route53.UpdateHealthCheckInput) (*service.Request, *route53.UpdateHealthCheckOutput)
+	UpdateHealthCheckRequest(*route53.UpdateHealthCheckInput) (*request.Request, *route53.UpdateHealthCheckOutput)
 
 	UpdateHealthCheck(*route53.UpdateHealthCheckInput) (*route53.UpdateHealthCheckOutput, error)
 
-	UpdateHostedZoneCommentRequest(*route53.UpdateHostedZoneCommentInput) (*service.Request, *route53.UpdateHostedZoneCommentOutput)
+	UpdateHostedZoneCommentRequest(*route53.UpdateHostedZoneCommentInput) (*request.Request, *route53.UpdateHostedZoneCommentOutput)
 
 	UpdateHostedZoneComment(*route53.UpdateHostedZoneCommentInput) (*route53.UpdateHostedZoneCommentOutput, error)
 }

--- a/service/route53/service.go
+++ b/service/route53/service.go
@@ -5,7 +5,9 @@ package route53
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restxml"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -19,14 +21,16 @@ type Route53 struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new Route53 client.
 func New(config *aws.Config) *Route53 {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "route53",
-		APIVersion:  "2013-04-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "route53",
+			APIVersion:  "2013-04-01",
+		},
 	}
 	service.Initialize()
 
@@ -47,8 +51,8 @@ func New(config *aws.Config) *Route53 {
 
 // newRequest creates a new request for a Route53 operation and runs any
 // custom request initialization.
-func (c *Route53) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *Route53) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/route53domains/api.go
+++ b/service/route53domains/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCheckDomainAvailability = "CheckDomainAvailability"
 
 // CheckDomainAvailabilityRequest generates a request for the CheckDomainAvailability operation.
-func (c *Route53Domains) CheckDomainAvailabilityRequest(input *CheckDomainAvailabilityInput) (req *service.Request, output *CheckDomainAvailabilityOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) CheckDomainAvailabilityRequest(input *CheckDomainAvailabilityInput) (req *request.Request, output *CheckDomainAvailabilityOutput) {
+	op := &request.Operation{
 		Name:       opCheckDomainAvailability,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -43,8 +43,8 @@ func (c *Route53Domains) CheckDomainAvailability(input *CheckDomainAvailabilityI
 const opDeleteTagsForDomain = "DeleteTagsForDomain"
 
 // DeleteTagsForDomainRequest generates a request for the DeleteTagsForDomain operation.
-func (c *Route53Domains) DeleteTagsForDomainRequest(input *DeleteTagsForDomainInput) (req *service.Request, output *DeleteTagsForDomainOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) DeleteTagsForDomainRequest(input *DeleteTagsForDomainInput) (req *request.Request, output *DeleteTagsForDomainOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTagsForDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -73,8 +73,8 @@ func (c *Route53Domains) DeleteTagsForDomain(input *DeleteTagsForDomainInput) (*
 const opDisableDomainAutoRenew = "DisableDomainAutoRenew"
 
 // DisableDomainAutoRenewRequest generates a request for the DisableDomainAutoRenew operation.
-func (c *Route53Domains) DisableDomainAutoRenewRequest(input *DisableDomainAutoRenewInput) (req *service.Request, output *DisableDomainAutoRenewOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) DisableDomainAutoRenewRequest(input *DisableDomainAutoRenewInput) (req *request.Request, output *DisableDomainAutoRenewOutput) {
+	op := &request.Operation{
 		Name:       opDisableDomainAutoRenew,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -106,8 +106,8 @@ func (c *Route53Domains) DisableDomainAutoRenew(input *DisableDomainAutoRenewInp
 const opDisableDomainTransferLock = "DisableDomainTransferLock"
 
 // DisableDomainTransferLockRequest generates a request for the DisableDomainTransferLock operation.
-func (c *Route53Domains) DisableDomainTransferLockRequest(input *DisableDomainTransferLockInput) (req *service.Request, output *DisableDomainTransferLockOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) DisableDomainTransferLockRequest(input *DisableDomainTransferLockInput) (req *request.Request, output *DisableDomainTransferLockOutput) {
+	op := &request.Operation{
 		Name:       opDisableDomainTransferLock,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -139,8 +139,8 @@ func (c *Route53Domains) DisableDomainTransferLock(input *DisableDomainTransferL
 const opEnableDomainAutoRenew = "EnableDomainAutoRenew"
 
 // EnableDomainAutoRenewRequest generates a request for the EnableDomainAutoRenew operation.
-func (c *Route53Domains) EnableDomainAutoRenewRequest(input *EnableDomainAutoRenewInput) (req *service.Request, output *EnableDomainAutoRenewOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) EnableDomainAutoRenewRequest(input *EnableDomainAutoRenewInput) (req *request.Request, output *EnableDomainAutoRenewOutput) {
+	op := &request.Operation{
 		Name:       opEnableDomainAutoRenew,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -175,8 +175,8 @@ func (c *Route53Domains) EnableDomainAutoRenew(input *EnableDomainAutoRenewInput
 const opEnableDomainTransferLock = "EnableDomainTransferLock"
 
 // EnableDomainTransferLockRequest generates a request for the EnableDomainTransferLock operation.
-func (c *Route53Domains) EnableDomainTransferLockRequest(input *EnableDomainTransferLockInput) (req *service.Request, output *EnableDomainTransferLockOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) EnableDomainTransferLockRequest(input *EnableDomainTransferLockInput) (req *request.Request, output *EnableDomainTransferLockOutput) {
+	op := &request.Operation{
 		Name:       opEnableDomainTransferLock,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -206,8 +206,8 @@ func (c *Route53Domains) EnableDomainTransferLock(input *EnableDomainTransferLoc
 const opGetDomainDetail = "GetDomainDetail"
 
 // GetDomainDetailRequest generates a request for the GetDomainDetail operation.
-func (c *Route53Domains) GetDomainDetailRequest(input *GetDomainDetailInput) (req *service.Request, output *GetDomainDetailOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) GetDomainDetailRequest(input *GetDomainDetailInput) (req *request.Request, output *GetDomainDetailOutput) {
+	op := &request.Operation{
 		Name:       opGetDomainDetail,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -234,8 +234,8 @@ func (c *Route53Domains) GetDomainDetail(input *GetDomainDetailInput) (*GetDomai
 const opGetOperationDetail = "GetOperationDetail"
 
 // GetOperationDetailRequest generates a request for the GetOperationDetail operation.
-func (c *Route53Domains) GetOperationDetailRequest(input *GetOperationDetailInput) (req *service.Request, output *GetOperationDetailOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) GetOperationDetailRequest(input *GetOperationDetailInput) (req *request.Request, output *GetOperationDetailOutput) {
+	op := &request.Operation{
 		Name:       opGetOperationDetail,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -261,12 +261,12 @@ func (c *Route53Domains) GetOperationDetail(input *GetOperationDetailInput) (*Ge
 const opListDomains = "ListDomains"
 
 // ListDomainsRequest generates a request for the ListDomains operation.
-func (c *Route53Domains) ListDomainsRequest(input *ListDomainsInput) (req *service.Request, output *ListDomainsOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) ListDomainsRequest(input *ListDomainsInput) (req *request.Request, output *ListDomainsOutput) {
+	op := &request.Operation{
 		Name:       opListDomains,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextPageMarker"},
 			LimitToken:      "MaxItems",
@@ -302,12 +302,12 @@ func (c *Route53Domains) ListDomainsPages(input *ListDomainsInput, fn func(p *Li
 const opListOperations = "ListOperations"
 
 // ListOperationsRequest generates a request for the ListOperations operation.
-func (c *Route53Domains) ListOperationsRequest(input *ListOperationsInput) (req *service.Request, output *ListOperationsOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) ListOperationsRequest(input *ListOperationsInput) (req *request.Request, output *ListOperationsOutput) {
+	op := &request.Operation{
 		Name:       opListOperations,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextPageMarker"},
 			LimitToken:      "MaxItems",
@@ -342,8 +342,8 @@ func (c *Route53Domains) ListOperationsPages(input *ListOperationsInput, fn func
 const opListTagsForDomain = "ListTagsForDomain"
 
 // ListTagsForDomainRequest generates a request for the ListTagsForDomain operation.
-func (c *Route53Domains) ListTagsForDomainRequest(input *ListTagsForDomainInput) (req *service.Request, output *ListTagsForDomainOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) ListTagsForDomainRequest(input *ListTagsForDomainInput) (req *request.Request, output *ListTagsForDomainOutput) {
+	op := &request.Operation{
 		Name:       opListTagsForDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -373,8 +373,8 @@ func (c *Route53Domains) ListTagsForDomain(input *ListTagsForDomainInput) (*List
 const opRegisterDomain = "RegisterDomain"
 
 // RegisterDomainRequest generates a request for the RegisterDomain operation.
-func (c *Route53Domains) RegisterDomainRequest(input *RegisterDomainInput) (req *service.Request, output *RegisterDomainOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) RegisterDomainRequest(input *RegisterDomainInput) (req *request.Request, output *RegisterDomainOutput) {
+	op := &request.Operation{
 		Name:       opRegisterDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -418,8 +418,8 @@ func (c *Route53Domains) RegisterDomain(input *RegisterDomainInput) (*RegisterDo
 const opRetrieveDomainAuthCode = "RetrieveDomainAuthCode"
 
 // RetrieveDomainAuthCodeRequest generates a request for the RetrieveDomainAuthCode operation.
-func (c *Route53Domains) RetrieveDomainAuthCodeRequest(input *RetrieveDomainAuthCodeInput) (req *service.Request, output *RetrieveDomainAuthCodeOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) RetrieveDomainAuthCodeRequest(input *RetrieveDomainAuthCodeInput) (req *request.Request, output *RetrieveDomainAuthCodeOutput) {
+	op := &request.Operation{
 		Name:       opRetrieveDomainAuthCode,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -446,8 +446,8 @@ func (c *Route53Domains) RetrieveDomainAuthCode(input *RetrieveDomainAuthCodeInp
 const opTransferDomain = "TransferDomain"
 
 // TransferDomainRequest generates a request for the TransferDomain operation.
-func (c *Route53Domains) TransferDomainRequest(input *TransferDomainInput) (req *service.Request, output *TransferDomainOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) TransferDomainRequest(input *TransferDomainInput) (req *request.Request, output *TransferDomainOutput) {
+	op := &request.Operation{
 		Name:       opTransferDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -496,8 +496,8 @@ func (c *Route53Domains) TransferDomain(input *TransferDomainInput) (*TransferDo
 const opUpdateDomainContact = "UpdateDomainContact"
 
 // UpdateDomainContactRequest generates a request for the UpdateDomainContact operation.
-func (c *Route53Domains) UpdateDomainContactRequest(input *UpdateDomainContactInput) (req *service.Request, output *UpdateDomainContactOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) UpdateDomainContactRequest(input *UpdateDomainContactInput) (req *request.Request, output *UpdateDomainContactOutput) {
+	op := &request.Operation{
 		Name:       opUpdateDomainContact,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -530,8 +530,8 @@ func (c *Route53Domains) UpdateDomainContact(input *UpdateDomainContactInput) (*
 const opUpdateDomainContactPrivacy = "UpdateDomainContactPrivacy"
 
 // UpdateDomainContactPrivacyRequest generates a request for the UpdateDomainContactPrivacy operation.
-func (c *Route53Domains) UpdateDomainContactPrivacyRequest(input *UpdateDomainContactPrivacyInput) (req *service.Request, output *UpdateDomainContactPrivacyOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) UpdateDomainContactPrivacyRequest(input *UpdateDomainContactPrivacyInput) (req *request.Request, output *UpdateDomainContactPrivacyOutput) {
+	op := &request.Operation{
 		Name:       opUpdateDomainContactPrivacy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -567,8 +567,8 @@ func (c *Route53Domains) UpdateDomainContactPrivacy(input *UpdateDomainContactPr
 const opUpdateDomainNameservers = "UpdateDomainNameservers"
 
 // UpdateDomainNameserversRequest generates a request for the UpdateDomainNameservers operation.
-func (c *Route53Domains) UpdateDomainNameserversRequest(input *UpdateDomainNameserversInput) (req *service.Request, output *UpdateDomainNameserversOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) UpdateDomainNameserversRequest(input *UpdateDomainNameserversInput) (req *request.Request, output *UpdateDomainNameserversOutput) {
+	op := &request.Operation{
 		Name:       opUpdateDomainNameservers,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -601,8 +601,8 @@ func (c *Route53Domains) UpdateDomainNameservers(input *UpdateDomainNameserversI
 const opUpdateTagsForDomain = "UpdateTagsForDomain"
 
 // UpdateTagsForDomainRequest generates a request for the UpdateTagsForDomain operation.
-func (c *Route53Domains) UpdateTagsForDomainRequest(input *UpdateTagsForDomainInput) (req *service.Request, output *UpdateTagsForDomainOutput) {
-	op := &service.Operation{
+func (c *Route53Domains) UpdateTagsForDomainRequest(input *UpdateTagsForDomainInput) (req *request.Request, output *UpdateTagsForDomainOutput) {
+	op := &request.Operation{
 		Name:       opUpdateTagsForDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/route53domains/route53domainsiface/interface.go
+++ b/service/route53domains/route53domainsiface/interface.go
@@ -4,85 +4,85 @@
 package route53domainsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/route53domains"
 )
 
 // Route53DomainsAPI is the interface type for route53domains.Route53Domains.
 type Route53DomainsAPI interface {
-	CheckDomainAvailabilityRequest(*route53domains.CheckDomainAvailabilityInput) (*service.Request, *route53domains.CheckDomainAvailabilityOutput)
+	CheckDomainAvailabilityRequest(*route53domains.CheckDomainAvailabilityInput) (*request.Request, *route53domains.CheckDomainAvailabilityOutput)
 
 	CheckDomainAvailability(*route53domains.CheckDomainAvailabilityInput) (*route53domains.CheckDomainAvailabilityOutput, error)
 
-	DeleteTagsForDomainRequest(*route53domains.DeleteTagsForDomainInput) (*service.Request, *route53domains.DeleteTagsForDomainOutput)
+	DeleteTagsForDomainRequest(*route53domains.DeleteTagsForDomainInput) (*request.Request, *route53domains.DeleteTagsForDomainOutput)
 
 	DeleteTagsForDomain(*route53domains.DeleteTagsForDomainInput) (*route53domains.DeleteTagsForDomainOutput, error)
 
-	DisableDomainAutoRenewRequest(*route53domains.DisableDomainAutoRenewInput) (*service.Request, *route53domains.DisableDomainAutoRenewOutput)
+	DisableDomainAutoRenewRequest(*route53domains.DisableDomainAutoRenewInput) (*request.Request, *route53domains.DisableDomainAutoRenewOutput)
 
 	DisableDomainAutoRenew(*route53domains.DisableDomainAutoRenewInput) (*route53domains.DisableDomainAutoRenewOutput, error)
 
-	DisableDomainTransferLockRequest(*route53domains.DisableDomainTransferLockInput) (*service.Request, *route53domains.DisableDomainTransferLockOutput)
+	DisableDomainTransferLockRequest(*route53domains.DisableDomainTransferLockInput) (*request.Request, *route53domains.DisableDomainTransferLockOutput)
 
 	DisableDomainTransferLock(*route53domains.DisableDomainTransferLockInput) (*route53domains.DisableDomainTransferLockOutput, error)
 
-	EnableDomainAutoRenewRequest(*route53domains.EnableDomainAutoRenewInput) (*service.Request, *route53domains.EnableDomainAutoRenewOutput)
+	EnableDomainAutoRenewRequest(*route53domains.EnableDomainAutoRenewInput) (*request.Request, *route53domains.EnableDomainAutoRenewOutput)
 
 	EnableDomainAutoRenew(*route53domains.EnableDomainAutoRenewInput) (*route53domains.EnableDomainAutoRenewOutput, error)
 
-	EnableDomainTransferLockRequest(*route53domains.EnableDomainTransferLockInput) (*service.Request, *route53domains.EnableDomainTransferLockOutput)
+	EnableDomainTransferLockRequest(*route53domains.EnableDomainTransferLockInput) (*request.Request, *route53domains.EnableDomainTransferLockOutput)
 
 	EnableDomainTransferLock(*route53domains.EnableDomainTransferLockInput) (*route53domains.EnableDomainTransferLockOutput, error)
 
-	GetDomainDetailRequest(*route53domains.GetDomainDetailInput) (*service.Request, *route53domains.GetDomainDetailOutput)
+	GetDomainDetailRequest(*route53domains.GetDomainDetailInput) (*request.Request, *route53domains.GetDomainDetailOutput)
 
 	GetDomainDetail(*route53domains.GetDomainDetailInput) (*route53domains.GetDomainDetailOutput, error)
 
-	GetOperationDetailRequest(*route53domains.GetOperationDetailInput) (*service.Request, *route53domains.GetOperationDetailOutput)
+	GetOperationDetailRequest(*route53domains.GetOperationDetailInput) (*request.Request, *route53domains.GetOperationDetailOutput)
 
 	GetOperationDetail(*route53domains.GetOperationDetailInput) (*route53domains.GetOperationDetailOutput, error)
 
-	ListDomainsRequest(*route53domains.ListDomainsInput) (*service.Request, *route53domains.ListDomainsOutput)
+	ListDomainsRequest(*route53domains.ListDomainsInput) (*request.Request, *route53domains.ListDomainsOutput)
 
 	ListDomains(*route53domains.ListDomainsInput) (*route53domains.ListDomainsOutput, error)
 
 	ListDomainsPages(*route53domains.ListDomainsInput, func(*route53domains.ListDomainsOutput, bool) bool) error
 
-	ListOperationsRequest(*route53domains.ListOperationsInput) (*service.Request, *route53domains.ListOperationsOutput)
+	ListOperationsRequest(*route53domains.ListOperationsInput) (*request.Request, *route53domains.ListOperationsOutput)
 
 	ListOperations(*route53domains.ListOperationsInput) (*route53domains.ListOperationsOutput, error)
 
 	ListOperationsPages(*route53domains.ListOperationsInput, func(*route53domains.ListOperationsOutput, bool) bool) error
 
-	ListTagsForDomainRequest(*route53domains.ListTagsForDomainInput) (*service.Request, *route53domains.ListTagsForDomainOutput)
+	ListTagsForDomainRequest(*route53domains.ListTagsForDomainInput) (*request.Request, *route53domains.ListTagsForDomainOutput)
 
 	ListTagsForDomain(*route53domains.ListTagsForDomainInput) (*route53domains.ListTagsForDomainOutput, error)
 
-	RegisterDomainRequest(*route53domains.RegisterDomainInput) (*service.Request, *route53domains.RegisterDomainOutput)
+	RegisterDomainRequest(*route53domains.RegisterDomainInput) (*request.Request, *route53domains.RegisterDomainOutput)
 
 	RegisterDomain(*route53domains.RegisterDomainInput) (*route53domains.RegisterDomainOutput, error)
 
-	RetrieveDomainAuthCodeRequest(*route53domains.RetrieveDomainAuthCodeInput) (*service.Request, *route53domains.RetrieveDomainAuthCodeOutput)
+	RetrieveDomainAuthCodeRequest(*route53domains.RetrieveDomainAuthCodeInput) (*request.Request, *route53domains.RetrieveDomainAuthCodeOutput)
 
 	RetrieveDomainAuthCode(*route53domains.RetrieveDomainAuthCodeInput) (*route53domains.RetrieveDomainAuthCodeOutput, error)
 
-	TransferDomainRequest(*route53domains.TransferDomainInput) (*service.Request, *route53domains.TransferDomainOutput)
+	TransferDomainRequest(*route53domains.TransferDomainInput) (*request.Request, *route53domains.TransferDomainOutput)
 
 	TransferDomain(*route53domains.TransferDomainInput) (*route53domains.TransferDomainOutput, error)
 
-	UpdateDomainContactRequest(*route53domains.UpdateDomainContactInput) (*service.Request, *route53domains.UpdateDomainContactOutput)
+	UpdateDomainContactRequest(*route53domains.UpdateDomainContactInput) (*request.Request, *route53domains.UpdateDomainContactOutput)
 
 	UpdateDomainContact(*route53domains.UpdateDomainContactInput) (*route53domains.UpdateDomainContactOutput, error)
 
-	UpdateDomainContactPrivacyRequest(*route53domains.UpdateDomainContactPrivacyInput) (*service.Request, *route53domains.UpdateDomainContactPrivacyOutput)
+	UpdateDomainContactPrivacyRequest(*route53domains.UpdateDomainContactPrivacyInput) (*request.Request, *route53domains.UpdateDomainContactPrivacyOutput)
 
 	UpdateDomainContactPrivacy(*route53domains.UpdateDomainContactPrivacyInput) (*route53domains.UpdateDomainContactPrivacyOutput, error)
 
-	UpdateDomainNameserversRequest(*route53domains.UpdateDomainNameserversInput) (*service.Request, *route53domains.UpdateDomainNameserversOutput)
+	UpdateDomainNameserversRequest(*route53domains.UpdateDomainNameserversInput) (*request.Request, *route53domains.UpdateDomainNameserversOutput)
 
 	UpdateDomainNameservers(*route53domains.UpdateDomainNameserversInput) (*route53domains.UpdateDomainNameserversOutput, error)
 
-	UpdateTagsForDomainRequest(*route53domains.UpdateTagsForDomainInput) (*service.Request, *route53domains.UpdateTagsForDomainOutput)
+	UpdateTagsForDomainRequest(*route53domains.UpdateTagsForDomainInput) (*request.Request, *route53domains.UpdateTagsForDomainOutput)
 
 	UpdateTagsForDomain(*route53domains.UpdateTagsForDomainInput) (*route53domains.UpdateTagsForDomainOutput, error)
 }

--- a/service/route53domains/service.go
+++ b/service/route53domains/service.go
@@ -5,7 +5,9 @@ package route53domains
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -19,16 +21,18 @@ type Route53Domains struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new Route53Domains client.
 func New(config *aws.Config) *Route53Domains {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "route53domains",
-		APIVersion:   "2014-05-15",
-		JSONVersion:  "1.1",
-		TargetPrefix: "Route53Domains_v20140515",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "route53domains",
+			APIVersion:   "2014-05-15",
+			JSONVersion:  "1.1",
+			TargetPrefix: "Route53Domains_v20140515",
+		},
 	}
 	service.Initialize()
 
@@ -49,8 +53,8 @@ func New(config *aws.Config) *Route53Domains {
 
 // newRequest creates a new request for a Route53Domains operation and runs any
 // custom request initialization.
-func (c *Route53Domains) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *Route53Domains) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/s3/api.go
+++ b/service/s3/api.go
@@ -8,14 +8,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAbortMultipartUpload = "AbortMultipartUpload"
 
 // AbortMultipartUploadRequest generates a request for the AbortMultipartUpload operation.
-func (c *S3) AbortMultipartUploadRequest(input *AbortMultipartUploadInput) (req *service.Request, output *AbortMultipartUploadOutput) {
-	op := &service.Operation{
+func (c *S3) AbortMultipartUploadRequest(input *AbortMultipartUploadInput) (req *request.Request, output *AbortMultipartUploadOutput) {
+	op := &request.Operation{
 		Name:       opAbortMultipartUpload,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -45,8 +45,8 @@ func (c *S3) AbortMultipartUpload(input *AbortMultipartUploadInput) (*AbortMulti
 const opCompleteMultipartUpload = "CompleteMultipartUpload"
 
 // CompleteMultipartUploadRequest generates a request for the CompleteMultipartUpload operation.
-func (c *S3) CompleteMultipartUploadRequest(input *CompleteMultipartUploadInput) (req *service.Request, output *CompleteMultipartUploadOutput) {
-	op := &service.Operation{
+func (c *S3) CompleteMultipartUploadRequest(input *CompleteMultipartUploadInput) (req *request.Request, output *CompleteMultipartUploadOutput) {
+	op := &request.Operation{
 		Name:       opCompleteMultipartUpload,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -72,8 +72,8 @@ func (c *S3) CompleteMultipartUpload(input *CompleteMultipartUploadInput) (*Comp
 const opCopyObject = "CopyObject"
 
 // CopyObjectRequest generates a request for the CopyObject operation.
-func (c *S3) CopyObjectRequest(input *CopyObjectInput) (req *service.Request, output *CopyObjectOutput) {
-	op := &service.Operation{
+func (c *S3) CopyObjectRequest(input *CopyObjectInput) (req *request.Request, output *CopyObjectOutput) {
+	op := &request.Operation{
 		Name:       opCopyObject,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -99,8 +99,8 @@ func (c *S3) CopyObject(input *CopyObjectInput) (*CopyObjectOutput, error) {
 const opCreateBucket = "CreateBucket"
 
 // CreateBucketRequest generates a request for the CreateBucket operation.
-func (c *S3) CreateBucketRequest(input *CreateBucketInput) (req *service.Request, output *CreateBucketOutput) {
-	op := &service.Operation{
+func (c *S3) CreateBucketRequest(input *CreateBucketInput) (req *request.Request, output *CreateBucketOutput) {
+	op := &request.Operation{
 		Name:       opCreateBucket,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}",
@@ -126,8 +126,8 @@ func (c *S3) CreateBucket(input *CreateBucketInput) (*CreateBucketOutput, error)
 const opCreateMultipartUpload = "CreateMultipartUpload"
 
 // CreateMultipartUploadRequest generates a request for the CreateMultipartUpload operation.
-func (c *S3) CreateMultipartUploadRequest(input *CreateMultipartUploadInput) (req *service.Request, output *CreateMultipartUploadOutput) {
-	op := &service.Operation{
+func (c *S3) CreateMultipartUploadRequest(input *CreateMultipartUploadInput) (req *request.Request, output *CreateMultipartUploadOutput) {
+	op := &request.Operation{
 		Name:       opCreateMultipartUpload,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{Bucket}/{Key+}?uploads",
@@ -159,8 +159,8 @@ func (c *S3) CreateMultipartUpload(input *CreateMultipartUploadInput) (*CreateMu
 const opDeleteBucket = "DeleteBucket"
 
 // DeleteBucketRequest generates a request for the DeleteBucket operation.
-func (c *S3) DeleteBucketRequest(input *DeleteBucketInput) (req *service.Request, output *DeleteBucketOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteBucketRequest(input *DeleteBucketInput) (req *request.Request, output *DeleteBucketOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBucket,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}",
@@ -187,8 +187,8 @@ func (c *S3) DeleteBucket(input *DeleteBucketInput) (*DeleteBucketOutput, error)
 const opDeleteBucketCors = "DeleteBucketCors"
 
 // DeleteBucketCorsRequest generates a request for the DeleteBucketCors operation.
-func (c *S3) DeleteBucketCorsRequest(input *DeleteBucketCorsInput) (req *service.Request, output *DeleteBucketCorsOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteBucketCorsRequest(input *DeleteBucketCorsInput) (req *request.Request, output *DeleteBucketCorsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBucketCors,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}?cors",
@@ -214,8 +214,8 @@ func (c *S3) DeleteBucketCors(input *DeleteBucketCorsInput) (*DeleteBucketCorsOu
 const opDeleteBucketLifecycle = "DeleteBucketLifecycle"
 
 // DeleteBucketLifecycleRequest generates a request for the DeleteBucketLifecycle operation.
-func (c *S3) DeleteBucketLifecycleRequest(input *DeleteBucketLifecycleInput) (req *service.Request, output *DeleteBucketLifecycleOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteBucketLifecycleRequest(input *DeleteBucketLifecycleInput) (req *request.Request, output *DeleteBucketLifecycleOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBucketLifecycle,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}?lifecycle",
@@ -241,8 +241,8 @@ func (c *S3) DeleteBucketLifecycle(input *DeleteBucketLifecycleInput) (*DeleteBu
 const opDeleteBucketPolicy = "DeleteBucketPolicy"
 
 // DeleteBucketPolicyRequest generates a request for the DeleteBucketPolicy operation.
-func (c *S3) DeleteBucketPolicyRequest(input *DeleteBucketPolicyInput) (req *service.Request, output *DeleteBucketPolicyOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteBucketPolicyRequest(input *DeleteBucketPolicyInput) (req *request.Request, output *DeleteBucketPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBucketPolicy,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}?policy",
@@ -268,8 +268,8 @@ func (c *S3) DeleteBucketPolicy(input *DeleteBucketPolicyInput) (*DeleteBucketPo
 const opDeleteBucketReplication = "DeleteBucketReplication"
 
 // DeleteBucketReplicationRequest generates a request for the DeleteBucketReplication operation.
-func (c *S3) DeleteBucketReplicationRequest(input *DeleteBucketReplicationInput) (req *service.Request, output *DeleteBucketReplicationOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteBucketReplicationRequest(input *DeleteBucketReplicationInput) (req *request.Request, output *DeleteBucketReplicationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBucketReplication,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}?replication",
@@ -294,8 +294,8 @@ func (c *S3) DeleteBucketReplication(input *DeleteBucketReplicationInput) (*Dele
 const opDeleteBucketTagging = "DeleteBucketTagging"
 
 // DeleteBucketTaggingRequest generates a request for the DeleteBucketTagging operation.
-func (c *S3) DeleteBucketTaggingRequest(input *DeleteBucketTaggingInput) (req *service.Request, output *DeleteBucketTaggingOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteBucketTaggingRequest(input *DeleteBucketTaggingInput) (req *request.Request, output *DeleteBucketTaggingOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBucketTagging,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}?tagging",
@@ -321,8 +321,8 @@ func (c *S3) DeleteBucketTagging(input *DeleteBucketTaggingInput) (*DeleteBucket
 const opDeleteBucketWebsite = "DeleteBucketWebsite"
 
 // DeleteBucketWebsiteRequest generates a request for the DeleteBucketWebsite operation.
-func (c *S3) DeleteBucketWebsiteRequest(input *DeleteBucketWebsiteInput) (req *service.Request, output *DeleteBucketWebsiteOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteBucketWebsiteRequest(input *DeleteBucketWebsiteInput) (req *request.Request, output *DeleteBucketWebsiteOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBucketWebsite,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}?website",
@@ -348,8 +348,8 @@ func (c *S3) DeleteBucketWebsite(input *DeleteBucketWebsiteInput) (*DeleteBucket
 const opDeleteObject = "DeleteObject"
 
 // DeleteObjectRequest generates a request for the DeleteObject operation.
-func (c *S3) DeleteObjectRequest(input *DeleteObjectInput) (req *service.Request, output *DeleteObjectOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteObjectRequest(input *DeleteObjectInput) (req *request.Request, output *DeleteObjectOutput) {
+	op := &request.Operation{
 		Name:       opDeleteObject,
 		HTTPMethod: "DELETE",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -377,8 +377,8 @@ func (c *S3) DeleteObject(input *DeleteObjectInput) (*DeleteObjectOutput, error)
 const opDeleteObjects = "DeleteObjects"
 
 // DeleteObjectsRequest generates a request for the DeleteObjects operation.
-func (c *S3) DeleteObjectsRequest(input *DeleteObjectsInput) (req *service.Request, output *DeleteObjectsOutput) {
-	op := &service.Operation{
+func (c *S3) DeleteObjectsRequest(input *DeleteObjectsInput) (req *request.Request, output *DeleteObjectsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteObjects,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{Bucket}?delete",
@@ -405,8 +405,8 @@ func (c *S3) DeleteObjects(input *DeleteObjectsInput) (*DeleteObjectsOutput, err
 const opGetBucketAcl = "GetBucketAcl"
 
 // GetBucketAclRequest generates a request for the GetBucketAcl operation.
-func (c *S3) GetBucketAclRequest(input *GetBucketAclInput) (req *service.Request, output *GetBucketAclOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketAclRequest(input *GetBucketAclInput) (req *request.Request, output *GetBucketAclOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketAcl,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?acl",
@@ -432,8 +432,8 @@ func (c *S3) GetBucketAcl(input *GetBucketAclInput) (*GetBucketAclOutput, error)
 const opGetBucketCors = "GetBucketCors"
 
 // GetBucketCorsRequest generates a request for the GetBucketCors operation.
-func (c *S3) GetBucketCorsRequest(input *GetBucketCorsInput) (req *service.Request, output *GetBucketCorsOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketCorsRequest(input *GetBucketCorsInput) (req *request.Request, output *GetBucketCorsOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketCors,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?cors",
@@ -459,8 +459,8 @@ func (c *S3) GetBucketCors(input *GetBucketCorsInput) (*GetBucketCorsOutput, err
 const opGetBucketLifecycle = "GetBucketLifecycle"
 
 // GetBucketLifecycleRequest generates a request for the GetBucketLifecycle operation.
-func (c *S3) GetBucketLifecycleRequest(input *GetBucketLifecycleInput) (req *service.Request, output *GetBucketLifecycleOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketLifecycleRequest(input *GetBucketLifecycleInput) (req *request.Request, output *GetBucketLifecycleOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketLifecycle,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?lifecycle",
@@ -486,8 +486,8 @@ func (c *S3) GetBucketLifecycle(input *GetBucketLifecycleInput) (*GetBucketLifec
 const opGetBucketLocation = "GetBucketLocation"
 
 // GetBucketLocationRequest generates a request for the GetBucketLocation operation.
-func (c *S3) GetBucketLocationRequest(input *GetBucketLocationInput) (req *service.Request, output *GetBucketLocationOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketLocationRequest(input *GetBucketLocationInput) (req *request.Request, output *GetBucketLocationOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketLocation,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?location",
@@ -513,8 +513,8 @@ func (c *S3) GetBucketLocation(input *GetBucketLocationInput) (*GetBucketLocatio
 const opGetBucketLogging = "GetBucketLogging"
 
 // GetBucketLoggingRequest generates a request for the GetBucketLogging operation.
-func (c *S3) GetBucketLoggingRequest(input *GetBucketLoggingInput) (req *service.Request, output *GetBucketLoggingOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketLoggingRequest(input *GetBucketLoggingInput) (req *request.Request, output *GetBucketLoggingOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketLogging,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?logging",
@@ -541,8 +541,8 @@ func (c *S3) GetBucketLogging(input *GetBucketLoggingInput) (*GetBucketLoggingOu
 const opGetBucketNotification = "GetBucketNotification"
 
 // GetBucketNotificationRequest generates a request for the GetBucketNotification operation.
-func (c *S3) GetBucketNotificationRequest(input *GetBucketNotificationConfigurationRequest) (req *service.Request, output *NotificationConfigurationDeprecated) {
-	op := &service.Operation{
+func (c *S3) GetBucketNotificationRequest(input *GetBucketNotificationConfigurationRequest) (req *request.Request, output *NotificationConfigurationDeprecated) {
+	op := &request.Operation{
 		Name:       opGetBucketNotification,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?notification",
@@ -568,8 +568,8 @@ func (c *S3) GetBucketNotification(input *GetBucketNotificationConfigurationRequ
 const opGetBucketNotificationConfiguration = "GetBucketNotificationConfiguration"
 
 // GetBucketNotificationConfigurationRequest generates a request for the GetBucketNotificationConfiguration operation.
-func (c *S3) GetBucketNotificationConfigurationRequest(input *GetBucketNotificationConfigurationRequest) (req *service.Request, output *NotificationConfiguration) {
-	op := &service.Operation{
+func (c *S3) GetBucketNotificationConfigurationRequest(input *GetBucketNotificationConfigurationRequest) (req *request.Request, output *NotificationConfiguration) {
+	op := &request.Operation{
 		Name:       opGetBucketNotificationConfiguration,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?notification",
@@ -595,8 +595,8 @@ func (c *S3) GetBucketNotificationConfiguration(input *GetBucketNotificationConf
 const opGetBucketPolicy = "GetBucketPolicy"
 
 // GetBucketPolicyRequest generates a request for the GetBucketPolicy operation.
-func (c *S3) GetBucketPolicyRequest(input *GetBucketPolicyInput) (req *service.Request, output *GetBucketPolicyOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketPolicyRequest(input *GetBucketPolicyInput) (req *request.Request, output *GetBucketPolicyOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketPolicy,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?policy",
@@ -622,8 +622,8 @@ func (c *S3) GetBucketPolicy(input *GetBucketPolicyInput) (*GetBucketPolicyOutpu
 const opGetBucketReplication = "GetBucketReplication"
 
 // GetBucketReplicationRequest generates a request for the GetBucketReplication operation.
-func (c *S3) GetBucketReplicationRequest(input *GetBucketReplicationInput) (req *service.Request, output *GetBucketReplicationOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketReplicationRequest(input *GetBucketReplicationInput) (req *request.Request, output *GetBucketReplicationOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketReplication,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?replication",
@@ -648,8 +648,8 @@ func (c *S3) GetBucketReplication(input *GetBucketReplicationInput) (*GetBucketR
 const opGetBucketRequestPayment = "GetBucketRequestPayment"
 
 // GetBucketRequestPaymentRequest generates a request for the GetBucketRequestPayment operation.
-func (c *S3) GetBucketRequestPaymentRequest(input *GetBucketRequestPaymentInput) (req *service.Request, output *GetBucketRequestPaymentOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketRequestPaymentRequest(input *GetBucketRequestPaymentInput) (req *request.Request, output *GetBucketRequestPaymentOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketRequestPayment,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?requestPayment",
@@ -675,8 +675,8 @@ func (c *S3) GetBucketRequestPayment(input *GetBucketRequestPaymentInput) (*GetB
 const opGetBucketTagging = "GetBucketTagging"
 
 // GetBucketTaggingRequest generates a request for the GetBucketTagging operation.
-func (c *S3) GetBucketTaggingRequest(input *GetBucketTaggingInput) (req *service.Request, output *GetBucketTaggingOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketTaggingRequest(input *GetBucketTaggingInput) (req *request.Request, output *GetBucketTaggingOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketTagging,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?tagging",
@@ -702,8 +702,8 @@ func (c *S3) GetBucketTagging(input *GetBucketTaggingInput) (*GetBucketTaggingOu
 const opGetBucketVersioning = "GetBucketVersioning"
 
 // GetBucketVersioningRequest generates a request for the GetBucketVersioning operation.
-func (c *S3) GetBucketVersioningRequest(input *GetBucketVersioningInput) (req *service.Request, output *GetBucketVersioningOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketVersioningRequest(input *GetBucketVersioningInput) (req *request.Request, output *GetBucketVersioningOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketVersioning,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?versioning",
@@ -729,8 +729,8 @@ func (c *S3) GetBucketVersioning(input *GetBucketVersioningInput) (*GetBucketVer
 const opGetBucketWebsite = "GetBucketWebsite"
 
 // GetBucketWebsiteRequest generates a request for the GetBucketWebsite operation.
-func (c *S3) GetBucketWebsiteRequest(input *GetBucketWebsiteInput) (req *service.Request, output *GetBucketWebsiteOutput) {
-	op := &service.Operation{
+func (c *S3) GetBucketWebsiteRequest(input *GetBucketWebsiteInput) (req *request.Request, output *GetBucketWebsiteOutput) {
+	op := &request.Operation{
 		Name:       opGetBucketWebsite,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?website",
@@ -756,8 +756,8 @@ func (c *S3) GetBucketWebsite(input *GetBucketWebsiteInput) (*GetBucketWebsiteOu
 const opGetObject = "GetObject"
 
 // GetObjectRequest generates a request for the GetObject operation.
-func (c *S3) GetObjectRequest(input *GetObjectInput) (req *service.Request, output *GetObjectOutput) {
-	op := &service.Operation{
+func (c *S3) GetObjectRequest(input *GetObjectInput) (req *request.Request, output *GetObjectOutput) {
+	op := &request.Operation{
 		Name:       opGetObject,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -783,8 +783,8 @@ func (c *S3) GetObject(input *GetObjectInput) (*GetObjectOutput, error) {
 const opGetObjectAcl = "GetObjectAcl"
 
 // GetObjectAclRequest generates a request for the GetObjectAcl operation.
-func (c *S3) GetObjectAclRequest(input *GetObjectAclInput) (req *service.Request, output *GetObjectAclOutput) {
-	op := &service.Operation{
+func (c *S3) GetObjectAclRequest(input *GetObjectAclInput) (req *request.Request, output *GetObjectAclOutput) {
+	op := &request.Operation{
 		Name:       opGetObjectAcl,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}/{Key+}?acl",
@@ -810,8 +810,8 @@ func (c *S3) GetObjectAcl(input *GetObjectAclInput) (*GetObjectAclOutput, error)
 const opGetObjectTorrent = "GetObjectTorrent"
 
 // GetObjectTorrentRequest generates a request for the GetObjectTorrent operation.
-func (c *S3) GetObjectTorrentRequest(input *GetObjectTorrentInput) (req *service.Request, output *GetObjectTorrentOutput) {
-	op := &service.Operation{
+func (c *S3) GetObjectTorrentRequest(input *GetObjectTorrentInput) (req *request.Request, output *GetObjectTorrentOutput) {
+	op := &request.Operation{
 		Name:       opGetObjectTorrent,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}/{Key+}?torrent",
@@ -837,8 +837,8 @@ func (c *S3) GetObjectTorrent(input *GetObjectTorrentInput) (*GetObjectTorrentOu
 const opHeadBucket = "HeadBucket"
 
 // HeadBucketRequest generates a request for the HeadBucket operation.
-func (c *S3) HeadBucketRequest(input *HeadBucketInput) (req *service.Request, output *HeadBucketOutput) {
-	op := &service.Operation{
+func (c *S3) HeadBucketRequest(input *HeadBucketInput) (req *request.Request, output *HeadBucketOutput) {
+	op := &request.Operation{
 		Name:       opHeadBucket,
 		HTTPMethod: "HEAD",
 		HTTPPath:   "/{Bucket}",
@@ -865,8 +865,8 @@ func (c *S3) HeadBucket(input *HeadBucketInput) (*HeadBucketOutput, error) {
 const opHeadObject = "HeadObject"
 
 // HeadObjectRequest generates a request for the HeadObject operation.
-func (c *S3) HeadObjectRequest(input *HeadObjectInput) (req *service.Request, output *HeadObjectOutput) {
-	op := &service.Operation{
+func (c *S3) HeadObjectRequest(input *HeadObjectInput) (req *request.Request, output *HeadObjectOutput) {
+	op := &request.Operation{
 		Name:       opHeadObject,
 		HTTPMethod: "HEAD",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -894,8 +894,8 @@ func (c *S3) HeadObject(input *HeadObjectInput) (*HeadObjectOutput, error) {
 const opListBuckets = "ListBuckets"
 
 // ListBucketsRequest generates a request for the ListBuckets operation.
-func (c *S3) ListBucketsRequest(input *ListBucketsInput) (req *service.Request, output *ListBucketsOutput) {
-	op := &service.Operation{
+func (c *S3) ListBucketsRequest(input *ListBucketsInput) (req *request.Request, output *ListBucketsOutput) {
+	op := &request.Operation{
 		Name:       opListBuckets,
 		HTTPMethod: "GET",
 		HTTPPath:   "/",
@@ -921,12 +921,12 @@ func (c *S3) ListBuckets(input *ListBucketsInput) (*ListBucketsOutput, error) {
 const opListMultipartUploads = "ListMultipartUploads"
 
 // ListMultipartUploadsRequest generates a request for the ListMultipartUploads operation.
-func (c *S3) ListMultipartUploadsRequest(input *ListMultipartUploadsInput) (req *service.Request, output *ListMultipartUploadsOutput) {
-	op := &service.Operation{
+func (c *S3) ListMultipartUploadsRequest(input *ListMultipartUploadsInput) (req *request.Request, output *ListMultipartUploadsOutput) {
+	op := &request.Operation{
 		Name:       opListMultipartUploads,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?uploads",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"KeyMarker", "UploadIdMarker"},
 			OutputTokens:    []string{"NextKeyMarker", "NextUploadIdMarker"},
 			LimitToken:      "MaxUploads",
@@ -961,12 +961,12 @@ func (c *S3) ListMultipartUploadsPages(input *ListMultipartUploadsInput, fn func
 const opListObjectVersions = "ListObjectVersions"
 
 // ListObjectVersionsRequest generates a request for the ListObjectVersions operation.
-func (c *S3) ListObjectVersionsRequest(input *ListObjectVersionsInput) (req *service.Request, output *ListObjectVersionsOutput) {
-	op := &service.Operation{
+func (c *S3) ListObjectVersionsRequest(input *ListObjectVersionsInput) (req *request.Request, output *ListObjectVersionsOutput) {
+	op := &request.Operation{
 		Name:       opListObjectVersions,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}?versions",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"KeyMarker", "VersionIdMarker"},
 			OutputTokens:    []string{"NextKeyMarker", "NextVersionIdMarker"},
 			LimitToken:      "MaxKeys",
@@ -1001,12 +1001,12 @@ func (c *S3) ListObjectVersionsPages(input *ListObjectVersionsInput, fn func(p *
 const opListObjects = "ListObjects"
 
 // ListObjectsRequest generates a request for the ListObjects operation.
-func (c *S3) ListObjectsRequest(input *ListObjectsInput) (req *service.Request, output *ListObjectsOutput) {
-	op := &service.Operation{
+func (c *S3) ListObjectsRequest(input *ListObjectsInput) (req *request.Request, output *ListObjectsOutput) {
+	op := &request.Operation{
 		Name:       opListObjects,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"NextMarker || Contents[-1].Key"},
 			LimitToken:      "MaxKeys",
@@ -1043,12 +1043,12 @@ func (c *S3) ListObjectsPages(input *ListObjectsInput, fn func(p *ListObjectsOut
 const opListParts = "ListParts"
 
 // ListPartsRequest generates a request for the ListParts operation.
-func (c *S3) ListPartsRequest(input *ListPartsInput) (req *service.Request, output *ListPartsOutput) {
-	op := &service.Operation{
+func (c *S3) ListPartsRequest(input *ListPartsInput) (req *request.Request, output *ListPartsOutput) {
+	op := &request.Operation{
 		Name:       opListParts,
 		HTTPMethod: "GET",
 		HTTPPath:   "/{Bucket}/{Key+}",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"PartNumberMarker"},
 			OutputTokens:    []string{"NextPartNumberMarker"},
 			LimitToken:      "MaxParts",
@@ -1083,8 +1083,8 @@ func (c *S3) ListPartsPages(input *ListPartsInput, fn func(p *ListPartsOutput, l
 const opPutBucketAcl = "PutBucketAcl"
 
 // PutBucketAclRequest generates a request for the PutBucketAcl operation.
-func (c *S3) PutBucketAclRequest(input *PutBucketAclInput) (req *service.Request, output *PutBucketAclOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketAclRequest(input *PutBucketAclInput) (req *request.Request, output *PutBucketAclOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketAcl,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?acl",
@@ -1110,8 +1110,8 @@ func (c *S3) PutBucketAcl(input *PutBucketAclInput) (*PutBucketAclOutput, error)
 const opPutBucketCors = "PutBucketCors"
 
 // PutBucketCorsRequest generates a request for the PutBucketCors operation.
-func (c *S3) PutBucketCorsRequest(input *PutBucketCorsInput) (req *service.Request, output *PutBucketCorsOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketCorsRequest(input *PutBucketCorsInput) (req *request.Request, output *PutBucketCorsOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketCors,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?cors",
@@ -1137,8 +1137,8 @@ func (c *S3) PutBucketCors(input *PutBucketCorsInput) (*PutBucketCorsOutput, err
 const opPutBucketLifecycle = "PutBucketLifecycle"
 
 // PutBucketLifecycleRequest generates a request for the PutBucketLifecycle operation.
-func (c *S3) PutBucketLifecycleRequest(input *PutBucketLifecycleInput) (req *service.Request, output *PutBucketLifecycleOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketLifecycleRequest(input *PutBucketLifecycleInput) (req *request.Request, output *PutBucketLifecycleOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketLifecycle,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?lifecycle",
@@ -1165,8 +1165,8 @@ func (c *S3) PutBucketLifecycle(input *PutBucketLifecycleInput) (*PutBucketLifec
 const opPutBucketLogging = "PutBucketLogging"
 
 // PutBucketLoggingRequest generates a request for the PutBucketLogging operation.
-func (c *S3) PutBucketLoggingRequest(input *PutBucketLoggingInput) (req *service.Request, output *PutBucketLoggingOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketLoggingRequest(input *PutBucketLoggingInput) (req *request.Request, output *PutBucketLoggingOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketLogging,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?logging",
@@ -1194,8 +1194,8 @@ func (c *S3) PutBucketLogging(input *PutBucketLoggingInput) (*PutBucketLoggingOu
 const opPutBucketNotification = "PutBucketNotification"
 
 // PutBucketNotificationRequest generates a request for the PutBucketNotification operation.
-func (c *S3) PutBucketNotificationRequest(input *PutBucketNotificationInput) (req *service.Request, output *PutBucketNotificationOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketNotificationRequest(input *PutBucketNotificationInput) (req *request.Request, output *PutBucketNotificationOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketNotification,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?notification",
@@ -1221,8 +1221,8 @@ func (c *S3) PutBucketNotification(input *PutBucketNotificationInput) (*PutBucke
 const opPutBucketNotificationConfiguration = "PutBucketNotificationConfiguration"
 
 // PutBucketNotificationConfigurationRequest generates a request for the PutBucketNotificationConfiguration operation.
-func (c *S3) PutBucketNotificationConfigurationRequest(input *PutBucketNotificationConfigurationInput) (req *service.Request, output *PutBucketNotificationConfigurationOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketNotificationConfigurationRequest(input *PutBucketNotificationConfigurationInput) (req *request.Request, output *PutBucketNotificationConfigurationOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketNotificationConfiguration,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?notification",
@@ -1248,8 +1248,8 @@ func (c *S3) PutBucketNotificationConfiguration(input *PutBucketNotificationConf
 const opPutBucketPolicy = "PutBucketPolicy"
 
 // PutBucketPolicyRequest generates a request for the PutBucketPolicy operation.
-func (c *S3) PutBucketPolicyRequest(input *PutBucketPolicyInput) (req *service.Request, output *PutBucketPolicyOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketPolicyRequest(input *PutBucketPolicyInput) (req *request.Request, output *PutBucketPolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketPolicy,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?policy",
@@ -1276,8 +1276,8 @@ func (c *S3) PutBucketPolicy(input *PutBucketPolicyInput) (*PutBucketPolicyOutpu
 const opPutBucketReplication = "PutBucketReplication"
 
 // PutBucketReplicationRequest generates a request for the PutBucketReplication operation.
-func (c *S3) PutBucketReplicationRequest(input *PutBucketReplicationInput) (req *service.Request, output *PutBucketReplicationOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketReplicationRequest(input *PutBucketReplicationInput) (req *request.Request, output *PutBucketReplicationOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketReplication,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?replication",
@@ -1304,8 +1304,8 @@ func (c *S3) PutBucketReplication(input *PutBucketReplicationInput) (*PutBucketR
 const opPutBucketRequestPayment = "PutBucketRequestPayment"
 
 // PutBucketRequestPaymentRequest generates a request for the PutBucketRequestPayment operation.
-func (c *S3) PutBucketRequestPaymentRequest(input *PutBucketRequestPaymentInput) (req *service.Request, output *PutBucketRequestPaymentOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketRequestPaymentRequest(input *PutBucketRequestPaymentInput) (req *request.Request, output *PutBucketRequestPaymentOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketRequestPayment,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?requestPayment",
@@ -1335,8 +1335,8 @@ func (c *S3) PutBucketRequestPayment(input *PutBucketRequestPaymentInput) (*PutB
 const opPutBucketTagging = "PutBucketTagging"
 
 // PutBucketTaggingRequest generates a request for the PutBucketTagging operation.
-func (c *S3) PutBucketTaggingRequest(input *PutBucketTaggingInput) (req *service.Request, output *PutBucketTaggingOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketTaggingRequest(input *PutBucketTaggingInput) (req *request.Request, output *PutBucketTaggingOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketTagging,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?tagging",
@@ -1362,8 +1362,8 @@ func (c *S3) PutBucketTagging(input *PutBucketTaggingInput) (*PutBucketTaggingOu
 const opPutBucketVersioning = "PutBucketVersioning"
 
 // PutBucketVersioningRequest generates a request for the PutBucketVersioning operation.
-func (c *S3) PutBucketVersioningRequest(input *PutBucketVersioningInput) (req *service.Request, output *PutBucketVersioningOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketVersioningRequest(input *PutBucketVersioningInput) (req *request.Request, output *PutBucketVersioningOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketVersioning,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?versioning",
@@ -1390,8 +1390,8 @@ func (c *S3) PutBucketVersioning(input *PutBucketVersioningInput) (*PutBucketVer
 const opPutBucketWebsite = "PutBucketWebsite"
 
 // PutBucketWebsiteRequest generates a request for the PutBucketWebsite operation.
-func (c *S3) PutBucketWebsiteRequest(input *PutBucketWebsiteInput) (req *service.Request, output *PutBucketWebsiteOutput) {
-	op := &service.Operation{
+func (c *S3) PutBucketWebsiteRequest(input *PutBucketWebsiteInput) (req *request.Request, output *PutBucketWebsiteOutput) {
+	op := &request.Operation{
 		Name:       opPutBucketWebsite,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}?website",
@@ -1417,8 +1417,8 @@ func (c *S3) PutBucketWebsite(input *PutBucketWebsiteInput) (*PutBucketWebsiteOu
 const opPutObject = "PutObject"
 
 // PutObjectRequest generates a request for the PutObject operation.
-func (c *S3) PutObjectRequest(input *PutObjectInput) (req *service.Request, output *PutObjectOutput) {
-	op := &service.Operation{
+func (c *S3) PutObjectRequest(input *PutObjectInput) (req *request.Request, output *PutObjectOutput) {
+	op := &request.Operation{
 		Name:       opPutObject,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -1444,8 +1444,8 @@ func (c *S3) PutObject(input *PutObjectInput) (*PutObjectOutput, error) {
 const opPutObjectAcl = "PutObjectAcl"
 
 // PutObjectAclRequest generates a request for the PutObjectAcl operation.
-func (c *S3) PutObjectAclRequest(input *PutObjectAclInput) (req *service.Request, output *PutObjectAclOutput) {
-	op := &service.Operation{
+func (c *S3) PutObjectAclRequest(input *PutObjectAclInput) (req *request.Request, output *PutObjectAclOutput) {
+	op := &request.Operation{
 		Name:       opPutObjectAcl,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}/{Key+}?acl",
@@ -1472,8 +1472,8 @@ func (c *S3) PutObjectAcl(input *PutObjectAclInput) (*PutObjectAclOutput, error)
 const opRestoreObject = "RestoreObject"
 
 // RestoreObjectRequest generates a request for the RestoreObject operation.
-func (c *S3) RestoreObjectRequest(input *RestoreObjectInput) (req *service.Request, output *RestoreObjectOutput) {
-	op := &service.Operation{
+func (c *S3) RestoreObjectRequest(input *RestoreObjectInput) (req *request.Request, output *RestoreObjectOutput) {
+	op := &request.Operation{
 		Name:       opRestoreObject,
 		HTTPMethod: "POST",
 		HTTPPath:   "/{Bucket}/{Key+}?restore",
@@ -1499,8 +1499,8 @@ func (c *S3) RestoreObject(input *RestoreObjectInput) (*RestoreObjectOutput, err
 const opUploadPart = "UploadPart"
 
 // UploadPartRequest generates a request for the UploadPart operation.
-func (c *S3) UploadPartRequest(input *UploadPartInput) (req *service.Request, output *UploadPartOutput) {
-	op := &service.Operation{
+func (c *S3) UploadPartRequest(input *UploadPartInput) (req *request.Request, output *UploadPartOutput) {
+	op := &request.Operation{
 		Name:       opUploadPart,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}/{Key+}",
@@ -1532,8 +1532,8 @@ func (c *S3) UploadPart(input *UploadPartInput) (*UploadPartOutput, error) {
 const opUploadPartCopy = "UploadPartCopy"
 
 // UploadPartCopyRequest generates a request for the UploadPartCopy operation.
-func (c *S3) UploadPartCopyRequest(input *UploadPartCopyInput) (req *service.Request, output *UploadPartCopyOutput) {
-	op := &service.Operation{
+func (c *S3) UploadPartCopyRequest(input *UploadPartCopyInput) (req *request.Request, output *UploadPartCopyOutput) {
+	op := &request.Operation{
 		Name:       opUploadPartCopy,
 		HTTPMethod: "PUT",
 		HTTPPath:   "/{Bucket}/{Key+}",

--- a/service/s3/bucket_location.go
+++ b/service/s3/bucket_location.go
@@ -7,12 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 var reBucketLocation = regexp.MustCompile(`>([^<>]+)<\/Location`)
 
-func buildGetBucketLocation(r *service.Request) {
+func buildGetBucketLocation(r *request.Request) {
 	if r.DataFilled() {
 		out := r.Data.(*GetBucketLocationOutput)
 		b, err := ioutil.ReadAll(r.HTTPResponse.Body)
@@ -29,14 +29,14 @@ func buildGetBucketLocation(r *service.Request) {
 	}
 }
 
-func populateLocationConstraint(r *service.Request) {
-	if r.ParamsFilled() && aws.StringValue(r.Config.Region) != "us-east-1" {
+func populateLocationConstraint(r *request.Request) {
+	if r.ParamsFilled() && aws.StringValue(r.Service.Config.Region) != "us-east-1" {
 		in := r.Params.(*CreateBucketInput)
 		if in.CreateBucketConfiguration == nil {
 			r.Params = awsutil.CopyOf(r.Params)
 			in = r.Params.(*CreateBucketInput)
 			in.CreateBucketConfiguration = &CreateBucketConfiguration{
-				LocationConstraint: r.Config.Region,
+				LocationConstraint: r.Service.Config.Region,
 			}
 		}
 	}

--- a/service/s3/bucket_location_test.go
+++ b/service/s3/bucket_location_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +27,7 @@ func TestGetBucketLocation(t *testing.T) {
 	for _, test := range s3LocationTests {
 		s := s3.New(nil)
 		s.Handlers.Send.Clear()
-		s.Handlers.Send.PushBack(func(r *service.Request) {
+		s.Handlers.Send.PushBack(func(r *request.Request) {
 			reader := ioutil.NopCloser(bytes.NewReader([]byte(test.body)))
 			r.HTTPResponse = &http.Response{StatusCode: 200, Body: reader}
 		})

--- a/service/s3/content_md5.go
+++ b/service/s3/content_md5.go
@@ -6,12 +6,12 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 // contentMD5 computes and sets the HTTP Content-MD5 header for requests that
 // require it.
-func contentMD5(r *service.Request) {
+func contentMD5(r *request.Request) {
 	h := md5.New()
 
 	// hash the body.  seek back to the first position after reading to reset

--- a/service/s3/customizations.go
+++ b/service/s3/customizations.go
@@ -1,6 +1,9 @@
 package s3
 
-import "github.com/aws/aws-sdk-go/aws/service"
+import (
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/service"
+)
 
 func init() {
 	initService = func(s *service.Service) {
@@ -16,7 +19,7 @@ func init() {
 		s.Handlers.UnmarshalError.PushBack(unmarshalError)
 	}
 
-	initRequest = func(r *service.Request) {
+	initRequest = func(r *request.Request) {
 		switch r.Operation.Name {
 		case opPutBucketCors, opPutBucketLifecycle, opPutBucketPolicy, opPutBucketTagging, opDeleteObjects:
 			// These S3 operations require Content-MD5 to be set

--- a/service/s3/customizations_test.go
+++ b/service/s3/customizations_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +15,7 @@ import (
 
 var _ = unit.Imported
 
-func assertMD5(t *testing.T, req *service.Request) {
+func assertMD5(t *testing.T, req *request.Request) {
 	err := req.Build()
 	assert.NoError(t, err)
 

--- a/service/s3/host_style_bucket.go
+++ b/service/s3/host_style_bucket.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 var reDomain = regexp.MustCompile(`^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$`)
@@ -23,8 +23,8 @@ func dnsCompatibleBucketName(bucket string) bool {
 // hostStyleBucketName returns true if the request should put the bucket in
 // the host. This is false if S3ForcePathStyle is explicitly set or if the
 // bucket is not DNS compatible.
-func hostStyleBucketName(r *service.Request, bucket string) bool {
-	if aws.BoolValue(r.Config.S3ForcePathStyle) {
+func hostStyleBucketName(r *request.Request, bucket string) bool {
+	if aws.BoolValue(r.Service.Config.S3ForcePathStyle) {
 		return false
 	}
 
@@ -38,7 +38,7 @@ func hostStyleBucketName(r *service.Request, bucket string) bool {
 	return dnsCompatibleBucketName(bucket)
 }
 
-func updateHostWithBucket(r *service.Request) {
+func updateHostWithBucket(r *request.Request) {
 	b := awsutil.ValuesAtPath(r.Params, "Bucket")
 	if len(b) == 0 {
 		return

--- a/service/s3/s3iface/interface.go
+++ b/service/s3/s3iface/interface.go
@@ -4,233 +4,233 @@
 package s3iface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 // S3API is the interface type for s3.S3.
 type S3API interface {
-	AbortMultipartUploadRequest(*s3.AbortMultipartUploadInput) (*service.Request, *s3.AbortMultipartUploadOutput)
+	AbortMultipartUploadRequest(*s3.AbortMultipartUploadInput) (*request.Request, *s3.AbortMultipartUploadOutput)
 
 	AbortMultipartUpload(*s3.AbortMultipartUploadInput) (*s3.AbortMultipartUploadOutput, error)
 
-	CompleteMultipartUploadRequest(*s3.CompleteMultipartUploadInput) (*service.Request, *s3.CompleteMultipartUploadOutput)
+	CompleteMultipartUploadRequest(*s3.CompleteMultipartUploadInput) (*request.Request, *s3.CompleteMultipartUploadOutput)
 
 	CompleteMultipartUpload(*s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 
-	CopyObjectRequest(*s3.CopyObjectInput) (*service.Request, *s3.CopyObjectOutput)
+	CopyObjectRequest(*s3.CopyObjectInput) (*request.Request, *s3.CopyObjectOutput)
 
 	CopyObject(*s3.CopyObjectInput) (*s3.CopyObjectOutput, error)
 
-	CreateBucketRequest(*s3.CreateBucketInput) (*service.Request, *s3.CreateBucketOutput)
+	CreateBucketRequest(*s3.CreateBucketInput) (*request.Request, *s3.CreateBucketOutput)
 
 	CreateBucket(*s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
 
-	CreateMultipartUploadRequest(*s3.CreateMultipartUploadInput) (*service.Request, *s3.CreateMultipartUploadOutput)
+	CreateMultipartUploadRequest(*s3.CreateMultipartUploadInput) (*request.Request, *s3.CreateMultipartUploadOutput)
 
 	CreateMultipartUpload(*s3.CreateMultipartUploadInput) (*s3.CreateMultipartUploadOutput, error)
 
-	DeleteBucketRequest(*s3.DeleteBucketInput) (*service.Request, *s3.DeleteBucketOutput)
+	DeleteBucketRequest(*s3.DeleteBucketInput) (*request.Request, *s3.DeleteBucketOutput)
 
 	DeleteBucket(*s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error)
 
-	DeleteBucketCorsRequest(*s3.DeleteBucketCorsInput) (*service.Request, *s3.DeleteBucketCorsOutput)
+	DeleteBucketCorsRequest(*s3.DeleteBucketCorsInput) (*request.Request, *s3.DeleteBucketCorsOutput)
 
 	DeleteBucketCors(*s3.DeleteBucketCorsInput) (*s3.DeleteBucketCorsOutput, error)
 
-	DeleteBucketLifecycleRequest(*s3.DeleteBucketLifecycleInput) (*service.Request, *s3.DeleteBucketLifecycleOutput)
+	DeleteBucketLifecycleRequest(*s3.DeleteBucketLifecycleInput) (*request.Request, *s3.DeleteBucketLifecycleOutput)
 
 	DeleteBucketLifecycle(*s3.DeleteBucketLifecycleInput) (*s3.DeleteBucketLifecycleOutput, error)
 
-	DeleteBucketPolicyRequest(*s3.DeleteBucketPolicyInput) (*service.Request, *s3.DeleteBucketPolicyOutput)
+	DeleteBucketPolicyRequest(*s3.DeleteBucketPolicyInput) (*request.Request, *s3.DeleteBucketPolicyOutput)
 
 	DeleteBucketPolicy(*s3.DeleteBucketPolicyInput) (*s3.DeleteBucketPolicyOutput, error)
 
-	DeleteBucketReplicationRequest(*s3.DeleteBucketReplicationInput) (*service.Request, *s3.DeleteBucketReplicationOutput)
+	DeleteBucketReplicationRequest(*s3.DeleteBucketReplicationInput) (*request.Request, *s3.DeleteBucketReplicationOutput)
 
 	DeleteBucketReplication(*s3.DeleteBucketReplicationInput) (*s3.DeleteBucketReplicationOutput, error)
 
-	DeleteBucketTaggingRequest(*s3.DeleteBucketTaggingInput) (*service.Request, *s3.DeleteBucketTaggingOutput)
+	DeleteBucketTaggingRequest(*s3.DeleteBucketTaggingInput) (*request.Request, *s3.DeleteBucketTaggingOutput)
 
 	DeleteBucketTagging(*s3.DeleteBucketTaggingInput) (*s3.DeleteBucketTaggingOutput, error)
 
-	DeleteBucketWebsiteRequest(*s3.DeleteBucketWebsiteInput) (*service.Request, *s3.DeleteBucketWebsiteOutput)
+	DeleteBucketWebsiteRequest(*s3.DeleteBucketWebsiteInput) (*request.Request, *s3.DeleteBucketWebsiteOutput)
 
 	DeleteBucketWebsite(*s3.DeleteBucketWebsiteInput) (*s3.DeleteBucketWebsiteOutput, error)
 
-	DeleteObjectRequest(*s3.DeleteObjectInput) (*service.Request, *s3.DeleteObjectOutput)
+	DeleteObjectRequest(*s3.DeleteObjectInput) (*request.Request, *s3.DeleteObjectOutput)
 
 	DeleteObject(*s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
 
-	DeleteObjectsRequest(*s3.DeleteObjectsInput) (*service.Request, *s3.DeleteObjectsOutput)
+	DeleteObjectsRequest(*s3.DeleteObjectsInput) (*request.Request, *s3.DeleteObjectsOutput)
 
 	DeleteObjects(*s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error)
 
-	GetBucketAclRequest(*s3.GetBucketAclInput) (*service.Request, *s3.GetBucketAclOutput)
+	GetBucketAclRequest(*s3.GetBucketAclInput) (*request.Request, *s3.GetBucketAclOutput)
 
 	GetBucketAcl(*s3.GetBucketAclInput) (*s3.GetBucketAclOutput, error)
 
-	GetBucketCorsRequest(*s3.GetBucketCorsInput) (*service.Request, *s3.GetBucketCorsOutput)
+	GetBucketCorsRequest(*s3.GetBucketCorsInput) (*request.Request, *s3.GetBucketCorsOutput)
 
 	GetBucketCors(*s3.GetBucketCorsInput) (*s3.GetBucketCorsOutput, error)
 
-	GetBucketLifecycleRequest(*s3.GetBucketLifecycleInput) (*service.Request, *s3.GetBucketLifecycleOutput)
+	GetBucketLifecycleRequest(*s3.GetBucketLifecycleInput) (*request.Request, *s3.GetBucketLifecycleOutput)
 
 	GetBucketLifecycle(*s3.GetBucketLifecycleInput) (*s3.GetBucketLifecycleOutput, error)
 
-	GetBucketLocationRequest(*s3.GetBucketLocationInput) (*service.Request, *s3.GetBucketLocationOutput)
+	GetBucketLocationRequest(*s3.GetBucketLocationInput) (*request.Request, *s3.GetBucketLocationOutput)
 
 	GetBucketLocation(*s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error)
 
-	GetBucketLoggingRequest(*s3.GetBucketLoggingInput) (*service.Request, *s3.GetBucketLoggingOutput)
+	GetBucketLoggingRequest(*s3.GetBucketLoggingInput) (*request.Request, *s3.GetBucketLoggingOutput)
 
 	GetBucketLogging(*s3.GetBucketLoggingInput) (*s3.GetBucketLoggingOutput, error)
 
-	GetBucketNotificationRequest(*s3.GetBucketNotificationConfigurationRequest) (*service.Request, *s3.NotificationConfigurationDeprecated)
+	GetBucketNotificationRequest(*s3.GetBucketNotificationConfigurationRequest) (*request.Request, *s3.NotificationConfigurationDeprecated)
 
 	GetBucketNotification(*s3.GetBucketNotificationConfigurationRequest) (*s3.NotificationConfigurationDeprecated, error)
 
-	GetBucketNotificationConfigurationRequest(*s3.GetBucketNotificationConfigurationRequest) (*service.Request, *s3.NotificationConfiguration)
+	GetBucketNotificationConfigurationRequest(*s3.GetBucketNotificationConfigurationRequest) (*request.Request, *s3.NotificationConfiguration)
 
 	GetBucketNotificationConfiguration(*s3.GetBucketNotificationConfigurationRequest) (*s3.NotificationConfiguration, error)
 
-	GetBucketPolicyRequest(*s3.GetBucketPolicyInput) (*service.Request, *s3.GetBucketPolicyOutput)
+	GetBucketPolicyRequest(*s3.GetBucketPolicyInput) (*request.Request, *s3.GetBucketPolicyOutput)
 
 	GetBucketPolicy(*s3.GetBucketPolicyInput) (*s3.GetBucketPolicyOutput, error)
 
-	GetBucketReplicationRequest(*s3.GetBucketReplicationInput) (*service.Request, *s3.GetBucketReplicationOutput)
+	GetBucketReplicationRequest(*s3.GetBucketReplicationInput) (*request.Request, *s3.GetBucketReplicationOutput)
 
 	GetBucketReplication(*s3.GetBucketReplicationInput) (*s3.GetBucketReplicationOutput, error)
 
-	GetBucketRequestPaymentRequest(*s3.GetBucketRequestPaymentInput) (*service.Request, *s3.GetBucketRequestPaymentOutput)
+	GetBucketRequestPaymentRequest(*s3.GetBucketRequestPaymentInput) (*request.Request, *s3.GetBucketRequestPaymentOutput)
 
 	GetBucketRequestPayment(*s3.GetBucketRequestPaymentInput) (*s3.GetBucketRequestPaymentOutput, error)
 
-	GetBucketTaggingRequest(*s3.GetBucketTaggingInput) (*service.Request, *s3.GetBucketTaggingOutput)
+	GetBucketTaggingRequest(*s3.GetBucketTaggingInput) (*request.Request, *s3.GetBucketTaggingOutput)
 
 	GetBucketTagging(*s3.GetBucketTaggingInput) (*s3.GetBucketTaggingOutput, error)
 
-	GetBucketVersioningRequest(*s3.GetBucketVersioningInput) (*service.Request, *s3.GetBucketVersioningOutput)
+	GetBucketVersioningRequest(*s3.GetBucketVersioningInput) (*request.Request, *s3.GetBucketVersioningOutput)
 
 	GetBucketVersioning(*s3.GetBucketVersioningInput) (*s3.GetBucketVersioningOutput, error)
 
-	GetBucketWebsiteRequest(*s3.GetBucketWebsiteInput) (*service.Request, *s3.GetBucketWebsiteOutput)
+	GetBucketWebsiteRequest(*s3.GetBucketWebsiteInput) (*request.Request, *s3.GetBucketWebsiteOutput)
 
 	GetBucketWebsite(*s3.GetBucketWebsiteInput) (*s3.GetBucketWebsiteOutput, error)
 
-	GetObjectRequest(*s3.GetObjectInput) (*service.Request, *s3.GetObjectOutput)
+	GetObjectRequest(*s3.GetObjectInput) (*request.Request, *s3.GetObjectOutput)
 
 	GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error)
 
-	GetObjectAclRequest(*s3.GetObjectAclInput) (*service.Request, *s3.GetObjectAclOutput)
+	GetObjectAclRequest(*s3.GetObjectAclInput) (*request.Request, *s3.GetObjectAclOutput)
 
 	GetObjectAcl(*s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error)
 
-	GetObjectTorrentRequest(*s3.GetObjectTorrentInput) (*service.Request, *s3.GetObjectTorrentOutput)
+	GetObjectTorrentRequest(*s3.GetObjectTorrentInput) (*request.Request, *s3.GetObjectTorrentOutput)
 
 	GetObjectTorrent(*s3.GetObjectTorrentInput) (*s3.GetObjectTorrentOutput, error)
 
-	HeadBucketRequest(*s3.HeadBucketInput) (*service.Request, *s3.HeadBucketOutput)
+	HeadBucketRequest(*s3.HeadBucketInput) (*request.Request, *s3.HeadBucketOutput)
 
 	HeadBucket(*s3.HeadBucketInput) (*s3.HeadBucketOutput, error)
 
-	HeadObjectRequest(*s3.HeadObjectInput) (*service.Request, *s3.HeadObjectOutput)
+	HeadObjectRequest(*s3.HeadObjectInput) (*request.Request, *s3.HeadObjectOutput)
 
 	HeadObject(*s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 
-	ListBucketsRequest(*s3.ListBucketsInput) (*service.Request, *s3.ListBucketsOutput)
+	ListBucketsRequest(*s3.ListBucketsInput) (*request.Request, *s3.ListBucketsOutput)
 
 	ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error)
 
-	ListMultipartUploadsRequest(*s3.ListMultipartUploadsInput) (*service.Request, *s3.ListMultipartUploadsOutput)
+	ListMultipartUploadsRequest(*s3.ListMultipartUploadsInput) (*request.Request, *s3.ListMultipartUploadsOutput)
 
 	ListMultipartUploads(*s3.ListMultipartUploadsInput) (*s3.ListMultipartUploadsOutput, error)
 
 	ListMultipartUploadsPages(*s3.ListMultipartUploadsInput, func(*s3.ListMultipartUploadsOutput, bool) bool) error
 
-	ListObjectVersionsRequest(*s3.ListObjectVersionsInput) (*service.Request, *s3.ListObjectVersionsOutput)
+	ListObjectVersionsRequest(*s3.ListObjectVersionsInput) (*request.Request, *s3.ListObjectVersionsOutput)
 
 	ListObjectVersions(*s3.ListObjectVersionsInput) (*s3.ListObjectVersionsOutput, error)
 
 	ListObjectVersionsPages(*s3.ListObjectVersionsInput, func(*s3.ListObjectVersionsOutput, bool) bool) error
 
-	ListObjectsRequest(*s3.ListObjectsInput) (*service.Request, *s3.ListObjectsOutput)
+	ListObjectsRequest(*s3.ListObjectsInput) (*request.Request, *s3.ListObjectsOutput)
 
 	ListObjects(*s3.ListObjectsInput) (*s3.ListObjectsOutput, error)
 
 	ListObjectsPages(*s3.ListObjectsInput, func(*s3.ListObjectsOutput, bool) bool) error
 
-	ListPartsRequest(*s3.ListPartsInput) (*service.Request, *s3.ListPartsOutput)
+	ListPartsRequest(*s3.ListPartsInput) (*request.Request, *s3.ListPartsOutput)
 
 	ListParts(*s3.ListPartsInput) (*s3.ListPartsOutput, error)
 
 	ListPartsPages(*s3.ListPartsInput, func(*s3.ListPartsOutput, bool) bool) error
 
-	PutBucketAclRequest(*s3.PutBucketAclInput) (*service.Request, *s3.PutBucketAclOutput)
+	PutBucketAclRequest(*s3.PutBucketAclInput) (*request.Request, *s3.PutBucketAclOutput)
 
 	PutBucketAcl(*s3.PutBucketAclInput) (*s3.PutBucketAclOutput, error)
 
-	PutBucketCorsRequest(*s3.PutBucketCorsInput) (*service.Request, *s3.PutBucketCorsOutput)
+	PutBucketCorsRequest(*s3.PutBucketCorsInput) (*request.Request, *s3.PutBucketCorsOutput)
 
 	PutBucketCors(*s3.PutBucketCorsInput) (*s3.PutBucketCorsOutput, error)
 
-	PutBucketLifecycleRequest(*s3.PutBucketLifecycleInput) (*service.Request, *s3.PutBucketLifecycleOutput)
+	PutBucketLifecycleRequest(*s3.PutBucketLifecycleInput) (*request.Request, *s3.PutBucketLifecycleOutput)
 
 	PutBucketLifecycle(*s3.PutBucketLifecycleInput) (*s3.PutBucketLifecycleOutput, error)
 
-	PutBucketLoggingRequest(*s3.PutBucketLoggingInput) (*service.Request, *s3.PutBucketLoggingOutput)
+	PutBucketLoggingRequest(*s3.PutBucketLoggingInput) (*request.Request, *s3.PutBucketLoggingOutput)
 
 	PutBucketLogging(*s3.PutBucketLoggingInput) (*s3.PutBucketLoggingOutput, error)
 
-	PutBucketNotificationRequest(*s3.PutBucketNotificationInput) (*service.Request, *s3.PutBucketNotificationOutput)
+	PutBucketNotificationRequest(*s3.PutBucketNotificationInput) (*request.Request, *s3.PutBucketNotificationOutput)
 
 	PutBucketNotification(*s3.PutBucketNotificationInput) (*s3.PutBucketNotificationOutput, error)
 
-	PutBucketNotificationConfigurationRequest(*s3.PutBucketNotificationConfigurationInput) (*service.Request, *s3.PutBucketNotificationConfigurationOutput)
+	PutBucketNotificationConfigurationRequest(*s3.PutBucketNotificationConfigurationInput) (*request.Request, *s3.PutBucketNotificationConfigurationOutput)
 
 	PutBucketNotificationConfiguration(*s3.PutBucketNotificationConfigurationInput) (*s3.PutBucketNotificationConfigurationOutput, error)
 
-	PutBucketPolicyRequest(*s3.PutBucketPolicyInput) (*service.Request, *s3.PutBucketPolicyOutput)
+	PutBucketPolicyRequest(*s3.PutBucketPolicyInput) (*request.Request, *s3.PutBucketPolicyOutput)
 
 	PutBucketPolicy(*s3.PutBucketPolicyInput) (*s3.PutBucketPolicyOutput, error)
 
-	PutBucketReplicationRequest(*s3.PutBucketReplicationInput) (*service.Request, *s3.PutBucketReplicationOutput)
+	PutBucketReplicationRequest(*s3.PutBucketReplicationInput) (*request.Request, *s3.PutBucketReplicationOutput)
 
 	PutBucketReplication(*s3.PutBucketReplicationInput) (*s3.PutBucketReplicationOutput, error)
 
-	PutBucketRequestPaymentRequest(*s3.PutBucketRequestPaymentInput) (*service.Request, *s3.PutBucketRequestPaymentOutput)
+	PutBucketRequestPaymentRequest(*s3.PutBucketRequestPaymentInput) (*request.Request, *s3.PutBucketRequestPaymentOutput)
 
 	PutBucketRequestPayment(*s3.PutBucketRequestPaymentInput) (*s3.PutBucketRequestPaymentOutput, error)
 
-	PutBucketTaggingRequest(*s3.PutBucketTaggingInput) (*service.Request, *s3.PutBucketTaggingOutput)
+	PutBucketTaggingRequest(*s3.PutBucketTaggingInput) (*request.Request, *s3.PutBucketTaggingOutput)
 
 	PutBucketTagging(*s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error)
 
-	PutBucketVersioningRequest(*s3.PutBucketVersioningInput) (*service.Request, *s3.PutBucketVersioningOutput)
+	PutBucketVersioningRequest(*s3.PutBucketVersioningInput) (*request.Request, *s3.PutBucketVersioningOutput)
 
 	PutBucketVersioning(*s3.PutBucketVersioningInput) (*s3.PutBucketVersioningOutput, error)
 
-	PutBucketWebsiteRequest(*s3.PutBucketWebsiteInput) (*service.Request, *s3.PutBucketWebsiteOutput)
+	PutBucketWebsiteRequest(*s3.PutBucketWebsiteInput) (*request.Request, *s3.PutBucketWebsiteOutput)
 
 	PutBucketWebsite(*s3.PutBucketWebsiteInput) (*s3.PutBucketWebsiteOutput, error)
 
-	PutObjectRequest(*s3.PutObjectInput) (*service.Request, *s3.PutObjectOutput)
+	PutObjectRequest(*s3.PutObjectInput) (*request.Request, *s3.PutObjectOutput)
 
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
 
-	PutObjectAclRequest(*s3.PutObjectAclInput) (*service.Request, *s3.PutObjectAclOutput)
+	PutObjectAclRequest(*s3.PutObjectAclInput) (*request.Request, *s3.PutObjectAclOutput)
 
 	PutObjectAcl(*s3.PutObjectAclInput) (*s3.PutObjectAclOutput, error)
 
-	RestoreObjectRequest(*s3.RestoreObjectInput) (*service.Request, *s3.RestoreObjectOutput)
+	RestoreObjectRequest(*s3.RestoreObjectInput) (*request.Request, *s3.RestoreObjectOutput)
 
 	RestoreObject(*s3.RestoreObjectInput) (*s3.RestoreObjectOutput, error)
 
-	UploadPartRequest(*s3.UploadPartInput) (*service.Request, *s3.UploadPartOutput)
+	UploadPartRequest(*s3.UploadPartInput) (*request.Request, *s3.UploadPartOutput)
 
 	UploadPart(*s3.UploadPartInput) (*s3.UploadPartOutput, error)
 
-	UploadPartCopyRequest(*s3.UploadPartCopyInput) (*service.Request, *s3.UploadPartCopyOutput)
+	UploadPartCopyRequest(*s3.UploadPartCopyInput) (*request.Request, *s3.UploadPartCopyOutput)
 
 	UploadPartCopy(*s3.UploadPartCopyInput) (*s3.UploadPartCopyOutput, error)
 }

--- a/service/s3/s3manager/download_test.go
+++ b/service/s3/s3manager/download_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -27,7 +27,7 @@ func dlLoggingSvc(data []byte) (*s3.S3, *[]string, *[]string) {
 
 	svc := s3.New(nil)
 	svc.Handlers.Send.Clear()
-	svc.Handlers.Send.PushBack(func(r *service.Request) {
+	svc.Handlers.Send.PushBack(func(r *request.Request) {
 		m.Lock()
 		defer m.Unlock()
 
@@ -119,7 +119,7 @@ func TestDownloadError(t *testing.T) {
 	opts := &s3manager.DownloadOptions{S3: s, PartSize: 1, Concurrency: 1}
 
 	num := 0
-	s.Handlers.Send.PushBack(func(r *service.Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		num++
 		if num > 1 {
 			r.HTTPResponse.StatusCode = 400

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -51,7 +51,7 @@ func loggingSvc(ignoreOps []string) (*s3.S3, *[]string, *[]interface{}) {
 	svc.Handlers.UnmarshalMeta.Clear()
 	svc.Handlers.UnmarshalError.Clear()
 	svc.Handlers.Send.Clear()
-	svc.Handlers.Send.PushBack(func(r *service.Request) {
+	svc.Handlers.Send.PushBack(func(r *request.Request) {
 		m.Lock()
 		defer m.Unlock()
 
@@ -203,7 +203,7 @@ func TestUploadOrderSingle(t *testing.T) {
 
 func TestUploadOrderSingleFailure(t *testing.T) {
 	s, ops, _ := loggingSvc(emptyList)
-	s.Handlers.Send.PushBack(func(r *service.Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		r.HTTPResponse.StatusCode = 400
 	})
 	mgr := s3manager.NewUploader(&s3manager.UploadOptions{S3: s})
@@ -236,7 +236,7 @@ func TestUploadOrderZero(t *testing.T) {
 
 func TestUploadOrderMultiFailure(t *testing.T) {
 	s, ops, _ := loggingSvc(emptyList)
-	s.Handlers.Send.PushBack(func(r *service.Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		switch t := r.Data.(type) {
 		case *s3.UploadPartOutput:
 			if *t.ETag == "ETAG2" {
@@ -258,7 +258,7 @@ func TestUploadOrderMultiFailure(t *testing.T) {
 
 func TestUploadOrderMultiFailureOnComplete(t *testing.T) {
 	s, ops, _ := loggingSvc(emptyList)
-	s.Handlers.Send.PushBack(func(r *service.Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		switch r.Data.(type) {
 		case *s3.CompleteMultipartUploadOutput:
 			r.HTTPResponse.StatusCode = 400
@@ -279,7 +279,7 @@ func TestUploadOrderMultiFailureOnComplete(t *testing.T) {
 
 func TestUploadOrderMultiFailureOnCreate(t *testing.T) {
 	s, ops, _ := loggingSvc(emptyList)
-	s.Handlers.Send.PushBack(func(r *service.Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		switch r.Data.(type) {
 		case *s3.CreateMultipartUploadOutput:
 			r.HTTPResponse.StatusCode = 400
@@ -299,7 +299,7 @@ func TestUploadOrderMultiFailureOnCreate(t *testing.T) {
 
 func TestUploadOrderMultiFailureLeaveParts(t *testing.T) {
 	s, ops, _ := loggingSvc(emptyList)
-	s.Handlers.Send.PushBack(func(r *service.Request) {
+	s.Handlers.Send.PushBack(func(r *request.Request) {
 		switch data := r.Data.(type) {
 		case *s3.UploadPartOutput:
 			if *data.ETag == "ETAG2" {

--- a/service/s3/service.go
+++ b/service/s3/service.go
@@ -5,7 +5,9 @@ package s3
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/restxml"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -19,14 +21,16 @@ type S3 struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new S3 client.
 func New(config *aws.Config) *S3 {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "s3",
-		APIVersion:  "2006-03-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "s3",
+			APIVersion:  "2006-03-01",
+		},
 	}
 	service.Initialize()
 
@@ -47,8 +51,8 @@ func New(config *aws.Config) *S3 {
 
 // newRequest creates a new request for a S3 operation and runs any
 // custom request initialization.
-func (c *S3) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *S3) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/s3/sse.go
+++ b/service/s3/sse.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 var errSSERequiresSSL = awserr.New("ConfigError", "cannot send SSE keys over HTTP.", nil)
 
-func validateSSERequiresSSL(r *service.Request) {
+func validateSSERequiresSSL(r *request.Request) {
 	if r.HTTPRequest.URL.Scheme != "https" {
 		p := awsutil.ValuesAtPath(r.Params, "SSECustomerKey||CopySourceSSECustomerKey")
 		if len(p) > 0 {
@@ -20,7 +20,7 @@ func validateSSERequiresSSL(r *service.Request) {
 	}
 }
 
-func computeSSEKeys(r *service.Request) {
+func computeSSEKeys(r *request.Request) {
 	headers := []string{
 		"x-amz-server-side-encryption-customer-key",
 		"x-amz-copy-source-server-side-encryption-customer-key",

--- a/service/s3/unmarshal_error.go
+++ b/service/s3/unmarshal_error.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 type xmlErrorResponse struct {
@@ -18,12 +18,12 @@ type xmlErrorResponse struct {
 	Message string   `xml:"Message"`
 }
 
-func unmarshalError(r *service.Request) {
+func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
 	if r.HTTPResponse.StatusCode == http.StatusMovedPermanently {
 		r.Error = awserr.New("BucketRegionError",
-			fmt.Sprintf("incorrect region, the bucket is not in '%s' region", aws.StringValue(r.Config.Region)), nil)
+			fmt.Sprintf("incorrect region, the bucket is not in '%s' region", aws.StringValue(r.Service.Config.Region)), nil)
 		return
 	}
 

--- a/service/s3/unmarshal_error_test.go
+++ b/service/s3/unmarshal_error_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +34,7 @@ func TestStatusCodeError(t *testing.T) {
 	for _, test := range s3StatusCodeErrorTests {
 		s := s3.New(nil)
 		s.Handlers.Send.Clear()
-		s.Handlers.Send.PushBack(func(r *service.Request) {
+		s.Handlers.Send.PushBack(func(r *request.Request) {
 			body := ioutil.NopCloser(bytes.NewReader([]byte(test.body)))
 			r.HTTPResponse = &http.Response{
 				ContentLength: int64(len(test.body)),

--- a/service/ses/api.go
+++ b/service/ses/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opDeleteIdentity = "DeleteIdentity"
 
 // DeleteIdentityRequest generates a request for the DeleteIdentity operation.
-func (c *SES) DeleteIdentityRequest(input *DeleteIdentityInput) (req *service.Request, output *DeleteIdentityOutput) {
-	op := &service.Operation{
+func (c *SES) DeleteIdentityRequest(input *DeleteIdentityInput) (req *request.Request, output *DeleteIdentityOutput) {
+	op := &request.Operation{
 		Name:       opDeleteIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -43,8 +43,8 @@ func (c *SES) DeleteIdentity(input *DeleteIdentityInput) (*DeleteIdentityOutput,
 const opDeleteIdentityPolicy = "DeleteIdentityPolicy"
 
 // DeleteIdentityPolicyRequest generates a request for the DeleteIdentityPolicy operation.
-func (c *SES) DeleteIdentityPolicyRequest(input *DeleteIdentityPolicyInput) (req *service.Request, output *DeleteIdentityPolicyOutput) {
-	op := &service.Operation{
+func (c *SES) DeleteIdentityPolicyRequest(input *DeleteIdentityPolicyInput) (req *request.Request, output *DeleteIdentityPolicyOutput) {
+	op := &request.Operation{
 		Name:       opDeleteIdentityPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -79,8 +79,8 @@ func (c *SES) DeleteIdentityPolicy(input *DeleteIdentityPolicyInput) (*DeleteIde
 const opDeleteVerifiedEmailAddress = "DeleteVerifiedEmailAddress"
 
 // DeleteVerifiedEmailAddressRequest generates a request for the DeleteVerifiedEmailAddress operation.
-func (c *SES) DeleteVerifiedEmailAddressRequest(input *DeleteVerifiedEmailAddressInput) (req *service.Request, output *DeleteVerifiedEmailAddressOutput) {
-	op := &service.Operation{
+func (c *SES) DeleteVerifiedEmailAddressRequest(input *DeleteVerifiedEmailAddressInput) (req *request.Request, output *DeleteVerifiedEmailAddressOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVerifiedEmailAddress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -110,8 +110,8 @@ func (c *SES) DeleteVerifiedEmailAddress(input *DeleteVerifiedEmailAddressInput)
 const opGetIdentityDkimAttributes = "GetIdentityDkimAttributes"
 
 // GetIdentityDkimAttributesRequest generates a request for the GetIdentityDkimAttributes operation.
-func (c *SES) GetIdentityDkimAttributesRequest(input *GetIdentityDkimAttributesInput) (req *service.Request, output *GetIdentityDkimAttributesOutput) {
-	op := &service.Operation{
+func (c *SES) GetIdentityDkimAttributesRequest(input *GetIdentityDkimAttributesInput) (req *request.Request, output *GetIdentityDkimAttributesOutput) {
+	op := &request.Operation{
 		Name:       opGetIdentityDkimAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -154,8 +154,8 @@ func (c *SES) GetIdentityDkimAttributes(input *GetIdentityDkimAttributesInput) (
 const opGetIdentityNotificationAttributes = "GetIdentityNotificationAttributes"
 
 // GetIdentityNotificationAttributesRequest generates a request for the GetIdentityNotificationAttributes operation.
-func (c *SES) GetIdentityNotificationAttributesRequest(input *GetIdentityNotificationAttributesInput) (req *service.Request, output *GetIdentityNotificationAttributesOutput) {
-	op := &service.Operation{
+func (c *SES) GetIdentityNotificationAttributesRequest(input *GetIdentityNotificationAttributesInput) (req *request.Request, output *GetIdentityNotificationAttributesOutput) {
+	op := &request.Operation{
 		Name:       opGetIdentityNotificationAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -188,8 +188,8 @@ func (c *SES) GetIdentityNotificationAttributes(input *GetIdentityNotificationAt
 const opGetIdentityPolicies = "GetIdentityPolicies"
 
 // GetIdentityPoliciesRequest generates a request for the GetIdentityPolicies operation.
-func (c *SES) GetIdentityPoliciesRequest(input *GetIdentityPoliciesInput) (req *service.Request, output *GetIdentityPoliciesOutput) {
-	op := &service.Operation{
+func (c *SES) GetIdentityPoliciesRequest(input *GetIdentityPoliciesInput) (req *request.Request, output *GetIdentityPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opGetIdentityPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -224,8 +224,8 @@ func (c *SES) GetIdentityPolicies(input *GetIdentityPoliciesInput) (*GetIdentity
 const opGetIdentityVerificationAttributes = "GetIdentityVerificationAttributes"
 
 // GetIdentityVerificationAttributesRequest generates a request for the GetIdentityVerificationAttributes operation.
-func (c *SES) GetIdentityVerificationAttributesRequest(input *GetIdentityVerificationAttributesInput) (req *service.Request, output *GetIdentityVerificationAttributesOutput) {
-	op := &service.Operation{
+func (c *SES) GetIdentityVerificationAttributesRequest(input *GetIdentityVerificationAttributesInput) (req *request.Request, output *GetIdentityVerificationAttributesOutput) {
+	op := &request.Operation{
 		Name:       opGetIdentityVerificationAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -256,8 +256,8 @@ func (c *SES) GetIdentityVerificationAttributes(input *GetIdentityVerificationAt
 const opGetSendQuota = "GetSendQuota"
 
 // GetSendQuotaRequest generates a request for the GetSendQuota operation.
-func (c *SES) GetSendQuotaRequest(input *GetSendQuotaInput) (req *service.Request, output *GetSendQuotaOutput) {
-	op := &service.Operation{
+func (c *SES) GetSendQuotaRequest(input *GetSendQuotaInput) (req *request.Request, output *GetSendQuotaOutput) {
+	op := &request.Operation{
 		Name:       opGetSendQuota,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -285,8 +285,8 @@ func (c *SES) GetSendQuota(input *GetSendQuotaInput) (*GetSendQuotaOutput, error
 const opGetSendStatistics = "GetSendStatistics"
 
 // GetSendStatisticsRequest generates a request for the GetSendStatistics operation.
-func (c *SES) GetSendStatisticsRequest(input *GetSendStatisticsInput) (req *service.Request, output *GetSendStatisticsOutput) {
-	op := &service.Operation{
+func (c *SES) GetSendStatisticsRequest(input *GetSendStatisticsInput) (req *request.Request, output *GetSendStatisticsOutput) {
+	op := &request.Operation{
 		Name:       opGetSendStatistics,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -317,12 +317,12 @@ func (c *SES) GetSendStatistics(input *GetSendStatisticsInput) (*GetSendStatisti
 const opListIdentities = "ListIdentities"
 
 // ListIdentitiesRequest generates a request for the ListIdentities operation.
-func (c *SES) ListIdentitiesRequest(input *ListIdentitiesInput) (req *service.Request, output *ListIdentitiesOutput) {
-	op := &service.Operation{
+func (c *SES) ListIdentitiesRequest(input *ListIdentitiesInput) (req *request.Request, output *ListIdentitiesOutput) {
+	op := &request.Operation{
 		Name:       opListIdentities,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "MaxItems",
@@ -360,8 +360,8 @@ func (c *SES) ListIdentitiesPages(input *ListIdentitiesInput, fn func(p *ListIde
 const opListIdentityPolicies = "ListIdentityPolicies"
 
 // ListIdentityPoliciesRequest generates a request for the ListIdentityPolicies operation.
-func (c *SES) ListIdentityPoliciesRequest(input *ListIdentityPoliciesInput) (req *service.Request, output *ListIdentityPoliciesOutput) {
-	op := &service.Operation{
+func (c *SES) ListIdentityPoliciesRequest(input *ListIdentityPoliciesInput) (req *request.Request, output *ListIdentityPoliciesOutput) {
+	op := &request.Operation{
 		Name:       opListIdentityPolicies,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -396,8 +396,8 @@ func (c *SES) ListIdentityPolicies(input *ListIdentityPoliciesInput) (*ListIdent
 const opListVerifiedEmailAddresses = "ListVerifiedEmailAddresses"
 
 // ListVerifiedEmailAddressesRequest generates a request for the ListVerifiedEmailAddresses operation.
-func (c *SES) ListVerifiedEmailAddressesRequest(input *ListVerifiedEmailAddressesInput) (req *service.Request, output *ListVerifiedEmailAddressesOutput) {
-	op := &service.Operation{
+func (c *SES) ListVerifiedEmailAddressesRequest(input *ListVerifiedEmailAddressesInput) (req *request.Request, output *ListVerifiedEmailAddressesOutput) {
+	op := &request.Operation{
 		Name:       opListVerifiedEmailAddresses,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -427,8 +427,8 @@ func (c *SES) ListVerifiedEmailAddresses(input *ListVerifiedEmailAddressesInput)
 const opPutIdentityPolicy = "PutIdentityPolicy"
 
 // PutIdentityPolicyRequest generates a request for the PutIdentityPolicy operation.
-func (c *SES) PutIdentityPolicyRequest(input *PutIdentityPolicyInput) (req *service.Request, output *PutIdentityPolicyOutput) {
-	op := &service.Operation{
+func (c *SES) PutIdentityPolicyRequest(input *PutIdentityPolicyInput) (req *request.Request, output *PutIdentityPolicyOutput) {
+	op := &request.Operation{
 		Name:       opPutIdentityPolicy,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -462,8 +462,8 @@ func (c *SES) PutIdentityPolicy(input *PutIdentityPolicyInput) (*PutIdentityPoli
 const opSendEmail = "SendEmail"
 
 // SendEmailRequest generates a request for the SendEmail operation.
-func (c *SES) SendEmailRequest(input *SendEmailInput) (req *service.Request, output *SendEmailOutput) {
-	op := &service.Operation{
+func (c *SES) SendEmailRequest(input *SendEmailInput) (req *request.Request, output *SendEmailOutput) {
+	op := &request.Operation{
 		Name:       opSendEmail,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -508,8 +508,8 @@ func (c *SES) SendEmail(input *SendEmailInput) (*SendEmailOutput, error) {
 const opSendRawEmail = "SendRawEmail"
 
 // SendRawEmailRequest generates a request for the SendRawEmail operation.
-func (c *SES) SendRawEmailRequest(input *SendRawEmailInput) (req *service.Request, output *SendRawEmailOutput) {
-	op := &service.Operation{
+func (c *SES) SendRawEmailRequest(input *SendRawEmailInput) (req *request.Request, output *SendRawEmailOutput) {
+	op := &request.Operation{
 		Name:       opSendRawEmail,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -572,8 +572,8 @@ func (c *SES) SendRawEmail(input *SendRawEmailInput) (*SendRawEmailOutput, error
 const opSetIdentityDkimEnabled = "SetIdentityDkimEnabled"
 
 // SetIdentityDkimEnabledRequest generates a request for the SetIdentityDkimEnabled operation.
-func (c *SES) SetIdentityDkimEnabledRequest(input *SetIdentityDkimEnabledInput) (req *service.Request, output *SetIdentityDkimEnabledOutput) {
-	op := &service.Operation{
+func (c *SES) SetIdentityDkimEnabledRequest(input *SetIdentityDkimEnabledInput) (req *request.Request, output *SetIdentityDkimEnabledOutput) {
+	op := &request.Operation{
 		Name:       opSetIdentityDkimEnabled,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -612,8 +612,8 @@ func (c *SES) SetIdentityDkimEnabled(input *SetIdentityDkimEnabledInput) (*SetId
 const opSetIdentityFeedbackForwardingEnabled = "SetIdentityFeedbackForwardingEnabled"
 
 // SetIdentityFeedbackForwardingEnabledRequest generates a request for the SetIdentityFeedbackForwardingEnabled operation.
-func (c *SES) SetIdentityFeedbackForwardingEnabledRequest(input *SetIdentityFeedbackForwardingEnabledInput) (req *service.Request, output *SetIdentityFeedbackForwardingEnabledOutput) {
-	op := &service.Operation{
+func (c *SES) SetIdentityFeedbackForwardingEnabledRequest(input *SetIdentityFeedbackForwardingEnabledInput) (req *request.Request, output *SetIdentityFeedbackForwardingEnabledOutput) {
+	op := &request.Operation{
 		Name:       opSetIdentityFeedbackForwardingEnabled,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -649,8 +649,8 @@ func (c *SES) SetIdentityFeedbackForwardingEnabled(input *SetIdentityFeedbackFor
 const opSetIdentityNotificationTopic = "SetIdentityNotificationTopic"
 
 // SetIdentityNotificationTopicRequest generates a request for the SetIdentityNotificationTopic operation.
-func (c *SES) SetIdentityNotificationTopicRequest(input *SetIdentityNotificationTopicInput) (req *service.Request, output *SetIdentityNotificationTopicOutput) {
-	op := &service.Operation{
+func (c *SES) SetIdentityNotificationTopicRequest(input *SetIdentityNotificationTopicInput) (req *request.Request, output *SetIdentityNotificationTopicOutput) {
+	op := &request.Operation{
 		Name:       opSetIdentityNotificationTopic,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -685,8 +685,8 @@ func (c *SES) SetIdentityNotificationTopic(input *SetIdentityNotificationTopicIn
 const opVerifyDomainDkim = "VerifyDomainDkim"
 
 // VerifyDomainDkimRequest generates a request for the VerifyDomainDkim operation.
-func (c *SES) VerifyDomainDkimRequest(input *VerifyDomainDkimInput) (req *service.Request, output *VerifyDomainDkimOutput) {
-	op := &service.Operation{
+func (c *SES) VerifyDomainDkimRequest(input *VerifyDomainDkimInput) (req *request.Request, output *VerifyDomainDkimOutput) {
+	op := &request.Operation{
 		Name:       opVerifyDomainDkim,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -726,8 +726,8 @@ func (c *SES) VerifyDomainDkim(input *VerifyDomainDkimInput) (*VerifyDomainDkimO
 const opVerifyDomainIdentity = "VerifyDomainIdentity"
 
 // VerifyDomainIdentityRequest generates a request for the VerifyDomainIdentity operation.
-func (c *SES) VerifyDomainIdentityRequest(input *VerifyDomainIdentityInput) (req *service.Request, output *VerifyDomainIdentityOutput) {
-	op := &service.Operation{
+func (c *SES) VerifyDomainIdentityRequest(input *VerifyDomainIdentityInput) (req *request.Request, output *VerifyDomainIdentityOutput) {
+	op := &request.Operation{
 		Name:       opVerifyDomainIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -755,8 +755,8 @@ func (c *SES) VerifyDomainIdentity(input *VerifyDomainIdentityInput) (*VerifyDom
 const opVerifyEmailAddress = "VerifyEmailAddress"
 
 // VerifyEmailAddressRequest generates a request for the VerifyEmailAddress operation.
-func (c *SES) VerifyEmailAddressRequest(input *VerifyEmailAddressInput) (req *service.Request, output *VerifyEmailAddressOutput) {
-	op := &service.Operation{
+func (c *SES) VerifyEmailAddressRequest(input *VerifyEmailAddressInput) (req *request.Request, output *VerifyEmailAddressOutput) {
+	op := &request.Operation{
 		Name:       opVerifyEmailAddress,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -787,8 +787,8 @@ func (c *SES) VerifyEmailAddress(input *VerifyEmailAddressInput) (*VerifyEmailAd
 const opVerifyEmailIdentity = "VerifyEmailIdentity"
 
 // VerifyEmailIdentityRequest generates a request for the VerifyEmailIdentity operation.
-func (c *SES) VerifyEmailIdentityRequest(input *VerifyEmailIdentityInput) (req *service.Request, output *VerifyEmailIdentityOutput) {
-	op := &service.Operation{
+func (c *SES) VerifyEmailIdentityRequest(input *VerifyEmailIdentityInput) (req *request.Request, output *VerifyEmailIdentityOutput) {
+	op := &request.Operation{
 		Name:       opVerifyEmailIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/ses/service.go
+++ b/service/ses/service.go
@@ -5,7 +5,9 @@ package ses
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -25,15 +27,17 @@ type SES struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new SES client.
 func New(config *aws.Config) *SES {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "email",
-		SigningName: "ses",
-		APIVersion:  "2010-12-01",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "email",
+			SigningName: "ses",
+			APIVersion:  "2010-12-01",
+		},
 	}
 	service.Initialize()
 
@@ -54,8 +58,8 @@ func New(config *aws.Config) *SES {
 
 // newRequest creates a new request for a SES operation and runs any
 // custom request initialization.
-func (c *SES) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *SES) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/ses/sesiface/interface.go
+++ b/service/ses/sesiface/interface.go
@@ -4,99 +4,99 @@
 package sesiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ses"
 )
 
 // SESAPI is the interface type for ses.SES.
 type SESAPI interface {
-	DeleteIdentityRequest(*ses.DeleteIdentityInput) (*service.Request, *ses.DeleteIdentityOutput)
+	DeleteIdentityRequest(*ses.DeleteIdentityInput) (*request.Request, *ses.DeleteIdentityOutput)
 
 	DeleteIdentity(*ses.DeleteIdentityInput) (*ses.DeleteIdentityOutput, error)
 
-	DeleteIdentityPolicyRequest(*ses.DeleteIdentityPolicyInput) (*service.Request, *ses.DeleteIdentityPolicyOutput)
+	DeleteIdentityPolicyRequest(*ses.DeleteIdentityPolicyInput) (*request.Request, *ses.DeleteIdentityPolicyOutput)
 
 	DeleteIdentityPolicy(*ses.DeleteIdentityPolicyInput) (*ses.DeleteIdentityPolicyOutput, error)
 
-	DeleteVerifiedEmailAddressRequest(*ses.DeleteVerifiedEmailAddressInput) (*service.Request, *ses.DeleteVerifiedEmailAddressOutput)
+	DeleteVerifiedEmailAddressRequest(*ses.DeleteVerifiedEmailAddressInput) (*request.Request, *ses.DeleteVerifiedEmailAddressOutput)
 
 	DeleteVerifiedEmailAddress(*ses.DeleteVerifiedEmailAddressInput) (*ses.DeleteVerifiedEmailAddressOutput, error)
 
-	GetIdentityDkimAttributesRequest(*ses.GetIdentityDkimAttributesInput) (*service.Request, *ses.GetIdentityDkimAttributesOutput)
+	GetIdentityDkimAttributesRequest(*ses.GetIdentityDkimAttributesInput) (*request.Request, *ses.GetIdentityDkimAttributesOutput)
 
 	GetIdentityDkimAttributes(*ses.GetIdentityDkimAttributesInput) (*ses.GetIdentityDkimAttributesOutput, error)
 
-	GetIdentityNotificationAttributesRequest(*ses.GetIdentityNotificationAttributesInput) (*service.Request, *ses.GetIdentityNotificationAttributesOutput)
+	GetIdentityNotificationAttributesRequest(*ses.GetIdentityNotificationAttributesInput) (*request.Request, *ses.GetIdentityNotificationAttributesOutput)
 
 	GetIdentityNotificationAttributes(*ses.GetIdentityNotificationAttributesInput) (*ses.GetIdentityNotificationAttributesOutput, error)
 
-	GetIdentityPoliciesRequest(*ses.GetIdentityPoliciesInput) (*service.Request, *ses.GetIdentityPoliciesOutput)
+	GetIdentityPoliciesRequest(*ses.GetIdentityPoliciesInput) (*request.Request, *ses.GetIdentityPoliciesOutput)
 
 	GetIdentityPolicies(*ses.GetIdentityPoliciesInput) (*ses.GetIdentityPoliciesOutput, error)
 
-	GetIdentityVerificationAttributesRequest(*ses.GetIdentityVerificationAttributesInput) (*service.Request, *ses.GetIdentityVerificationAttributesOutput)
+	GetIdentityVerificationAttributesRequest(*ses.GetIdentityVerificationAttributesInput) (*request.Request, *ses.GetIdentityVerificationAttributesOutput)
 
 	GetIdentityVerificationAttributes(*ses.GetIdentityVerificationAttributesInput) (*ses.GetIdentityVerificationAttributesOutput, error)
 
-	GetSendQuotaRequest(*ses.GetSendQuotaInput) (*service.Request, *ses.GetSendQuotaOutput)
+	GetSendQuotaRequest(*ses.GetSendQuotaInput) (*request.Request, *ses.GetSendQuotaOutput)
 
 	GetSendQuota(*ses.GetSendQuotaInput) (*ses.GetSendQuotaOutput, error)
 
-	GetSendStatisticsRequest(*ses.GetSendStatisticsInput) (*service.Request, *ses.GetSendStatisticsOutput)
+	GetSendStatisticsRequest(*ses.GetSendStatisticsInput) (*request.Request, *ses.GetSendStatisticsOutput)
 
 	GetSendStatistics(*ses.GetSendStatisticsInput) (*ses.GetSendStatisticsOutput, error)
 
-	ListIdentitiesRequest(*ses.ListIdentitiesInput) (*service.Request, *ses.ListIdentitiesOutput)
+	ListIdentitiesRequest(*ses.ListIdentitiesInput) (*request.Request, *ses.ListIdentitiesOutput)
 
 	ListIdentities(*ses.ListIdentitiesInput) (*ses.ListIdentitiesOutput, error)
 
 	ListIdentitiesPages(*ses.ListIdentitiesInput, func(*ses.ListIdentitiesOutput, bool) bool) error
 
-	ListIdentityPoliciesRequest(*ses.ListIdentityPoliciesInput) (*service.Request, *ses.ListIdentityPoliciesOutput)
+	ListIdentityPoliciesRequest(*ses.ListIdentityPoliciesInput) (*request.Request, *ses.ListIdentityPoliciesOutput)
 
 	ListIdentityPolicies(*ses.ListIdentityPoliciesInput) (*ses.ListIdentityPoliciesOutput, error)
 
-	ListVerifiedEmailAddressesRequest(*ses.ListVerifiedEmailAddressesInput) (*service.Request, *ses.ListVerifiedEmailAddressesOutput)
+	ListVerifiedEmailAddressesRequest(*ses.ListVerifiedEmailAddressesInput) (*request.Request, *ses.ListVerifiedEmailAddressesOutput)
 
 	ListVerifiedEmailAddresses(*ses.ListVerifiedEmailAddressesInput) (*ses.ListVerifiedEmailAddressesOutput, error)
 
-	PutIdentityPolicyRequest(*ses.PutIdentityPolicyInput) (*service.Request, *ses.PutIdentityPolicyOutput)
+	PutIdentityPolicyRequest(*ses.PutIdentityPolicyInput) (*request.Request, *ses.PutIdentityPolicyOutput)
 
 	PutIdentityPolicy(*ses.PutIdentityPolicyInput) (*ses.PutIdentityPolicyOutput, error)
 
-	SendEmailRequest(*ses.SendEmailInput) (*service.Request, *ses.SendEmailOutput)
+	SendEmailRequest(*ses.SendEmailInput) (*request.Request, *ses.SendEmailOutput)
 
 	SendEmail(*ses.SendEmailInput) (*ses.SendEmailOutput, error)
 
-	SendRawEmailRequest(*ses.SendRawEmailInput) (*service.Request, *ses.SendRawEmailOutput)
+	SendRawEmailRequest(*ses.SendRawEmailInput) (*request.Request, *ses.SendRawEmailOutput)
 
 	SendRawEmail(*ses.SendRawEmailInput) (*ses.SendRawEmailOutput, error)
 
-	SetIdentityDkimEnabledRequest(*ses.SetIdentityDkimEnabledInput) (*service.Request, *ses.SetIdentityDkimEnabledOutput)
+	SetIdentityDkimEnabledRequest(*ses.SetIdentityDkimEnabledInput) (*request.Request, *ses.SetIdentityDkimEnabledOutput)
 
 	SetIdentityDkimEnabled(*ses.SetIdentityDkimEnabledInput) (*ses.SetIdentityDkimEnabledOutput, error)
 
-	SetIdentityFeedbackForwardingEnabledRequest(*ses.SetIdentityFeedbackForwardingEnabledInput) (*service.Request, *ses.SetIdentityFeedbackForwardingEnabledOutput)
+	SetIdentityFeedbackForwardingEnabledRequest(*ses.SetIdentityFeedbackForwardingEnabledInput) (*request.Request, *ses.SetIdentityFeedbackForwardingEnabledOutput)
 
 	SetIdentityFeedbackForwardingEnabled(*ses.SetIdentityFeedbackForwardingEnabledInput) (*ses.SetIdentityFeedbackForwardingEnabledOutput, error)
 
-	SetIdentityNotificationTopicRequest(*ses.SetIdentityNotificationTopicInput) (*service.Request, *ses.SetIdentityNotificationTopicOutput)
+	SetIdentityNotificationTopicRequest(*ses.SetIdentityNotificationTopicInput) (*request.Request, *ses.SetIdentityNotificationTopicOutput)
 
 	SetIdentityNotificationTopic(*ses.SetIdentityNotificationTopicInput) (*ses.SetIdentityNotificationTopicOutput, error)
 
-	VerifyDomainDkimRequest(*ses.VerifyDomainDkimInput) (*service.Request, *ses.VerifyDomainDkimOutput)
+	VerifyDomainDkimRequest(*ses.VerifyDomainDkimInput) (*request.Request, *ses.VerifyDomainDkimOutput)
 
 	VerifyDomainDkim(*ses.VerifyDomainDkimInput) (*ses.VerifyDomainDkimOutput, error)
 
-	VerifyDomainIdentityRequest(*ses.VerifyDomainIdentityInput) (*service.Request, *ses.VerifyDomainIdentityOutput)
+	VerifyDomainIdentityRequest(*ses.VerifyDomainIdentityInput) (*request.Request, *ses.VerifyDomainIdentityOutput)
 
 	VerifyDomainIdentity(*ses.VerifyDomainIdentityInput) (*ses.VerifyDomainIdentityOutput, error)
 
-	VerifyEmailAddressRequest(*ses.VerifyEmailAddressInput) (*service.Request, *ses.VerifyEmailAddressOutput)
+	VerifyEmailAddressRequest(*ses.VerifyEmailAddressInput) (*request.Request, *ses.VerifyEmailAddressOutput)
 
 	VerifyEmailAddress(*ses.VerifyEmailAddressInput) (*ses.VerifyEmailAddressOutput, error)
 
-	VerifyEmailIdentityRequest(*ses.VerifyEmailIdentityInput) (*service.Request, *ses.VerifyEmailIdentityOutput)
+	VerifyEmailIdentityRequest(*ses.VerifyEmailIdentityInput) (*request.Request, *ses.VerifyEmailIdentityOutput)
 
 	VerifyEmailIdentity(*ses.VerifyEmailIdentityInput) (*ses.VerifyEmailIdentityOutput, error)
 }

--- a/service/sns/api.go
+++ b/service/sns/api.go
@@ -5,14 +5,14 @@ package sns
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddPermission = "AddPermission"
 
 // AddPermissionRequest generates a request for the AddPermission operation.
-func (c *SNS) AddPermissionRequest(input *AddPermissionInput) (req *service.Request, output *AddPermissionOutput) {
-	op := &service.Operation{
+func (c *SNS) AddPermissionRequest(input *AddPermissionInput) (req *request.Request, output *AddPermissionOutput) {
+	op := &request.Operation{
 		Name:       opAddPermission,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -39,8 +39,8 @@ func (c *SNS) AddPermission(input *AddPermissionInput) (*AddPermissionOutput, er
 const opConfirmSubscription = "ConfirmSubscription"
 
 // ConfirmSubscriptionRequest generates a request for the ConfirmSubscription operation.
-func (c *SNS) ConfirmSubscriptionRequest(input *ConfirmSubscriptionInput) (req *service.Request, output *ConfirmSubscriptionOutput) {
-	op := &service.Operation{
+func (c *SNS) ConfirmSubscriptionRequest(input *ConfirmSubscriptionInput) (req *request.Request, output *ConfirmSubscriptionOutput) {
+	op := &request.Operation{
 		Name:       opConfirmSubscription,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -70,8 +70,8 @@ func (c *SNS) ConfirmSubscription(input *ConfirmSubscriptionInput) (*ConfirmSubs
 const opCreatePlatformApplication = "CreatePlatformApplication"
 
 // CreatePlatformApplicationRequest generates a request for the CreatePlatformApplication operation.
-func (c *SNS) CreatePlatformApplicationRequest(input *CreatePlatformApplicationInput) (req *service.Request, output *CreatePlatformApplicationOutput) {
-	op := &service.Operation{
+func (c *SNS) CreatePlatformApplicationRequest(input *CreatePlatformApplicationInput) (req *request.Request, output *CreatePlatformApplicationOutput) {
+	op := &request.Operation{
 		Name:       opCreatePlatformApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -109,8 +109,8 @@ func (c *SNS) CreatePlatformApplication(input *CreatePlatformApplicationInput) (
 const opCreatePlatformEndpoint = "CreatePlatformEndpoint"
 
 // CreatePlatformEndpointRequest generates a request for the CreatePlatformEndpoint operation.
-func (c *SNS) CreatePlatformEndpointRequest(input *CreatePlatformEndpointInput) (req *service.Request, output *CreatePlatformEndpointOutput) {
-	op := &service.Operation{
+func (c *SNS) CreatePlatformEndpointRequest(input *CreatePlatformEndpointInput) (req *request.Request, output *CreatePlatformEndpointOutput) {
+	op := &request.Operation{
 		Name:       opCreatePlatformEndpoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -149,8 +149,8 @@ func (c *SNS) CreatePlatformEndpoint(input *CreatePlatformEndpointInput) (*Creat
 const opCreateTopic = "CreateTopic"
 
 // CreateTopicRequest generates a request for the CreateTopic operation.
-func (c *SNS) CreateTopicRequest(input *CreateTopicInput) (req *service.Request, output *CreateTopicOutput) {
-	op := &service.Operation{
+func (c *SNS) CreateTopicRequest(input *CreateTopicInput) (req *request.Request, output *CreateTopicOutput) {
+	op := &request.Operation{
 		Name:       opCreateTopic,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -180,8 +180,8 @@ func (c *SNS) CreateTopic(input *CreateTopicInput) (*CreateTopicOutput, error) {
 const opDeleteEndpoint = "DeleteEndpoint"
 
 // DeleteEndpointRequest generates a request for the DeleteEndpoint operation.
-func (c *SNS) DeleteEndpointRequest(input *DeleteEndpointInput) (req *service.Request, output *DeleteEndpointOutput) {
-	op := &service.Operation{
+func (c *SNS) DeleteEndpointRequest(input *DeleteEndpointInput) (req *request.Request, output *DeleteEndpointOutput) {
+	op := &request.Operation{
 		Name:       opDeleteEndpoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -208,8 +208,8 @@ func (c *SNS) DeleteEndpoint(input *DeleteEndpointInput) (*DeleteEndpointOutput,
 const opDeletePlatformApplication = "DeletePlatformApplication"
 
 // DeletePlatformApplicationRequest generates a request for the DeletePlatformApplication operation.
-func (c *SNS) DeletePlatformApplicationRequest(input *DeletePlatformApplicationInput) (req *service.Request, output *DeletePlatformApplicationOutput) {
-	op := &service.Operation{
+func (c *SNS) DeletePlatformApplicationRequest(input *DeletePlatformApplicationInput) (req *request.Request, output *DeletePlatformApplicationOutput) {
+	op := &request.Operation{
 		Name:       opDeletePlatformApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -237,8 +237,8 @@ func (c *SNS) DeletePlatformApplication(input *DeletePlatformApplicationInput) (
 const opDeleteTopic = "DeleteTopic"
 
 // DeleteTopicRequest generates a request for the DeleteTopic operation.
-func (c *SNS) DeleteTopicRequest(input *DeleteTopicInput) (req *service.Request, output *DeleteTopicOutput) {
-	op := &service.Operation{
+func (c *SNS) DeleteTopicRequest(input *DeleteTopicInput) (req *request.Request, output *DeleteTopicOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTopic,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -267,8 +267,8 @@ func (c *SNS) DeleteTopic(input *DeleteTopicInput) (*DeleteTopicOutput, error) {
 const opGetEndpointAttributes = "GetEndpointAttributes"
 
 // GetEndpointAttributesRequest generates a request for the GetEndpointAttributes operation.
-func (c *SNS) GetEndpointAttributesRequest(input *GetEndpointAttributesInput) (req *service.Request, output *GetEndpointAttributesOutput) {
-	op := &service.Operation{
+func (c *SNS) GetEndpointAttributesRequest(input *GetEndpointAttributesInput) (req *request.Request, output *GetEndpointAttributesOutput) {
+	op := &request.Operation{
 		Name:       opGetEndpointAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -296,8 +296,8 @@ func (c *SNS) GetEndpointAttributes(input *GetEndpointAttributesInput) (*GetEndp
 const opGetPlatformApplicationAttributes = "GetPlatformApplicationAttributes"
 
 // GetPlatformApplicationAttributesRequest generates a request for the GetPlatformApplicationAttributes operation.
-func (c *SNS) GetPlatformApplicationAttributesRequest(input *GetPlatformApplicationAttributesInput) (req *service.Request, output *GetPlatformApplicationAttributesOutput) {
-	op := &service.Operation{
+func (c *SNS) GetPlatformApplicationAttributesRequest(input *GetPlatformApplicationAttributesInput) (req *request.Request, output *GetPlatformApplicationAttributesOutput) {
+	op := &request.Operation{
 		Name:       opGetPlatformApplicationAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -325,8 +325,8 @@ func (c *SNS) GetPlatformApplicationAttributes(input *GetPlatformApplicationAttr
 const opGetSubscriptionAttributes = "GetSubscriptionAttributes"
 
 // GetSubscriptionAttributesRequest generates a request for the GetSubscriptionAttributes operation.
-func (c *SNS) GetSubscriptionAttributesRequest(input *GetSubscriptionAttributesInput) (req *service.Request, output *GetSubscriptionAttributesOutput) {
-	op := &service.Operation{
+func (c *SNS) GetSubscriptionAttributesRequest(input *GetSubscriptionAttributesInput) (req *request.Request, output *GetSubscriptionAttributesOutput) {
+	op := &request.Operation{
 		Name:       opGetSubscriptionAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -352,8 +352,8 @@ func (c *SNS) GetSubscriptionAttributes(input *GetSubscriptionAttributesInput) (
 const opGetTopicAttributes = "GetTopicAttributes"
 
 // GetTopicAttributesRequest generates a request for the GetTopicAttributes operation.
-func (c *SNS) GetTopicAttributesRequest(input *GetTopicAttributesInput) (req *service.Request, output *GetTopicAttributesOutput) {
-	op := &service.Operation{
+func (c *SNS) GetTopicAttributesRequest(input *GetTopicAttributesInput) (req *request.Request, output *GetTopicAttributesOutput) {
+	op := &request.Operation{
 		Name:       opGetTopicAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -380,12 +380,12 @@ func (c *SNS) GetTopicAttributes(input *GetTopicAttributesInput) (*GetTopicAttri
 const opListEndpointsByPlatformApplication = "ListEndpointsByPlatformApplication"
 
 // ListEndpointsByPlatformApplicationRequest generates a request for the ListEndpointsByPlatformApplication operation.
-func (c *SNS) ListEndpointsByPlatformApplicationRequest(input *ListEndpointsByPlatformApplicationInput) (req *service.Request, output *ListEndpointsByPlatformApplicationOutput) {
-	op := &service.Operation{
+func (c *SNS) ListEndpointsByPlatformApplicationRequest(input *ListEndpointsByPlatformApplicationInput) (req *request.Request, output *ListEndpointsByPlatformApplicationOutput) {
+	op := &request.Operation{
 		Name:       opListEndpointsByPlatformApplication,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -427,12 +427,12 @@ func (c *SNS) ListEndpointsByPlatformApplicationPages(input *ListEndpointsByPlat
 const opListPlatformApplications = "ListPlatformApplications"
 
 // ListPlatformApplicationsRequest generates a request for the ListPlatformApplications operation.
-func (c *SNS) ListPlatformApplicationsRequest(input *ListPlatformApplicationsInput) (req *service.Request, output *ListPlatformApplicationsOutput) {
-	op := &service.Operation{
+func (c *SNS) ListPlatformApplicationsRequest(input *ListPlatformApplicationsInput) (req *request.Request, output *ListPlatformApplicationsOutput) {
+	op := &request.Operation{
 		Name:       opListPlatformApplications,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -474,12 +474,12 @@ func (c *SNS) ListPlatformApplicationsPages(input *ListPlatformApplicationsInput
 const opListSubscriptions = "ListSubscriptions"
 
 // ListSubscriptionsRequest generates a request for the ListSubscriptions operation.
-func (c *SNS) ListSubscriptionsRequest(input *ListSubscriptionsInput) (req *service.Request, output *ListSubscriptionsOutput) {
-	op := &service.Operation{
+func (c *SNS) ListSubscriptionsRequest(input *ListSubscriptionsInput) (req *request.Request, output *ListSubscriptionsOutput) {
+	op := &request.Operation{
 		Name:       opListSubscriptions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -517,12 +517,12 @@ func (c *SNS) ListSubscriptionsPages(input *ListSubscriptionsInput, fn func(p *L
 const opListSubscriptionsByTopic = "ListSubscriptionsByTopic"
 
 // ListSubscriptionsByTopicRequest generates a request for the ListSubscriptionsByTopic operation.
-func (c *SNS) ListSubscriptionsByTopicRequest(input *ListSubscriptionsByTopicInput) (req *service.Request, output *ListSubscriptionsByTopicOutput) {
-	op := &service.Operation{
+func (c *SNS) ListSubscriptionsByTopicRequest(input *ListSubscriptionsByTopicInput) (req *request.Request, output *ListSubscriptionsByTopicOutput) {
+	op := &request.Operation{
 		Name:       opListSubscriptionsByTopic,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -560,12 +560,12 @@ func (c *SNS) ListSubscriptionsByTopicPages(input *ListSubscriptionsByTopicInput
 const opListTopics = "ListTopics"
 
 // ListTopicsRequest generates a request for the ListTopics operation.
-func (c *SNS) ListTopicsRequest(input *ListTopicsInput) (req *service.Request, output *ListTopicsOutput) {
-	op := &service.Operation{
+func (c *SNS) ListTopicsRequest(input *ListTopicsInput) (req *request.Request, output *ListTopicsOutput) {
+	op := &request.Operation{
 		Name:       opListTopics,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -602,8 +602,8 @@ func (c *SNS) ListTopicsPages(input *ListTopicsInput, fn func(p *ListTopicsOutpu
 const opPublish = "Publish"
 
 // PublishRequest generates a request for the Publish operation.
-func (c *SNS) PublishRequest(input *PublishInput) (req *service.Request, output *PublishOutput) {
-	op := &service.Operation{
+func (c *SNS) PublishRequest(input *PublishInput) (req *request.Request, output *PublishOutput) {
+	op := &request.Operation{
 		Name:       opPublish,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -638,8 +638,8 @@ func (c *SNS) Publish(input *PublishInput) (*PublishOutput, error) {
 const opRemovePermission = "RemovePermission"
 
 // RemovePermissionRequest generates a request for the RemovePermission operation.
-func (c *SNS) RemovePermissionRequest(input *RemovePermissionInput) (req *service.Request, output *RemovePermissionOutput) {
-	op := &service.Operation{
+func (c *SNS) RemovePermissionRequest(input *RemovePermissionInput) (req *request.Request, output *RemovePermissionOutput) {
+	op := &request.Operation{
 		Name:       opRemovePermission,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -665,8 +665,8 @@ func (c *SNS) RemovePermission(input *RemovePermissionInput) (*RemovePermissionO
 const opSetEndpointAttributes = "SetEndpointAttributes"
 
 // SetEndpointAttributesRequest generates a request for the SetEndpointAttributes operation.
-func (c *SNS) SetEndpointAttributesRequest(input *SetEndpointAttributesInput) (req *service.Request, output *SetEndpointAttributesOutput) {
-	op := &service.Operation{
+func (c *SNS) SetEndpointAttributesRequest(input *SetEndpointAttributesInput) (req *request.Request, output *SetEndpointAttributesOutput) {
+	op := &request.Operation{
 		Name:       opSetEndpointAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -694,8 +694,8 @@ func (c *SNS) SetEndpointAttributes(input *SetEndpointAttributesInput) (*SetEndp
 const opSetPlatformApplicationAttributes = "SetPlatformApplicationAttributes"
 
 // SetPlatformApplicationAttributesRequest generates a request for the SetPlatformApplicationAttributes operation.
-func (c *SNS) SetPlatformApplicationAttributesRequest(input *SetPlatformApplicationAttributesInput) (req *service.Request, output *SetPlatformApplicationAttributesOutput) {
-	op := &service.Operation{
+func (c *SNS) SetPlatformApplicationAttributesRequest(input *SetPlatformApplicationAttributesInput) (req *request.Request, output *SetPlatformApplicationAttributesOutput) {
+	op := &request.Operation{
 		Name:       opSetPlatformApplicationAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -723,8 +723,8 @@ func (c *SNS) SetPlatformApplicationAttributes(input *SetPlatformApplicationAttr
 const opSetSubscriptionAttributes = "SetSubscriptionAttributes"
 
 // SetSubscriptionAttributesRequest generates a request for the SetSubscriptionAttributes operation.
-func (c *SNS) SetSubscriptionAttributesRequest(input *SetSubscriptionAttributesInput) (req *service.Request, output *SetSubscriptionAttributesOutput) {
-	op := &service.Operation{
+func (c *SNS) SetSubscriptionAttributesRequest(input *SetSubscriptionAttributesInput) (req *request.Request, output *SetSubscriptionAttributesOutput) {
+	op := &request.Operation{
 		Name:       opSetSubscriptionAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -750,8 +750,8 @@ func (c *SNS) SetSubscriptionAttributes(input *SetSubscriptionAttributesInput) (
 const opSetTopicAttributes = "SetTopicAttributes"
 
 // SetTopicAttributesRequest generates a request for the SetTopicAttributes operation.
-func (c *SNS) SetTopicAttributesRequest(input *SetTopicAttributesInput) (req *service.Request, output *SetTopicAttributesOutput) {
-	op := &service.Operation{
+func (c *SNS) SetTopicAttributesRequest(input *SetTopicAttributesInput) (req *request.Request, output *SetTopicAttributesOutput) {
+	op := &request.Operation{
 		Name:       opSetTopicAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -777,8 +777,8 @@ func (c *SNS) SetTopicAttributes(input *SetTopicAttributesInput) (*SetTopicAttri
 const opSubscribe = "Subscribe"
 
 // SubscribeRequest generates a request for the Subscribe operation.
-func (c *SNS) SubscribeRequest(input *SubscribeInput) (req *service.Request, output *SubscribeOutput) {
-	op := &service.Operation{
+func (c *SNS) SubscribeRequest(input *SubscribeInput) (req *request.Request, output *SubscribeOutput) {
+	op := &request.Operation{
 		Name:       opSubscribe,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -807,8 +807,8 @@ func (c *SNS) Subscribe(input *SubscribeInput) (*SubscribeOutput, error) {
 const opUnsubscribe = "Unsubscribe"
 
 // UnsubscribeRequest generates a request for the Unsubscribe operation.
-func (c *SNS) UnsubscribeRequest(input *UnsubscribeInput) (req *service.Request, output *UnsubscribeOutput) {
-	op := &service.Operation{
+func (c *SNS) UnsubscribeRequest(input *UnsubscribeInput) (req *request.Request, output *UnsubscribeOutput) {
+	op := &request.Operation{
 		Name:       opUnsubscribe,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/sns/service.go
+++ b/service/sns/service.go
@@ -5,7 +5,9 @@ package sns
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -31,14 +33,16 @@ type SNS struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new SNS client.
 func New(config *aws.Config) *SNS {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "sns",
-		APIVersion:  "2010-03-31",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "sns",
+			APIVersion:  "2010-03-31",
+		},
 	}
 	service.Initialize()
 
@@ -59,8 +63,8 @@ func New(config *aws.Config) *SNS {
 
 // newRequest creates a new request for a SNS operation and runs any
 // custom request initialization.
-func (c *SNS) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *SNS) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/sns/snsiface/interface.go
+++ b/service/sns/snsiface/interface.go
@@ -4,119 +4,119 @@
 package snsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sns"
 )
 
 // SNSAPI is the interface type for sns.SNS.
 type SNSAPI interface {
-	AddPermissionRequest(*sns.AddPermissionInput) (*service.Request, *sns.AddPermissionOutput)
+	AddPermissionRequest(*sns.AddPermissionInput) (*request.Request, *sns.AddPermissionOutput)
 
 	AddPermission(*sns.AddPermissionInput) (*sns.AddPermissionOutput, error)
 
-	ConfirmSubscriptionRequest(*sns.ConfirmSubscriptionInput) (*service.Request, *sns.ConfirmSubscriptionOutput)
+	ConfirmSubscriptionRequest(*sns.ConfirmSubscriptionInput) (*request.Request, *sns.ConfirmSubscriptionOutput)
 
 	ConfirmSubscription(*sns.ConfirmSubscriptionInput) (*sns.ConfirmSubscriptionOutput, error)
 
-	CreatePlatformApplicationRequest(*sns.CreatePlatformApplicationInput) (*service.Request, *sns.CreatePlatformApplicationOutput)
+	CreatePlatformApplicationRequest(*sns.CreatePlatformApplicationInput) (*request.Request, *sns.CreatePlatformApplicationOutput)
 
 	CreatePlatformApplication(*sns.CreatePlatformApplicationInput) (*sns.CreatePlatformApplicationOutput, error)
 
-	CreatePlatformEndpointRequest(*sns.CreatePlatformEndpointInput) (*service.Request, *sns.CreatePlatformEndpointOutput)
+	CreatePlatformEndpointRequest(*sns.CreatePlatformEndpointInput) (*request.Request, *sns.CreatePlatformEndpointOutput)
 
 	CreatePlatformEndpoint(*sns.CreatePlatformEndpointInput) (*sns.CreatePlatformEndpointOutput, error)
 
-	CreateTopicRequest(*sns.CreateTopicInput) (*service.Request, *sns.CreateTopicOutput)
+	CreateTopicRequest(*sns.CreateTopicInput) (*request.Request, *sns.CreateTopicOutput)
 
 	CreateTopic(*sns.CreateTopicInput) (*sns.CreateTopicOutput, error)
 
-	DeleteEndpointRequest(*sns.DeleteEndpointInput) (*service.Request, *sns.DeleteEndpointOutput)
+	DeleteEndpointRequest(*sns.DeleteEndpointInput) (*request.Request, *sns.DeleteEndpointOutput)
 
 	DeleteEndpoint(*sns.DeleteEndpointInput) (*sns.DeleteEndpointOutput, error)
 
-	DeletePlatformApplicationRequest(*sns.DeletePlatformApplicationInput) (*service.Request, *sns.DeletePlatformApplicationOutput)
+	DeletePlatformApplicationRequest(*sns.DeletePlatformApplicationInput) (*request.Request, *sns.DeletePlatformApplicationOutput)
 
 	DeletePlatformApplication(*sns.DeletePlatformApplicationInput) (*sns.DeletePlatformApplicationOutput, error)
 
-	DeleteTopicRequest(*sns.DeleteTopicInput) (*service.Request, *sns.DeleteTopicOutput)
+	DeleteTopicRequest(*sns.DeleteTopicInput) (*request.Request, *sns.DeleteTopicOutput)
 
 	DeleteTopic(*sns.DeleteTopicInput) (*sns.DeleteTopicOutput, error)
 
-	GetEndpointAttributesRequest(*sns.GetEndpointAttributesInput) (*service.Request, *sns.GetEndpointAttributesOutput)
+	GetEndpointAttributesRequest(*sns.GetEndpointAttributesInput) (*request.Request, *sns.GetEndpointAttributesOutput)
 
 	GetEndpointAttributes(*sns.GetEndpointAttributesInput) (*sns.GetEndpointAttributesOutput, error)
 
-	GetPlatformApplicationAttributesRequest(*sns.GetPlatformApplicationAttributesInput) (*service.Request, *sns.GetPlatformApplicationAttributesOutput)
+	GetPlatformApplicationAttributesRequest(*sns.GetPlatformApplicationAttributesInput) (*request.Request, *sns.GetPlatformApplicationAttributesOutput)
 
 	GetPlatformApplicationAttributes(*sns.GetPlatformApplicationAttributesInput) (*sns.GetPlatformApplicationAttributesOutput, error)
 
-	GetSubscriptionAttributesRequest(*sns.GetSubscriptionAttributesInput) (*service.Request, *sns.GetSubscriptionAttributesOutput)
+	GetSubscriptionAttributesRequest(*sns.GetSubscriptionAttributesInput) (*request.Request, *sns.GetSubscriptionAttributesOutput)
 
 	GetSubscriptionAttributes(*sns.GetSubscriptionAttributesInput) (*sns.GetSubscriptionAttributesOutput, error)
 
-	GetTopicAttributesRequest(*sns.GetTopicAttributesInput) (*service.Request, *sns.GetTopicAttributesOutput)
+	GetTopicAttributesRequest(*sns.GetTopicAttributesInput) (*request.Request, *sns.GetTopicAttributesOutput)
 
 	GetTopicAttributes(*sns.GetTopicAttributesInput) (*sns.GetTopicAttributesOutput, error)
 
-	ListEndpointsByPlatformApplicationRequest(*sns.ListEndpointsByPlatformApplicationInput) (*service.Request, *sns.ListEndpointsByPlatformApplicationOutput)
+	ListEndpointsByPlatformApplicationRequest(*sns.ListEndpointsByPlatformApplicationInput) (*request.Request, *sns.ListEndpointsByPlatformApplicationOutput)
 
 	ListEndpointsByPlatformApplication(*sns.ListEndpointsByPlatformApplicationInput) (*sns.ListEndpointsByPlatformApplicationOutput, error)
 
 	ListEndpointsByPlatformApplicationPages(*sns.ListEndpointsByPlatformApplicationInput, func(*sns.ListEndpointsByPlatformApplicationOutput, bool) bool) error
 
-	ListPlatformApplicationsRequest(*sns.ListPlatformApplicationsInput) (*service.Request, *sns.ListPlatformApplicationsOutput)
+	ListPlatformApplicationsRequest(*sns.ListPlatformApplicationsInput) (*request.Request, *sns.ListPlatformApplicationsOutput)
 
 	ListPlatformApplications(*sns.ListPlatformApplicationsInput) (*sns.ListPlatformApplicationsOutput, error)
 
 	ListPlatformApplicationsPages(*sns.ListPlatformApplicationsInput, func(*sns.ListPlatformApplicationsOutput, bool) bool) error
 
-	ListSubscriptionsRequest(*sns.ListSubscriptionsInput) (*service.Request, *sns.ListSubscriptionsOutput)
+	ListSubscriptionsRequest(*sns.ListSubscriptionsInput) (*request.Request, *sns.ListSubscriptionsOutput)
 
 	ListSubscriptions(*sns.ListSubscriptionsInput) (*sns.ListSubscriptionsOutput, error)
 
 	ListSubscriptionsPages(*sns.ListSubscriptionsInput, func(*sns.ListSubscriptionsOutput, bool) bool) error
 
-	ListSubscriptionsByTopicRequest(*sns.ListSubscriptionsByTopicInput) (*service.Request, *sns.ListSubscriptionsByTopicOutput)
+	ListSubscriptionsByTopicRequest(*sns.ListSubscriptionsByTopicInput) (*request.Request, *sns.ListSubscriptionsByTopicOutput)
 
 	ListSubscriptionsByTopic(*sns.ListSubscriptionsByTopicInput) (*sns.ListSubscriptionsByTopicOutput, error)
 
 	ListSubscriptionsByTopicPages(*sns.ListSubscriptionsByTopicInput, func(*sns.ListSubscriptionsByTopicOutput, bool) bool) error
 
-	ListTopicsRequest(*sns.ListTopicsInput) (*service.Request, *sns.ListTopicsOutput)
+	ListTopicsRequest(*sns.ListTopicsInput) (*request.Request, *sns.ListTopicsOutput)
 
 	ListTopics(*sns.ListTopicsInput) (*sns.ListTopicsOutput, error)
 
 	ListTopicsPages(*sns.ListTopicsInput, func(*sns.ListTopicsOutput, bool) bool) error
 
-	PublishRequest(*sns.PublishInput) (*service.Request, *sns.PublishOutput)
+	PublishRequest(*sns.PublishInput) (*request.Request, *sns.PublishOutput)
 
 	Publish(*sns.PublishInput) (*sns.PublishOutput, error)
 
-	RemovePermissionRequest(*sns.RemovePermissionInput) (*service.Request, *sns.RemovePermissionOutput)
+	RemovePermissionRequest(*sns.RemovePermissionInput) (*request.Request, *sns.RemovePermissionOutput)
 
 	RemovePermission(*sns.RemovePermissionInput) (*sns.RemovePermissionOutput, error)
 
-	SetEndpointAttributesRequest(*sns.SetEndpointAttributesInput) (*service.Request, *sns.SetEndpointAttributesOutput)
+	SetEndpointAttributesRequest(*sns.SetEndpointAttributesInput) (*request.Request, *sns.SetEndpointAttributesOutput)
 
 	SetEndpointAttributes(*sns.SetEndpointAttributesInput) (*sns.SetEndpointAttributesOutput, error)
 
-	SetPlatformApplicationAttributesRequest(*sns.SetPlatformApplicationAttributesInput) (*service.Request, *sns.SetPlatformApplicationAttributesOutput)
+	SetPlatformApplicationAttributesRequest(*sns.SetPlatformApplicationAttributesInput) (*request.Request, *sns.SetPlatformApplicationAttributesOutput)
 
 	SetPlatformApplicationAttributes(*sns.SetPlatformApplicationAttributesInput) (*sns.SetPlatformApplicationAttributesOutput, error)
 
-	SetSubscriptionAttributesRequest(*sns.SetSubscriptionAttributesInput) (*service.Request, *sns.SetSubscriptionAttributesOutput)
+	SetSubscriptionAttributesRequest(*sns.SetSubscriptionAttributesInput) (*request.Request, *sns.SetSubscriptionAttributesOutput)
 
 	SetSubscriptionAttributes(*sns.SetSubscriptionAttributesInput) (*sns.SetSubscriptionAttributesOutput, error)
 
-	SetTopicAttributesRequest(*sns.SetTopicAttributesInput) (*service.Request, *sns.SetTopicAttributesOutput)
+	SetTopicAttributesRequest(*sns.SetTopicAttributesInput) (*request.Request, *sns.SetTopicAttributesOutput)
 
 	SetTopicAttributes(*sns.SetTopicAttributesInput) (*sns.SetTopicAttributesOutput, error)
 
-	SubscribeRequest(*sns.SubscribeInput) (*service.Request, *sns.SubscribeOutput)
+	SubscribeRequest(*sns.SubscribeInput) (*request.Request, *sns.SubscribeOutput)
 
 	Subscribe(*sns.SubscribeInput) (*sns.SubscribeOutput, error)
 
-	UnsubscribeRequest(*sns.UnsubscribeInput) (*service.Request, *sns.UnsubscribeOutput)
+	UnsubscribeRequest(*sns.UnsubscribeInput) (*request.Request, *sns.UnsubscribeOutput)
 
 	Unsubscribe(*sns.UnsubscribeInput) (*sns.UnsubscribeOutput, error)
 }

--- a/service/sqs/api.go
+++ b/service/sqs/api.go
@@ -5,14 +5,14 @@ package sqs
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddPermission = "AddPermission"
 
 // AddPermissionRequest generates a request for the AddPermission operation.
-func (c *SQS) AddPermissionRequest(input *AddPermissionInput) (req *service.Request, output *AddPermissionOutput) {
-	op := &service.Operation{
+func (c *SQS) AddPermissionRequest(input *AddPermissionInput) (req *request.Request, output *AddPermissionOutput) {
+	op := &request.Operation{
 		Name:       opAddPermission,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -55,8 +55,8 @@ func (c *SQS) AddPermission(input *AddPermissionInput) (*AddPermissionOutput, er
 const opChangeMessageVisibility = "ChangeMessageVisibility"
 
 // ChangeMessageVisibilityRequest generates a request for the ChangeMessageVisibility operation.
-func (c *SQS) ChangeMessageVisibilityRequest(input *ChangeMessageVisibilityInput) (req *service.Request, output *ChangeMessageVisibilityOutput) {
-	op := &service.Operation{
+func (c *SQS) ChangeMessageVisibilityRequest(input *ChangeMessageVisibilityInput) (req *request.Request, output *ChangeMessageVisibilityOutput) {
+	op := &request.Operation{
 		Name:       opChangeMessageVisibility,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -111,8 +111,8 @@ func (c *SQS) ChangeMessageVisibility(input *ChangeMessageVisibilityInput) (*Cha
 const opChangeMessageVisibilityBatch = "ChangeMessageVisibilityBatch"
 
 // ChangeMessageVisibilityBatchRequest generates a request for the ChangeMessageVisibilityBatch operation.
-func (c *SQS) ChangeMessageVisibilityBatchRequest(input *ChangeMessageVisibilityBatchInput) (req *service.Request, output *ChangeMessageVisibilityBatchOutput) {
-	op := &service.Operation{
+func (c *SQS) ChangeMessageVisibilityBatchRequest(input *ChangeMessageVisibilityBatchInput) (req *request.Request, output *ChangeMessageVisibilityBatchOutput) {
+	op := &request.Operation{
 		Name:       opChangeMessageVisibilityBatch,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -150,8 +150,8 @@ func (c *SQS) ChangeMessageVisibilityBatch(input *ChangeMessageVisibilityBatchIn
 const opCreateQueue = "CreateQueue"
 
 // CreateQueueRequest generates a request for the CreateQueue operation.
-func (c *SQS) CreateQueueRequest(input *CreateQueueInput) (req *service.Request, output *CreateQueueOutput) {
-	op := &service.Operation{
+func (c *SQS) CreateQueueRequest(input *CreateQueueInput) (req *request.Request, output *CreateQueueOutput) {
+	op := &request.Operation{
 		Name:       opCreateQueue,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -201,8 +201,8 @@ func (c *SQS) CreateQueue(input *CreateQueueInput) (*CreateQueueOutput, error) {
 const opDeleteMessage = "DeleteMessage"
 
 // DeleteMessageRequest generates a request for the DeleteMessage operation.
-func (c *SQS) DeleteMessageRequest(input *DeleteMessageInput) (req *service.Request, output *DeleteMessageOutput) {
-	op := &service.Operation{
+func (c *SQS) DeleteMessageRequest(input *DeleteMessageInput) (req *request.Request, output *DeleteMessageOutput) {
+	op := &request.Operation{
 		Name:       opDeleteMessage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -247,8 +247,8 @@ func (c *SQS) DeleteMessage(input *DeleteMessageInput) (*DeleteMessageOutput, er
 const opDeleteMessageBatch = "DeleteMessageBatch"
 
 // DeleteMessageBatchRequest generates a request for the DeleteMessageBatch operation.
-func (c *SQS) DeleteMessageBatchRequest(input *DeleteMessageBatchInput) (req *service.Request, output *DeleteMessageBatchOutput) {
-	op := &service.Operation{
+func (c *SQS) DeleteMessageBatchRequest(input *DeleteMessageBatchInput) (req *request.Request, output *DeleteMessageBatchOutput) {
+	op := &request.Operation{
 		Name:       opDeleteMessageBatch,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -286,8 +286,8 @@ func (c *SQS) DeleteMessageBatch(input *DeleteMessageBatchInput) (*DeleteMessage
 const opDeleteQueue = "DeleteQueue"
 
 // DeleteQueueRequest generates a request for the DeleteQueue operation.
-func (c *SQS) DeleteQueueRequest(input *DeleteQueueInput) (req *service.Request, output *DeleteQueueOutput) {
-	op := &service.Operation{
+func (c *SQS) DeleteQueueRequest(input *DeleteQueueInput) (req *request.Request, output *DeleteQueueOutput) {
+	op := &request.Operation{
 		Name:       opDeleteQueue,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -329,8 +329,8 @@ func (c *SQS) DeleteQueue(input *DeleteQueueInput) (*DeleteQueueOutput, error) {
 const opGetQueueAttributes = "GetQueueAttributes"
 
 // GetQueueAttributesRequest generates a request for the GetQueueAttributes operation.
-func (c *SQS) GetQueueAttributesRequest(input *GetQueueAttributesInput) (req *service.Request, output *GetQueueAttributesOutput) {
-	op := &service.Operation{
+func (c *SQS) GetQueueAttributesRequest(input *GetQueueAttributesInput) (req *request.Request, output *GetQueueAttributesOutput) {
+	op := &request.Operation{
 		Name:       opGetQueueAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -390,8 +390,8 @@ func (c *SQS) GetQueueAttributes(input *GetQueueAttributesInput) (*GetQueueAttri
 const opGetQueueUrl = "GetQueueUrl"
 
 // GetQueueUrlRequest generates a request for the GetQueueUrl operation.
-func (c *SQS) GetQueueUrlRequest(input *GetQueueUrlInput) (req *service.Request, output *GetQueueUrlOutput) {
-	op := &service.Operation{
+func (c *SQS) GetQueueUrlRequest(input *GetQueueUrlInput) (req *request.Request, output *GetQueueUrlOutput) {
+	op := &request.Operation{
 		Name:       opGetQueueUrl,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -424,8 +424,8 @@ func (c *SQS) GetQueueUrl(input *GetQueueUrlInput) (*GetQueueUrlOutput, error) {
 const opListDeadLetterSourceQueues = "ListDeadLetterSourceQueues"
 
 // ListDeadLetterSourceQueuesRequest generates a request for the ListDeadLetterSourceQueues operation.
-func (c *SQS) ListDeadLetterSourceQueuesRequest(input *ListDeadLetterSourceQueuesInput) (req *service.Request, output *ListDeadLetterSourceQueuesOutput) {
-	op := &service.Operation{
+func (c *SQS) ListDeadLetterSourceQueuesRequest(input *ListDeadLetterSourceQueuesInput) (req *request.Request, output *ListDeadLetterSourceQueuesOutput) {
+	op := &request.Operation{
 		Name:       opListDeadLetterSourceQueues,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -455,8 +455,8 @@ func (c *SQS) ListDeadLetterSourceQueues(input *ListDeadLetterSourceQueuesInput)
 const opListQueues = "ListQueues"
 
 // ListQueuesRequest generates a request for the ListQueues operation.
-func (c *SQS) ListQueuesRequest(input *ListQueuesInput) (req *service.Request, output *ListQueuesOutput) {
-	op := &service.Operation{
+func (c *SQS) ListQueuesRequest(input *ListQueuesInput) (req *request.Request, output *ListQueuesOutput) {
+	op := &request.Operation{
 		Name:       opListQueues,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -484,8 +484,8 @@ func (c *SQS) ListQueues(input *ListQueuesInput) (*ListQueuesOutput, error) {
 const opPurgeQueue = "PurgeQueue"
 
 // PurgeQueueRequest generates a request for the PurgeQueue operation.
-func (c *SQS) PurgeQueueRequest(input *PurgeQueueInput) (req *service.Request, output *PurgeQueueOutput) {
-	op := &service.Operation{
+func (c *SQS) PurgeQueueRequest(input *PurgeQueueInput) (req *request.Request, output *PurgeQueueOutput) {
+	op := &request.Operation{
 		Name:       opPurgeQueue,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -519,8 +519,8 @@ func (c *SQS) PurgeQueue(input *PurgeQueueInput) (*PurgeQueueOutput, error) {
 const opReceiveMessage = "ReceiveMessage"
 
 // ReceiveMessageRequest generates a request for the ReceiveMessage operation.
-func (c *SQS) ReceiveMessageRequest(input *ReceiveMessageInput) (req *service.Request, output *ReceiveMessageOutput) {
-	op := &service.Operation{
+func (c *SQS) ReceiveMessageRequest(input *ReceiveMessageInput) (req *request.Request, output *ReceiveMessageOutput) {
+	op := &request.Operation{
 		Name:       opReceiveMessage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -587,8 +587,8 @@ func (c *SQS) ReceiveMessage(input *ReceiveMessageInput) (*ReceiveMessageOutput,
 const opRemovePermission = "RemovePermission"
 
 // RemovePermissionRequest generates a request for the RemovePermission operation.
-func (c *SQS) RemovePermissionRequest(input *RemovePermissionInput) (req *service.Request, output *RemovePermissionOutput) {
-	op := &service.Operation{
+func (c *SQS) RemovePermissionRequest(input *RemovePermissionInput) (req *request.Request, output *RemovePermissionOutput) {
+	op := &request.Operation{
 		Name:       opRemovePermission,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -615,8 +615,8 @@ func (c *SQS) RemovePermission(input *RemovePermissionInput) (*RemovePermissionO
 const opSendMessage = "SendMessage"
 
 // SendMessageRequest generates a request for the SendMessage operation.
-func (c *SQS) SendMessageRequest(input *SendMessageInput) (req *service.Request, output *SendMessageOutput) {
-	op := &service.Operation{
+func (c *SQS) SendMessageRequest(input *SendMessageInput) (req *request.Request, output *SendMessageOutput) {
+	op := &request.Operation{
 		Name:       opSendMessage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -653,8 +653,8 @@ func (c *SQS) SendMessage(input *SendMessageInput) (*SendMessageOutput, error) {
 const opSendMessageBatch = "SendMessageBatch"
 
 // SendMessageBatchRequest generates a request for the SendMessageBatch operation.
-func (c *SQS) SendMessageBatchRequest(input *SendMessageBatchInput) (req *service.Request, output *SendMessageBatchOutput) {
-	op := &service.Operation{
+func (c *SQS) SendMessageBatchRequest(input *SendMessageBatchInput) (req *request.Request, output *SendMessageBatchOutput) {
+	op := &request.Operation{
 		Name:       opSendMessageBatch,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -705,8 +705,8 @@ func (c *SQS) SendMessageBatch(input *SendMessageBatchInput) (*SendMessageBatchO
 const opSetQueueAttributes = "SetQueueAttributes"
 
 // SetQueueAttributesRequest generates a request for the SetQueueAttributes operation.
-func (c *SQS) SetQueueAttributesRequest(input *SetQueueAttributesInput) (req *service.Request, output *SetQueueAttributesOutput) {
-	op := &service.Operation{
+func (c *SQS) SetQueueAttributesRequest(input *SetQueueAttributesInput) (req *request.Request, output *SetQueueAttributesOutput) {
+	op := &request.Operation{
 		Name:       opSetQueueAttributes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/sqs/checksums.go
+++ b/service/sqs/checksums.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 var (
@@ -16,8 +16,8 @@ var (
 	errChecksumMissingMD5  = fmt.Errorf("cannot verify checksum. missing response MD5")
 )
 
-func setupChecksumValidation(r *service.Request) {
-	if aws.BoolValue(r.Config.DisableComputeChecksums) {
+func setupChecksumValidation(r *request.Request) {
+	if aws.BoolValue(r.Service.Config.DisableComputeChecksums) {
 		return
 	}
 
@@ -31,7 +31,7 @@ func setupChecksumValidation(r *service.Request) {
 	}
 }
 
-func verifySendMessage(r *service.Request) {
+func verifySendMessage(r *request.Request) {
 	if r.DataFilled() && r.ParamsFilled() {
 		in := r.Params.(*SendMessageInput)
 		out := r.Data.(*SendMessageOutput)
@@ -42,7 +42,7 @@ func verifySendMessage(r *service.Request) {
 	}
 }
 
-func verifySendMessageBatch(r *service.Request) {
+func verifySendMessageBatch(r *request.Request) {
 	if r.DataFilled() && r.ParamsFilled() {
 		entries := map[string]*SendMessageBatchResultEntry{}
 		ids := []string{}
@@ -67,7 +67,7 @@ func verifySendMessageBatch(r *service.Request) {
 	}
 }
 
-func verifyReceiveMessage(r *service.Request) {
+func verifyReceiveMessage(r *request.Request) {
 	if r.DataFilled() && r.ParamsFilled() {
 		ids := []string{}
 		out := r.Data.(*ReceiveMessageOutput)
@@ -99,7 +99,7 @@ func checksumsMatch(body, expectedMD5 *string) error {
 	return nil
 }
 
-func setChecksumError(r *service.Request, format string, args ...interface{}) {
+func setChecksumError(r *request.Request, format string, args ...interface{}) {
 	r.Retryable = aws.Bool(true)
 	r.Error = awserr.New("InvalidChecksum", fmt.Sprintf(format, args...), nil)
 }

--- a/service/sqs/checksums_test.go
+++ b/service/sqs/checksums_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/internal/test/unit"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func TestSendMessageChecksum(t *testing.T) {
 	req, _ := svc.SendMessageRequest(&sqs.SendMessageInput{
 		MessageBody: aws.String("test"),
 	})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{
@@ -44,7 +44,7 @@ func TestSendMessageChecksumInvalid(t *testing.T) {
 	req, _ := svc.SendMessageRequest(&sqs.SendMessageInput{
 		MessageBody: aws.String("test"),
 	})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{
@@ -69,7 +69,7 @@ func TestSendMessageChecksumInvalidNoValidation(t *testing.T) {
 	req, _ := s.SendMessageRequest(&sqs.SendMessageInput{
 		MessageBody: aws.String("test"),
 	})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{
@@ -83,7 +83,7 @@ func TestSendMessageChecksumInvalidNoValidation(t *testing.T) {
 
 func TestSendMessageChecksumNoInput(t *testing.T) {
 	req, _ := svc.SendMessageRequest(&sqs.SendMessageInput{})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{}
@@ -99,7 +99,7 @@ func TestSendMessageChecksumNoOutput(t *testing.T) {
 	req, _ := svc.SendMessageRequest(&sqs.SendMessageInput{
 		MessageBody: aws.String("test"),
 	})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
 		r.Data = &sqs.SendMessageOutput{}
@@ -113,7 +113,7 @@ func TestSendMessageChecksumNoOutput(t *testing.T) {
 
 func TestRecieveMessageChecksum(t *testing.T) {
 	req, _ := svc.ReceiveMessageRequest(&sqs.ReceiveMessageInput{})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		md5 := "098f6bcd4621d373cade4e832627b4f6"
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
@@ -132,7 +132,7 @@ func TestRecieveMessageChecksum(t *testing.T) {
 
 func TestRecieveMessageChecksumInvalid(t *testing.T) {
 	req, _ := svc.ReceiveMessageRequest(&sqs.ReceiveMessageInput{})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		md5 := "098f6bcd4621d373cade4e832627b4f6"
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
@@ -161,7 +161,7 @@ func TestSendMessageBatchChecksum(t *testing.T) {
 			{Id: aws.String("4"), MessageBody: aws.String("test")},
 		},
 	})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		md5 := "098f6bcd4621d373cade4e832627b4f6"
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}
@@ -187,7 +187,7 @@ func TestSendMessageBatchChecksumInvalid(t *testing.T) {
 			{Id: aws.String("4"), MessageBody: aws.String("test")},
 		},
 	})
-	req.Handlers.Send.PushBack(func(r *service.Request) {
+	req.Handlers.Send.PushBack(func(r *request.Request) {
 		md5 := "098f6bcd4621d373cade4e832627b4f6"
 		body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 		r.HTTPResponse = &http.Response{StatusCode: 200, Body: body}

--- a/service/sqs/customizations.go
+++ b/service/sqs/customizations.go
@@ -1,9 +1,9 @@
 package sqs
 
-import "github.com/aws/aws-sdk-go/aws/service"
+import "github.com/aws/aws-sdk-go/aws/request"
 
 func init() {
-	initRequest = func(r *service.Request) {
+	initRequest = func(r *request.Request) {
 		setupChecksumValidation(r)
 	}
 }

--- a/service/sqs/service.go
+++ b/service/sqs/service.go
@@ -5,7 +5,9 @@ package sqs
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -43,14 +45,16 @@ type SQS struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new SQS client.
 func New(config *aws.Config) *SQS {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "sqs",
-		APIVersion:  "2012-11-05",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "sqs",
+			APIVersion:  "2012-11-05",
+		},
 	}
 	service.Initialize()
 
@@ -71,8 +75,8 @@ func New(config *aws.Config) *SQS {
 
 // newRequest creates a new request for a SQS operation and runs any
 // custom request initialization.
-func (c *SQS) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *SQS) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/sqs/sqsiface/interface.go
+++ b/service/sqs/sqsiface/interface.go
@@ -4,77 +4,77 @@
 package sqsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 // SQSAPI is the interface type for sqs.SQS.
 type SQSAPI interface {
-	AddPermissionRequest(*sqs.AddPermissionInput) (*service.Request, *sqs.AddPermissionOutput)
+	AddPermissionRequest(*sqs.AddPermissionInput) (*request.Request, *sqs.AddPermissionOutput)
 
 	AddPermission(*sqs.AddPermissionInput) (*sqs.AddPermissionOutput, error)
 
-	ChangeMessageVisibilityRequest(*sqs.ChangeMessageVisibilityInput) (*service.Request, *sqs.ChangeMessageVisibilityOutput)
+	ChangeMessageVisibilityRequest(*sqs.ChangeMessageVisibilityInput) (*request.Request, *sqs.ChangeMessageVisibilityOutput)
 
 	ChangeMessageVisibility(*sqs.ChangeMessageVisibilityInput) (*sqs.ChangeMessageVisibilityOutput, error)
 
-	ChangeMessageVisibilityBatchRequest(*sqs.ChangeMessageVisibilityBatchInput) (*service.Request, *sqs.ChangeMessageVisibilityBatchOutput)
+	ChangeMessageVisibilityBatchRequest(*sqs.ChangeMessageVisibilityBatchInput) (*request.Request, *sqs.ChangeMessageVisibilityBatchOutput)
 
 	ChangeMessageVisibilityBatch(*sqs.ChangeMessageVisibilityBatchInput) (*sqs.ChangeMessageVisibilityBatchOutput, error)
 
-	CreateQueueRequest(*sqs.CreateQueueInput) (*service.Request, *sqs.CreateQueueOutput)
+	CreateQueueRequest(*sqs.CreateQueueInput) (*request.Request, *sqs.CreateQueueOutput)
 
 	CreateQueue(*sqs.CreateQueueInput) (*sqs.CreateQueueOutput, error)
 
-	DeleteMessageRequest(*sqs.DeleteMessageInput) (*service.Request, *sqs.DeleteMessageOutput)
+	DeleteMessageRequest(*sqs.DeleteMessageInput) (*request.Request, *sqs.DeleteMessageOutput)
 
 	DeleteMessage(*sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error)
 
-	DeleteMessageBatchRequest(*sqs.DeleteMessageBatchInput) (*service.Request, *sqs.DeleteMessageBatchOutput)
+	DeleteMessageBatchRequest(*sqs.DeleteMessageBatchInput) (*request.Request, *sqs.DeleteMessageBatchOutput)
 
 	DeleteMessageBatch(*sqs.DeleteMessageBatchInput) (*sqs.DeleteMessageBatchOutput, error)
 
-	DeleteQueueRequest(*sqs.DeleteQueueInput) (*service.Request, *sqs.DeleteQueueOutput)
+	DeleteQueueRequest(*sqs.DeleteQueueInput) (*request.Request, *sqs.DeleteQueueOutput)
 
 	DeleteQueue(*sqs.DeleteQueueInput) (*sqs.DeleteQueueOutput, error)
 
-	GetQueueAttributesRequest(*sqs.GetQueueAttributesInput) (*service.Request, *sqs.GetQueueAttributesOutput)
+	GetQueueAttributesRequest(*sqs.GetQueueAttributesInput) (*request.Request, *sqs.GetQueueAttributesOutput)
 
 	GetQueueAttributes(*sqs.GetQueueAttributesInput) (*sqs.GetQueueAttributesOutput, error)
 
-	GetQueueUrlRequest(*sqs.GetQueueUrlInput) (*service.Request, *sqs.GetQueueUrlOutput)
+	GetQueueUrlRequest(*sqs.GetQueueUrlInput) (*request.Request, *sqs.GetQueueUrlOutput)
 
 	GetQueueUrl(*sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error)
 
-	ListDeadLetterSourceQueuesRequest(*sqs.ListDeadLetterSourceQueuesInput) (*service.Request, *sqs.ListDeadLetterSourceQueuesOutput)
+	ListDeadLetterSourceQueuesRequest(*sqs.ListDeadLetterSourceQueuesInput) (*request.Request, *sqs.ListDeadLetterSourceQueuesOutput)
 
 	ListDeadLetterSourceQueues(*sqs.ListDeadLetterSourceQueuesInput) (*sqs.ListDeadLetterSourceQueuesOutput, error)
 
-	ListQueuesRequest(*sqs.ListQueuesInput) (*service.Request, *sqs.ListQueuesOutput)
+	ListQueuesRequest(*sqs.ListQueuesInput) (*request.Request, *sqs.ListQueuesOutput)
 
 	ListQueues(*sqs.ListQueuesInput) (*sqs.ListQueuesOutput, error)
 
-	PurgeQueueRequest(*sqs.PurgeQueueInput) (*service.Request, *sqs.PurgeQueueOutput)
+	PurgeQueueRequest(*sqs.PurgeQueueInput) (*request.Request, *sqs.PurgeQueueOutput)
 
 	PurgeQueue(*sqs.PurgeQueueInput) (*sqs.PurgeQueueOutput, error)
 
-	ReceiveMessageRequest(*sqs.ReceiveMessageInput) (*service.Request, *sqs.ReceiveMessageOutput)
+	ReceiveMessageRequest(*sqs.ReceiveMessageInput) (*request.Request, *sqs.ReceiveMessageOutput)
 
 	ReceiveMessage(*sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error)
 
-	RemovePermissionRequest(*sqs.RemovePermissionInput) (*service.Request, *sqs.RemovePermissionOutput)
+	RemovePermissionRequest(*sqs.RemovePermissionInput) (*request.Request, *sqs.RemovePermissionOutput)
 
 	RemovePermission(*sqs.RemovePermissionInput) (*sqs.RemovePermissionOutput, error)
 
-	SendMessageRequest(*sqs.SendMessageInput) (*service.Request, *sqs.SendMessageOutput)
+	SendMessageRequest(*sqs.SendMessageInput) (*request.Request, *sqs.SendMessageOutput)
 
 	SendMessage(*sqs.SendMessageInput) (*sqs.SendMessageOutput, error)
 
-	SendMessageBatchRequest(*sqs.SendMessageBatchInput) (*service.Request, *sqs.SendMessageBatchOutput)
+	SendMessageBatchRequest(*sqs.SendMessageBatchInput) (*request.Request, *sqs.SendMessageBatchOutput)
 
 	SendMessageBatch(*sqs.SendMessageBatchInput) (*sqs.SendMessageBatchOutput, error)
 
-	SetQueueAttributesRequest(*sqs.SetQueueAttributesInput) (*service.Request, *sqs.SetQueueAttributesOutput)
+	SetQueueAttributesRequest(*sqs.SetQueueAttributesInput) (*request.Request, *sqs.SetQueueAttributesOutput)
 
 	SetQueueAttributes(*sqs.SetQueueAttributesInput) (*sqs.SetQueueAttributesOutput, error)
 }

--- a/service/ssm/api.go
+++ b/service/ssm/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateAssociation = "CreateAssociation"
 
 // CreateAssociationRequest generates a request for the CreateAssociation operation.
-func (c *SSM) CreateAssociationRequest(input *CreateAssociationInput) (req *service.Request, output *CreateAssociationOutput) {
-	op := &service.Operation{
+func (c *SSM) CreateAssociationRequest(input *CreateAssociationInput) (req *request.Request, output *CreateAssociationOutput) {
+	op := &request.Operation{
 		Name:       opCreateAssociation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -48,8 +48,8 @@ func (c *SSM) CreateAssociation(input *CreateAssociationInput) (*CreateAssociati
 const opCreateAssociationBatch = "CreateAssociationBatch"
 
 // CreateAssociationBatchRequest generates a request for the CreateAssociationBatch operation.
-func (c *SSM) CreateAssociationBatchRequest(input *CreateAssociationBatchInput) (req *service.Request, output *CreateAssociationBatchOutput) {
-	op := &service.Operation{
+func (c *SSM) CreateAssociationBatchRequest(input *CreateAssociationBatchInput) (req *request.Request, output *CreateAssociationBatchOutput) {
+	op := &request.Operation{
 		Name:       opCreateAssociationBatch,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -83,8 +83,8 @@ func (c *SSM) CreateAssociationBatch(input *CreateAssociationBatchInput) (*Creat
 const opCreateDocument = "CreateDocument"
 
 // CreateDocumentRequest generates a request for the CreateDocument operation.
-func (c *SSM) CreateDocumentRequest(input *CreateDocumentInput) (req *service.Request, output *CreateDocumentOutput) {
-	op := &service.Operation{
+func (c *SSM) CreateDocumentRequest(input *CreateDocumentInput) (req *request.Request, output *CreateDocumentOutput) {
+	op := &request.Operation{
 		Name:       opCreateDocument,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -113,8 +113,8 @@ func (c *SSM) CreateDocument(input *CreateDocumentInput) (*CreateDocumentOutput,
 const opDeleteAssociation = "DeleteAssociation"
 
 // DeleteAssociationRequest generates a request for the DeleteAssociation operation.
-func (c *SSM) DeleteAssociationRequest(input *DeleteAssociationInput) (req *service.Request, output *DeleteAssociationOutput) {
-	op := &service.Operation{
+func (c *SSM) DeleteAssociationRequest(input *DeleteAssociationInput) (req *request.Request, output *DeleteAssociationOutput) {
+	op := &request.Operation{
 		Name:       opDeleteAssociation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -146,8 +146,8 @@ func (c *SSM) DeleteAssociation(input *DeleteAssociationInput) (*DeleteAssociati
 const opDeleteDocument = "DeleteDocument"
 
 // DeleteDocumentRequest generates a request for the DeleteDocument operation.
-func (c *SSM) DeleteDocumentRequest(input *DeleteDocumentInput) (req *service.Request, output *DeleteDocumentOutput) {
-	op := &service.Operation{
+func (c *SSM) DeleteDocumentRequest(input *DeleteDocumentInput) (req *request.Request, output *DeleteDocumentOutput) {
+	op := &request.Operation{
 		Name:       opDeleteDocument,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -176,8 +176,8 @@ func (c *SSM) DeleteDocument(input *DeleteDocumentInput) (*DeleteDocumentOutput,
 const opDescribeAssociation = "DescribeAssociation"
 
 // DescribeAssociationRequest generates a request for the DescribeAssociation operation.
-func (c *SSM) DescribeAssociationRequest(input *DescribeAssociationInput) (req *service.Request, output *DescribeAssociationOutput) {
-	op := &service.Operation{
+func (c *SSM) DescribeAssociationRequest(input *DescribeAssociationInput) (req *request.Request, output *DescribeAssociationOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAssociation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -203,8 +203,8 @@ func (c *SSM) DescribeAssociation(input *DescribeAssociationInput) (*DescribeAss
 const opDescribeDocument = "DescribeDocument"
 
 // DescribeDocumentRequest generates a request for the DescribeDocument operation.
-func (c *SSM) DescribeDocumentRequest(input *DescribeDocumentInput) (req *service.Request, output *DescribeDocumentOutput) {
-	op := &service.Operation{
+func (c *SSM) DescribeDocumentRequest(input *DescribeDocumentInput) (req *request.Request, output *DescribeDocumentOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDocument,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -230,8 +230,8 @@ func (c *SSM) DescribeDocument(input *DescribeDocumentInput) (*DescribeDocumentO
 const opGetDocument = "GetDocument"
 
 // GetDocumentRequest generates a request for the GetDocument operation.
-func (c *SSM) GetDocumentRequest(input *GetDocumentInput) (req *service.Request, output *GetDocumentOutput) {
-	op := &service.Operation{
+func (c *SSM) GetDocumentRequest(input *GetDocumentInput) (req *request.Request, output *GetDocumentOutput) {
+	op := &request.Operation{
 		Name:       opGetDocument,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -257,8 +257,8 @@ func (c *SSM) GetDocument(input *GetDocumentInput) (*GetDocumentOutput, error) {
 const opListAssociations = "ListAssociations"
 
 // ListAssociationsRequest generates a request for the ListAssociations operation.
-func (c *SSM) ListAssociationsRequest(input *ListAssociationsInput) (req *service.Request, output *ListAssociationsOutput) {
-	op := &service.Operation{
+func (c *SSM) ListAssociationsRequest(input *ListAssociationsInput) (req *request.Request, output *ListAssociationsOutput) {
+	op := &request.Operation{
 		Name:       opListAssociations,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -284,8 +284,8 @@ func (c *SSM) ListAssociations(input *ListAssociationsInput) (*ListAssociationsO
 const opListDocuments = "ListDocuments"
 
 // ListDocumentsRequest generates a request for the ListDocuments operation.
-func (c *SSM) ListDocumentsRequest(input *ListDocumentsInput) (req *service.Request, output *ListDocumentsOutput) {
-	op := &service.Operation{
+func (c *SSM) ListDocumentsRequest(input *ListDocumentsInput) (req *request.Request, output *ListDocumentsOutput) {
+	op := &request.Operation{
 		Name:       opListDocuments,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -311,8 +311,8 @@ func (c *SSM) ListDocuments(input *ListDocumentsInput) (*ListDocumentsOutput, er
 const opUpdateAssociationStatus = "UpdateAssociationStatus"
 
 // UpdateAssociationStatusRequest generates a request for the UpdateAssociationStatus operation.
-func (c *SSM) UpdateAssociationStatusRequest(input *UpdateAssociationStatusInput) (req *service.Request, output *UpdateAssociationStatusOutput) {
-	op := &service.Operation{
+func (c *SSM) UpdateAssociationStatusRequest(input *UpdateAssociationStatusInput) (req *request.Request, output *UpdateAssociationStatusOutput) {
+	op := &request.Operation{
 		Name:       opUpdateAssociationStatus,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/ssm/service.go
+++ b/service/ssm/service.go
@@ -5,7 +5,9 @@ package ssm
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -34,16 +36,18 @@ type SSM struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new SSM client.
 func New(config *aws.Config) *SSM {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "ssm",
-		APIVersion:   "2014-11-06",
-		JSONVersion:  "1.1",
-		TargetPrefix: "AmazonSSM",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "ssm",
+			APIVersion:   "2014-11-06",
+			JSONVersion:  "1.1",
+			TargetPrefix: "AmazonSSM",
+		},
 	}
 	service.Initialize()
 
@@ -64,8 +68,8 @@ func New(config *aws.Config) *SSM {
 
 // newRequest creates a new request for a SSM operation and runs any
 // custom request initialization.
-func (c *SSM) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *SSM) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/ssm/ssmiface/interface.go
+++ b/service/ssm/ssmiface/interface.go
@@ -4,53 +4,53 @@
 package ssmiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
 // SSMAPI is the interface type for ssm.SSM.
 type SSMAPI interface {
-	CreateAssociationRequest(*ssm.CreateAssociationInput) (*service.Request, *ssm.CreateAssociationOutput)
+	CreateAssociationRequest(*ssm.CreateAssociationInput) (*request.Request, *ssm.CreateAssociationOutput)
 
 	CreateAssociation(*ssm.CreateAssociationInput) (*ssm.CreateAssociationOutput, error)
 
-	CreateAssociationBatchRequest(*ssm.CreateAssociationBatchInput) (*service.Request, *ssm.CreateAssociationBatchOutput)
+	CreateAssociationBatchRequest(*ssm.CreateAssociationBatchInput) (*request.Request, *ssm.CreateAssociationBatchOutput)
 
 	CreateAssociationBatch(*ssm.CreateAssociationBatchInput) (*ssm.CreateAssociationBatchOutput, error)
 
-	CreateDocumentRequest(*ssm.CreateDocumentInput) (*service.Request, *ssm.CreateDocumentOutput)
+	CreateDocumentRequest(*ssm.CreateDocumentInput) (*request.Request, *ssm.CreateDocumentOutput)
 
 	CreateDocument(*ssm.CreateDocumentInput) (*ssm.CreateDocumentOutput, error)
 
-	DeleteAssociationRequest(*ssm.DeleteAssociationInput) (*service.Request, *ssm.DeleteAssociationOutput)
+	DeleteAssociationRequest(*ssm.DeleteAssociationInput) (*request.Request, *ssm.DeleteAssociationOutput)
 
 	DeleteAssociation(*ssm.DeleteAssociationInput) (*ssm.DeleteAssociationOutput, error)
 
-	DeleteDocumentRequest(*ssm.DeleteDocumentInput) (*service.Request, *ssm.DeleteDocumentOutput)
+	DeleteDocumentRequest(*ssm.DeleteDocumentInput) (*request.Request, *ssm.DeleteDocumentOutput)
 
 	DeleteDocument(*ssm.DeleteDocumentInput) (*ssm.DeleteDocumentOutput, error)
 
-	DescribeAssociationRequest(*ssm.DescribeAssociationInput) (*service.Request, *ssm.DescribeAssociationOutput)
+	DescribeAssociationRequest(*ssm.DescribeAssociationInput) (*request.Request, *ssm.DescribeAssociationOutput)
 
 	DescribeAssociation(*ssm.DescribeAssociationInput) (*ssm.DescribeAssociationOutput, error)
 
-	DescribeDocumentRequest(*ssm.DescribeDocumentInput) (*service.Request, *ssm.DescribeDocumentOutput)
+	DescribeDocumentRequest(*ssm.DescribeDocumentInput) (*request.Request, *ssm.DescribeDocumentOutput)
 
 	DescribeDocument(*ssm.DescribeDocumentInput) (*ssm.DescribeDocumentOutput, error)
 
-	GetDocumentRequest(*ssm.GetDocumentInput) (*service.Request, *ssm.GetDocumentOutput)
+	GetDocumentRequest(*ssm.GetDocumentInput) (*request.Request, *ssm.GetDocumentOutput)
 
 	GetDocument(*ssm.GetDocumentInput) (*ssm.GetDocumentOutput, error)
 
-	ListAssociationsRequest(*ssm.ListAssociationsInput) (*service.Request, *ssm.ListAssociationsOutput)
+	ListAssociationsRequest(*ssm.ListAssociationsInput) (*request.Request, *ssm.ListAssociationsOutput)
 
 	ListAssociations(*ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error)
 
-	ListDocumentsRequest(*ssm.ListDocumentsInput) (*service.Request, *ssm.ListDocumentsOutput)
+	ListDocumentsRequest(*ssm.ListDocumentsInput) (*request.Request, *ssm.ListDocumentsOutput)
 
 	ListDocuments(*ssm.ListDocumentsInput) (*ssm.ListDocumentsOutput, error)
 
-	UpdateAssociationStatusRequest(*ssm.UpdateAssociationStatusInput) (*service.Request, *ssm.UpdateAssociationStatusOutput)
+	UpdateAssociationStatusRequest(*ssm.UpdateAssociationStatusInput) (*request.Request, *ssm.UpdateAssociationStatusOutput)
 
 	UpdateAssociationStatus(*ssm.UpdateAssociationStatusInput) (*ssm.UpdateAssociationStatusOutput, error)
 }

--- a/service/storagegateway/api.go
+++ b/service/storagegateway/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opActivateGateway = "ActivateGateway"
 
 // ActivateGatewayRequest generates a request for the ActivateGateway operation.
-func (c *StorageGateway) ActivateGatewayRequest(input *ActivateGatewayInput) (req *service.Request, output *ActivateGatewayOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) ActivateGatewayRequest(input *ActivateGatewayInput) (req *request.Request, output *ActivateGatewayOutput) {
+	op := &request.Operation{
 		Name:       opActivateGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -48,8 +48,8 @@ func (c *StorageGateway) ActivateGateway(input *ActivateGatewayInput) (*Activate
 const opAddCache = "AddCache"
 
 // AddCacheRequest generates a request for the AddCache operation.
-func (c *StorageGateway) AddCacheRequest(input *AddCacheInput) (req *service.Request, output *AddCacheOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) AddCacheRequest(input *AddCacheInput) (req *request.Request, output *AddCacheOutput) {
+	op := &request.Operation{
 		Name:       opAddCache,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -81,8 +81,8 @@ func (c *StorageGateway) AddCache(input *AddCacheInput) (*AddCacheOutput, error)
 const opAddUploadBuffer = "AddUploadBuffer"
 
 // AddUploadBufferRequest generates a request for the AddUploadBuffer operation.
-func (c *StorageGateway) AddUploadBufferRequest(input *AddUploadBufferInput) (req *service.Request, output *AddUploadBufferOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) AddUploadBufferRequest(input *AddUploadBufferInput) (req *request.Request, output *AddUploadBufferOutput) {
+	op := &request.Operation{
 		Name:       opAddUploadBuffer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -114,8 +114,8 @@ func (c *StorageGateway) AddUploadBuffer(input *AddUploadBufferInput) (*AddUploa
 const opAddWorkingStorage = "AddWorkingStorage"
 
 // AddWorkingStorageRequest generates a request for the AddWorkingStorage operation.
-func (c *StorageGateway) AddWorkingStorageRequest(input *AddWorkingStorageInput) (req *service.Request, output *AddWorkingStorageOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) AddWorkingStorageRequest(input *AddWorkingStorageInput) (req *request.Request, output *AddWorkingStorageOutput) {
+	op := &request.Operation{
 		Name:       opAddWorkingStorage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -151,8 +151,8 @@ func (c *StorageGateway) AddWorkingStorage(input *AddWorkingStorageInput) (*AddW
 const opCancelArchival = "CancelArchival"
 
 // CancelArchivalRequest generates a request for the CancelArchival operation.
-func (c *StorageGateway) CancelArchivalRequest(input *CancelArchivalInput) (req *service.Request, output *CancelArchivalOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) CancelArchivalRequest(input *CancelArchivalInput) (req *request.Request, output *CancelArchivalOutput) {
+	op := &request.Operation{
 		Name:       opCancelArchival,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -179,8 +179,8 @@ func (c *StorageGateway) CancelArchival(input *CancelArchivalInput) (*CancelArch
 const opCancelRetrieval = "CancelRetrieval"
 
 // CancelRetrievalRequest generates a request for the CancelRetrieval operation.
-func (c *StorageGateway) CancelRetrievalRequest(input *CancelRetrievalInput) (req *service.Request, output *CancelRetrievalOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) CancelRetrievalRequest(input *CancelRetrievalInput) (req *request.Request, output *CancelRetrievalOutput) {
+	op := &request.Operation{
 		Name:       opCancelRetrieval,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -208,8 +208,8 @@ func (c *StorageGateway) CancelRetrieval(input *CancelRetrievalInput) (*CancelRe
 const opCreateCachediSCSIVolume = "CreateCachediSCSIVolume"
 
 // CreateCachediSCSIVolumeRequest generates a request for the CreateCachediSCSIVolume operation.
-func (c *StorageGateway) CreateCachediSCSIVolumeRequest(input *CreateCachediSCSIVolumeInput) (req *service.Request, output *CreateCachediSCSIVolumeOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) CreateCachediSCSIVolumeRequest(input *CreateCachediSCSIVolumeInput) (req *request.Request, output *CreateCachediSCSIVolumeOutput) {
+	op := &request.Operation{
 		Name:       opCreateCachediSCSIVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -245,8 +245,8 @@ func (c *StorageGateway) CreateCachediSCSIVolume(input *CreateCachediSCSIVolumeI
 const opCreateSnapshot = "CreateSnapshot"
 
 // CreateSnapshotRequest generates a request for the CreateSnapshot operation.
-func (c *StorageGateway) CreateSnapshotRequest(input *CreateSnapshotInput) (req *service.Request, output *CreateSnapshotOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) CreateSnapshotRequest(input *CreateSnapshotInput) (req *request.Request, output *CreateSnapshotOutput) {
+	op := &request.Operation{
 		Name:       opCreateSnapshot,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -292,8 +292,8 @@ func (c *StorageGateway) CreateSnapshot(input *CreateSnapshotInput) (*CreateSnap
 const opCreateSnapshotFromVolumeRecoveryPoint = "CreateSnapshotFromVolumeRecoveryPoint"
 
 // CreateSnapshotFromVolumeRecoveryPointRequest generates a request for the CreateSnapshotFromVolumeRecoveryPoint operation.
-func (c *StorageGateway) CreateSnapshotFromVolumeRecoveryPointRequest(input *CreateSnapshotFromVolumeRecoveryPointInput) (req *service.Request, output *CreateSnapshotFromVolumeRecoveryPointOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) CreateSnapshotFromVolumeRecoveryPointRequest(input *CreateSnapshotFromVolumeRecoveryPointInput) (req *request.Request, output *CreateSnapshotFromVolumeRecoveryPointOutput) {
+	op := &request.Operation{
 		Name:       opCreateSnapshotFromVolumeRecoveryPoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -336,8 +336,8 @@ func (c *StorageGateway) CreateSnapshotFromVolumeRecoveryPoint(input *CreateSnap
 const opCreateStorediSCSIVolume = "CreateStorediSCSIVolume"
 
 // CreateStorediSCSIVolumeRequest generates a request for the CreateStorediSCSIVolume operation.
-func (c *StorageGateway) CreateStorediSCSIVolumeRequest(input *CreateStorediSCSIVolumeInput) (req *service.Request, output *CreateStorediSCSIVolumeOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) CreateStorediSCSIVolumeRequest(input *CreateStorediSCSIVolumeInput) (req *request.Request, output *CreateStorediSCSIVolumeOutput) {
+	op := &request.Operation{
 		Name:       opCreateStorediSCSIVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -375,8 +375,8 @@ func (c *StorageGateway) CreateStorediSCSIVolume(input *CreateStorediSCSIVolumeI
 const opCreateTapes = "CreateTapes"
 
 // CreateTapesRequest generates a request for the CreateTapes operation.
-func (c *StorageGateway) CreateTapesRequest(input *CreateTapesInput) (req *service.Request, output *CreateTapesOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) CreateTapesRequest(input *CreateTapesInput) (req *request.Request, output *CreateTapesOutput) {
+	op := &request.Operation{
 		Name:       opCreateTapes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -406,8 +406,8 @@ func (c *StorageGateway) CreateTapes(input *CreateTapesInput) (*CreateTapesOutpu
 const opDeleteBandwidthRateLimit = "DeleteBandwidthRateLimit"
 
 // DeleteBandwidthRateLimitRequest generates a request for the DeleteBandwidthRateLimit operation.
-func (c *StorageGateway) DeleteBandwidthRateLimitRequest(input *DeleteBandwidthRateLimitInput) (req *service.Request, output *DeleteBandwidthRateLimitOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DeleteBandwidthRateLimitRequest(input *DeleteBandwidthRateLimitInput) (req *request.Request, output *DeleteBandwidthRateLimitOutput) {
+	op := &request.Operation{
 		Name:       opDeleteBandwidthRateLimit,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -437,8 +437,8 @@ func (c *StorageGateway) DeleteBandwidthRateLimit(input *DeleteBandwidthRateLimi
 const opDeleteChapCredentials = "DeleteChapCredentials"
 
 // DeleteChapCredentialsRequest generates a request for the DeleteChapCredentials operation.
-func (c *StorageGateway) DeleteChapCredentialsRequest(input *DeleteChapCredentialsInput) (req *service.Request, output *DeleteChapCredentialsOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DeleteChapCredentialsRequest(input *DeleteChapCredentialsInput) (req *request.Request, output *DeleteChapCredentialsOutput) {
+	op := &request.Operation{
 		Name:       opDeleteChapCredentials,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -465,8 +465,8 @@ func (c *StorageGateway) DeleteChapCredentials(input *DeleteChapCredentialsInput
 const opDeleteGateway = "DeleteGateway"
 
 // DeleteGatewayRequest generates a request for the DeleteGateway operation.
-func (c *StorageGateway) DeleteGatewayRequest(input *DeleteGatewayInput) (req *service.Request, output *DeleteGatewayOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DeleteGatewayRequest(input *DeleteGatewayInput) (req *request.Request, output *DeleteGatewayOutput) {
+	op := &request.Operation{
 		Name:       opDeleteGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -507,8 +507,8 @@ func (c *StorageGateway) DeleteGateway(input *DeleteGatewayInput) (*DeleteGatewa
 const opDeleteSnapshotSchedule = "DeleteSnapshotSchedule"
 
 // DeleteSnapshotScheduleRequest generates a request for the DeleteSnapshotSchedule operation.
-func (c *StorageGateway) DeleteSnapshotScheduleRequest(input *DeleteSnapshotScheduleInput) (req *service.Request, output *DeleteSnapshotScheduleOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DeleteSnapshotScheduleRequest(input *DeleteSnapshotScheduleInput) (req *request.Request, output *DeleteSnapshotScheduleOutput) {
+	op := &request.Operation{
 		Name:       opDeleteSnapshotSchedule,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -543,8 +543,8 @@ func (c *StorageGateway) DeleteSnapshotSchedule(input *DeleteSnapshotScheduleInp
 const opDeleteTape = "DeleteTape"
 
 // DeleteTapeRequest generates a request for the DeleteTape operation.
-func (c *StorageGateway) DeleteTapeRequest(input *DeleteTapeInput) (req *service.Request, output *DeleteTapeOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DeleteTapeRequest(input *DeleteTapeInput) (req *request.Request, output *DeleteTapeOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTape,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -570,8 +570,8 @@ func (c *StorageGateway) DeleteTape(input *DeleteTapeInput) (*DeleteTapeOutput, 
 const opDeleteTapeArchive = "DeleteTapeArchive"
 
 // DeleteTapeArchiveRequest generates a request for the DeleteTapeArchive operation.
-func (c *StorageGateway) DeleteTapeArchiveRequest(input *DeleteTapeArchiveInput) (req *service.Request, output *DeleteTapeArchiveOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DeleteTapeArchiveRequest(input *DeleteTapeArchiveInput) (req *request.Request, output *DeleteTapeArchiveOutput) {
+	op := &request.Operation{
 		Name:       opDeleteTapeArchive,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -597,8 +597,8 @@ func (c *StorageGateway) DeleteTapeArchive(input *DeleteTapeArchiveInput) (*Dele
 const opDeleteVolume = "DeleteVolume"
 
 // DeleteVolumeRequest generates a request for the DeleteVolume operation.
-func (c *StorageGateway) DeleteVolumeRequest(input *DeleteVolumeInput) (req *service.Request, output *DeleteVolumeOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DeleteVolumeRequest(input *DeleteVolumeInput) (req *request.Request, output *DeleteVolumeOutput) {
+	op := &request.Operation{
 		Name:       opDeleteVolume,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -637,8 +637,8 @@ func (c *StorageGateway) DeleteVolume(input *DeleteVolumeInput) (*DeleteVolumeOu
 const opDescribeBandwidthRateLimit = "DescribeBandwidthRateLimit"
 
 // DescribeBandwidthRateLimitRequest generates a request for the DescribeBandwidthRateLimit operation.
-func (c *StorageGateway) DescribeBandwidthRateLimitRequest(input *DescribeBandwidthRateLimitInput) (req *service.Request, output *DescribeBandwidthRateLimitOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeBandwidthRateLimitRequest(input *DescribeBandwidthRateLimitInput) (req *request.Request, output *DescribeBandwidthRateLimitOutput) {
+	op := &request.Operation{
 		Name:       opDescribeBandwidthRateLimit,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -670,8 +670,8 @@ func (c *StorageGateway) DescribeBandwidthRateLimit(input *DescribeBandwidthRate
 const opDescribeCache = "DescribeCache"
 
 // DescribeCacheRequest generates a request for the DescribeCache operation.
-func (c *StorageGateway) DescribeCacheRequest(input *DescribeCacheInput) (req *service.Request, output *DescribeCacheOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeCacheRequest(input *DescribeCacheInput) (req *request.Request, output *DescribeCacheOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCache,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -701,8 +701,8 @@ func (c *StorageGateway) DescribeCache(input *DescribeCacheInput) (*DescribeCach
 const opDescribeCachediSCSIVolumes = "DescribeCachediSCSIVolumes"
 
 // DescribeCachediSCSIVolumesRequest generates a request for the DescribeCachediSCSIVolumes operation.
-func (c *StorageGateway) DescribeCachediSCSIVolumesRequest(input *DescribeCachediSCSIVolumesInput) (req *service.Request, output *DescribeCachediSCSIVolumesOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeCachediSCSIVolumesRequest(input *DescribeCachediSCSIVolumesInput) (req *request.Request, output *DescribeCachediSCSIVolumesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCachediSCSIVolumes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -734,8 +734,8 @@ func (c *StorageGateway) DescribeCachediSCSIVolumes(input *DescribeCachediSCSIVo
 const opDescribeChapCredentials = "DescribeChapCredentials"
 
 // DescribeChapCredentialsRequest generates a request for the DescribeChapCredentials operation.
-func (c *StorageGateway) DescribeChapCredentialsRequest(input *DescribeChapCredentialsInput) (req *service.Request, output *DescribeChapCredentialsOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeChapCredentialsRequest(input *DescribeChapCredentialsInput) (req *request.Request, output *DescribeChapCredentialsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeChapCredentials,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -763,8 +763,8 @@ func (c *StorageGateway) DescribeChapCredentials(input *DescribeChapCredentialsI
 const opDescribeGatewayInformation = "DescribeGatewayInformation"
 
 // DescribeGatewayInformationRequest generates a request for the DescribeGatewayInformation operation.
-func (c *StorageGateway) DescribeGatewayInformationRequest(input *DescribeGatewayInformationInput) (req *service.Request, output *DescribeGatewayInformationOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeGatewayInformationRequest(input *DescribeGatewayInformationInput) (req *request.Request, output *DescribeGatewayInformationOutput) {
+	op := &request.Operation{
 		Name:       opDescribeGatewayInformation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -793,8 +793,8 @@ func (c *StorageGateway) DescribeGatewayInformation(input *DescribeGatewayInform
 const opDescribeMaintenanceStartTime = "DescribeMaintenanceStartTime"
 
 // DescribeMaintenanceStartTimeRequest generates a request for the DescribeMaintenanceStartTime operation.
-func (c *StorageGateway) DescribeMaintenanceStartTimeRequest(input *DescribeMaintenanceStartTimeInput) (req *service.Request, output *DescribeMaintenanceStartTimeOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeMaintenanceStartTimeRequest(input *DescribeMaintenanceStartTimeInput) (req *request.Request, output *DescribeMaintenanceStartTimeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeMaintenanceStartTime,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -822,8 +822,8 @@ func (c *StorageGateway) DescribeMaintenanceStartTime(input *DescribeMaintenance
 const opDescribeSnapshotSchedule = "DescribeSnapshotSchedule"
 
 // DescribeSnapshotScheduleRequest generates a request for the DescribeSnapshotSchedule operation.
-func (c *StorageGateway) DescribeSnapshotScheduleRequest(input *DescribeSnapshotScheduleInput) (req *service.Request, output *DescribeSnapshotScheduleOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeSnapshotScheduleRequest(input *DescribeSnapshotScheduleInput) (req *request.Request, output *DescribeSnapshotScheduleOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSnapshotSchedule,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -851,8 +851,8 @@ func (c *StorageGateway) DescribeSnapshotSchedule(input *DescribeSnapshotSchedul
 const opDescribeStorediSCSIVolumes = "DescribeStorediSCSIVolumes"
 
 // DescribeStorediSCSIVolumesRequest generates a request for the DescribeStorediSCSIVolumes operation.
-func (c *StorageGateway) DescribeStorediSCSIVolumesRequest(input *DescribeStorediSCSIVolumesInput) (req *service.Request, output *DescribeStorediSCSIVolumesOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeStorediSCSIVolumesRequest(input *DescribeStorediSCSIVolumesInput) (req *request.Request, output *DescribeStorediSCSIVolumesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeStorediSCSIVolumes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -881,12 +881,12 @@ func (c *StorageGateway) DescribeStorediSCSIVolumes(input *DescribeStorediSCSIVo
 const opDescribeTapeArchives = "DescribeTapeArchives"
 
 // DescribeTapeArchivesRequest generates a request for the DescribeTapeArchives operation.
-func (c *StorageGateway) DescribeTapeArchivesRequest(input *DescribeTapeArchivesInput) (req *service.Request, output *DescribeTapeArchivesOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeTapeArchivesRequest(input *DescribeTapeArchivesInput) (req *request.Request, output *DescribeTapeArchivesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTapeArchives,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "Limit",
@@ -925,12 +925,12 @@ func (c *StorageGateway) DescribeTapeArchivesPages(input *DescribeTapeArchivesIn
 const opDescribeTapeRecoveryPoints = "DescribeTapeRecoveryPoints"
 
 // DescribeTapeRecoveryPointsRequest generates a request for the DescribeTapeRecoveryPoints operation.
-func (c *StorageGateway) DescribeTapeRecoveryPointsRequest(input *DescribeTapeRecoveryPointsInput) (req *service.Request, output *DescribeTapeRecoveryPointsOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeTapeRecoveryPointsRequest(input *DescribeTapeRecoveryPointsInput) (req *request.Request, output *DescribeTapeRecoveryPointsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTapeRecoveryPoints,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "Limit",
@@ -970,12 +970,12 @@ func (c *StorageGateway) DescribeTapeRecoveryPointsPages(input *DescribeTapeReco
 const opDescribeTapes = "DescribeTapes"
 
 // DescribeTapesRequest generates a request for the DescribeTapes operation.
-func (c *StorageGateway) DescribeTapesRequest(input *DescribeTapesInput) (req *service.Request, output *DescribeTapesOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeTapesRequest(input *DescribeTapesInput) (req *request.Request, output *DescribeTapesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTapes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "Limit",
@@ -1012,8 +1012,8 @@ func (c *StorageGateway) DescribeTapesPages(input *DescribeTapesInput, fn func(p
 const opDescribeUploadBuffer = "DescribeUploadBuffer"
 
 // DescribeUploadBufferRequest generates a request for the DescribeUploadBuffer operation.
-func (c *StorageGateway) DescribeUploadBufferRequest(input *DescribeUploadBufferInput) (req *service.Request, output *DescribeUploadBufferOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeUploadBufferRequest(input *DescribeUploadBufferInput) (req *request.Request, output *DescribeUploadBufferOutput) {
+	op := &request.Operation{
 		Name:       opDescribeUploadBuffer,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1044,12 +1044,12 @@ func (c *StorageGateway) DescribeUploadBuffer(input *DescribeUploadBufferInput) 
 const opDescribeVTLDevices = "DescribeVTLDevices"
 
 // DescribeVTLDevicesRequest generates a request for the DescribeVTLDevices operation.
-func (c *StorageGateway) DescribeVTLDevicesRequest(input *DescribeVTLDevicesInput) (req *service.Request, output *DescribeVTLDevicesOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeVTLDevicesRequest(input *DescribeVTLDevicesInput) (req *request.Request, output *DescribeVTLDevicesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeVTLDevices,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "Limit",
@@ -1087,8 +1087,8 @@ func (c *StorageGateway) DescribeVTLDevicesPages(input *DescribeVTLDevicesInput,
 const opDescribeWorkingStorage = "DescribeWorkingStorage"
 
 // DescribeWorkingStorageRequest generates a request for the DescribeWorkingStorage operation.
-func (c *StorageGateway) DescribeWorkingStorageRequest(input *DescribeWorkingStorageInput) (req *service.Request, output *DescribeWorkingStorageOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DescribeWorkingStorageRequest(input *DescribeWorkingStorageInput) (req *request.Request, output *DescribeWorkingStorageOutput) {
+	op := &request.Operation{
 		Name:       opDescribeWorkingStorage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1123,8 +1123,8 @@ func (c *StorageGateway) DescribeWorkingStorage(input *DescribeWorkingStorageInp
 const opDisableGateway = "DisableGateway"
 
 // DisableGatewayRequest generates a request for the DisableGateway operation.
-func (c *StorageGateway) DisableGatewayRequest(input *DisableGatewayInput) (req *service.Request, output *DisableGatewayOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) DisableGatewayRequest(input *DisableGatewayInput) (req *request.Request, output *DisableGatewayOutput) {
+	op := &request.Operation{
 		Name:       opDisableGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1156,12 +1156,12 @@ func (c *StorageGateway) DisableGateway(input *DisableGatewayInput) (*DisableGat
 const opListGateways = "ListGateways"
 
 // ListGatewaysRequest generates a request for the ListGateways operation.
-func (c *StorageGateway) ListGatewaysRequest(input *ListGatewaysInput) (req *service.Request, output *ListGatewaysOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) ListGatewaysRequest(input *ListGatewaysInput) (req *request.Request, output *ListGatewaysOutput) {
+	op := &request.Operation{
 		Name:       opListGateways,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "Limit",
@@ -1206,8 +1206,8 @@ func (c *StorageGateway) ListGatewaysPages(input *ListGatewaysInput, fn func(p *
 const opListLocalDisks = "ListLocalDisks"
 
 // ListLocalDisksRequest generates a request for the ListLocalDisks operation.
-func (c *StorageGateway) ListLocalDisksRequest(input *ListLocalDisksInput) (req *service.Request, output *ListLocalDisksOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) ListLocalDisksRequest(input *ListLocalDisksInput) (req *request.Request, output *ListLocalDisksOutput) {
+	op := &request.Operation{
 		Name:       opListLocalDisks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1242,8 +1242,8 @@ func (c *StorageGateway) ListLocalDisks(input *ListLocalDisksInput) (*ListLocalD
 const opListVolumeInitiators = "ListVolumeInitiators"
 
 // ListVolumeInitiatorsRequest generates a request for the ListVolumeInitiators operation.
-func (c *StorageGateway) ListVolumeInitiatorsRequest(input *ListVolumeInitiatorsInput) (req *service.Request, output *ListVolumeInitiatorsOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) ListVolumeInitiatorsRequest(input *ListVolumeInitiatorsInput) (req *request.Request, output *ListVolumeInitiatorsOutput) {
+	op := &request.Operation{
 		Name:       opListVolumeInitiators,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1270,8 +1270,8 @@ func (c *StorageGateway) ListVolumeInitiators(input *ListVolumeInitiatorsInput) 
 const opListVolumeRecoveryPoints = "ListVolumeRecoveryPoints"
 
 // ListVolumeRecoveryPointsRequest generates a request for the ListVolumeRecoveryPoints operation.
-func (c *StorageGateway) ListVolumeRecoveryPointsRequest(input *ListVolumeRecoveryPointsInput) (req *service.Request, output *ListVolumeRecoveryPointsOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) ListVolumeRecoveryPointsRequest(input *ListVolumeRecoveryPointsInput) (req *request.Request, output *ListVolumeRecoveryPointsOutput) {
+	op := &request.Operation{
 		Name:       opListVolumeRecoveryPoints,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1303,12 +1303,12 @@ func (c *StorageGateway) ListVolumeRecoveryPoints(input *ListVolumeRecoveryPoint
 const opListVolumes = "ListVolumes"
 
 // ListVolumesRequest generates a request for the ListVolumes operation.
-func (c *StorageGateway) ListVolumesRequest(input *ListVolumesInput) (req *service.Request, output *ListVolumesOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) ListVolumesRequest(input *ListVolumesInput) (req *request.Request, output *ListVolumesOutput) {
+	op := &request.Operation{
 		Name:       opListVolumes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"Marker"},
 			OutputTokens:    []string{"Marker"},
 			LimitToken:      "Limit",
@@ -1352,8 +1352,8 @@ func (c *StorageGateway) ListVolumesPages(input *ListVolumesInput, fn func(p *Li
 const opResetCache = "ResetCache"
 
 // ResetCacheRequest generates a request for the ResetCache operation.
-func (c *StorageGateway) ResetCacheRequest(input *ResetCacheInput) (req *service.Request, output *ResetCacheOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) ResetCacheRequest(input *ResetCacheInput) (req *request.Request, output *ResetCacheOutput) {
+	op := &request.Operation{
 		Name:       opResetCache,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1389,8 +1389,8 @@ func (c *StorageGateway) ResetCache(input *ResetCacheInput) (*ResetCacheOutput, 
 const opRetrieveTapeArchive = "RetrieveTapeArchive"
 
 // RetrieveTapeArchiveRequest generates a request for the RetrieveTapeArchive operation.
-func (c *StorageGateway) RetrieveTapeArchiveRequest(input *RetrieveTapeArchiveInput) (req *service.Request, output *RetrieveTapeArchiveOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) RetrieveTapeArchiveRequest(input *RetrieveTapeArchiveInput) (req *request.Request, output *RetrieveTapeArchiveOutput) {
+	op := &request.Operation{
 		Name:       opRetrieveTapeArchive,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1423,8 +1423,8 @@ func (c *StorageGateway) RetrieveTapeArchive(input *RetrieveTapeArchiveInput) (*
 const opRetrieveTapeRecoveryPoint = "RetrieveTapeRecoveryPoint"
 
 // RetrieveTapeRecoveryPointRequest generates a request for the RetrieveTapeRecoveryPoint operation.
-func (c *StorageGateway) RetrieveTapeRecoveryPointRequest(input *RetrieveTapeRecoveryPointInput) (req *service.Request, output *RetrieveTapeRecoveryPointOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) RetrieveTapeRecoveryPointRequest(input *RetrieveTapeRecoveryPointInput) (req *request.Request, output *RetrieveTapeRecoveryPointOutput) {
+	op := &request.Operation{
 		Name:       opRetrieveTapeRecoveryPoint,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1458,8 +1458,8 @@ func (c *StorageGateway) RetrieveTapeRecoveryPoint(input *RetrieveTapeRecoveryPo
 const opShutdownGateway = "ShutdownGateway"
 
 // ShutdownGatewayRequest generates a request for the ShutdownGateway operation.
-func (c *StorageGateway) ShutdownGatewayRequest(input *ShutdownGatewayInput) (req *service.Request, output *ShutdownGatewayOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) ShutdownGatewayRequest(input *ShutdownGatewayInput) (req *request.Request, output *ShutdownGatewayOutput) {
+	op := &request.Operation{
 		Name:       opShutdownGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1503,8 +1503,8 @@ func (c *StorageGateway) ShutdownGateway(input *ShutdownGatewayInput) (*Shutdown
 const opStartGateway = "StartGateway"
 
 // StartGatewayRequest generates a request for the StartGateway operation.
-func (c *StorageGateway) StartGatewayRequest(input *StartGatewayInput) (req *service.Request, output *StartGatewayOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) StartGatewayRequest(input *StartGatewayInput) (req *request.Request, output *StartGatewayOutput) {
+	op := &request.Operation{
 		Name:       opStartGateway,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1539,8 +1539,8 @@ func (c *StorageGateway) StartGateway(input *StartGatewayInput) (*StartGatewayOu
 const opUpdateBandwidthRateLimit = "UpdateBandwidthRateLimit"
 
 // UpdateBandwidthRateLimitRequest generates a request for the UpdateBandwidthRateLimit operation.
-func (c *StorageGateway) UpdateBandwidthRateLimitRequest(input *UpdateBandwidthRateLimitInput) (req *service.Request, output *UpdateBandwidthRateLimitOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) UpdateBandwidthRateLimitRequest(input *UpdateBandwidthRateLimitInput) (req *request.Request, output *UpdateBandwidthRateLimitOutput) {
+	op := &request.Operation{
 		Name:       opUpdateBandwidthRateLimit,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1576,8 +1576,8 @@ func (c *StorageGateway) UpdateBandwidthRateLimit(input *UpdateBandwidthRateLimi
 const opUpdateChapCredentials = "UpdateChapCredentials"
 
 // UpdateChapCredentialsRequest generates a request for the UpdateChapCredentials operation.
-func (c *StorageGateway) UpdateChapCredentialsRequest(input *UpdateChapCredentialsInput) (req *service.Request, output *UpdateChapCredentialsOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) UpdateChapCredentialsRequest(input *UpdateChapCredentialsInput) (req *request.Request, output *UpdateChapCredentialsOutput) {
+	op := &request.Operation{
 		Name:       opUpdateChapCredentials,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1608,8 +1608,8 @@ func (c *StorageGateway) UpdateChapCredentials(input *UpdateChapCredentialsInput
 const opUpdateGatewayInformation = "UpdateGatewayInformation"
 
 // UpdateGatewayInformationRequest generates a request for the UpdateGatewayInformation operation.
-func (c *StorageGateway) UpdateGatewayInformationRequest(input *UpdateGatewayInformationInput) (req *service.Request, output *UpdateGatewayInformationOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) UpdateGatewayInformationRequest(input *UpdateGatewayInformationInput) (req *request.Request, output *UpdateGatewayInformationOutput) {
+	op := &request.Operation{
 		Name:       opUpdateGatewayInformation,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1637,8 +1637,8 @@ func (c *StorageGateway) UpdateGatewayInformation(input *UpdateGatewayInformatio
 const opUpdateGatewaySoftwareNow = "UpdateGatewaySoftwareNow"
 
 // UpdateGatewaySoftwareNowRequest generates a request for the UpdateGatewaySoftwareNow operation.
-func (c *StorageGateway) UpdateGatewaySoftwareNowRequest(input *UpdateGatewaySoftwareNowInput) (req *service.Request, output *UpdateGatewaySoftwareNowOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) UpdateGatewaySoftwareNowRequest(input *UpdateGatewaySoftwareNowInput) (req *request.Request, output *UpdateGatewaySoftwareNowOutput) {
+	op := &request.Operation{
 		Name:       opUpdateGatewaySoftwareNow,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1676,8 +1676,8 @@ func (c *StorageGateway) UpdateGatewaySoftwareNow(input *UpdateGatewaySoftwareNo
 const opUpdateMaintenanceStartTime = "UpdateMaintenanceStartTime"
 
 // UpdateMaintenanceStartTimeRequest generates a request for the UpdateMaintenanceStartTime operation.
-func (c *StorageGateway) UpdateMaintenanceStartTimeRequest(input *UpdateMaintenanceStartTimeInput) (req *service.Request, output *UpdateMaintenanceStartTimeOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) UpdateMaintenanceStartTimeRequest(input *UpdateMaintenanceStartTimeInput) (req *request.Request, output *UpdateMaintenanceStartTimeOutput) {
+	op := &request.Operation{
 		Name:       opUpdateMaintenanceStartTime,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1705,8 +1705,8 @@ func (c *StorageGateway) UpdateMaintenanceStartTime(input *UpdateMaintenanceStar
 const opUpdateSnapshotSchedule = "UpdateSnapshotSchedule"
 
 // UpdateSnapshotScheduleRequest generates a request for the UpdateSnapshotSchedule operation.
-func (c *StorageGateway) UpdateSnapshotScheduleRequest(input *UpdateSnapshotScheduleInput) (req *service.Request, output *UpdateSnapshotScheduleOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) UpdateSnapshotScheduleRequest(input *UpdateSnapshotScheduleInput) (req *request.Request, output *UpdateSnapshotScheduleOutput) {
+	op := &request.Operation{
 		Name:       opUpdateSnapshotSchedule,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1740,8 +1740,8 @@ func (c *StorageGateway) UpdateSnapshotSchedule(input *UpdateSnapshotScheduleInp
 const opUpdateVTLDeviceType = "UpdateVTLDeviceType"
 
 // UpdateVTLDeviceTypeRequest generates a request for the UpdateVTLDeviceType operation.
-func (c *StorageGateway) UpdateVTLDeviceTypeRequest(input *UpdateVTLDeviceTypeInput) (req *service.Request, output *UpdateVTLDeviceTypeOutput) {
-	op := &service.Operation{
+func (c *StorageGateway) UpdateVTLDeviceTypeRequest(input *UpdateVTLDeviceTypeInput) (req *request.Request, output *UpdateVTLDeviceTypeOutput) {
+	op := &request.Operation{
 		Name:       opUpdateVTLDeviceType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/storagegateway/service.go
+++ b/service/storagegateway/service.go
@@ -5,7 +5,9 @@ package storagegateway
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -39,16 +41,18 @@ type StorageGateway struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new StorageGateway client.
 func New(config *aws.Config) *StorageGateway {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "storagegateway",
-		APIVersion:   "2013-06-30",
-		JSONVersion:  "1.1",
-		TargetPrefix: "StorageGateway_20130630",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "storagegateway",
+			APIVersion:   "2013-06-30",
+			JSONVersion:  "1.1",
+			TargetPrefix: "StorageGateway_20130630",
+		},
 	}
 	service.Initialize()
 
@@ -69,8 +73,8 @@ func New(config *aws.Config) *StorageGateway {
 
 // newRequest creates a new request for a StorageGateway operation and runs any
 // custom request initialization.
-func (c *StorageGateway) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *StorageGateway) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/storagegateway/storagegatewayiface/interface.go
+++ b/service/storagegateway/storagegatewayiface/interface.go
@@ -4,221 +4,221 @@
 package storagegatewayiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 )
 
 // StorageGatewayAPI is the interface type for storagegateway.StorageGateway.
 type StorageGatewayAPI interface {
-	ActivateGatewayRequest(*storagegateway.ActivateGatewayInput) (*service.Request, *storagegateway.ActivateGatewayOutput)
+	ActivateGatewayRequest(*storagegateway.ActivateGatewayInput) (*request.Request, *storagegateway.ActivateGatewayOutput)
 
 	ActivateGateway(*storagegateway.ActivateGatewayInput) (*storagegateway.ActivateGatewayOutput, error)
 
-	AddCacheRequest(*storagegateway.AddCacheInput) (*service.Request, *storagegateway.AddCacheOutput)
+	AddCacheRequest(*storagegateway.AddCacheInput) (*request.Request, *storagegateway.AddCacheOutput)
 
 	AddCache(*storagegateway.AddCacheInput) (*storagegateway.AddCacheOutput, error)
 
-	AddUploadBufferRequest(*storagegateway.AddUploadBufferInput) (*service.Request, *storagegateway.AddUploadBufferOutput)
+	AddUploadBufferRequest(*storagegateway.AddUploadBufferInput) (*request.Request, *storagegateway.AddUploadBufferOutput)
 
 	AddUploadBuffer(*storagegateway.AddUploadBufferInput) (*storagegateway.AddUploadBufferOutput, error)
 
-	AddWorkingStorageRequest(*storagegateway.AddWorkingStorageInput) (*service.Request, *storagegateway.AddWorkingStorageOutput)
+	AddWorkingStorageRequest(*storagegateway.AddWorkingStorageInput) (*request.Request, *storagegateway.AddWorkingStorageOutput)
 
 	AddWorkingStorage(*storagegateway.AddWorkingStorageInput) (*storagegateway.AddWorkingStorageOutput, error)
 
-	CancelArchivalRequest(*storagegateway.CancelArchivalInput) (*service.Request, *storagegateway.CancelArchivalOutput)
+	CancelArchivalRequest(*storagegateway.CancelArchivalInput) (*request.Request, *storagegateway.CancelArchivalOutput)
 
 	CancelArchival(*storagegateway.CancelArchivalInput) (*storagegateway.CancelArchivalOutput, error)
 
-	CancelRetrievalRequest(*storagegateway.CancelRetrievalInput) (*service.Request, *storagegateway.CancelRetrievalOutput)
+	CancelRetrievalRequest(*storagegateway.CancelRetrievalInput) (*request.Request, *storagegateway.CancelRetrievalOutput)
 
 	CancelRetrieval(*storagegateway.CancelRetrievalInput) (*storagegateway.CancelRetrievalOutput, error)
 
-	CreateCachediSCSIVolumeRequest(*storagegateway.CreateCachediSCSIVolumeInput) (*service.Request, *storagegateway.CreateCachediSCSIVolumeOutput)
+	CreateCachediSCSIVolumeRequest(*storagegateway.CreateCachediSCSIVolumeInput) (*request.Request, *storagegateway.CreateCachediSCSIVolumeOutput)
 
 	CreateCachediSCSIVolume(*storagegateway.CreateCachediSCSIVolumeInput) (*storagegateway.CreateCachediSCSIVolumeOutput, error)
 
-	CreateSnapshotRequest(*storagegateway.CreateSnapshotInput) (*service.Request, *storagegateway.CreateSnapshotOutput)
+	CreateSnapshotRequest(*storagegateway.CreateSnapshotInput) (*request.Request, *storagegateway.CreateSnapshotOutput)
 
 	CreateSnapshot(*storagegateway.CreateSnapshotInput) (*storagegateway.CreateSnapshotOutput, error)
 
-	CreateSnapshotFromVolumeRecoveryPointRequest(*storagegateway.CreateSnapshotFromVolumeRecoveryPointInput) (*service.Request, *storagegateway.CreateSnapshotFromVolumeRecoveryPointOutput)
+	CreateSnapshotFromVolumeRecoveryPointRequest(*storagegateway.CreateSnapshotFromVolumeRecoveryPointInput) (*request.Request, *storagegateway.CreateSnapshotFromVolumeRecoveryPointOutput)
 
 	CreateSnapshotFromVolumeRecoveryPoint(*storagegateway.CreateSnapshotFromVolumeRecoveryPointInput) (*storagegateway.CreateSnapshotFromVolumeRecoveryPointOutput, error)
 
-	CreateStorediSCSIVolumeRequest(*storagegateway.CreateStorediSCSIVolumeInput) (*service.Request, *storagegateway.CreateStorediSCSIVolumeOutput)
+	CreateStorediSCSIVolumeRequest(*storagegateway.CreateStorediSCSIVolumeInput) (*request.Request, *storagegateway.CreateStorediSCSIVolumeOutput)
 
 	CreateStorediSCSIVolume(*storagegateway.CreateStorediSCSIVolumeInput) (*storagegateway.CreateStorediSCSIVolumeOutput, error)
 
-	CreateTapesRequest(*storagegateway.CreateTapesInput) (*service.Request, *storagegateway.CreateTapesOutput)
+	CreateTapesRequest(*storagegateway.CreateTapesInput) (*request.Request, *storagegateway.CreateTapesOutput)
 
 	CreateTapes(*storagegateway.CreateTapesInput) (*storagegateway.CreateTapesOutput, error)
 
-	DeleteBandwidthRateLimitRequest(*storagegateway.DeleteBandwidthRateLimitInput) (*service.Request, *storagegateway.DeleteBandwidthRateLimitOutput)
+	DeleteBandwidthRateLimitRequest(*storagegateway.DeleteBandwidthRateLimitInput) (*request.Request, *storagegateway.DeleteBandwidthRateLimitOutput)
 
 	DeleteBandwidthRateLimit(*storagegateway.DeleteBandwidthRateLimitInput) (*storagegateway.DeleteBandwidthRateLimitOutput, error)
 
-	DeleteChapCredentialsRequest(*storagegateway.DeleteChapCredentialsInput) (*service.Request, *storagegateway.DeleteChapCredentialsOutput)
+	DeleteChapCredentialsRequest(*storagegateway.DeleteChapCredentialsInput) (*request.Request, *storagegateway.DeleteChapCredentialsOutput)
 
 	DeleteChapCredentials(*storagegateway.DeleteChapCredentialsInput) (*storagegateway.DeleteChapCredentialsOutput, error)
 
-	DeleteGatewayRequest(*storagegateway.DeleteGatewayInput) (*service.Request, *storagegateway.DeleteGatewayOutput)
+	DeleteGatewayRequest(*storagegateway.DeleteGatewayInput) (*request.Request, *storagegateway.DeleteGatewayOutput)
 
 	DeleteGateway(*storagegateway.DeleteGatewayInput) (*storagegateway.DeleteGatewayOutput, error)
 
-	DeleteSnapshotScheduleRequest(*storagegateway.DeleteSnapshotScheduleInput) (*service.Request, *storagegateway.DeleteSnapshotScheduleOutput)
+	DeleteSnapshotScheduleRequest(*storagegateway.DeleteSnapshotScheduleInput) (*request.Request, *storagegateway.DeleteSnapshotScheduleOutput)
 
 	DeleteSnapshotSchedule(*storagegateway.DeleteSnapshotScheduleInput) (*storagegateway.DeleteSnapshotScheduleOutput, error)
 
-	DeleteTapeRequest(*storagegateway.DeleteTapeInput) (*service.Request, *storagegateway.DeleteTapeOutput)
+	DeleteTapeRequest(*storagegateway.DeleteTapeInput) (*request.Request, *storagegateway.DeleteTapeOutput)
 
 	DeleteTape(*storagegateway.DeleteTapeInput) (*storagegateway.DeleteTapeOutput, error)
 
-	DeleteTapeArchiveRequest(*storagegateway.DeleteTapeArchiveInput) (*service.Request, *storagegateway.DeleteTapeArchiveOutput)
+	DeleteTapeArchiveRequest(*storagegateway.DeleteTapeArchiveInput) (*request.Request, *storagegateway.DeleteTapeArchiveOutput)
 
 	DeleteTapeArchive(*storagegateway.DeleteTapeArchiveInput) (*storagegateway.DeleteTapeArchiveOutput, error)
 
-	DeleteVolumeRequest(*storagegateway.DeleteVolumeInput) (*service.Request, *storagegateway.DeleteVolumeOutput)
+	DeleteVolumeRequest(*storagegateway.DeleteVolumeInput) (*request.Request, *storagegateway.DeleteVolumeOutput)
 
 	DeleteVolume(*storagegateway.DeleteVolumeInput) (*storagegateway.DeleteVolumeOutput, error)
 
-	DescribeBandwidthRateLimitRequest(*storagegateway.DescribeBandwidthRateLimitInput) (*service.Request, *storagegateway.DescribeBandwidthRateLimitOutput)
+	DescribeBandwidthRateLimitRequest(*storagegateway.DescribeBandwidthRateLimitInput) (*request.Request, *storagegateway.DescribeBandwidthRateLimitOutput)
 
 	DescribeBandwidthRateLimit(*storagegateway.DescribeBandwidthRateLimitInput) (*storagegateway.DescribeBandwidthRateLimitOutput, error)
 
-	DescribeCacheRequest(*storagegateway.DescribeCacheInput) (*service.Request, *storagegateway.DescribeCacheOutput)
+	DescribeCacheRequest(*storagegateway.DescribeCacheInput) (*request.Request, *storagegateway.DescribeCacheOutput)
 
 	DescribeCache(*storagegateway.DescribeCacheInput) (*storagegateway.DescribeCacheOutput, error)
 
-	DescribeCachediSCSIVolumesRequest(*storagegateway.DescribeCachediSCSIVolumesInput) (*service.Request, *storagegateway.DescribeCachediSCSIVolumesOutput)
+	DescribeCachediSCSIVolumesRequest(*storagegateway.DescribeCachediSCSIVolumesInput) (*request.Request, *storagegateway.DescribeCachediSCSIVolumesOutput)
 
 	DescribeCachediSCSIVolumes(*storagegateway.DescribeCachediSCSIVolumesInput) (*storagegateway.DescribeCachediSCSIVolumesOutput, error)
 
-	DescribeChapCredentialsRequest(*storagegateway.DescribeChapCredentialsInput) (*service.Request, *storagegateway.DescribeChapCredentialsOutput)
+	DescribeChapCredentialsRequest(*storagegateway.DescribeChapCredentialsInput) (*request.Request, *storagegateway.DescribeChapCredentialsOutput)
 
 	DescribeChapCredentials(*storagegateway.DescribeChapCredentialsInput) (*storagegateway.DescribeChapCredentialsOutput, error)
 
-	DescribeGatewayInformationRequest(*storagegateway.DescribeGatewayInformationInput) (*service.Request, *storagegateway.DescribeGatewayInformationOutput)
+	DescribeGatewayInformationRequest(*storagegateway.DescribeGatewayInformationInput) (*request.Request, *storagegateway.DescribeGatewayInformationOutput)
 
 	DescribeGatewayInformation(*storagegateway.DescribeGatewayInformationInput) (*storagegateway.DescribeGatewayInformationOutput, error)
 
-	DescribeMaintenanceStartTimeRequest(*storagegateway.DescribeMaintenanceStartTimeInput) (*service.Request, *storagegateway.DescribeMaintenanceStartTimeOutput)
+	DescribeMaintenanceStartTimeRequest(*storagegateway.DescribeMaintenanceStartTimeInput) (*request.Request, *storagegateway.DescribeMaintenanceStartTimeOutput)
 
 	DescribeMaintenanceStartTime(*storagegateway.DescribeMaintenanceStartTimeInput) (*storagegateway.DescribeMaintenanceStartTimeOutput, error)
 
-	DescribeSnapshotScheduleRequest(*storagegateway.DescribeSnapshotScheduleInput) (*service.Request, *storagegateway.DescribeSnapshotScheduleOutput)
+	DescribeSnapshotScheduleRequest(*storagegateway.DescribeSnapshotScheduleInput) (*request.Request, *storagegateway.DescribeSnapshotScheduleOutput)
 
 	DescribeSnapshotSchedule(*storagegateway.DescribeSnapshotScheduleInput) (*storagegateway.DescribeSnapshotScheduleOutput, error)
 
-	DescribeStorediSCSIVolumesRequest(*storagegateway.DescribeStorediSCSIVolumesInput) (*service.Request, *storagegateway.DescribeStorediSCSIVolumesOutput)
+	DescribeStorediSCSIVolumesRequest(*storagegateway.DescribeStorediSCSIVolumesInput) (*request.Request, *storagegateway.DescribeStorediSCSIVolumesOutput)
 
 	DescribeStorediSCSIVolumes(*storagegateway.DescribeStorediSCSIVolumesInput) (*storagegateway.DescribeStorediSCSIVolumesOutput, error)
 
-	DescribeTapeArchivesRequest(*storagegateway.DescribeTapeArchivesInput) (*service.Request, *storagegateway.DescribeTapeArchivesOutput)
+	DescribeTapeArchivesRequest(*storagegateway.DescribeTapeArchivesInput) (*request.Request, *storagegateway.DescribeTapeArchivesOutput)
 
 	DescribeTapeArchives(*storagegateway.DescribeTapeArchivesInput) (*storagegateway.DescribeTapeArchivesOutput, error)
 
 	DescribeTapeArchivesPages(*storagegateway.DescribeTapeArchivesInput, func(*storagegateway.DescribeTapeArchivesOutput, bool) bool) error
 
-	DescribeTapeRecoveryPointsRequest(*storagegateway.DescribeTapeRecoveryPointsInput) (*service.Request, *storagegateway.DescribeTapeRecoveryPointsOutput)
+	DescribeTapeRecoveryPointsRequest(*storagegateway.DescribeTapeRecoveryPointsInput) (*request.Request, *storagegateway.DescribeTapeRecoveryPointsOutput)
 
 	DescribeTapeRecoveryPoints(*storagegateway.DescribeTapeRecoveryPointsInput) (*storagegateway.DescribeTapeRecoveryPointsOutput, error)
 
 	DescribeTapeRecoveryPointsPages(*storagegateway.DescribeTapeRecoveryPointsInput, func(*storagegateway.DescribeTapeRecoveryPointsOutput, bool) bool) error
 
-	DescribeTapesRequest(*storagegateway.DescribeTapesInput) (*service.Request, *storagegateway.DescribeTapesOutput)
+	DescribeTapesRequest(*storagegateway.DescribeTapesInput) (*request.Request, *storagegateway.DescribeTapesOutput)
 
 	DescribeTapes(*storagegateway.DescribeTapesInput) (*storagegateway.DescribeTapesOutput, error)
 
 	DescribeTapesPages(*storagegateway.DescribeTapesInput, func(*storagegateway.DescribeTapesOutput, bool) bool) error
 
-	DescribeUploadBufferRequest(*storagegateway.DescribeUploadBufferInput) (*service.Request, *storagegateway.DescribeUploadBufferOutput)
+	DescribeUploadBufferRequest(*storagegateway.DescribeUploadBufferInput) (*request.Request, *storagegateway.DescribeUploadBufferOutput)
 
 	DescribeUploadBuffer(*storagegateway.DescribeUploadBufferInput) (*storagegateway.DescribeUploadBufferOutput, error)
 
-	DescribeVTLDevicesRequest(*storagegateway.DescribeVTLDevicesInput) (*service.Request, *storagegateway.DescribeVTLDevicesOutput)
+	DescribeVTLDevicesRequest(*storagegateway.DescribeVTLDevicesInput) (*request.Request, *storagegateway.DescribeVTLDevicesOutput)
 
 	DescribeVTLDevices(*storagegateway.DescribeVTLDevicesInput) (*storagegateway.DescribeVTLDevicesOutput, error)
 
 	DescribeVTLDevicesPages(*storagegateway.DescribeVTLDevicesInput, func(*storagegateway.DescribeVTLDevicesOutput, bool) bool) error
 
-	DescribeWorkingStorageRequest(*storagegateway.DescribeWorkingStorageInput) (*service.Request, *storagegateway.DescribeWorkingStorageOutput)
+	DescribeWorkingStorageRequest(*storagegateway.DescribeWorkingStorageInput) (*request.Request, *storagegateway.DescribeWorkingStorageOutput)
 
 	DescribeWorkingStorage(*storagegateway.DescribeWorkingStorageInput) (*storagegateway.DescribeWorkingStorageOutput, error)
 
-	DisableGatewayRequest(*storagegateway.DisableGatewayInput) (*service.Request, *storagegateway.DisableGatewayOutput)
+	DisableGatewayRequest(*storagegateway.DisableGatewayInput) (*request.Request, *storagegateway.DisableGatewayOutput)
 
 	DisableGateway(*storagegateway.DisableGatewayInput) (*storagegateway.DisableGatewayOutput, error)
 
-	ListGatewaysRequest(*storagegateway.ListGatewaysInput) (*service.Request, *storagegateway.ListGatewaysOutput)
+	ListGatewaysRequest(*storagegateway.ListGatewaysInput) (*request.Request, *storagegateway.ListGatewaysOutput)
 
 	ListGateways(*storagegateway.ListGatewaysInput) (*storagegateway.ListGatewaysOutput, error)
 
 	ListGatewaysPages(*storagegateway.ListGatewaysInput, func(*storagegateway.ListGatewaysOutput, bool) bool) error
 
-	ListLocalDisksRequest(*storagegateway.ListLocalDisksInput) (*service.Request, *storagegateway.ListLocalDisksOutput)
+	ListLocalDisksRequest(*storagegateway.ListLocalDisksInput) (*request.Request, *storagegateway.ListLocalDisksOutput)
 
 	ListLocalDisks(*storagegateway.ListLocalDisksInput) (*storagegateway.ListLocalDisksOutput, error)
 
-	ListVolumeInitiatorsRequest(*storagegateway.ListVolumeInitiatorsInput) (*service.Request, *storagegateway.ListVolumeInitiatorsOutput)
+	ListVolumeInitiatorsRequest(*storagegateway.ListVolumeInitiatorsInput) (*request.Request, *storagegateway.ListVolumeInitiatorsOutput)
 
 	ListVolumeInitiators(*storagegateway.ListVolumeInitiatorsInput) (*storagegateway.ListVolumeInitiatorsOutput, error)
 
-	ListVolumeRecoveryPointsRequest(*storagegateway.ListVolumeRecoveryPointsInput) (*service.Request, *storagegateway.ListVolumeRecoveryPointsOutput)
+	ListVolumeRecoveryPointsRequest(*storagegateway.ListVolumeRecoveryPointsInput) (*request.Request, *storagegateway.ListVolumeRecoveryPointsOutput)
 
 	ListVolumeRecoveryPoints(*storagegateway.ListVolumeRecoveryPointsInput) (*storagegateway.ListVolumeRecoveryPointsOutput, error)
 
-	ListVolumesRequest(*storagegateway.ListVolumesInput) (*service.Request, *storagegateway.ListVolumesOutput)
+	ListVolumesRequest(*storagegateway.ListVolumesInput) (*request.Request, *storagegateway.ListVolumesOutput)
 
 	ListVolumes(*storagegateway.ListVolumesInput) (*storagegateway.ListVolumesOutput, error)
 
 	ListVolumesPages(*storagegateway.ListVolumesInput, func(*storagegateway.ListVolumesOutput, bool) bool) error
 
-	ResetCacheRequest(*storagegateway.ResetCacheInput) (*service.Request, *storagegateway.ResetCacheOutput)
+	ResetCacheRequest(*storagegateway.ResetCacheInput) (*request.Request, *storagegateway.ResetCacheOutput)
 
 	ResetCache(*storagegateway.ResetCacheInput) (*storagegateway.ResetCacheOutput, error)
 
-	RetrieveTapeArchiveRequest(*storagegateway.RetrieveTapeArchiveInput) (*service.Request, *storagegateway.RetrieveTapeArchiveOutput)
+	RetrieveTapeArchiveRequest(*storagegateway.RetrieveTapeArchiveInput) (*request.Request, *storagegateway.RetrieveTapeArchiveOutput)
 
 	RetrieveTapeArchive(*storagegateway.RetrieveTapeArchiveInput) (*storagegateway.RetrieveTapeArchiveOutput, error)
 
-	RetrieveTapeRecoveryPointRequest(*storagegateway.RetrieveTapeRecoveryPointInput) (*service.Request, *storagegateway.RetrieveTapeRecoveryPointOutput)
+	RetrieveTapeRecoveryPointRequest(*storagegateway.RetrieveTapeRecoveryPointInput) (*request.Request, *storagegateway.RetrieveTapeRecoveryPointOutput)
 
 	RetrieveTapeRecoveryPoint(*storagegateway.RetrieveTapeRecoveryPointInput) (*storagegateway.RetrieveTapeRecoveryPointOutput, error)
 
-	ShutdownGatewayRequest(*storagegateway.ShutdownGatewayInput) (*service.Request, *storagegateway.ShutdownGatewayOutput)
+	ShutdownGatewayRequest(*storagegateway.ShutdownGatewayInput) (*request.Request, *storagegateway.ShutdownGatewayOutput)
 
 	ShutdownGateway(*storagegateway.ShutdownGatewayInput) (*storagegateway.ShutdownGatewayOutput, error)
 
-	StartGatewayRequest(*storagegateway.StartGatewayInput) (*service.Request, *storagegateway.StartGatewayOutput)
+	StartGatewayRequest(*storagegateway.StartGatewayInput) (*request.Request, *storagegateway.StartGatewayOutput)
 
 	StartGateway(*storagegateway.StartGatewayInput) (*storagegateway.StartGatewayOutput, error)
 
-	UpdateBandwidthRateLimitRequest(*storagegateway.UpdateBandwidthRateLimitInput) (*service.Request, *storagegateway.UpdateBandwidthRateLimitOutput)
+	UpdateBandwidthRateLimitRequest(*storagegateway.UpdateBandwidthRateLimitInput) (*request.Request, *storagegateway.UpdateBandwidthRateLimitOutput)
 
 	UpdateBandwidthRateLimit(*storagegateway.UpdateBandwidthRateLimitInput) (*storagegateway.UpdateBandwidthRateLimitOutput, error)
 
-	UpdateChapCredentialsRequest(*storagegateway.UpdateChapCredentialsInput) (*service.Request, *storagegateway.UpdateChapCredentialsOutput)
+	UpdateChapCredentialsRequest(*storagegateway.UpdateChapCredentialsInput) (*request.Request, *storagegateway.UpdateChapCredentialsOutput)
 
 	UpdateChapCredentials(*storagegateway.UpdateChapCredentialsInput) (*storagegateway.UpdateChapCredentialsOutput, error)
 
-	UpdateGatewayInformationRequest(*storagegateway.UpdateGatewayInformationInput) (*service.Request, *storagegateway.UpdateGatewayInformationOutput)
+	UpdateGatewayInformationRequest(*storagegateway.UpdateGatewayInformationInput) (*request.Request, *storagegateway.UpdateGatewayInformationOutput)
 
 	UpdateGatewayInformation(*storagegateway.UpdateGatewayInformationInput) (*storagegateway.UpdateGatewayInformationOutput, error)
 
-	UpdateGatewaySoftwareNowRequest(*storagegateway.UpdateGatewaySoftwareNowInput) (*service.Request, *storagegateway.UpdateGatewaySoftwareNowOutput)
+	UpdateGatewaySoftwareNowRequest(*storagegateway.UpdateGatewaySoftwareNowInput) (*request.Request, *storagegateway.UpdateGatewaySoftwareNowOutput)
 
 	UpdateGatewaySoftwareNow(*storagegateway.UpdateGatewaySoftwareNowInput) (*storagegateway.UpdateGatewaySoftwareNowOutput, error)
 
-	UpdateMaintenanceStartTimeRequest(*storagegateway.UpdateMaintenanceStartTimeInput) (*service.Request, *storagegateway.UpdateMaintenanceStartTimeOutput)
+	UpdateMaintenanceStartTimeRequest(*storagegateway.UpdateMaintenanceStartTimeInput) (*request.Request, *storagegateway.UpdateMaintenanceStartTimeOutput)
 
 	UpdateMaintenanceStartTime(*storagegateway.UpdateMaintenanceStartTimeInput) (*storagegateway.UpdateMaintenanceStartTimeOutput, error)
 
-	UpdateSnapshotScheduleRequest(*storagegateway.UpdateSnapshotScheduleInput) (*service.Request, *storagegateway.UpdateSnapshotScheduleOutput)
+	UpdateSnapshotScheduleRequest(*storagegateway.UpdateSnapshotScheduleInput) (*request.Request, *storagegateway.UpdateSnapshotScheduleOutput)
 
 	UpdateSnapshotSchedule(*storagegateway.UpdateSnapshotScheduleInput) (*storagegateway.UpdateSnapshotScheduleOutput, error)
 
-	UpdateVTLDeviceTypeRequest(*storagegateway.UpdateVTLDeviceTypeInput) (*service.Request, *storagegateway.UpdateVTLDeviceTypeOutput)
+	UpdateVTLDeviceTypeRequest(*storagegateway.UpdateVTLDeviceTypeInput) (*request.Request, *storagegateway.UpdateVTLDeviceTypeOutput)
 
 	UpdateVTLDeviceType(*storagegateway.UpdateVTLDeviceTypeInput) (*storagegateway.UpdateVTLDeviceTypeOutput, error)
 }

--- a/service/sts/api.go
+++ b/service/sts/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAssumeRole = "AssumeRole"
 
 // AssumeRoleRequest generates a request for the AssumeRole operation.
-func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *service.Request, output *AssumeRoleOutput) {
-	op := &service.Operation{
+func (c *STS) AssumeRoleRequest(input *AssumeRoleInput) (req *request.Request, output *AssumeRoleOutput) {
+	op := &request.Operation{
 		Name:       opAssumeRole,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -111,8 +111,8 @@ func (c *STS) AssumeRole(input *AssumeRoleInput) (*AssumeRoleOutput, error) {
 const opAssumeRoleWithSAML = "AssumeRoleWithSAML"
 
 // AssumeRoleWithSAMLRequest generates a request for the AssumeRoleWithSAML operation.
-func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *service.Request, output *AssumeRoleWithSAMLOutput) {
-	op := &service.Operation{
+func (c *STS) AssumeRoleWithSAMLRequest(input *AssumeRoleWithSAMLInput) (req *request.Request, output *AssumeRoleWithSAMLOutput) {
+	op := &request.Operation{
 		Name:       opAssumeRoleWithSAML,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -182,8 +182,8 @@ func (c *STS) AssumeRoleWithSAML(input *AssumeRoleWithSAMLInput) (*AssumeRoleWit
 const opAssumeRoleWithWebIdentity = "AssumeRoleWithWebIdentity"
 
 // AssumeRoleWithWebIdentityRequest generates a request for the AssumeRoleWithWebIdentity operation.
-func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityInput) (req *service.Request, output *AssumeRoleWithWebIdentityOutput) {
-	op := &service.Operation{
+func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityInput) (req *request.Request, output *AssumeRoleWithWebIdentityOutput) {
+	op := &request.Operation{
 		Name:       opAssumeRoleWithWebIdentity,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -273,8 +273,8 @@ func (c *STS) AssumeRoleWithWebIdentity(input *AssumeRoleWithWebIdentityInput) (
 const opDecodeAuthorizationMessage = "DecodeAuthorizationMessage"
 
 // DecodeAuthorizationMessageRequest generates a request for the DecodeAuthorizationMessage operation.
-func (c *STS) DecodeAuthorizationMessageRequest(input *DecodeAuthorizationMessageInput) (req *service.Request, output *DecodeAuthorizationMessageOutput) {
-	op := &service.Operation{
+func (c *STS) DecodeAuthorizationMessageRequest(input *DecodeAuthorizationMessageInput) (req *request.Request, output *DecodeAuthorizationMessageOutput) {
+	op := &request.Operation{
 		Name:       opDecodeAuthorizationMessage,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -323,8 +323,8 @@ func (c *STS) DecodeAuthorizationMessage(input *DecodeAuthorizationMessageInput)
 const opGetFederationToken = "GetFederationToken"
 
 // GetFederationTokenRequest generates a request for the GetFederationToken operation.
-func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *service.Request, output *GetFederationTokenOutput) {
-	op := &service.Operation{
+func (c *STS) GetFederationTokenRequest(input *GetFederationTokenInput) (req *request.Request, output *GetFederationTokenOutput) {
+	op := &request.Operation{
 		Name:       opGetFederationToken,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -413,8 +413,8 @@ func (c *STS) GetFederationToken(input *GetFederationTokenInput) (*GetFederation
 const opGetSessionToken = "GetSessionToken"
 
 // GetSessionTokenRequest generates a request for the GetSessionToken operation.
-func (c *STS) GetSessionTokenRequest(input *GetSessionTokenInput) (req *service.Request, output *GetSessionTokenOutput) {
-	op := &service.Operation{
+func (c *STS) GetSessionTokenRequest(input *GetSessionTokenInput) (req *request.Request, output *GetSessionTokenOutput) {
+	op := &request.Operation{
 		Name:       opGetSessionToken,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/sts/customizations.go
+++ b/service/sts/customizations.go
@@ -1,9 +1,9 @@
 package sts
 
-import "github.com/aws/aws-sdk-go/aws/service"
+import "github.com/aws/aws-sdk-go/aws/request"
 
 func init() {
-	initRequest = func(r *service.Request) {
+	initRequest = func(r *request.Request) {
 		switch r.Operation.Name {
 		case opAssumeRoleWithSAML, opAssumeRoleWithWebIdentity:
 			r.Handlers.Sign.Clear() // these operations are unsigned

--- a/service/sts/service.go
+++ b/service/sts/service.go
@@ -5,7 +5,9 @@ package sts
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/query"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -65,14 +67,16 @@ type STS struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new STS client.
 func New(config *aws.Config) *STS {
 	service := &service.Service{
-		Config:      defaults.DefaultConfig.Merge(config),
-		ServiceName: "sts",
-		APIVersion:  "2011-06-15",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:      defaults.DefaultConfig.Merge(config),
+			ServiceName: "sts",
+			APIVersion:  "2011-06-15",
+		},
 	}
 	service.Initialize()
 
@@ -93,8 +97,8 @@ func New(config *aws.Config) *STS {
 
 // newRequest creates a new request for a STS operation and runs any
 // custom request initialization.
-func (c *STS) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *STS) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/sts/stsiface/interface.go
+++ b/service/sts/stsiface/interface.go
@@ -4,33 +4,33 @@
 package stsiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 // STSAPI is the interface type for sts.STS.
 type STSAPI interface {
-	AssumeRoleRequest(*sts.AssumeRoleInput) (*service.Request, *sts.AssumeRoleOutput)
+	AssumeRoleRequest(*sts.AssumeRoleInput) (*request.Request, *sts.AssumeRoleOutput)
 
 	AssumeRole(*sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
 
-	AssumeRoleWithSAMLRequest(*sts.AssumeRoleWithSAMLInput) (*service.Request, *sts.AssumeRoleWithSAMLOutput)
+	AssumeRoleWithSAMLRequest(*sts.AssumeRoleWithSAMLInput) (*request.Request, *sts.AssumeRoleWithSAMLOutput)
 
 	AssumeRoleWithSAML(*sts.AssumeRoleWithSAMLInput) (*sts.AssumeRoleWithSAMLOutput, error)
 
-	AssumeRoleWithWebIdentityRequest(*sts.AssumeRoleWithWebIdentityInput) (*service.Request, *sts.AssumeRoleWithWebIdentityOutput)
+	AssumeRoleWithWebIdentityRequest(*sts.AssumeRoleWithWebIdentityInput) (*request.Request, *sts.AssumeRoleWithWebIdentityOutput)
 
 	AssumeRoleWithWebIdentity(*sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error)
 
-	DecodeAuthorizationMessageRequest(*sts.DecodeAuthorizationMessageInput) (*service.Request, *sts.DecodeAuthorizationMessageOutput)
+	DecodeAuthorizationMessageRequest(*sts.DecodeAuthorizationMessageInput) (*request.Request, *sts.DecodeAuthorizationMessageOutput)
 
 	DecodeAuthorizationMessage(*sts.DecodeAuthorizationMessageInput) (*sts.DecodeAuthorizationMessageOutput, error)
 
-	GetFederationTokenRequest(*sts.GetFederationTokenInput) (*service.Request, *sts.GetFederationTokenOutput)
+	GetFederationTokenRequest(*sts.GetFederationTokenInput) (*request.Request, *sts.GetFederationTokenOutput)
 
 	GetFederationToken(*sts.GetFederationTokenInput) (*sts.GetFederationTokenOutput, error)
 
-	GetSessionTokenRequest(*sts.GetSessionTokenInput) (*service.Request, *sts.GetSessionTokenOutput)
+	GetSessionTokenRequest(*sts.GetSessionTokenInput) (*request.Request, *sts.GetSessionTokenOutput)
 
 	GetSessionToken(*sts.GetSessionTokenInput) (*sts.GetSessionTokenOutput, error)
 }

--- a/service/support/api.go
+++ b/service/support/api.go
@@ -5,14 +5,14 @@ package support
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opAddAttachmentsToSet = "AddAttachmentsToSet"
 
 // AddAttachmentsToSetRequest generates a request for the AddAttachmentsToSet operation.
-func (c *Support) AddAttachmentsToSetRequest(input *AddAttachmentsToSetInput) (req *service.Request, output *AddAttachmentsToSetOutput) {
-	op := &service.Operation{
+func (c *Support) AddAttachmentsToSetRequest(input *AddAttachmentsToSetInput) (req *request.Request, output *AddAttachmentsToSetOutput) {
+	op := &request.Operation{
 		Name:       opAddAttachmentsToSet,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -47,8 +47,8 @@ func (c *Support) AddAttachmentsToSet(input *AddAttachmentsToSetInput) (*AddAtta
 const opAddCommunicationToCase = "AddCommunicationToCase"
 
 // AddCommunicationToCaseRequest generates a request for the AddCommunicationToCase operation.
-func (c *Support) AddCommunicationToCaseRequest(input *AddCommunicationToCaseInput) (req *service.Request, output *AddCommunicationToCaseOutput) {
-	op := &service.Operation{
+func (c *Support) AddCommunicationToCaseRequest(input *AddCommunicationToCaseInput) (req *request.Request, output *AddCommunicationToCaseOutput) {
+	op := &request.Operation{
 		Name:       opAddCommunicationToCase,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -81,8 +81,8 @@ func (c *Support) AddCommunicationToCase(input *AddCommunicationToCaseInput) (*A
 const opCreateCase = "CreateCase"
 
 // CreateCaseRequest generates a request for the CreateCase operation.
-func (c *Support) CreateCaseRequest(input *CreateCaseInput) (req *service.Request, output *CreateCaseOutput) {
-	op := &service.Operation{
+func (c *Support) CreateCaseRequest(input *CreateCaseInput) (req *request.Request, output *CreateCaseOutput) {
+	op := &request.Operation{
 		Name:       opCreateCase,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -137,8 +137,8 @@ func (c *Support) CreateCase(input *CreateCaseInput) (*CreateCaseOutput, error) 
 const opDescribeAttachment = "DescribeAttachment"
 
 // DescribeAttachmentRequest generates a request for the DescribeAttachment operation.
-func (c *Support) DescribeAttachmentRequest(input *DescribeAttachmentInput) (req *service.Request, output *DescribeAttachmentOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeAttachmentRequest(input *DescribeAttachmentInput) (req *request.Request, output *DescribeAttachmentOutput) {
+	op := &request.Operation{
 		Name:       opDescribeAttachment,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -167,12 +167,12 @@ func (c *Support) DescribeAttachment(input *DescribeAttachmentInput) (*DescribeA
 const opDescribeCases = "DescribeCases"
 
 // DescribeCasesRequest generates a request for the DescribeCases operation.
-func (c *Support) DescribeCasesRequest(input *DescribeCasesInput) (req *service.Request, output *DescribeCasesOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeCasesRequest(input *DescribeCasesInput) (req *request.Request, output *DescribeCasesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCases,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "maxResults",
@@ -220,12 +220,12 @@ func (c *Support) DescribeCasesPages(input *DescribeCasesInput, fn func(p *Descr
 const opDescribeCommunications = "DescribeCommunications"
 
 // DescribeCommunicationsRequest generates a request for the DescribeCommunications operation.
-func (c *Support) DescribeCommunicationsRequest(input *DescribeCommunicationsInput) (req *service.Request, output *DescribeCommunicationsOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeCommunicationsRequest(input *DescribeCommunicationsInput) (req *request.Request, output *DescribeCommunicationsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeCommunications,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextToken"},
 			OutputTokens:    []string{"nextToken"},
 			LimitToken:      "maxResults",
@@ -269,8 +269,8 @@ func (c *Support) DescribeCommunicationsPages(input *DescribeCommunicationsInput
 const opDescribeServices = "DescribeServices"
 
 // DescribeServicesRequest generates a request for the DescribeServices operation.
-func (c *Support) DescribeServicesRequest(input *DescribeServicesInput) (req *service.Request, output *DescribeServicesOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeServicesRequest(input *DescribeServicesInput) (req *request.Request, output *DescribeServicesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeServices,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -306,8 +306,8 @@ func (c *Support) DescribeServices(input *DescribeServicesInput) (*DescribeServi
 const opDescribeSeverityLevels = "DescribeSeverityLevels"
 
 // DescribeSeverityLevelsRequest generates a request for the DescribeSeverityLevels operation.
-func (c *Support) DescribeSeverityLevelsRequest(input *DescribeSeverityLevelsInput) (req *service.Request, output *DescribeSeverityLevelsOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeSeverityLevelsRequest(input *DescribeSeverityLevelsInput) (req *request.Request, output *DescribeSeverityLevelsOutput) {
+	op := &request.Operation{
 		Name:       opDescribeSeverityLevels,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -335,8 +335,8 @@ func (c *Support) DescribeSeverityLevels(input *DescribeSeverityLevelsInput) (*D
 const opDescribeTrustedAdvisorCheckRefreshStatuses = "DescribeTrustedAdvisorCheckRefreshStatuses"
 
 // DescribeTrustedAdvisorCheckRefreshStatusesRequest generates a request for the DescribeTrustedAdvisorCheckRefreshStatuses operation.
-func (c *Support) DescribeTrustedAdvisorCheckRefreshStatusesRequest(input *DescribeTrustedAdvisorCheckRefreshStatusesInput) (req *service.Request, output *DescribeTrustedAdvisorCheckRefreshStatusesOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeTrustedAdvisorCheckRefreshStatusesRequest(input *DescribeTrustedAdvisorCheckRefreshStatusesInput) (req *request.Request, output *DescribeTrustedAdvisorCheckRefreshStatusesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTrustedAdvisorCheckRefreshStatuses,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -363,8 +363,8 @@ func (c *Support) DescribeTrustedAdvisorCheckRefreshStatuses(input *DescribeTrus
 const opDescribeTrustedAdvisorCheckResult = "DescribeTrustedAdvisorCheckResult"
 
 // DescribeTrustedAdvisorCheckResultRequest generates a request for the DescribeTrustedAdvisorCheckResult operation.
-func (c *Support) DescribeTrustedAdvisorCheckResultRequest(input *DescribeTrustedAdvisorCheckResultInput) (req *service.Request, output *DescribeTrustedAdvisorCheckResultOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeTrustedAdvisorCheckResultRequest(input *DescribeTrustedAdvisorCheckResultInput) (req *request.Request, output *DescribeTrustedAdvisorCheckResultOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTrustedAdvisorCheckResult,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -401,8 +401,8 @@ func (c *Support) DescribeTrustedAdvisorCheckResult(input *DescribeTrustedAdviso
 const opDescribeTrustedAdvisorCheckSummaries = "DescribeTrustedAdvisorCheckSummaries"
 
 // DescribeTrustedAdvisorCheckSummariesRequest generates a request for the DescribeTrustedAdvisorCheckSummaries operation.
-func (c *Support) DescribeTrustedAdvisorCheckSummariesRequest(input *DescribeTrustedAdvisorCheckSummariesInput) (req *service.Request, output *DescribeTrustedAdvisorCheckSummariesOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeTrustedAdvisorCheckSummariesRequest(input *DescribeTrustedAdvisorCheckSummariesInput) (req *request.Request, output *DescribeTrustedAdvisorCheckSummariesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTrustedAdvisorCheckSummaries,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -431,8 +431,8 @@ func (c *Support) DescribeTrustedAdvisorCheckSummaries(input *DescribeTrustedAdv
 const opDescribeTrustedAdvisorChecks = "DescribeTrustedAdvisorChecks"
 
 // DescribeTrustedAdvisorChecksRequest generates a request for the DescribeTrustedAdvisorChecks operation.
-func (c *Support) DescribeTrustedAdvisorChecksRequest(input *DescribeTrustedAdvisorChecksInput) (req *service.Request, output *DescribeTrustedAdvisorChecksOutput) {
-	op := &service.Operation{
+func (c *Support) DescribeTrustedAdvisorChecksRequest(input *DescribeTrustedAdvisorChecksInput) (req *request.Request, output *DescribeTrustedAdvisorChecksOutput) {
+	op := &request.Operation{
 		Name:       opDescribeTrustedAdvisorChecks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -461,8 +461,8 @@ func (c *Support) DescribeTrustedAdvisorChecks(input *DescribeTrustedAdvisorChec
 const opRefreshTrustedAdvisorCheck = "RefreshTrustedAdvisorCheck"
 
 // RefreshTrustedAdvisorCheckRequest generates a request for the RefreshTrustedAdvisorCheck operation.
-func (c *Support) RefreshTrustedAdvisorCheckRequest(input *RefreshTrustedAdvisorCheckInput) (req *service.Request, output *RefreshTrustedAdvisorCheckOutput) {
-	op := &service.Operation{
+func (c *Support) RefreshTrustedAdvisorCheckRequest(input *RefreshTrustedAdvisorCheckInput) (req *request.Request, output *RefreshTrustedAdvisorCheckOutput) {
+	op := &request.Operation{
 		Name:       opRefreshTrustedAdvisorCheck,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -497,8 +497,8 @@ func (c *Support) RefreshTrustedAdvisorCheck(input *RefreshTrustedAdvisorCheckIn
 const opResolveCase = "ResolveCase"
 
 // ResolveCaseRequest generates a request for the ResolveCase operation.
-func (c *Support) ResolveCaseRequest(input *ResolveCaseInput) (req *service.Request, output *ResolveCaseOutput) {
-	op := &service.Operation{
+func (c *Support) ResolveCaseRequest(input *ResolveCaseInput) (req *request.Request, output *ResolveCaseOutput) {
+	op := &request.Operation{
 		Name:       opResolveCase,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/support/service.go
+++ b/service/support/service.go
@@ -5,7 +5,9 @@ package support
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -53,16 +55,18 @@ type Support struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new Support client.
 func New(config *aws.Config) *Support {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "support",
-		APIVersion:   "2013-04-15",
-		JSONVersion:  "1.1",
-		TargetPrefix: "AWSSupport_20130415",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "support",
+			APIVersion:   "2013-04-15",
+			JSONVersion:  "1.1",
+			TargetPrefix: "AWSSupport_20130415",
+		},
 	}
 	service.Initialize()
 
@@ -83,8 +87,8 @@ func New(config *aws.Config) *Support {
 
 // newRequest creates a new request for a Support operation and runs any
 // custom request initialization.
-func (c *Support) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *Support) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/support/supportiface/interface.go
+++ b/service/support/supportiface/interface.go
@@ -4,69 +4,69 @@
 package supportiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/support"
 )
 
 // SupportAPI is the interface type for support.Support.
 type SupportAPI interface {
-	AddAttachmentsToSetRequest(*support.AddAttachmentsToSetInput) (*service.Request, *support.AddAttachmentsToSetOutput)
+	AddAttachmentsToSetRequest(*support.AddAttachmentsToSetInput) (*request.Request, *support.AddAttachmentsToSetOutput)
 
 	AddAttachmentsToSet(*support.AddAttachmentsToSetInput) (*support.AddAttachmentsToSetOutput, error)
 
-	AddCommunicationToCaseRequest(*support.AddCommunicationToCaseInput) (*service.Request, *support.AddCommunicationToCaseOutput)
+	AddCommunicationToCaseRequest(*support.AddCommunicationToCaseInput) (*request.Request, *support.AddCommunicationToCaseOutput)
 
 	AddCommunicationToCase(*support.AddCommunicationToCaseInput) (*support.AddCommunicationToCaseOutput, error)
 
-	CreateCaseRequest(*support.CreateCaseInput) (*service.Request, *support.CreateCaseOutput)
+	CreateCaseRequest(*support.CreateCaseInput) (*request.Request, *support.CreateCaseOutput)
 
 	CreateCase(*support.CreateCaseInput) (*support.CreateCaseOutput, error)
 
-	DescribeAttachmentRequest(*support.DescribeAttachmentInput) (*service.Request, *support.DescribeAttachmentOutput)
+	DescribeAttachmentRequest(*support.DescribeAttachmentInput) (*request.Request, *support.DescribeAttachmentOutput)
 
 	DescribeAttachment(*support.DescribeAttachmentInput) (*support.DescribeAttachmentOutput, error)
 
-	DescribeCasesRequest(*support.DescribeCasesInput) (*service.Request, *support.DescribeCasesOutput)
+	DescribeCasesRequest(*support.DescribeCasesInput) (*request.Request, *support.DescribeCasesOutput)
 
 	DescribeCases(*support.DescribeCasesInput) (*support.DescribeCasesOutput, error)
 
 	DescribeCasesPages(*support.DescribeCasesInput, func(*support.DescribeCasesOutput, bool) bool) error
 
-	DescribeCommunicationsRequest(*support.DescribeCommunicationsInput) (*service.Request, *support.DescribeCommunicationsOutput)
+	DescribeCommunicationsRequest(*support.DescribeCommunicationsInput) (*request.Request, *support.DescribeCommunicationsOutput)
 
 	DescribeCommunications(*support.DescribeCommunicationsInput) (*support.DescribeCommunicationsOutput, error)
 
 	DescribeCommunicationsPages(*support.DescribeCommunicationsInput, func(*support.DescribeCommunicationsOutput, bool) bool) error
 
-	DescribeServicesRequest(*support.DescribeServicesInput) (*service.Request, *support.DescribeServicesOutput)
+	DescribeServicesRequest(*support.DescribeServicesInput) (*request.Request, *support.DescribeServicesOutput)
 
 	DescribeServices(*support.DescribeServicesInput) (*support.DescribeServicesOutput, error)
 
-	DescribeSeverityLevelsRequest(*support.DescribeSeverityLevelsInput) (*service.Request, *support.DescribeSeverityLevelsOutput)
+	DescribeSeverityLevelsRequest(*support.DescribeSeverityLevelsInput) (*request.Request, *support.DescribeSeverityLevelsOutput)
 
 	DescribeSeverityLevels(*support.DescribeSeverityLevelsInput) (*support.DescribeSeverityLevelsOutput, error)
 
-	DescribeTrustedAdvisorCheckRefreshStatusesRequest(*support.DescribeTrustedAdvisorCheckRefreshStatusesInput) (*service.Request, *support.DescribeTrustedAdvisorCheckRefreshStatusesOutput)
+	DescribeTrustedAdvisorCheckRefreshStatusesRequest(*support.DescribeTrustedAdvisorCheckRefreshStatusesInput) (*request.Request, *support.DescribeTrustedAdvisorCheckRefreshStatusesOutput)
 
 	DescribeTrustedAdvisorCheckRefreshStatuses(*support.DescribeTrustedAdvisorCheckRefreshStatusesInput) (*support.DescribeTrustedAdvisorCheckRefreshStatusesOutput, error)
 
-	DescribeTrustedAdvisorCheckResultRequest(*support.DescribeTrustedAdvisorCheckResultInput) (*service.Request, *support.DescribeTrustedAdvisorCheckResultOutput)
+	DescribeTrustedAdvisorCheckResultRequest(*support.DescribeTrustedAdvisorCheckResultInput) (*request.Request, *support.DescribeTrustedAdvisorCheckResultOutput)
 
 	DescribeTrustedAdvisorCheckResult(*support.DescribeTrustedAdvisorCheckResultInput) (*support.DescribeTrustedAdvisorCheckResultOutput, error)
 
-	DescribeTrustedAdvisorCheckSummariesRequest(*support.DescribeTrustedAdvisorCheckSummariesInput) (*service.Request, *support.DescribeTrustedAdvisorCheckSummariesOutput)
+	DescribeTrustedAdvisorCheckSummariesRequest(*support.DescribeTrustedAdvisorCheckSummariesInput) (*request.Request, *support.DescribeTrustedAdvisorCheckSummariesOutput)
 
 	DescribeTrustedAdvisorCheckSummaries(*support.DescribeTrustedAdvisorCheckSummariesInput) (*support.DescribeTrustedAdvisorCheckSummariesOutput, error)
 
-	DescribeTrustedAdvisorChecksRequest(*support.DescribeTrustedAdvisorChecksInput) (*service.Request, *support.DescribeTrustedAdvisorChecksOutput)
+	DescribeTrustedAdvisorChecksRequest(*support.DescribeTrustedAdvisorChecksInput) (*request.Request, *support.DescribeTrustedAdvisorChecksOutput)
 
 	DescribeTrustedAdvisorChecks(*support.DescribeTrustedAdvisorChecksInput) (*support.DescribeTrustedAdvisorChecksOutput, error)
 
-	RefreshTrustedAdvisorCheckRequest(*support.RefreshTrustedAdvisorCheckInput) (*service.Request, *support.RefreshTrustedAdvisorCheckOutput)
+	RefreshTrustedAdvisorCheckRequest(*support.RefreshTrustedAdvisorCheckInput) (*request.Request, *support.RefreshTrustedAdvisorCheckOutput)
 
 	RefreshTrustedAdvisorCheck(*support.RefreshTrustedAdvisorCheckInput) (*support.RefreshTrustedAdvisorCheckOutput, error)
 
-	ResolveCaseRequest(*support.ResolveCaseInput) (*service.Request, *support.ResolveCaseOutput)
+	ResolveCaseRequest(*support.ResolveCaseInput) (*request.Request, *support.ResolveCaseOutput)
 
 	ResolveCase(*support.ResolveCaseInput) (*support.ResolveCaseOutput, error)
 }

--- a/service/swf/api.go
+++ b/service/swf/api.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCountClosedWorkflowExecutions = "CountClosedWorkflowExecutions"
 
 // CountClosedWorkflowExecutionsRequest generates a request for the CountClosedWorkflowExecutions operation.
-func (c *SWF) CountClosedWorkflowExecutionsRequest(input *CountClosedWorkflowExecutionsInput) (req *service.Request, output *WorkflowExecutionCount) {
-	op := &service.Operation{
+func (c *SWF) CountClosedWorkflowExecutionsRequest(input *CountClosedWorkflowExecutionsInput) (req *request.Request, output *WorkflowExecutionCount) {
+	op := &request.Operation{
 		Name:       opCountClosedWorkflowExecutions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -59,8 +59,8 @@ func (c *SWF) CountClosedWorkflowExecutions(input *CountClosedWorkflowExecutions
 const opCountOpenWorkflowExecutions = "CountOpenWorkflowExecutions"
 
 // CountOpenWorkflowExecutionsRequest generates a request for the CountOpenWorkflowExecutions operation.
-func (c *SWF) CountOpenWorkflowExecutionsRequest(input *CountOpenWorkflowExecutionsInput) (req *service.Request, output *WorkflowExecutionCount) {
-	op := &service.Operation{
+func (c *SWF) CountOpenWorkflowExecutionsRequest(input *CountOpenWorkflowExecutionsInput) (req *request.Request, output *WorkflowExecutionCount) {
+	op := &request.Operation{
 		Name:       opCountOpenWorkflowExecutions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -105,8 +105,8 @@ func (c *SWF) CountOpenWorkflowExecutions(input *CountOpenWorkflowExecutionsInpu
 const opCountPendingActivityTasks = "CountPendingActivityTasks"
 
 // CountPendingActivityTasksRequest generates a request for the CountPendingActivityTasks operation.
-func (c *SWF) CountPendingActivityTasksRequest(input *CountPendingActivityTasksInput) (req *service.Request, output *PendingTaskCount) {
-	op := &service.Operation{
+func (c *SWF) CountPendingActivityTasksRequest(input *CountPendingActivityTasksInput) (req *request.Request, output *PendingTaskCount) {
+	op := &request.Operation{
 		Name:       opCountPendingActivityTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -150,8 +150,8 @@ func (c *SWF) CountPendingActivityTasks(input *CountPendingActivityTasksInput) (
 const opCountPendingDecisionTasks = "CountPendingDecisionTasks"
 
 // CountPendingDecisionTasksRequest generates a request for the CountPendingDecisionTasks operation.
-func (c *SWF) CountPendingDecisionTasksRequest(input *CountPendingDecisionTasksInput) (req *service.Request, output *PendingTaskCount) {
-	op := &service.Operation{
+func (c *SWF) CountPendingDecisionTasksRequest(input *CountPendingDecisionTasksInput) (req *request.Request, output *PendingTaskCount) {
+	op := &request.Operation{
 		Name:       opCountPendingDecisionTasks,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -195,8 +195,8 @@ func (c *SWF) CountPendingDecisionTasks(input *CountPendingDecisionTasksInput) (
 const opDeprecateActivityType = "DeprecateActivityType"
 
 // DeprecateActivityTypeRequest generates a request for the DeprecateActivityType operation.
-func (c *SWF) DeprecateActivityTypeRequest(input *DeprecateActivityTypeInput) (req *service.Request, output *DeprecateActivityTypeOutput) {
-	op := &service.Operation{
+func (c *SWF) DeprecateActivityTypeRequest(input *DeprecateActivityTypeInput) (req *request.Request, output *DeprecateActivityTypeOutput) {
+	op := &request.Operation{
 		Name:       opDeprecateActivityType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -241,8 +241,8 @@ func (c *SWF) DeprecateActivityType(input *DeprecateActivityTypeInput) (*Depreca
 const opDeprecateDomain = "DeprecateDomain"
 
 // DeprecateDomainRequest generates a request for the DeprecateDomain operation.
-func (c *SWF) DeprecateDomainRequest(input *DeprecateDomainInput) (req *service.Request, output *DeprecateDomainOutput) {
-	op := &service.Operation{
+func (c *SWF) DeprecateDomainRequest(input *DeprecateDomainInput) (req *request.Request, output *DeprecateDomainOutput) {
+	op := &request.Operation{
 		Name:       opDeprecateDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -288,8 +288,8 @@ func (c *SWF) DeprecateDomain(input *DeprecateDomainInput) (*DeprecateDomainOutp
 const opDeprecateWorkflowType = "DeprecateWorkflowType"
 
 // DeprecateWorkflowTypeRequest generates a request for the DeprecateWorkflowType operation.
-func (c *SWF) DeprecateWorkflowTypeRequest(input *DeprecateWorkflowTypeInput) (req *service.Request, output *DeprecateWorkflowTypeOutput) {
-	op := &service.Operation{
+func (c *SWF) DeprecateWorkflowTypeRequest(input *DeprecateWorkflowTypeInput) (req *request.Request, output *DeprecateWorkflowTypeOutput) {
+	op := &request.Operation{
 		Name:       opDeprecateWorkflowType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -335,8 +335,8 @@ func (c *SWF) DeprecateWorkflowType(input *DeprecateWorkflowTypeInput) (*Depreca
 const opDescribeActivityType = "DescribeActivityType"
 
 // DescribeActivityTypeRequest generates a request for the DescribeActivityType operation.
-func (c *SWF) DescribeActivityTypeRequest(input *DescribeActivityTypeInput) (req *service.Request, output *DescribeActivityTypeOutput) {
-	op := &service.Operation{
+func (c *SWF) DescribeActivityTypeRequest(input *DescribeActivityTypeInput) (req *request.Request, output *DescribeActivityTypeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeActivityType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -380,8 +380,8 @@ func (c *SWF) DescribeActivityType(input *DescribeActivityTypeInput) (*DescribeA
 const opDescribeDomain = "DescribeDomain"
 
 // DescribeDomainRequest generates a request for the DescribeDomain operation.
-func (c *SWF) DescribeDomainRequest(input *DescribeDomainInput) (req *service.Request, output *DescribeDomainOutput) {
-	op := &service.Operation{
+func (c *SWF) DescribeDomainRequest(input *DescribeDomainInput) (req *request.Request, output *DescribeDomainOutput) {
+	op := &request.Operation{
 		Name:       opDescribeDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -422,8 +422,8 @@ func (c *SWF) DescribeDomain(input *DescribeDomainInput) (*DescribeDomainOutput,
 const opDescribeWorkflowExecution = "DescribeWorkflowExecution"
 
 // DescribeWorkflowExecutionRequest generates a request for the DescribeWorkflowExecution operation.
-func (c *SWF) DescribeWorkflowExecutionRequest(input *DescribeWorkflowExecutionInput) (req *service.Request, output *DescribeWorkflowExecutionOutput) {
-	op := &service.Operation{
+func (c *SWF) DescribeWorkflowExecutionRequest(input *DescribeWorkflowExecutionInput) (req *request.Request, output *DescribeWorkflowExecutionOutput) {
+	op := &request.Operation{
 		Name:       opDescribeWorkflowExecution,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -465,8 +465,8 @@ func (c *SWF) DescribeWorkflowExecution(input *DescribeWorkflowExecutionInput) (
 const opDescribeWorkflowType = "DescribeWorkflowType"
 
 // DescribeWorkflowTypeRequest generates a request for the DescribeWorkflowType operation.
-func (c *SWF) DescribeWorkflowTypeRequest(input *DescribeWorkflowTypeInput) (req *service.Request, output *DescribeWorkflowTypeOutput) {
-	op := &service.Operation{
+func (c *SWF) DescribeWorkflowTypeRequest(input *DescribeWorkflowTypeInput) (req *request.Request, output *DescribeWorkflowTypeOutput) {
+	op := &request.Operation{
 		Name:       opDescribeWorkflowType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -510,12 +510,12 @@ func (c *SWF) DescribeWorkflowType(input *DescribeWorkflowTypeInput) (*DescribeW
 const opGetWorkflowExecutionHistory = "GetWorkflowExecutionHistory"
 
 // GetWorkflowExecutionHistoryRequest generates a request for the GetWorkflowExecutionHistory operation.
-func (c *SWF) GetWorkflowExecutionHistoryRequest(input *GetWorkflowExecutionHistoryInput) (req *service.Request, output *GetWorkflowExecutionHistoryOutput) {
-	op := &service.Operation{
+func (c *SWF) GetWorkflowExecutionHistoryRequest(input *GetWorkflowExecutionHistoryInput) (req *request.Request, output *GetWorkflowExecutionHistoryOutput) {
+	op := &request.Operation{
 		Name:       opGetWorkflowExecutionHistory,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextPageToken"},
 			OutputTokens:    []string{"nextPageToken"},
 			LimitToken:      "maximumPageSize",
@@ -567,12 +567,12 @@ func (c *SWF) GetWorkflowExecutionHistoryPages(input *GetWorkflowExecutionHistor
 const opListActivityTypes = "ListActivityTypes"
 
 // ListActivityTypesRequest generates a request for the ListActivityTypes operation.
-func (c *SWF) ListActivityTypesRequest(input *ListActivityTypesInput) (req *service.Request, output *ListActivityTypesOutput) {
-	op := &service.Operation{
+func (c *SWF) ListActivityTypesRequest(input *ListActivityTypesInput) (req *request.Request, output *ListActivityTypesOutput) {
+	op := &request.Operation{
 		Name:       opListActivityTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextPageToken"},
 			OutputTokens:    []string{"nextPageToken"},
 			LimitToken:      "maximumPageSize",
@@ -625,12 +625,12 @@ func (c *SWF) ListActivityTypesPages(input *ListActivityTypesInput, fn func(p *L
 const opListClosedWorkflowExecutions = "ListClosedWorkflowExecutions"
 
 // ListClosedWorkflowExecutionsRequest generates a request for the ListClosedWorkflowExecutions operation.
-func (c *SWF) ListClosedWorkflowExecutionsRequest(input *ListClosedWorkflowExecutionsInput) (req *service.Request, output *WorkflowExecutionInfos) {
-	op := &service.Operation{
+func (c *SWF) ListClosedWorkflowExecutionsRequest(input *ListClosedWorkflowExecutionsInput) (req *request.Request, output *WorkflowExecutionInfos) {
+	op := &request.Operation{
 		Name:       opListClosedWorkflowExecutions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextPageToken"},
 			OutputTokens:    []string{"nextPageToken"},
 			LimitToken:      "maximumPageSize",
@@ -686,12 +686,12 @@ func (c *SWF) ListClosedWorkflowExecutionsPages(input *ListClosedWorkflowExecuti
 const opListDomains = "ListDomains"
 
 // ListDomainsRequest generates a request for the ListDomains operation.
-func (c *SWF) ListDomainsRequest(input *ListDomainsInput) (req *service.Request, output *ListDomainsOutput) {
-	op := &service.Operation{
+func (c *SWF) ListDomainsRequest(input *ListDomainsInput) (req *request.Request, output *ListDomainsOutput) {
+	op := &request.Operation{
 		Name:       opListDomains,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextPageToken"},
 			OutputTokens:    []string{"nextPageToken"},
 			LimitToken:      "maximumPageSize",
@@ -744,12 +744,12 @@ func (c *SWF) ListDomainsPages(input *ListDomainsInput, fn func(p *ListDomainsOu
 const opListOpenWorkflowExecutions = "ListOpenWorkflowExecutions"
 
 // ListOpenWorkflowExecutionsRequest generates a request for the ListOpenWorkflowExecutions operation.
-func (c *SWF) ListOpenWorkflowExecutionsRequest(input *ListOpenWorkflowExecutionsInput) (req *service.Request, output *WorkflowExecutionInfos) {
-	op := &service.Operation{
+func (c *SWF) ListOpenWorkflowExecutionsRequest(input *ListOpenWorkflowExecutionsInput) (req *request.Request, output *WorkflowExecutionInfos) {
+	op := &request.Operation{
 		Name:       opListOpenWorkflowExecutions,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextPageToken"},
 			OutputTokens:    []string{"nextPageToken"},
 			LimitToken:      "maximumPageSize",
@@ -805,12 +805,12 @@ func (c *SWF) ListOpenWorkflowExecutionsPages(input *ListOpenWorkflowExecutionsI
 const opListWorkflowTypes = "ListWorkflowTypes"
 
 // ListWorkflowTypesRequest generates a request for the ListWorkflowTypes operation.
-func (c *SWF) ListWorkflowTypesRequest(input *ListWorkflowTypesInput) (req *service.Request, output *ListWorkflowTypesOutput) {
-	op := &service.Operation{
+func (c *SWF) ListWorkflowTypesRequest(input *ListWorkflowTypesInput) (req *request.Request, output *ListWorkflowTypesOutput) {
+	op := &request.Operation{
 		Name:       opListWorkflowTypes,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextPageToken"},
 			OutputTokens:    []string{"nextPageToken"},
 			LimitToken:      "maximumPageSize",
@@ -861,8 +861,8 @@ func (c *SWF) ListWorkflowTypesPages(input *ListWorkflowTypesInput, fn func(p *L
 const opPollForActivityTask = "PollForActivityTask"
 
 // PollForActivityTaskRequest generates a request for the PollForActivityTask operation.
-func (c *SWF) PollForActivityTaskRequest(input *PollForActivityTaskInput) (req *service.Request, output *PollForActivityTaskOutput) {
-	op := &service.Operation{
+func (c *SWF) PollForActivityTaskRequest(input *PollForActivityTaskInput) (req *request.Request, output *PollForActivityTaskOutput) {
+	op := &request.Operation{
 		Name:       opPollForActivityTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -912,12 +912,12 @@ func (c *SWF) PollForActivityTask(input *PollForActivityTaskInput) (*PollForActi
 const opPollForDecisionTask = "PollForDecisionTask"
 
 // PollForDecisionTaskRequest generates a request for the PollForDecisionTask operation.
-func (c *SWF) PollForDecisionTaskRequest(input *PollForDecisionTaskInput) (req *service.Request, output *PollForDecisionTaskOutput) {
-	op := &service.Operation{
+func (c *SWF) PollForDecisionTaskRequest(input *PollForDecisionTaskInput) (req *request.Request, output *PollForDecisionTaskOutput) {
+	op := &request.Operation{
 		Name:       opPollForDecisionTask,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"nextPageToken"},
 			OutputTokens:    []string{"nextPageToken"},
 			LimitToken:      "maximumPageSize",
@@ -984,8 +984,8 @@ func (c *SWF) PollForDecisionTaskPages(input *PollForDecisionTaskInput, fn func(
 const opRecordActivityTaskHeartbeat = "RecordActivityTaskHeartbeat"
 
 // RecordActivityTaskHeartbeatRequest generates a request for the RecordActivityTaskHeartbeat operation.
-func (c *SWF) RecordActivityTaskHeartbeatRequest(input *RecordActivityTaskHeartbeatInput) (req *service.Request, output *RecordActivityTaskHeartbeatOutput) {
-	op := &service.Operation{
+func (c *SWF) RecordActivityTaskHeartbeatRequest(input *RecordActivityTaskHeartbeatInput) (req *request.Request, output *RecordActivityTaskHeartbeatOutput) {
+	op := &request.Operation{
 		Name:       opRecordActivityTaskHeartbeat,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1046,8 +1046,8 @@ func (c *SWF) RecordActivityTaskHeartbeat(input *RecordActivityTaskHeartbeatInpu
 const opRegisterActivityType = "RegisterActivityType"
 
 // RegisterActivityTypeRequest generates a request for the RegisterActivityType operation.
-func (c *SWF) RegisterActivityTypeRequest(input *RegisterActivityTypeInput) (req *service.Request, output *RegisterActivityTypeOutput) {
-	op := &service.Operation{
+func (c *SWF) RegisterActivityTypeRequest(input *RegisterActivityTypeInput) (req *request.Request, output *RegisterActivityTypeOutput) {
+	op := &request.Operation{
 		Name:       opRegisterActivityType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1093,8 +1093,8 @@ func (c *SWF) RegisterActivityType(input *RegisterActivityTypeInput) (*RegisterA
 const opRegisterDomain = "RegisterDomain"
 
 // RegisterDomainRequest generates a request for the RegisterDomain operation.
-func (c *SWF) RegisterDomainRequest(input *RegisterDomainInput) (req *service.Request, output *RegisterDomainOutput) {
-	op := &service.Operation{
+func (c *SWF) RegisterDomainRequest(input *RegisterDomainInput) (req *request.Request, output *RegisterDomainOutput) {
+	op := &request.Operation{
 		Name:       opRegisterDomain,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1135,8 +1135,8 @@ func (c *SWF) RegisterDomain(input *RegisterDomainInput) (*RegisterDomainOutput,
 const opRegisterWorkflowType = "RegisterWorkflowType"
 
 // RegisterWorkflowTypeRequest generates a request for the RegisterWorkflowType operation.
-func (c *SWF) RegisterWorkflowTypeRequest(input *RegisterWorkflowTypeInput) (req *service.Request, output *RegisterWorkflowTypeOutput) {
-	op := &service.Operation{
+func (c *SWF) RegisterWorkflowTypeRequest(input *RegisterWorkflowTypeInput) (req *request.Request, output *RegisterWorkflowTypeOutput) {
+	op := &request.Operation{
 		Name:       opRegisterWorkflowType,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1185,8 +1185,8 @@ func (c *SWF) RegisterWorkflowType(input *RegisterWorkflowTypeInput) (*RegisterW
 const opRequestCancelWorkflowExecution = "RequestCancelWorkflowExecution"
 
 // RequestCancelWorkflowExecutionRequest generates a request for the RequestCancelWorkflowExecution operation.
-func (c *SWF) RequestCancelWorkflowExecutionRequest(input *RequestCancelWorkflowExecutionInput) (req *service.Request, output *RequestCancelWorkflowExecutionOutput) {
-	op := &service.Operation{
+func (c *SWF) RequestCancelWorkflowExecutionRequest(input *RequestCancelWorkflowExecutionInput) (req *request.Request, output *RequestCancelWorkflowExecutionOutput) {
+	op := &request.Operation{
 		Name:       opRequestCancelWorkflowExecution,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1234,8 +1234,8 @@ func (c *SWF) RequestCancelWorkflowExecution(input *RequestCancelWorkflowExecuti
 const opRespondActivityTaskCanceled = "RespondActivityTaskCanceled"
 
 // RespondActivityTaskCanceledRequest generates a request for the RespondActivityTaskCanceled operation.
-func (c *SWF) RespondActivityTaskCanceledRequest(input *RespondActivityTaskCanceledInput) (req *service.Request, output *RespondActivityTaskCanceledOutput) {
-	op := &service.Operation{
+func (c *SWF) RespondActivityTaskCanceledRequest(input *RespondActivityTaskCanceledInput) (req *request.Request, output *RespondActivityTaskCanceledOutput) {
+	op := &request.Operation{
 		Name:       opRespondActivityTaskCanceled,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1288,8 +1288,8 @@ func (c *SWF) RespondActivityTaskCanceled(input *RespondActivityTaskCanceledInpu
 const opRespondActivityTaskCompleted = "RespondActivityTaskCompleted"
 
 // RespondActivityTaskCompletedRequest generates a request for the RespondActivityTaskCompleted operation.
-func (c *SWF) RespondActivityTaskCompletedRequest(input *RespondActivityTaskCompletedInput) (req *service.Request, output *RespondActivityTaskCompletedOutput) {
-	op := &service.Operation{
+func (c *SWF) RespondActivityTaskCompletedRequest(input *RespondActivityTaskCompletedInput) (req *request.Request, output *RespondActivityTaskCompletedOutput) {
+	op := &request.Operation{
 		Name:       opRespondActivityTaskCompleted,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1340,8 +1340,8 @@ func (c *SWF) RespondActivityTaskCompleted(input *RespondActivityTaskCompletedIn
 const opRespondActivityTaskFailed = "RespondActivityTaskFailed"
 
 // RespondActivityTaskFailedRequest generates a request for the RespondActivityTaskFailed operation.
-func (c *SWF) RespondActivityTaskFailedRequest(input *RespondActivityTaskFailedInput) (req *service.Request, output *RespondActivityTaskFailedOutput) {
-	op := &service.Operation{
+func (c *SWF) RespondActivityTaskFailedRequest(input *RespondActivityTaskFailedInput) (req *request.Request, output *RespondActivityTaskFailedOutput) {
+	op := &request.Operation{
 		Name:       opRespondActivityTaskFailed,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1389,8 +1389,8 @@ func (c *SWF) RespondActivityTaskFailed(input *RespondActivityTaskFailedInput) (
 const opRespondDecisionTaskCompleted = "RespondDecisionTaskCompleted"
 
 // RespondDecisionTaskCompletedRequest generates a request for the RespondDecisionTaskCompleted operation.
-func (c *SWF) RespondDecisionTaskCompletedRequest(input *RespondDecisionTaskCompletedInput) (req *service.Request, output *RespondDecisionTaskCompletedOutput) {
-	op := &service.Operation{
+func (c *SWF) RespondDecisionTaskCompletedRequest(input *RespondDecisionTaskCompletedInput) (req *request.Request, output *RespondDecisionTaskCompletedOutput) {
+	op := &request.Operation{
 		Name:       opRespondDecisionTaskCompleted,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1431,8 +1431,8 @@ func (c *SWF) RespondDecisionTaskCompleted(input *RespondDecisionTaskCompletedIn
 const opSignalWorkflowExecution = "SignalWorkflowExecution"
 
 // SignalWorkflowExecutionRequest generates a request for the SignalWorkflowExecution operation.
-func (c *SWF) SignalWorkflowExecutionRequest(input *SignalWorkflowExecutionInput) (req *service.Request, output *SignalWorkflowExecutionOutput) {
-	op := &service.Operation{
+func (c *SWF) SignalWorkflowExecutionRequest(input *SignalWorkflowExecutionInput) (req *request.Request, output *SignalWorkflowExecutionOutput) {
+	op := &request.Operation{
 		Name:       opSignalWorkflowExecution,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1478,8 +1478,8 @@ func (c *SWF) SignalWorkflowExecution(input *SignalWorkflowExecutionInput) (*Sig
 const opStartWorkflowExecution = "StartWorkflowExecution"
 
 // StartWorkflowExecutionRequest generates a request for the StartWorkflowExecution operation.
-func (c *SWF) StartWorkflowExecutionRequest(input *StartWorkflowExecutionInput) (req *service.Request, output *StartWorkflowExecutionOutput) {
-	op := &service.Operation{
+func (c *SWF) StartWorkflowExecutionRequest(input *StartWorkflowExecutionInput) (req *request.Request, output *StartWorkflowExecutionOutput) {
+	op := &request.Operation{
 		Name:       opStartWorkflowExecution,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -1528,8 +1528,8 @@ func (c *SWF) StartWorkflowExecution(input *StartWorkflowExecutionInput) (*Start
 const opTerminateWorkflowExecution = "TerminateWorkflowExecution"
 
 // TerminateWorkflowExecutionRequest generates a request for the TerminateWorkflowExecution operation.
-func (c *SWF) TerminateWorkflowExecutionRequest(input *TerminateWorkflowExecutionInput) (req *service.Request, output *TerminateWorkflowExecutionOutput) {
-	op := &service.Operation{
+func (c *SWF) TerminateWorkflowExecutionRequest(input *TerminateWorkflowExecutionInput) (req *request.Request, output *TerminateWorkflowExecutionOutput) {
+	op := &request.Operation{
 		Name:       opTerminateWorkflowExecution,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/swf/service.go
+++ b/service/swf/service.go
@@ -5,7 +5,9 @@ package swf
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -31,16 +33,18 @@ type SWF struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new SWF client.
 func New(config *aws.Config) *SWF {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "swf",
-		APIVersion:   "2012-01-25",
-		JSONVersion:  "1.0",
-		TargetPrefix: "SimpleWorkflowService",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "swf",
+			APIVersion:   "2012-01-25",
+			JSONVersion:  "1.0",
+			TargetPrefix: "SimpleWorkflowService",
+		},
 	}
 	service.Initialize()
 
@@ -61,8 +65,8 @@ func New(config *aws.Config) *SWF {
 
 // newRequest creates a new request for a SWF operation and runs any
 // custom request initialization.
-func (c *SWF) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *SWF) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/swf/swfiface/interface.go
+++ b/service/swf/swfiface/interface.go
@@ -4,147 +4,147 @@
 package swfiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/swf"
 )
 
 // SWFAPI is the interface type for swf.SWF.
 type SWFAPI interface {
-	CountClosedWorkflowExecutionsRequest(*swf.CountClosedWorkflowExecutionsInput) (*service.Request, *swf.WorkflowExecutionCount)
+	CountClosedWorkflowExecutionsRequest(*swf.CountClosedWorkflowExecutionsInput) (*request.Request, *swf.WorkflowExecutionCount)
 
 	CountClosedWorkflowExecutions(*swf.CountClosedWorkflowExecutionsInput) (*swf.WorkflowExecutionCount, error)
 
-	CountOpenWorkflowExecutionsRequest(*swf.CountOpenWorkflowExecutionsInput) (*service.Request, *swf.WorkflowExecutionCount)
+	CountOpenWorkflowExecutionsRequest(*swf.CountOpenWorkflowExecutionsInput) (*request.Request, *swf.WorkflowExecutionCount)
 
 	CountOpenWorkflowExecutions(*swf.CountOpenWorkflowExecutionsInput) (*swf.WorkflowExecutionCount, error)
 
-	CountPendingActivityTasksRequest(*swf.CountPendingActivityTasksInput) (*service.Request, *swf.PendingTaskCount)
+	CountPendingActivityTasksRequest(*swf.CountPendingActivityTasksInput) (*request.Request, *swf.PendingTaskCount)
 
 	CountPendingActivityTasks(*swf.CountPendingActivityTasksInput) (*swf.PendingTaskCount, error)
 
-	CountPendingDecisionTasksRequest(*swf.CountPendingDecisionTasksInput) (*service.Request, *swf.PendingTaskCount)
+	CountPendingDecisionTasksRequest(*swf.CountPendingDecisionTasksInput) (*request.Request, *swf.PendingTaskCount)
 
 	CountPendingDecisionTasks(*swf.CountPendingDecisionTasksInput) (*swf.PendingTaskCount, error)
 
-	DeprecateActivityTypeRequest(*swf.DeprecateActivityTypeInput) (*service.Request, *swf.DeprecateActivityTypeOutput)
+	DeprecateActivityTypeRequest(*swf.DeprecateActivityTypeInput) (*request.Request, *swf.DeprecateActivityTypeOutput)
 
 	DeprecateActivityType(*swf.DeprecateActivityTypeInput) (*swf.DeprecateActivityTypeOutput, error)
 
-	DeprecateDomainRequest(*swf.DeprecateDomainInput) (*service.Request, *swf.DeprecateDomainOutput)
+	DeprecateDomainRequest(*swf.DeprecateDomainInput) (*request.Request, *swf.DeprecateDomainOutput)
 
 	DeprecateDomain(*swf.DeprecateDomainInput) (*swf.DeprecateDomainOutput, error)
 
-	DeprecateWorkflowTypeRequest(*swf.DeprecateWorkflowTypeInput) (*service.Request, *swf.DeprecateWorkflowTypeOutput)
+	DeprecateWorkflowTypeRequest(*swf.DeprecateWorkflowTypeInput) (*request.Request, *swf.DeprecateWorkflowTypeOutput)
 
 	DeprecateWorkflowType(*swf.DeprecateWorkflowTypeInput) (*swf.DeprecateWorkflowTypeOutput, error)
 
-	DescribeActivityTypeRequest(*swf.DescribeActivityTypeInput) (*service.Request, *swf.DescribeActivityTypeOutput)
+	DescribeActivityTypeRequest(*swf.DescribeActivityTypeInput) (*request.Request, *swf.DescribeActivityTypeOutput)
 
 	DescribeActivityType(*swf.DescribeActivityTypeInput) (*swf.DescribeActivityTypeOutput, error)
 
-	DescribeDomainRequest(*swf.DescribeDomainInput) (*service.Request, *swf.DescribeDomainOutput)
+	DescribeDomainRequest(*swf.DescribeDomainInput) (*request.Request, *swf.DescribeDomainOutput)
 
 	DescribeDomain(*swf.DescribeDomainInput) (*swf.DescribeDomainOutput, error)
 
-	DescribeWorkflowExecutionRequest(*swf.DescribeWorkflowExecutionInput) (*service.Request, *swf.DescribeWorkflowExecutionOutput)
+	DescribeWorkflowExecutionRequest(*swf.DescribeWorkflowExecutionInput) (*request.Request, *swf.DescribeWorkflowExecutionOutput)
 
 	DescribeWorkflowExecution(*swf.DescribeWorkflowExecutionInput) (*swf.DescribeWorkflowExecutionOutput, error)
 
-	DescribeWorkflowTypeRequest(*swf.DescribeWorkflowTypeInput) (*service.Request, *swf.DescribeWorkflowTypeOutput)
+	DescribeWorkflowTypeRequest(*swf.DescribeWorkflowTypeInput) (*request.Request, *swf.DescribeWorkflowTypeOutput)
 
 	DescribeWorkflowType(*swf.DescribeWorkflowTypeInput) (*swf.DescribeWorkflowTypeOutput, error)
 
-	GetWorkflowExecutionHistoryRequest(*swf.GetWorkflowExecutionHistoryInput) (*service.Request, *swf.GetWorkflowExecutionHistoryOutput)
+	GetWorkflowExecutionHistoryRequest(*swf.GetWorkflowExecutionHistoryInput) (*request.Request, *swf.GetWorkflowExecutionHistoryOutput)
 
 	GetWorkflowExecutionHistory(*swf.GetWorkflowExecutionHistoryInput) (*swf.GetWorkflowExecutionHistoryOutput, error)
 
 	GetWorkflowExecutionHistoryPages(*swf.GetWorkflowExecutionHistoryInput, func(*swf.GetWorkflowExecutionHistoryOutput, bool) bool) error
 
-	ListActivityTypesRequest(*swf.ListActivityTypesInput) (*service.Request, *swf.ListActivityTypesOutput)
+	ListActivityTypesRequest(*swf.ListActivityTypesInput) (*request.Request, *swf.ListActivityTypesOutput)
 
 	ListActivityTypes(*swf.ListActivityTypesInput) (*swf.ListActivityTypesOutput, error)
 
 	ListActivityTypesPages(*swf.ListActivityTypesInput, func(*swf.ListActivityTypesOutput, bool) bool) error
 
-	ListClosedWorkflowExecutionsRequest(*swf.ListClosedWorkflowExecutionsInput) (*service.Request, *swf.WorkflowExecutionInfos)
+	ListClosedWorkflowExecutionsRequest(*swf.ListClosedWorkflowExecutionsInput) (*request.Request, *swf.WorkflowExecutionInfos)
 
 	ListClosedWorkflowExecutions(*swf.ListClosedWorkflowExecutionsInput) (*swf.WorkflowExecutionInfos, error)
 
 	ListClosedWorkflowExecutionsPages(*swf.ListClosedWorkflowExecutionsInput, func(*swf.WorkflowExecutionInfos, bool) bool) error
 
-	ListDomainsRequest(*swf.ListDomainsInput) (*service.Request, *swf.ListDomainsOutput)
+	ListDomainsRequest(*swf.ListDomainsInput) (*request.Request, *swf.ListDomainsOutput)
 
 	ListDomains(*swf.ListDomainsInput) (*swf.ListDomainsOutput, error)
 
 	ListDomainsPages(*swf.ListDomainsInput, func(*swf.ListDomainsOutput, bool) bool) error
 
-	ListOpenWorkflowExecutionsRequest(*swf.ListOpenWorkflowExecutionsInput) (*service.Request, *swf.WorkflowExecutionInfos)
+	ListOpenWorkflowExecutionsRequest(*swf.ListOpenWorkflowExecutionsInput) (*request.Request, *swf.WorkflowExecutionInfos)
 
 	ListOpenWorkflowExecutions(*swf.ListOpenWorkflowExecutionsInput) (*swf.WorkflowExecutionInfos, error)
 
 	ListOpenWorkflowExecutionsPages(*swf.ListOpenWorkflowExecutionsInput, func(*swf.WorkflowExecutionInfos, bool) bool) error
 
-	ListWorkflowTypesRequest(*swf.ListWorkflowTypesInput) (*service.Request, *swf.ListWorkflowTypesOutput)
+	ListWorkflowTypesRequest(*swf.ListWorkflowTypesInput) (*request.Request, *swf.ListWorkflowTypesOutput)
 
 	ListWorkflowTypes(*swf.ListWorkflowTypesInput) (*swf.ListWorkflowTypesOutput, error)
 
 	ListWorkflowTypesPages(*swf.ListWorkflowTypesInput, func(*swf.ListWorkflowTypesOutput, bool) bool) error
 
-	PollForActivityTaskRequest(*swf.PollForActivityTaskInput) (*service.Request, *swf.PollForActivityTaskOutput)
+	PollForActivityTaskRequest(*swf.PollForActivityTaskInput) (*request.Request, *swf.PollForActivityTaskOutput)
 
 	PollForActivityTask(*swf.PollForActivityTaskInput) (*swf.PollForActivityTaskOutput, error)
 
-	PollForDecisionTaskRequest(*swf.PollForDecisionTaskInput) (*service.Request, *swf.PollForDecisionTaskOutput)
+	PollForDecisionTaskRequest(*swf.PollForDecisionTaskInput) (*request.Request, *swf.PollForDecisionTaskOutput)
 
 	PollForDecisionTask(*swf.PollForDecisionTaskInput) (*swf.PollForDecisionTaskOutput, error)
 
 	PollForDecisionTaskPages(*swf.PollForDecisionTaskInput, func(*swf.PollForDecisionTaskOutput, bool) bool) error
 
-	RecordActivityTaskHeartbeatRequest(*swf.RecordActivityTaskHeartbeatInput) (*service.Request, *swf.RecordActivityTaskHeartbeatOutput)
+	RecordActivityTaskHeartbeatRequest(*swf.RecordActivityTaskHeartbeatInput) (*request.Request, *swf.RecordActivityTaskHeartbeatOutput)
 
 	RecordActivityTaskHeartbeat(*swf.RecordActivityTaskHeartbeatInput) (*swf.RecordActivityTaskHeartbeatOutput, error)
 
-	RegisterActivityTypeRequest(*swf.RegisterActivityTypeInput) (*service.Request, *swf.RegisterActivityTypeOutput)
+	RegisterActivityTypeRequest(*swf.RegisterActivityTypeInput) (*request.Request, *swf.RegisterActivityTypeOutput)
 
 	RegisterActivityType(*swf.RegisterActivityTypeInput) (*swf.RegisterActivityTypeOutput, error)
 
-	RegisterDomainRequest(*swf.RegisterDomainInput) (*service.Request, *swf.RegisterDomainOutput)
+	RegisterDomainRequest(*swf.RegisterDomainInput) (*request.Request, *swf.RegisterDomainOutput)
 
 	RegisterDomain(*swf.RegisterDomainInput) (*swf.RegisterDomainOutput, error)
 
-	RegisterWorkflowTypeRequest(*swf.RegisterWorkflowTypeInput) (*service.Request, *swf.RegisterWorkflowTypeOutput)
+	RegisterWorkflowTypeRequest(*swf.RegisterWorkflowTypeInput) (*request.Request, *swf.RegisterWorkflowTypeOutput)
 
 	RegisterWorkflowType(*swf.RegisterWorkflowTypeInput) (*swf.RegisterWorkflowTypeOutput, error)
 
-	RequestCancelWorkflowExecutionRequest(*swf.RequestCancelWorkflowExecutionInput) (*service.Request, *swf.RequestCancelWorkflowExecutionOutput)
+	RequestCancelWorkflowExecutionRequest(*swf.RequestCancelWorkflowExecutionInput) (*request.Request, *swf.RequestCancelWorkflowExecutionOutput)
 
 	RequestCancelWorkflowExecution(*swf.RequestCancelWorkflowExecutionInput) (*swf.RequestCancelWorkflowExecutionOutput, error)
 
-	RespondActivityTaskCanceledRequest(*swf.RespondActivityTaskCanceledInput) (*service.Request, *swf.RespondActivityTaskCanceledOutput)
+	RespondActivityTaskCanceledRequest(*swf.RespondActivityTaskCanceledInput) (*request.Request, *swf.RespondActivityTaskCanceledOutput)
 
 	RespondActivityTaskCanceled(*swf.RespondActivityTaskCanceledInput) (*swf.RespondActivityTaskCanceledOutput, error)
 
-	RespondActivityTaskCompletedRequest(*swf.RespondActivityTaskCompletedInput) (*service.Request, *swf.RespondActivityTaskCompletedOutput)
+	RespondActivityTaskCompletedRequest(*swf.RespondActivityTaskCompletedInput) (*request.Request, *swf.RespondActivityTaskCompletedOutput)
 
 	RespondActivityTaskCompleted(*swf.RespondActivityTaskCompletedInput) (*swf.RespondActivityTaskCompletedOutput, error)
 
-	RespondActivityTaskFailedRequest(*swf.RespondActivityTaskFailedInput) (*service.Request, *swf.RespondActivityTaskFailedOutput)
+	RespondActivityTaskFailedRequest(*swf.RespondActivityTaskFailedInput) (*request.Request, *swf.RespondActivityTaskFailedOutput)
 
 	RespondActivityTaskFailed(*swf.RespondActivityTaskFailedInput) (*swf.RespondActivityTaskFailedOutput, error)
 
-	RespondDecisionTaskCompletedRequest(*swf.RespondDecisionTaskCompletedInput) (*service.Request, *swf.RespondDecisionTaskCompletedOutput)
+	RespondDecisionTaskCompletedRequest(*swf.RespondDecisionTaskCompletedInput) (*request.Request, *swf.RespondDecisionTaskCompletedOutput)
 
 	RespondDecisionTaskCompleted(*swf.RespondDecisionTaskCompletedInput) (*swf.RespondDecisionTaskCompletedOutput, error)
 
-	SignalWorkflowExecutionRequest(*swf.SignalWorkflowExecutionInput) (*service.Request, *swf.SignalWorkflowExecutionOutput)
+	SignalWorkflowExecutionRequest(*swf.SignalWorkflowExecutionInput) (*request.Request, *swf.SignalWorkflowExecutionOutput)
 
 	SignalWorkflowExecution(*swf.SignalWorkflowExecutionInput) (*swf.SignalWorkflowExecutionOutput, error)
 
-	StartWorkflowExecutionRequest(*swf.StartWorkflowExecutionInput) (*service.Request, *swf.StartWorkflowExecutionOutput)
+	StartWorkflowExecutionRequest(*swf.StartWorkflowExecutionInput) (*request.Request, *swf.StartWorkflowExecutionOutput)
 
 	StartWorkflowExecution(*swf.StartWorkflowExecutionInput) (*swf.StartWorkflowExecutionOutput, error)
 
-	TerminateWorkflowExecutionRequest(*swf.TerminateWorkflowExecutionInput) (*service.Request, *swf.TerminateWorkflowExecutionOutput)
+	TerminateWorkflowExecutionRequest(*swf.TerminateWorkflowExecutionInput) (*request.Request, *swf.TerminateWorkflowExecutionOutput)
 
 	TerminateWorkflowExecution(*swf.TerminateWorkflowExecutionInput) (*swf.TerminateWorkflowExecutionOutput, error)
 }

--- a/service/workspaces/api.go
+++ b/service/workspaces/api.go
@@ -5,14 +5,14 @@ package workspaces
 
 import (
 	"github.com/aws/aws-sdk-go/aws/awsutil"
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 )
 
 const opCreateWorkspaces = "CreateWorkspaces"
 
 // CreateWorkspacesRequest generates a request for the CreateWorkspaces operation.
-func (c *WorkSpaces) CreateWorkspacesRequest(input *CreateWorkspacesInput) (req *service.Request, output *CreateWorkspacesOutput) {
-	op := &service.Operation{
+func (c *WorkSpaces) CreateWorkspacesRequest(input *CreateWorkspacesInput) (req *request.Request, output *CreateWorkspacesOutput) {
+	op := &request.Operation{
 		Name:       opCreateWorkspaces,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -40,12 +40,12 @@ func (c *WorkSpaces) CreateWorkspaces(input *CreateWorkspacesInput) (*CreateWork
 const opDescribeWorkspaceBundles = "DescribeWorkspaceBundles"
 
 // DescribeWorkspaceBundlesRequest generates a request for the DescribeWorkspaceBundles operation.
-func (c *WorkSpaces) DescribeWorkspaceBundlesRequest(input *DescribeWorkspaceBundlesInput) (req *service.Request, output *DescribeWorkspaceBundlesOutput) {
-	op := &service.Operation{
+func (c *WorkSpaces) DescribeWorkspaceBundlesRequest(input *DescribeWorkspaceBundlesInput) (req *request.Request, output *DescribeWorkspaceBundlesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeWorkspaceBundles,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -89,12 +89,12 @@ func (c *WorkSpaces) DescribeWorkspaceBundlesPages(input *DescribeWorkspaceBundl
 const opDescribeWorkspaceDirectories = "DescribeWorkspaceDirectories"
 
 // DescribeWorkspaceDirectoriesRequest generates a request for the DescribeWorkspaceDirectories operation.
-func (c *WorkSpaces) DescribeWorkspaceDirectoriesRequest(input *DescribeWorkspaceDirectoriesInput) (req *service.Request, output *DescribeWorkspaceDirectoriesOutput) {
-	op := &service.Operation{
+func (c *WorkSpaces) DescribeWorkspaceDirectoriesRequest(input *DescribeWorkspaceDirectoriesInput) (req *request.Request, output *DescribeWorkspaceDirectoriesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeWorkspaceDirectories,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "",
@@ -136,12 +136,12 @@ func (c *WorkSpaces) DescribeWorkspaceDirectoriesPages(input *DescribeWorkspaceD
 const opDescribeWorkspaces = "DescribeWorkspaces"
 
 // DescribeWorkspacesRequest generates a request for the DescribeWorkspaces operation.
-func (c *WorkSpaces) DescribeWorkspacesRequest(input *DescribeWorkspacesInput) (req *service.Request, output *DescribeWorkspacesOutput) {
-	op := &service.Operation{
+func (c *WorkSpaces) DescribeWorkspacesRequest(input *DescribeWorkspacesInput) (req *request.Request, output *DescribeWorkspacesOutput) {
+	op := &request.Operation{
 		Name:       opDescribeWorkspaces,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
-		Paginator: &service.Paginator{
+		Paginator: &request.Paginator{
 			InputTokens:     []string{"NextToken"},
 			OutputTokens:    []string{"NextToken"},
 			LimitToken:      "Limit",
@@ -184,8 +184,8 @@ func (c *WorkSpaces) DescribeWorkspacesPages(input *DescribeWorkspacesInput, fn 
 const opRebootWorkspaces = "RebootWorkspaces"
 
 // RebootWorkspacesRequest generates a request for the RebootWorkspaces operation.
-func (c *WorkSpaces) RebootWorkspacesRequest(input *RebootWorkspacesInput) (req *service.Request, output *RebootWorkspacesOutput) {
-	op := &service.Operation{
+func (c *WorkSpaces) RebootWorkspacesRequest(input *RebootWorkspacesInput) (req *request.Request, output *RebootWorkspacesOutput) {
+	op := &request.Operation{
 		Name:       opRebootWorkspaces,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -217,8 +217,8 @@ func (c *WorkSpaces) RebootWorkspaces(input *RebootWorkspacesInput) (*RebootWork
 const opRebuildWorkspaces = "RebuildWorkspaces"
 
 // RebuildWorkspacesRequest generates a request for the RebuildWorkspaces operation.
-func (c *WorkSpaces) RebuildWorkspacesRequest(input *RebuildWorkspacesInput) (req *service.Request, output *RebuildWorkspacesOutput) {
-	op := &service.Operation{
+func (c *WorkSpaces) RebuildWorkspacesRequest(input *RebuildWorkspacesInput) (req *request.Request, output *RebuildWorkspacesOutput) {
+	op := &request.Operation{
 		Name:       opRebuildWorkspaces,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",
@@ -259,8 +259,8 @@ func (c *WorkSpaces) RebuildWorkspaces(input *RebuildWorkspacesInput) (*RebuildW
 const opTerminateWorkspaces = "TerminateWorkspaces"
 
 // TerminateWorkspacesRequest generates a request for the TerminateWorkspaces operation.
-func (c *WorkSpaces) TerminateWorkspacesRequest(input *TerminateWorkspacesInput) (req *service.Request, output *TerminateWorkspacesOutput) {
-	op := &service.Operation{
+func (c *WorkSpaces) TerminateWorkspacesRequest(input *TerminateWorkspacesInput) (req *request.Request, output *TerminateWorkspacesOutput) {
+	op := &request.Operation{
 		Name:       opTerminateWorkspaces,
 		HTTPMethod: "POST",
 		HTTPPath:   "/",

--- a/service/workspaces/service.go
+++ b/service/workspaces/service.go
@@ -5,7 +5,9 @@ package workspaces
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/service/serviceinfo"
 	"github.com/aws/aws-sdk-go/internal/protocol/jsonrpc"
 	"github.com/aws/aws-sdk-go/internal/signer/v4"
 )
@@ -21,16 +23,18 @@ type WorkSpaces struct {
 var initService func(*service.Service)
 
 // Used for custom request initialization logic
-var initRequest func(*service.Request)
+var initRequest func(*request.Request)
 
 // New returns a new WorkSpaces client.
 func New(config *aws.Config) *WorkSpaces {
 	service := &service.Service{
-		Config:       defaults.DefaultConfig.Merge(config),
-		ServiceName:  "workspaces",
-		APIVersion:   "2015-04-08",
-		JSONVersion:  "1.1",
-		TargetPrefix: "WorkspacesService",
+		ServiceInfo: serviceinfo.ServiceInfo{
+			Config:       defaults.DefaultConfig.Merge(config),
+			ServiceName:  "workspaces",
+			APIVersion:   "2015-04-08",
+			JSONVersion:  "1.1",
+			TargetPrefix: "WorkspacesService",
+		},
 	}
 	service.Initialize()
 
@@ -51,8 +55,8 @@ func New(config *aws.Config) *WorkSpaces {
 
 // newRequest creates a new request for a WorkSpaces operation and runs any
 // custom request initialization.
-func (c *WorkSpaces) newRequest(op *service.Operation, params, data interface{}) *service.Request {
-	req := service.NewRequest(c.Service, op, params, data)
+func (c *WorkSpaces) newRequest(op *request.Operation, params, data interface{}) *request.Request {
+	req := c.NewRequest(op, params, data)
 
 	// Run custom request initialization if present
 	if initRequest != nil {

--- a/service/workspaces/workspacesiface/interface.go
+++ b/service/workspaces/workspacesiface/interface.go
@@ -4,43 +4,43 @@
 package workspacesiface
 
 import (
-	"github.com/aws/aws-sdk-go/aws/service"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/workspaces"
 )
 
 // WorkSpacesAPI is the interface type for workspaces.WorkSpaces.
 type WorkSpacesAPI interface {
-	CreateWorkspacesRequest(*workspaces.CreateWorkspacesInput) (*service.Request, *workspaces.CreateWorkspacesOutput)
+	CreateWorkspacesRequest(*workspaces.CreateWorkspacesInput) (*request.Request, *workspaces.CreateWorkspacesOutput)
 
 	CreateWorkspaces(*workspaces.CreateWorkspacesInput) (*workspaces.CreateWorkspacesOutput, error)
 
-	DescribeWorkspaceBundlesRequest(*workspaces.DescribeWorkspaceBundlesInput) (*service.Request, *workspaces.DescribeWorkspaceBundlesOutput)
+	DescribeWorkspaceBundlesRequest(*workspaces.DescribeWorkspaceBundlesInput) (*request.Request, *workspaces.DescribeWorkspaceBundlesOutput)
 
 	DescribeWorkspaceBundles(*workspaces.DescribeWorkspaceBundlesInput) (*workspaces.DescribeWorkspaceBundlesOutput, error)
 
 	DescribeWorkspaceBundlesPages(*workspaces.DescribeWorkspaceBundlesInput, func(*workspaces.DescribeWorkspaceBundlesOutput, bool) bool) error
 
-	DescribeWorkspaceDirectoriesRequest(*workspaces.DescribeWorkspaceDirectoriesInput) (*service.Request, *workspaces.DescribeWorkspaceDirectoriesOutput)
+	DescribeWorkspaceDirectoriesRequest(*workspaces.DescribeWorkspaceDirectoriesInput) (*request.Request, *workspaces.DescribeWorkspaceDirectoriesOutput)
 
 	DescribeWorkspaceDirectories(*workspaces.DescribeWorkspaceDirectoriesInput) (*workspaces.DescribeWorkspaceDirectoriesOutput, error)
 
 	DescribeWorkspaceDirectoriesPages(*workspaces.DescribeWorkspaceDirectoriesInput, func(*workspaces.DescribeWorkspaceDirectoriesOutput, bool) bool) error
 
-	DescribeWorkspacesRequest(*workspaces.DescribeWorkspacesInput) (*service.Request, *workspaces.DescribeWorkspacesOutput)
+	DescribeWorkspacesRequest(*workspaces.DescribeWorkspacesInput) (*request.Request, *workspaces.DescribeWorkspacesOutput)
 
 	DescribeWorkspaces(*workspaces.DescribeWorkspacesInput) (*workspaces.DescribeWorkspacesOutput, error)
 
 	DescribeWorkspacesPages(*workspaces.DescribeWorkspacesInput, func(*workspaces.DescribeWorkspacesOutput, bool) bool) error
 
-	RebootWorkspacesRequest(*workspaces.RebootWorkspacesInput) (*service.Request, *workspaces.RebootWorkspacesOutput)
+	RebootWorkspacesRequest(*workspaces.RebootWorkspacesInput) (*request.Request, *workspaces.RebootWorkspacesOutput)
 
 	RebootWorkspaces(*workspaces.RebootWorkspacesInput) (*workspaces.RebootWorkspacesOutput, error)
 
-	RebuildWorkspacesRequest(*workspaces.RebuildWorkspacesInput) (*service.Request, *workspaces.RebuildWorkspacesOutput)
+	RebuildWorkspacesRequest(*workspaces.RebuildWorkspacesInput) (*request.Request, *workspaces.RebuildWorkspacesOutput)
 
 	RebuildWorkspaces(*workspaces.RebuildWorkspacesInput) (*workspaces.RebuildWorkspacesOutput, error)
 
-	TerminateWorkspacesRequest(*workspaces.TerminateWorkspacesInput) (*service.Request, *workspaces.TerminateWorkspacesOutput)
+	TerminateWorkspacesRequest(*workspaces.TerminateWorkspacesInput) (*request.Request, *workspaces.TerminateWorkspacesOutput)
 
 	TerminateWorkspaces(*workspaces.TerminateWorkspacesInput) (*workspaces.TerminateWorkspacesOutput, error)
 }


### PR DESCRIPTION
This change adds "named handlers" to handler lists, which can be removed by running `HandlerList.Remove(namedhandler)`. This change also moves core named handlers into the `corehandlers` package for better visibility.

For example, to remove only the `corehandlers.SendHandler` on a request:

```go
req, _ := s3.ListBucketsRequest(nil)
req.Handlers.Send.Remove(corehandlers.SendHandler)
```

In order to make this change, the handlers functions and Request struct were moved from the service package into their own packages. **This is a breaking change**.