### PR TITLE
Removed rogue fmt.Println

### DIFF
--- a/aws/corehandlers/handlers.go
+++ b/aws/corehandlers/handlers.go
@@ -110,7 +110,6 @@ var AfterRetryHandler = request.NamedHandler{"core.AfterRetryHandler", func(r *r
 
 	if r.WillRetry() {
 		r.RetryDelay = r.RetryRules(r)
-		fmt.Println(r.Service.Config.SleepDelay)
 		r.Service.Config.SleepDelay(r.RetryDelay)
 
 		// when the expired token exception occurs the credentials


### PR DESCRIPTION
I saw this showing up in one of my projects. I think it's safe to remove?