### PR TITLE
internal/protocol/json: Reduce unmarshal allocs

### DIFF
--- a/internal/protocol/json/jsonutil/unmarshal.go
+++ b/internal/protocol/json/jsonutil/unmarshal.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"reflect"
-	"strings"
 	"time"
 )
 
@@ -99,7 +98,7 @@ func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTa
 
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
-		if c := field.Name[0:1]; strings.ToLower(c) == c {
+		if field.PkgPath != "" {
 			continue // ignore unexported fields
 		}
 


### PR DESCRIPTION
Check PkgPath on StructField which will be empty for exported fields
(http://golang.org/pkg/reflect/#StructField).

We have an application which heavily uses DynamoDB and we are seeing a lot of allocations in `jsonutil/unmarshal`. Based on a heap dump nearly 25% of the allocations (program wide) are coming from `strings.ToLower` in unmarshalStruct:

```
(pprof) peek ToLower
241578716 of 252105072 total (95.82%)
Dropped 547 nodes (cum <= 1260525)
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                          57705326   100% |   github.com/aws/aws-sdk-go/internal/protocol/json/jsonutil.unmarshalStruct
         0     0%     0%   57836399 22.94%                | strings.ToLower
                                          57836399   100% |   strings.Map
----------------------------------------------------------+-------------
```