### PR TITLE
internal: Allow toggling off shape renames

### DIFF
--- a/awsmigrate/awsmigrate-renamer/gen/gen.go
+++ b/awsmigrate/awsmigrate-renamer/gen/gen.go
@@ -127,7 +127,6 @@ func load(file string) *pkg {
 	p.oldAPI.Attach(file)
 	p.oldAPI.Setup()
 
-	p.newAPI.NoInflections = true
 	p.newAPI.Attach(file)
 	p.newAPI.Setup()
 

--- a/internal/fixtures/protocol/generate.go
+++ b/internal/fixtures/protocol/generate.go
@@ -254,7 +254,6 @@ func generateTestSuite(filename string) string {
 			suite.API.Operations[c.Given.ExportedName] = c.Given
 		}
 
-		suite.API.NoInflections = true     // don't require inflections
 		suite.API.NoInitMethods = true     // don't generate init methods
 		suite.API.NoStringerMethods = true // don't generate stringer methods
 		suite.API.Setup()

--- a/internal/model/api/api.go
+++ b/internal/model/api/api.go
@@ -17,11 +17,11 @@ type API struct {
 	Shapes        map[string]*Shape
 	Documentation string
 
-	// Disables inflection checks. Only use this when generating tests
-	NoInflections bool
-
 	// Set to true to avoid removing unused shapes
 	NoRemoveUnusedShapes bool
+
+	// Set to true to avoid renaming to 'Input/Output' postfixed shapes
+	NoRenameToplevelShapes bool
 
 	// Set to true to ignore service/request init methods (for testing)
 	NoInitMethods bool
@@ -29,11 +29,10 @@ type API struct {
 	// Set to true to ignore String() and GoString methods (for generated tests)
 	NoStringerMethods bool
 
-	initialized       bool
-	imports           map[string]bool
-	name              string
-	unrecognizedNames map[string]string
-	path              string
+	initialized bool
+	imports     map[string]bool
+	name        string
+	path        string
 }
 
 // A Metadata is the metadata about an API's definition.

--- a/internal/model/api/load.go
+++ b/internal/model/api/load.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -46,34 +45,19 @@ func (a *API) AttachString(str string) {
 
 // Setup initializes the API.
 func (a *API) Setup() {
-	a.unrecognizedNames = map[string]string{}
 	a.writeShapeNames()
 	a.resolveReferences()
 	a.fixStutterNames()
 	a.renameExportable()
-	a.renameToplevelShapes()
+	if !a.NoRenameToplevelShapes {
+		a.renameToplevelShapes()
+	}
 	a.updateTopLevelShapeReferences()
 	a.createInputOutputShapes()
 	a.customizationPasses()
 
 	if !a.NoRemoveUnusedShapes {
 		a.removeUnusedShapes()
-	}
-
-	if len(a.unrecognizedNames) > 0 {
-		msg := []string{
-			"Unrecognized inflections for the following export names:",
-			"(Add these to inflections.csv with any inflections added after the ':')",
-		}
-		fmt.Fprintf(os.Stderr, "%s\n%s\n\n", msg[0], msg[1])
-		for n, m := range a.unrecognizedNames {
-			if n == m {
-				m = ""
-			}
-			fmt.Fprintf(os.Stderr, "%s:%s\n", n, m)
-		}
-		os.Stderr.WriteString("\n\n")
-		panic("Found unrecognized exported names in API " + a.PackageName())
 	}
 
 	a.initialized = true


### PR DESCRIPTION
This adds an extra option to the API generation code to allow opting out of the `Input`/`Output` names so you can get types with their original names, best used in conjunction with the existing `NoRemoveUnusedShapes` option.
Being able to get the original shape names is useful for ECS.

If you'd like a more nuanced approach, I could refactor it a bit more and accomplish this 'more correctly', but this does resolve our specific issue now.

This also removes the `NoInflections` option which is no longer read anywhere and some leftover code related to it.