### PR TITLE
fix RFC822 time parsing template

### DIFF
--- a/internal/protocol/rest/build.go
+++ b/internal/protocol/rest/build.go
@@ -18,7 +18,7 @@ import (
 )
 
 // RFC822 returns an RFC822 formatted timestamp for AWS protocols
-const RFC822 = "Mon, 2 Jan 2006 15:04:05 GMT"
+const RFC822 = "Mon, 2 Jan 2006 15:04:05 MST"
 
 // Whether the byte value can be sent without escaping in AWS URLs
 var noEscape [256]bool


### PR DESCRIPTION
Go time parsing uses the literal `MST` to indicate time zone, not `GMT`.