### PR TITLE
Lambda- and Dynamodb tables deletion throttling exceptions

### DIFF
--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -24,6 +24,8 @@ var retryableCodes = map[string]struct{}{
 	"ThrottlingException":                    {},
 	"RequestLimitExceeded":                   {},
 	"RequestThrottled":                       {},
+	"LimitExceededException":                 {}, // Deleting 10+ DynamoDb tables at once
+	"TooManyRequestsException":               {}, // Lambda functions
 }
 
 // credsExpiredCodes is a collection of error codes which signify the credentials


### PR DESCRIPTION
We’re using Terraform for our infrastructure-as-code, and it depends on aws-sdk-go – the infrastructure we’re building out are quite large (250’ish components - lots of Lambda functions and DynamoDB tables), so we’re probably hitting API concurrency limits that most other people aren’t bothered by.

We’ve seen that Lambda casts TooManyRequestsException and DynamoDB casts LimitsExceededException when deleting more than 10 tables at once. Both seems to be retryable, and I would think that aws-sdk-go would be the optimal place to fix it reliably for everyone to enjoy?
