### PR TITLE
Statically typed CloudFormation Templates

### DIFF
--- a/service/cloudformation/template/basic_functions.go
+++ b/service/cloudformation/template/basic_functions.go
@@ -2,24 +2,36 @@ package template
 
 import "fmt"
 
+// FnBase64 marshals to the CloudFormation intrinsic function Fn::Base64
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-base64.html
 func FnBase64(valueToEncode interface{}) interface{} {
 	return struct {
 		Encode interface{} `json:"Fn::Base64"`
 	}{valueToEncode}
 }
 
+// FnFindInMap marshals to the CloudFormation intrinsic function Fn::FindInMap
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap.html
 func FnFindInMap(mapName string, topLevelKey interface{}, secondLevelKey interface{}) interface{} {
 	return struct {
 		Keys []interface{} `json:"Fn::FindInMap"`
 	}{[]interface{}{mapName, topLevelKey, secondLevelKey}}
 }
 
+// FnGetAtt marshals to the CloudFormation intrinsic function Fn::GetAtt
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html
 func FnGetAtt(logicalNameOfResource string, attributeName interface{}) interface{} {
 	return struct {
 		Att []interface{} `json:"Fn::GetAtt"`
 	}{[]interface{}{logicalNameOfResource, attributeName}}
 }
 
+// FnGetAZs marshals to the CloudFormation intrinsic function Fn::GetAZs
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html
 func FnGetAZs(region interface{}) interface{} {
 	if region == nil {
 		region = ""
@@ -29,6 +41,18 @@ func FnGetAZs(region interface{}) interface{} {
 	}{region}
 }
 
+// FnJoin marshals to the CloudFormation intrinsic function Fn::Join
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-join.html
+func FnJoin(delimeter interface{}, listOfValues ...interface{}) interface{} {
+	return struct {
+		Join []interface{} `json:"Fn::Join"`
+	}{[]interface{}{delimeter, listOfValues}}
+}
+
+// FnSelect marshals to the CloudFormation intrinsic function Fn::Select
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-select.html
 func FnSelect(index interface{}, listOfObjects interface{}) interface{} {
 	switch intIndex := index.(type) {
 	case int:
@@ -39,12 +63,9 @@ func FnSelect(index interface{}, listOfObjects interface{}) interface{} {
 	}{[]interface{}{index, listOfObjects}}
 }
 
-func FnJoin(delimeter interface{}, listOfValues ...interface{}) interface{} {
-	return struct {
-		Join []interface{} `json:"Fn::Join"`
-	}{[]interface{}{delimeter, listOfValues}}
-}
-
+// Ref marshals to the CloudFormation intrinsic function Ref
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html
 func Ref(logicalName string) interface{} {
 	return struct{ Ref string }{logicalName}
 }

--- a/service/cloudformation/template/basic_functions.go
+++ b/service/cloudformation/template/basic_functions.go
@@ -1,0 +1,50 @@
+package template
+
+import "fmt"
+
+func FnBase64(valueToEncode interface{}) interface{} {
+	return struct {
+		Encode interface{} `json:"Fn::Base64"`
+	}{valueToEncode}
+}
+
+func FnFindInMap(mapName string, topLevelKey interface{}, secondLevelKey interface{}) interface{} {
+	return struct {
+		Keys []interface{} `json:"Fn::FindInMap"`
+	}{[]interface{}{mapName, topLevelKey, secondLevelKey}}
+}
+
+func FnGetAtt(logicalNameOfResource string, attributeName interface{}) interface{} {
+	return struct {
+		Att []interface{} `json:"Fn::GetAtt"`
+	}{[]interface{}{logicalNameOfResource, attributeName}}
+}
+
+func FnGetAZs(region interface{}) interface{} {
+	if region == nil {
+		region = ""
+	}
+	return struct {
+		AZs interface{} `json:"Fn::GetAZs"`
+	}{region}
+}
+
+func FnSelect(index interface{}, listOfObjects interface{}) interface{} {
+	switch intIndex := index.(type) {
+	case int:
+		index = fmt.Sprintf("%d", intIndex)
+	}
+	return struct {
+		Select []interface{} `json:"Fn::Select"`
+	}{[]interface{}{index, listOfObjects}}
+}
+
+func FnJoin(delimeter interface{}, listOfValues ...interface{}) interface{} {
+	return struct {
+		Join []interface{} `json:"Fn::Join"`
+	}{[]interface{}{delimeter, listOfValues}}
+}
+
+func Ref(logicalName string) interface{} {
+	return struct{ Ref string }{logicalName}
+}

--- a/service/cloudformation/template/basic_functions_test.go
+++ b/service/cloudformation/template/basic_functions_test.go
@@ -1,0 +1,62 @@
+package template_test
+
+import (
+	"testing"
+
+	. "github.com/aws/aws-sdk-go/service/cloudformation/template"
+)
+
+func TestFnBase64(t *testing.T) {
+	base64 := FnBase64("some string to encode")
+	assertMarshalsTo(t, base64, `{ "Fn::Base64" : "some string to encode" }`)
+}
+
+func TestFnBase64WithObjects(t *testing.T) {
+	base64 := FnBase64(Ref("some-logical-name"))
+	assertMarshalsTo(t, base64, `{ "Fn::Base64" : { "Ref": "some-logical-name" } }`)
+}
+
+func TestFnFindInMap(t *testing.T) {
+	mapped := FnFindInMap("RegionMap", Ref("AWS::Region"), "32")
+	assertMarshalsTo(t, mapped, `{ "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "32"]}`)
+}
+
+func TestFnGetAtt(t *testing.T) {
+	att := FnGetAtt("MyLB", Ref("something"))
+	assertMarshalsTo(t, att, `{ "Fn::GetAtt": [ "MyLB" , { "Ref": "something" } ] }`)
+}
+
+func TestFnGetAZs(t *testing.T) {
+	azs := FnGetAZs(Ref("AWS::Region"))
+	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": { "Ref": "AWS::Region" } }`)
+}
+
+func TestFnGetAZsEmpty(t *testing.T) {
+	azs := FnGetAZs("")
+	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": "" }`)
+}
+
+func TestFnGetAZsNil(t *testing.T) {
+	azs := FnGetAZs(nil)
+	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": "" }`)
+}
+
+func TestFnJoin(t *testing.T) {
+	joined := FnJoin("\n", "some", "list", Ref("AWS::StackId"))
+	assertMarshalsTo(t, joined, `{ "Fn::Join" : ["\n", [ "some", "list", { "Ref" : "AWS::StackId" } ] ] }`)
+}
+
+func TestFnSelect(t *testing.T) {
+	selected := FnSelect(Ref("MyIndex"), FnGetAZs(""))
+	assertMarshalsTo(t, selected, `{ "Fn::Select" : [ { "Ref": "MyIndex" }, { "Fn::GetAZs": "" } ] }`)
+}
+
+func TestFnSelectWithLiteralIndex(t *testing.T) {
+	selected := FnSelect(2, FnGetAZs(""))
+	assertMarshalsTo(t, selected, `{ "Fn::Select" : [ "2", { "Fn::GetAZs": "" } ] }`)
+}
+
+func TestRefs(t *testing.T) {
+	ref := Ref("AWS::StackId")
+	assertMarshalsTo(t, ref, `{"Ref":"AWS::StackId" }`)
+}

--- a/service/cloudformation/template/template.go
+++ b/service/cloudformation/template/template.go
@@ -1,6 +1,9 @@
 package template
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html
 type Template struct {
@@ -63,6 +66,31 @@ func FnFindInMap(mapName string, topLevelKey interface{}, secondLevelKey interfa
 	return struct {
 		Keys []interface{} `json:"Fn::FindInMap"`
 	}{[]interface{}{mapName, topLevelKey, secondLevelKey}}
+}
+
+func FnGetAtt(logicalNameOfResource string, attributeName interface{}) interface{} {
+	return struct {
+		Att []interface{} `json:"Fn::GetAtt"`
+	}{[]interface{}{logicalNameOfResource, attributeName}}
+}
+
+func FnGetAZs(region interface{}) interface{} {
+	if region == nil {
+		region = ""
+	}
+	return struct {
+		AZs interface{} `json:"Fn::GetAZs"`
+	}{region}
+}
+
+func FnSelect(index interface{}, listOfObjects interface{}) interface{} {
+	switch intIndex := index.(type) {
+	case int:
+		index = fmt.Sprintf("%d", intIndex)
+	}
+	return struct {
+		Select []interface{} `json:"Fn::Select"`
+	}{[]interface{}{index, listOfObjects}}
 }
 
 func FnJoin(delimeter interface{}, listOfValues ...interface{}) interface{} {

--- a/service/cloudformation/template/template.go
+++ b/service/cloudformation/template/template.go
@@ -59,6 +59,12 @@ func FnBase64(valueToEncode interface{}) interface{} {
 	}{valueToEncode}
 }
 
+func FnFindInMap(mapName string, topLevelKey interface{}, secondLevelKey interface{}) interface{} {
+	return struct {
+		Keys []interface{} `json:"Fn::FindInMap"`
+	}{[]interface{}{mapName, topLevelKey, secondLevelKey}}
+}
+
 func FnJoin(delimeter interface{}, listOfValues ...interface{}) interface{} {
 	return struct {
 		Join []interface{} `json:"Fn::Join"`

--- a/service/cloudformation/template/template.go
+++ b/service/cloudformation/template/template.go
@@ -2,6 +2,8 @@ package template
 
 import "encoding/json"
 
+// Template defines a CloudFormation template.
+//
 // http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html
 type Template struct {
 	AWSTemplateFormatVersion string                 `json:",omitempty"`
@@ -14,6 +16,9 @@ type Template struct {
 	Outputs                  map[string]Output      `json:",omitempty"`
 }
 
+// Parameter defines a CloudFormation template parameter
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
 type Parameter struct {
 	Type                  string
 	Default               string   `json:",omitempty"`
@@ -26,21 +31,35 @@ type Parameter struct {
 	ConstraintDescription string   `json:",omitempty"`
 }
 
+// Mapping defines a CloudFormation template mapping
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html
 type Mapping map[string]map[string]string
 
+// Condition defines a CloudFormation template condition
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html
 type Condition map[string]interface{}
 
+// Resource defines a CloudFormation template resource
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resources-section-structure.html
 type Resource struct {
 	Type       string
 	Properties map[string]interface{}
 	Metadata   map[string]interface{} `json:",omitempty"`
 }
 
+// Output defines a CloudFormation template output
+//
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html
 type Output struct {
 	Description string `json:",omitempty"`
 	Value       interface{}
 }
 
+// String returns a JSON representation of the Template suitable for use
+// in CloudFormation requests such as CreateStack and UpdateStack
 func (t *Template) String() string {
 	bytes, err := json.Marshal(t)
 	if err != nil {

--- a/service/cloudformation/template/template.go
+++ b/service/cloudformation/template/template.go
@@ -1,3 +1,4 @@
+// Package template provides types and functions that enable programmatic generation of CloudFormation templates
 package template
 
 import "encoding/json"

--- a/service/cloudformation/template/template.go
+++ b/service/cloudformation/template/template.go
@@ -1,4 +1,4 @@
-package cloudformation
+package template
 
 import "encoding/json"
 
@@ -33,14 +33,13 @@ type Condition map[string]interface{}
 type Resource struct {
 	Type       string
 	Properties map[string]interface{}
+	Metadata   map[string]interface{} `json:",omitempty"`
 }
 
 type Output struct {
 	Description string `json:",omitempty"`
-	Value       string
+	Value       interface{}
 }
-
-type Ref struct{ Ref string }
 
 func (t *Template) String() string {
 	bytes, err := json.Marshal(t)
@@ -48,4 +47,20 @@ func (t *Template) String() string {
 		panic(err)
 	}
 	return string(bytes)
+}
+
+func Ref(logicalName string) interface{} {
+	return struct{ Ref string }{logicalName}
+}
+
+func FnBase64(valueToEncode interface{}) interface{} {
+	return struct {
+		Encode interface{} `json:"Fn::Base64"`
+	}{valueToEncode}
+}
+
+func FnJoin(delimeter interface{}, listOfValues ...interface{}) interface{} {
+	return struct {
+		Join []interface{} `json:"Fn::Join"`
+	}{[]interface{}{delimeter, listOfValues}}
 }

--- a/service/cloudformation/template/template.go
+++ b/service/cloudformation/template/template.go
@@ -1,0 +1,51 @@
+package cloudformation
+
+import "encoding/json"
+
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html
+type Template struct {
+	AWSTemplateFormatVersion string                 `json:",omitempty"`
+	Description              string                 `json:",omitempty"`
+	Metadata                 map[string]interface{} `json:",omitempty"`
+	Parameters               map[string]Parameter   `json:",omitempty"`
+	Mappings                 map[string]Mapping     `json:",omitempty"`
+	Conditions               map[string]Condition   `json:",omitempty"`
+	Resources                map[string]Resource    `json:",omitempty"`
+	Outputs                  map[string]Output      `json:",omitempty"`
+}
+
+type Parameter struct {
+	Type                  string
+	Default               string   `json:",omitempty"`
+	NoEcho                bool     `json:",omitempty,string"`
+	AllowedValues         []string `json:",omitempty"`
+	AllowedPattern        string   `json:",omitempty"`
+	MaxLength             int      `json:",omitempty,string"`
+	MinLength             int      `json:",omitempty,string"`
+	Description           string   `json:",omitempty"`
+	ConstraintDescription string   `json:",omitempty"`
+}
+
+type Mapping map[string]map[string]string
+
+type Condition map[string]interface{}
+
+type Resource struct {
+	Type       string
+	Properties map[string]interface{}
+}
+
+type Output struct {
+	Description string `json:",omitempty"`
+	Value       string
+}
+
+type Ref struct{ Ref string }
+
+func (t *Template) String() string {
+	bytes, err := json.Marshal(t)
+	if err != nil {
+		panic(err)
+	}
+	return string(bytes)
+}

--- a/service/cloudformation/template/template.go
+++ b/service/cloudformation/template/template.go
@@ -1,9 +1,6 @@
 package template
 
-import (
-	"encoding/json"
-	"fmt"
-)
+import "encoding/json"
 
 // http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html
 type Template struct {
@@ -50,51 +47,4 @@ func (t *Template) String() string {
 		panic(err)
 	}
 	return string(bytes)
-}
-
-func Ref(logicalName string) interface{} {
-	return struct{ Ref string }{logicalName}
-}
-
-func FnBase64(valueToEncode interface{}) interface{} {
-	return struct {
-		Encode interface{} `json:"Fn::Base64"`
-	}{valueToEncode}
-}
-
-func FnFindInMap(mapName string, topLevelKey interface{}, secondLevelKey interface{}) interface{} {
-	return struct {
-		Keys []interface{} `json:"Fn::FindInMap"`
-	}{[]interface{}{mapName, topLevelKey, secondLevelKey}}
-}
-
-func FnGetAtt(logicalNameOfResource string, attributeName interface{}) interface{} {
-	return struct {
-		Att []interface{} `json:"Fn::GetAtt"`
-	}{[]interface{}{logicalNameOfResource, attributeName}}
-}
-
-func FnGetAZs(region interface{}) interface{} {
-	if region == nil {
-		region = ""
-	}
-	return struct {
-		AZs interface{} `json:"Fn::GetAZs"`
-	}{region}
-}
-
-func FnSelect(index interface{}, listOfObjects interface{}) interface{} {
-	switch intIndex := index.(type) {
-	case int:
-		index = fmt.Sprintf("%d", intIndex)
-	}
-	return struct {
-		Select []interface{} `json:"Fn::Select"`
-	}{[]interface{}{index, listOfObjects}}
-}
-
-func FnJoin(delimeter interface{}, listOfValues ...interface{}) interface{} {
-	return struct {
-		Join []interface{} `json:"Fn::Join"`
-	}{[]interface{}{delimeter, listOfValues}}
 }

--- a/service/cloudformation/template/template_test.go
+++ b/service/cloudformation/template/template_test.go
@@ -54,6 +54,15 @@ func TestFnBase64WithObjects(t *testing.T) {
 	assertEquivalentJSON(t, `{ "Fn::Base64" : { "Ref": "some-logical-name" } }`, string(actual))
 }
 
+func TestFnFindInMap(t *testing.T) {
+	mapped := FnFindInMap("RegionMap", Ref("AWS::Region"), "32")
+
+	actual, err := json.Marshal(mapped)
+	assert.Nil(t, err)
+
+	assertEquivalentJSON(t, `{ "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "32"]}`, string(actual))
+}
+
 func TestFnJoin(t *testing.T) {
 	joined := FnJoin("\n", "some", "list", Ref("AWS::StackId"))
 

--- a/service/cloudformation/template/template_test.go
+++ b/service/cloudformation/template/template_test.go
@@ -2,12 +2,12 @@ package template_test
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/aws/aws-sdk-go/awstesting"
 	. "github.com/aws/aws-sdk-go/service/cloudformation/template"
 )
 
@@ -91,28 +91,12 @@ func TestTemplateCreation(t *testing.T) {
 	assertMarshalsTo(t, template, expected)
 
 	asString := template.String()
-	assertEquivalentJSON(t, expected, asString)
+	awstesting.AssertJSON(t, expected, asString)
 }
 
 func assertMarshalsTo(t *testing.T, value interface{}, expectedJSON string) {
 	actual, err := json.Marshal(value)
 	assert.Nil(t, err)
 
-	assertEquivalentJSON(t, expectedJSON, string(actual))
-}
-
-func assertEquivalentJSON(t *testing.T, expected, actual string) {
-	var rawExpected, rawActual interface{}
-
-	err := json.Unmarshal([]byte(expected), &rawExpected)
-	if err != nil {
-		t.Errorf("Unable to unmarshal expected data (%s) as JSON: %s", expected, err)
-	}
-
-	err = json.Unmarshal([]byte(actual), &rawActual)
-	if err != nil {
-		t.Errorf("Unable to unmarshal actual data (%s) as JSON: %s", actual, err)
-	}
-
-	assert.EqualValues(t, rawExpected, rawActual, fmt.Sprintf("JSON mismatch: Expected\n\n%s\n\n\t\tbut instead got\n\n%s", expected, actual))
+	awstesting.AssertJSON(t, expectedJSON, string(actual))
 }

--- a/service/cloudformation/template/template_test.go
+++ b/service/cloudformation/template/template_test.go
@@ -1,0 +1,152 @@
+package template_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/aws/aws-sdk-go/service/cloudformation/template"
+)
+
+func TestParameterStringify(t *testing.T) {
+	param := Parameter{
+		Type:      "some-parameter",
+		NoEcho:    true,
+		MaxLength: 22,
+		MinLength: 2,
+	}
+
+	actual, err := json.Marshal(param)
+	assert.Nil(t, err)
+
+	expected := `{ "Type": "some-parameter", "NoEcho": "true", "MinLength": "2", "MaxLength": "22" }`
+
+	assertEquivalentJSON(t, expected, string(actual))
+}
+
+func TestRefs(t *testing.T) {
+	ref := Ref("AWS::StackId")
+
+	actual, err := json.Marshal(ref)
+	assert.Nil(t, err)
+
+	assertEquivalentJSON(t, `{"Ref":"AWS::StackId" }`, string(actual))
+}
+
+func TestFnBase64(t *testing.T) {
+	base64 := FnBase64("some string to encode")
+
+	actual, err := json.Marshal(base64)
+	assert.Nil(t, err)
+
+	assertEquivalentJSON(t, `{ "Fn::Base64" : "some string to encode" }`, string(actual))
+}
+
+func TestFnBase64WithObjects(t *testing.T) {
+	base64 := FnBase64(Ref("some-logical-name"))
+
+	actual, err := json.Marshal(base64)
+	assert.Nil(t, err)
+
+	assertEquivalentJSON(t, `{ "Fn::Base64" : { "Ref": "some-logical-name" } }`, string(actual))
+}
+
+func TestFnJoin(t *testing.T) {
+	joined := FnJoin("\n", "some", "list", Ref("AWS::StackId"))
+
+	actual, err := json.Marshal(joined)
+	assert.Nil(t, err)
+
+	assertEquivalentJSON(t, `{ "Fn::Join" : ["\n", [ "some", "list", { "Ref" : "AWS::StackId" } ] ] }`, string(actual))
+}
+
+func TestTemplateCreation(t *testing.T) {
+	template := Template{
+
+		AWSTemplateFormatVersion: "2010-09-09",
+
+		Description: "This is a test template",
+
+		Metadata: map[string]interface{}{
+			"some-key":       map[string]int{"thing": 42},
+			"some-other-key": []bool{true, true, false, true},
+		},
+
+		Parameters: map[string]Parameter{
+			"KeyName": {
+				Type:        "AWS::EC2::KeyPair::KeyName",
+				Description: "SSH KeyPair to use for instances",
+			},
+			"DBPassword": {
+				NoEcho:                true,
+				Description:           "Password for the DB",
+				Type:                  "String",
+				MinLength:             5,
+				MaxLength:             31,
+				AllowedPattern:        "[a-zA-Z0-9]*",
+				ConstraintDescription: "must contain only alphanumeric characters",
+			},
+			"InstanceType": {
+				Type:          "String",
+				Default:       "t1.micro",
+				AllowedValues: []string{"t1.micro", "t2.micro"},
+			},
+		},
+	}
+
+	actual := template.String()
+
+	expected := `
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "This is a test template",
+
+    "Metadata": {
+        "some-key": { "thing": 42 },
+        "some-other-key": [ true, true, false, true ]
+    },
+
+  "Parameters": {
+    "KeyName": {
+      "Description" : "SSH KeyPair to use for instances",
+      "Type": "AWS::EC2::KeyPair::KeyName"
+    },
+    "DBPassword": {
+      "NoEcho": "true",
+      "Description" : "Password for the DB",
+      "Type": "String",
+      "MinLength": "5",
+      "MaxLength": "31",
+      "AllowedPattern" : "[a-zA-Z0-9]*",
+      "ConstraintDescription" : "must contain only alphanumeric characters"
+    },
+    "InstanceType" : {
+      "Type" : "String",
+      "Default" : "t1.micro",
+      "AllowedValues" : [ "t1.micro", "t2.micro" ]
+    }
+  }
+}
+`
+	assertEquivalentJSON(t, expected, actual)
+}
+
+func assertEquivalentJSON(t *testing.T, expected, actual string) {
+	var rawExpected, rawActual interface{}
+
+	err := json.Unmarshal([]byte(expected), &rawExpected)
+	if err != nil {
+		t.Errorf("Unable to unmarshal expected data (%s) as JSON: %s", expected, err)
+	}
+
+	err = json.Unmarshal([]byte(actual), &rawActual)
+	if err != nil {
+		t.Errorf("Unable to unmarshal actual data (%s) as JSON: %s", actual, err)
+	}
+
+	assert.EqualValues(t, rawExpected, rawActual, fmt.Sprintf("JSON mismatch: Expected\n\n%s\n\n\t\tbut instead got\n\n%s", expected, actual))
+}

--- a/service/cloudformation/template/template_test.go
+++ b/service/cloudformation/template/template_test.go
@@ -21,61 +21,6 @@ func TestParameterStringify(t *testing.T) {
 	assertMarshalsTo(t, param, `{ "Type": "some-parameter", "NoEcho": "true", "MinLength": "2", "MaxLength": "22" }`)
 }
 
-func TestFnBase64(t *testing.T) {
-	base64 := FnBase64("some string to encode")
-	assertMarshalsTo(t, base64, `{ "Fn::Base64" : "some string to encode" }`)
-}
-
-func TestFnBase64WithObjects(t *testing.T) {
-	base64 := FnBase64(Ref("some-logical-name"))
-	assertMarshalsTo(t, base64, `{ "Fn::Base64" : { "Ref": "some-logical-name" } }`)
-}
-
-func TestFnFindInMap(t *testing.T) {
-	mapped := FnFindInMap("RegionMap", Ref("AWS::Region"), "32")
-	assertMarshalsTo(t, mapped, `{ "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "32"]}`)
-}
-
-func TestFnGetAtt(t *testing.T) {
-	att := FnGetAtt("MyLB", Ref("something"))
-	assertMarshalsTo(t, att, `{ "Fn::GetAtt": [ "MyLB" , { "Ref": "something" } ] }`)
-}
-
-func TestFnGetAZs(t *testing.T) {
-	azs := FnGetAZs(Ref("AWS::Region"))
-	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": { "Ref": "AWS::Region" } }`)
-}
-
-func TestFnGetAZsEmpty(t *testing.T) {
-	azs := FnGetAZs("")
-	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": "" }`)
-}
-
-func TestFnGetAZsNil(t *testing.T) {
-	azs := FnGetAZs(nil)
-	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": "" }`)
-}
-
-func TestFnJoin(t *testing.T) {
-	joined := FnJoin("\n", "some", "list", Ref("AWS::StackId"))
-	assertMarshalsTo(t, joined, `{ "Fn::Join" : ["\n", [ "some", "list", { "Ref" : "AWS::StackId" } ] ] }`)
-}
-
-func TestFnSelect(t *testing.T) {
-	selected := FnSelect(Ref("MyIndex"), FnGetAZs(""))
-	assertMarshalsTo(t, selected, `{ "Fn::Select" : [ { "Ref": "MyIndex" }, { "Fn::GetAZs": "" } ] }`)
-}
-
-func TestFnSelectWithLiteralIndex(t *testing.T) {
-	selected := FnSelect(2, FnGetAZs(""))
-	assertMarshalsTo(t, selected, `{ "Fn::Select" : [ "2", { "Fn::GetAZs": "" } ] }`)
-}
-
-func TestRefs(t *testing.T) {
-	ref := Ref("AWS::StackId")
-	assertMarshalsTo(t, ref, `{"Ref":"AWS::StackId" }`)
-}
-
 func TestTemplateCreation(t *testing.T) {
 	template := Template{
 

--- a/service/cloudformation/template/template_test.go
+++ b/service/cloudformation/template/template_test.go
@@ -18,58 +18,62 @@ func TestParameterStringify(t *testing.T) {
 		MaxLength: 22,
 		MinLength: 2,
 	}
-
-	actual, err := json.Marshal(param)
-	assert.Nil(t, err)
-
-	expected := `{ "Type": "some-parameter", "NoEcho": "true", "MinLength": "2", "MaxLength": "22" }`
-
-	assertEquivalentJSON(t, expected, string(actual))
-}
-
-func TestRefs(t *testing.T) {
-	ref := Ref("AWS::StackId")
-
-	actual, err := json.Marshal(ref)
-	assert.Nil(t, err)
-
-	assertEquivalentJSON(t, `{"Ref":"AWS::StackId" }`, string(actual))
+	assertMarshalsTo(t, param, `{ "Type": "some-parameter", "NoEcho": "true", "MinLength": "2", "MaxLength": "22" }`)
 }
 
 func TestFnBase64(t *testing.T) {
 	base64 := FnBase64("some string to encode")
-
-	actual, err := json.Marshal(base64)
-	assert.Nil(t, err)
-
-	assertEquivalentJSON(t, `{ "Fn::Base64" : "some string to encode" }`, string(actual))
+	assertMarshalsTo(t, base64, `{ "Fn::Base64" : "some string to encode" }`)
 }
 
 func TestFnBase64WithObjects(t *testing.T) {
 	base64 := FnBase64(Ref("some-logical-name"))
-
-	actual, err := json.Marshal(base64)
-	assert.Nil(t, err)
-
-	assertEquivalentJSON(t, `{ "Fn::Base64" : { "Ref": "some-logical-name" } }`, string(actual))
+	assertMarshalsTo(t, base64, `{ "Fn::Base64" : { "Ref": "some-logical-name" } }`)
 }
 
 func TestFnFindInMap(t *testing.T) {
 	mapped := FnFindInMap("RegionMap", Ref("AWS::Region"), "32")
+	assertMarshalsTo(t, mapped, `{ "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "32"]}`)
+}
 
-	actual, err := json.Marshal(mapped)
-	assert.Nil(t, err)
+func TestFnGetAtt(t *testing.T) {
+	att := FnGetAtt("MyLB", Ref("something"))
+	assertMarshalsTo(t, att, `{ "Fn::GetAtt": [ "MyLB" , { "Ref": "something" } ] }`)
+}
 
-	assertEquivalentJSON(t, `{ "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "32"]}`, string(actual))
+func TestFnGetAZs(t *testing.T) {
+	azs := FnGetAZs(Ref("AWS::Region"))
+	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": { "Ref": "AWS::Region" } }`)
+}
+
+func TestFnGetAZsEmpty(t *testing.T) {
+	azs := FnGetAZs("")
+	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": "" }`)
+}
+
+func TestFnGetAZsNil(t *testing.T) {
+	azs := FnGetAZs(nil)
+	assertMarshalsTo(t, azs, `{ "Fn::GetAZs": "" }`)
 }
 
 func TestFnJoin(t *testing.T) {
 	joined := FnJoin("\n", "some", "list", Ref("AWS::StackId"))
+	assertMarshalsTo(t, joined, `{ "Fn::Join" : ["\n", [ "some", "list", { "Ref" : "AWS::StackId" } ] ] }`)
+}
 
-	actual, err := json.Marshal(joined)
-	assert.Nil(t, err)
+func TestFnSelect(t *testing.T) {
+	selected := FnSelect(Ref("MyIndex"), FnGetAZs(""))
+	assertMarshalsTo(t, selected, `{ "Fn::Select" : [ { "Ref": "MyIndex" }, { "Fn::GetAZs": "" } ] }`)
+}
 
-	assertEquivalentJSON(t, `{ "Fn::Join" : ["\n", [ "some", "list", { "Ref" : "AWS::StackId" } ] ] }`, string(actual))
+func TestFnSelectWithLiteralIndex(t *testing.T) {
+	selected := FnSelect(2, FnGetAZs(""))
+	assertMarshalsTo(t, selected, `{ "Fn::Select" : [ "2", { "Fn::GetAZs": "" } ] }`)
+}
+
+func TestRefs(t *testing.T) {
+	ref := Ref("AWS::StackId")
+	assertMarshalsTo(t, ref, `{"Ref":"AWS::StackId" }`)
 }
 
 func TestTemplateCreation(t *testing.T) {
@@ -106,8 +110,6 @@ func TestTemplateCreation(t *testing.T) {
 		},
 	}
 
-	actual := template.String()
-
 	expected := `
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
@@ -141,7 +143,17 @@ func TestTemplateCreation(t *testing.T) {
   }
 }
 `
-	assertEquivalentJSON(t, expected, actual)
+	assertMarshalsTo(t, template, expected)
+
+	asString := template.String()
+	assertEquivalentJSON(t, expected, asString)
+}
+
+func assertMarshalsTo(t *testing.T, value interface{}, expectedJSON string) {
+	actual, err := json.Marshal(value)
+	assert.Nil(t, err)
+
+	assertEquivalentJSON(t, expectedJSON, string(actual))
 }
 
 func assertEquivalentJSON(t *testing.T, expected, actual string) {


### PR DESCRIPTION
A draft, and not feature-complete.  Feedback appreciated.

Context from my original issue #393:
>I'm trying to programmatically generate CloudFormation templates.
>
>`cloudformation.CreateStackInput` has its `TemplateBody` field typed as a `*string`.  I'd like to be able to build up a strongly-typed Template in memory, call `json.Marshal()` and use the result as the `TemplateBody`.

I've roughly followed [the approach outlined](https://github.com/aws/aws-sdk-go/issues/393#issuecomment-144875078) by @jasdel .  One difference is that the intrinsic `Fn::x`  and `Ref` functions are modeled as Go functions, not types.  It makes the usage syntax a bit cleaner:
```go
FnJoin("\n", "Stack ID is:", Ref("AWS::StackId") )
```
instead of 
```go
FnJoin{ "\n", []interface{}{ "Stack ID is:", Ref{ "AWS::StackId" } } }
```
But perhaps there are some drawbacks I haven't considered.  And regardless, you'll probably want to dot-import this package.

What's missing:
- Types for [all the different resources](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html)
- Types for [all the different resource properties](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-product-property-reference.html)
- [Resource attributes](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-product-attribute-reference.html) including [`DependsOn`](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) which shows up a lot with VPCs

It would be great to auto-generate the resource and resource-property types somehow.

But I wanted to get feedback before I invested too much more time.  