### PR TITLE
internal/protocol/json: reduce marshal allocs

### DIFF
--- a/internal/protocol/json/jsonutil/unmarshal.go
+++ b/internal/protocol/json/jsonutil/unmarshal.go
@@ -108,7 +108,7 @@ func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTa
 			name = locName
 		}
 
-		member := value.FieldByName(field.Name)
+		member := value.FieldByIndex(field.Index)
 		err := unmarshalAny(member, mapData[name], field.Tag)
 		if err != nil {
 			return err


### PR DESCRIPTION
Most of these changes are cribbed from the json encoder in the standard library. About a 30% decrease in allocations and cpu usage. We're still pretty far off from the stdlib json encoder performance, we'll probably have to implement some of their caching strategies to avoid reflections if we want to make up that gap.

```
PASS
BenchmarkBuildJSON-4 	  100000	     20332 ns/op	    4649 B/op	     141 allocs/op
BenchmarkStdlibJSON-4	  200000	      7260 ns/op	    1200 B/op	      13 allocs/op
ok  	github.com/aws/aws-sdk-go/internal/protocol/json/jsonutil	3.777s
```

```
PASS
BenchmarkBuildJSON-4 	  100000	     12625 ns/op	    1936 B/op	      94 allocs/op
BenchmarkStdlibJSON-4	  200000	      7149 ns/op	    1200 B/op	      13 allocs/op
ok  	github.com/aws/aws-sdk-go/internal/protocol/json/jsonutil	2.933s
```