### PR TITLE
retry on 400 RequestTimeout

### DIFF
--- a/aws/request/retryer.go
+++ b/aws/request/retryer.go
@@ -19,6 +19,7 @@ type Retryer interface {
 // without any further action.
 var retryableCodes = map[string]struct{}{
 	"RequestError":                           {},
+	"RequestTimeout":                         {},
 	"ProvisionedThroughputExceededException": {},
 	"Throttling":                             {},
 	"ThrottlingException":                    {},


### PR DESCRIPTION
I sometimes get "Your socket connection to the server was not read
from or written to within the timeout period. Idle connections
will be closed."

Seems like these errors should be automatically retried.