### PR TITLE
Integer division truncation undersizes Parts

### DIFF
--- a/service/s3/s3manager/upload.go
+++ b/service/s3/s3manager/upload.go
@@ -322,7 +322,7 @@ func (u *uploader) initSize() {
 
 		// try to adjust partSize if it is too small
 		if u.totalSize/u.opts.PartSize >= int64(MaxUploadParts) {
-			u.opts.PartSize = u.totalSize / int64(MaxUploadParts)
+			u.opts.PartSize = (u.totalSize / int64(MaxUploadParts)) + 1
 		}
 	}
 }

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -166,7 +166,7 @@ func TestUploadIncreasePartSize(t *testing.T) {
 
 	// Part lengths
 	assert.Equal(t, (1024*1024*6) + 1, buflen(val((*args)[1], "Body")))
-	assert.Equal(t, (1024*1024*6) + 1, buflen(val((*args)[2], "Body")))
+	assert.Equal(t, (1024*1024*6) - 1, buflen(val((*args)[2], "Body")))
 }
 
 func TestUploadFailIfPartSizeTooSmall(t *testing.T) {

--- a/service/s3/s3manager/upload_test.go
+++ b/service/s3/s3manager/upload_test.go
@@ -165,8 +165,8 @@ func TestUploadIncreasePartSize(t *testing.T) {
 	assert.Equal(t, []string{"CreateMultipartUpload", "UploadPart", "UploadPart", "CompleteMultipartUpload"}, *ops)
 
 	// Part lengths
-	assert.Equal(t, 1024*1024*6, buflen(val((*args)[1], "Body")))
-	assert.Equal(t, 1024*1024*6, buflen(val((*args)[2], "Body")))
+	assert.Equal(t, (1024*1024*6) + 1, buflen(val((*args)[1], "Body")))
+	assert.Equal(t, (1024*1024*6) + 1, buflen(val((*args)[2], "Body")))
 }
 
 func TestUploadFailIfPartSizeTooSmall(t *testing.T) {


### PR DESCRIPTION
For example, existing code calculates a PartSize of 5,356,973 for a total upload size of 53,569,737,611. But that PartSize times MaxUploadParts of 10,000 equals 53,569,730,000, which is less than the original file size, resulting in a TotalPartsExceeded error. Add 1 to recapture fractional PartSize.