### PR TITLE
CloudFormation template Resource has optional attributes

### DIFF
--- a/service/cloudformation/template/template.go
+++ b/service/cloudformation/template/template.go
@@ -49,6 +49,11 @@ type Resource struct {
 	Type       string
 	Properties map[string]interface{}
 	Metadata   map[string]interface{} `json:",omitempty"`
+
+	DependsOn      interface{} `json:",omitempty"`
+	CreationPolicy interface{} `json:",omitempty"`
+	UpdatePolicy   interface{} `json:",omitempty"`
+	DeletionPolicy interface{} `json:",omitempty"`
 }
 
 // Output defines a CloudFormation template output


### PR DESCRIPTION
My motivation here is [`DependsOn`](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html).  I added the other ones for completeness, but I'm unfamiliar with them.

[Docs here.](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-product-attribute-reference.html)