### PR TITLE
service/dynamodb: hook up custom retryer

### DIFF
--- a/service/dynamodb/customizations.go
+++ b/service/dynamodb/customizations.go
@@ -26,9 +26,13 @@ func (d retryer) RetryRules(r *request.Request) time.Duration {
 
 func init() {
 	initClient = func(c *client.Client) {
+		r := retryer{}
 		if c.Config.MaxRetries == nil || aws.IntValue(c.Config.MaxRetries) == aws.UseServiceDefaultRetries {
-			c.Retryer = client.DefaultRetryer{NumMaxRetries: 10}
+			r.NumMaxRetries = 10
+		} else {
+			r.NumMaxRetries = *c.Config.MaxRetries
 		}
+		c.Retryer = r
 
 		c.Handlers.Build.PushBack(disableCompression)
 		c.Handlers.Unmarshal.PushFront(validateCRC32)


### PR DESCRIPTION
I noticed that there was a custom `retryer` type for `dynamodb` but it wasn't hooked up. This hooks it up.

Not sure if this was intentional or just an oversight.