### PR TITLE
private/protocol/json/jsonutil: reduce build allocs

### DIFF
--- a/private/protocol/json/jsonutil/build.go
+++ b/private/protocol/json/jsonutil/build.go
@@ -84,11 +84,12 @@ func buildStruct(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) 
 	t := value.Type()
 	first := true
 	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		member := value.FieldByIndex(field.Index)
+		member := value.Field(i)
 		if (member.Kind() == reflect.Ptr || member.Kind() == reflect.Slice || member.Kind() == reflect.Map) && member.IsNil() {
 			continue // ignore unset fields
 		}
+
+		field := t.Field(i)
 		if field.PkgPath != "" {
 			continue // ignore unexported fields
 		}


### PR DESCRIPTION
More work on https://github.com/aws/aws-sdk-go/issues/377

Avoids fetching a field if its value is empty. There are many cases
where most fields will be empty. For example, `dynamodb.AttributeValue`.

```
benchmark                 old ns/op     new ns/op     delta
BenchmarkBuildJSON-4      8942          7807          -12.69%

benchmark                 old allocs     new allocs     delta
BenchmarkBuildJSON-4      58             45             -22.41%

benchmark                 old bytes     new bytes     delta
BenchmarkBuildJSON-4      1344          1136          -15.48%
```