### PR TITLE
private/protocol/json: cache SDKShapeTraits tag

### DIFF
--- a/private/protocol/json/jsonutil/build.go
+++ b/private/protocol/json/jsonutil/build.go
@@ -50,10 +50,7 @@ func buildAny(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) err
 
 	switch t {
 	case "structure":
-		if field, ok := vtype.FieldByName("SDKShapeTraits"); ok {
-			tag = field.Tag
-		}
-		return buildStruct(value, buf, tag)
+		return buildStruct(value, buf, cachedPayloadTag(vtype))
 	case "list":
 		return buildList(value, buf, tag)
 	case "map":
@@ -63,15 +60,13 @@ func buildAny(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) err
 	}
 }
 
-func buildStruct(value reflect.Value, buf *bytes.Buffer, tag reflect.StructTag) error {
+func buildStruct(value reflect.Value, buf *bytes.Buffer, payload string) error {
 	if !value.IsValid() {
 		return nil
 	}
 
 	// unwrap payloads
-	if payload := tag.Get("payload"); payload != "" {
-		field, _ := value.Type().FieldByName(payload)
-		tag = field.Tag
+	if payload != "" {
 		value = elemOf(value.FieldByName(payload))
 
 		if !value.IsValid() {

--- a/private/protocol/json/jsonutil/build_test.go
+++ b/private/protocol/json/jsonutil/build_test.go
@@ -31,6 +31,12 @@ type J struct {
 	D  *int64
 	F  *float64
 	T  *time.Time
+
+	metadataAttributeValue `json:"-" xml:"-"`
+}
+
+type metadataAttributeValue struct {
+	SDKShapeTraits bool `type:"structure"`
 }
 
 var jsonTests = []struct {

--- a/private/protocol/json/jsonutil/cache.go
+++ b/private/protocol/json/jsonutil/cache.go
@@ -1,0 +1,33 @@
+package jsonutil
+
+import (
+	"reflect"
+	"sync"
+)
+
+var payloadCache struct {
+	sync.RWMutex
+	m map[reflect.Type]string
+}
+
+func cachedPayloadTag(t reflect.Type) string {
+	payloadCache.RLock()
+	payload, found := payloadCache.m[t]
+	payloadCache.RUnlock()
+
+	if found {
+		return payload
+	}
+
+	if field, ok := t.FieldByName("SDKShapeTraits"); ok {
+		payloadCache.Lock()
+		if payloadCache.m == nil {
+			payloadCache.m = map[reflect.Type]string{}
+		}
+		payload = field.Tag.Get("payload")
+		payloadCache.m[t] = payload
+		payloadCache.Unlock()
+	}
+
+	return payload
+}

--- a/private/protocol/json/jsonutil/unmarshal.go
+++ b/private/protocol/json/jsonutil/unmarshal.go
@@ -56,10 +56,7 @@ func unmarshalAny(value reflect.Value, data interface{}, tag reflect.StructTag) 
 
 	switch t {
 	case "structure":
-		if field, ok := vtype.FieldByName("SDKShapeTraits"); ok {
-			tag = field.Tag
-		}
-		return unmarshalStruct(value, data, tag)
+		return unmarshalStruct(value, data, cachedPayloadTag(vtype))
 	case "list":
 		return unmarshalList(value, data, tag)
 	case "map":
@@ -69,7 +66,7 @@ func unmarshalAny(value reflect.Value, data interface{}, tag reflect.StructTag) 
 	}
 }
 
-func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTag) error {
+func unmarshalStruct(value reflect.Value, data interface{}, payload string) error {
 	if data == nil {
 		return nil
 	}
@@ -91,7 +88,7 @@ func unmarshalStruct(value reflect.Value, data interface{}, tag reflect.StructTa
 	}
 
 	// unwrap any payloads
-	if payload := tag.Get("payload"); payload != "" {
+	if payload != "" {
 		field, _ := t.FieldByName(payload)
 		return unmarshalAny(value.FieldByName(payload), data, field.Tag)
 	}


### PR DESCRIPTION
More work on https://github.com/aws/aws-sdk-go/issues/377

The `reflect.FieldByName` call is expensive. This caches that lookup.

Benchmark (with SDKShapeTraits field) to capture the cost of this call:

```
benchmark                 old ns/op     new ns/op     delta
BenchmarkBuildJSON-4      15180         9690          -36.17%

benchmark                 old allocs     new allocs     delta
BenchmarkBuildJSON-4      98             62             -36.73%

benchmark                 old bytes     new bytes     delta
BenchmarkBuildJSON-4      3136          1408          -55.10%
```

A downside of using a global cache like this is that it will stay around taking up memory even if the process will never (un)marshal that type again. At least in this case the cache is bounded to types with a `SDKShapeTraits` field.

Another (more invasive?) solution would be to have the (un)marshal handlers own the cache so it can be garbage collected when a client is no longer referenced. But this could lead to a duplication of the cache if there are multiple client instances for a service.