### PR TITLE
Use custom unmarshalError handler for Route53

### DIFF
--- a/aws/awserr/error.go
+++ b/aws/awserr/error.go
@@ -103,3 +103,20 @@ type RequestFailure interface {
 func NewRequestFailure(err Error, statusCode int, reqID string) RequestFailure {
 	return newRequestError(err, statusCode, reqID)
 }
+
+// A BatchedErrors is an interface to extract the list of errors that caused a
+// batch call to fail.
+type BatchedErrors interface {
+	Error
+
+	// The status code of the HTTP response.
+	StatusCode() int
+
+	// Errors returns the list of errors that caused the call to fail.
+	Errors() []Error
+}
+
+// NewBatchedErrors returns a new batched errors wrapper for the given errors.
+func NewBatchedErrors(code string, statusCode int, errors []Error) BatchedErrors {
+	return newBatchedErrors(code, statusCode, errors)
+}

--- a/service/route53/service.go
+++ b/service/route53/service.go
@@ -62,7 +62,9 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 	svc.Handlers.Build.PushBack(restxml.Build)
 	svc.Handlers.Unmarshal.PushBack(restxml.Unmarshal)
 	svc.Handlers.UnmarshalMeta.PushBack(restxml.UnmarshalMeta)
-	svc.Handlers.UnmarshalError.PushBack(restxml.UnmarshalError)
+
+	// Route53 uses a custom error parser
+	svc.Handlers.UnmarshalError.PushBack(unmarshalError)
 
 	// Run custom client initialization if present
 	if initClient != nil {

--- a/service/route53/unmarshal_error.go
+++ b/service/route53/unmarshal_error.go
@@ -1,0 +1,81 @@
+package route53
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io/ioutil"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/private/protocol/restxml"
+)
+
+type baseXMLErrorResponse struct {
+	XMLName xml.Name
+}
+
+type standardXMLErrorResponse struct {
+	XMLName   xml.Name `xml:"ErrorResponse"`
+	Code      string   `xml:"Error>Code"`
+	Message   string   `xml:"Error>Message"`
+	RequestID string   `xml:"RequestId"`
+}
+
+type invalidChangeBatchXMLErrorResponse struct {
+	XMLName  xml.Name `xml:"InvalidChangeBatch"`
+	Messages []string `xml:"Messages>Message"`
+}
+
+func unmarshalError(r *request.Request) {
+	switch r.Operation.Name {
+	case opChangeResourceRecordSets:
+		unmarshalChangeResourceRecordSetsError(r)
+	default:
+		restxml.UnmarshalError(r)
+	}
+}
+
+func unmarshalChangeResourceRecordSetsError(r *request.Request) {
+	defer r.HTTPResponse.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(r.HTTPResponse.Body)
+
+	if err != nil {
+		r.Error = awserr.New("SerializationError", "failed to read Route53 XML error response", err)
+		return
+	}
+
+	baseError := &baseXMLErrorResponse{}
+
+	if err := xml.Unmarshal(responseBody, baseError); err != nil {
+		r.Error = awserr.New("SerializationError", "failed to decode Route53 XML error response", err)
+		return
+	}
+
+	switch baseError.XMLName.Local {
+	case "InvalidChangeBatch":
+		unmarshalInvalidChangeBatchError(r, responseBody)
+	default:
+		r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewReader(responseBody))
+		restxml.UnmarshalError(r)
+	}
+}
+
+func unmarshalInvalidChangeBatchError(r *request.Request, requestBody []byte) {
+	resp := &invalidChangeBatchXMLErrorResponse{}
+	err := xml.Unmarshal(requestBody, resp)
+
+	if err != nil {
+		r.Error = awserr.New("SerializationError", "failed to decode query XML error response", err)
+		return
+	}
+
+	const errorCode = "InvalidChangeBatch"
+	errors := []awserr.Error{}
+
+	for _, msg := range resp.Messages {
+		errors = append(errors, awserr.New(errorCode, msg, nil))
+	}
+
+	r.Error = awserr.NewBatchedErrors(errorCode, r.HTTPResponse.StatusCode, errors)
+}

--- a/service/route53/unmarshal_error_test.go
+++ b/service/route53/unmarshal_error_test.go
@@ -1,0 +1,98 @@
+package route53_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/awstesting/unit"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+func makeClientWithResponse(response string) *route53.Route53 {
+	r := route53.New(unit.Session)
+	r.Handlers.Send.Clear()
+	r.Handlers.Send.PushBack(func(r *request.Request) {
+		body := ioutil.NopCloser(bytes.NewReader([]byte(response)))
+		r.HTTPResponse = &http.Response{
+			ContentLength: int64(len(response)),
+			StatusCode:    400,
+			Status:        "Bad Request",
+			Body:          body,
+		}
+	})
+
+	return r
+}
+
+func TestUnmarshalStandardError(t *testing.T) {
+	const errorResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Error>
+    <Code>InvalidDomainName</Code>
+    <Message>The domain name is invalid</Message>
+  </Error>
+  <RequestId>12345</RequestId>
+</ErrorResponse>
+`
+
+	r := makeClientWithResponse(errorResponse)
+
+	_, err := r.CreateHostedZone(&route53.CreateHostedZoneInput{
+		CallerReference: aws.String("test"),
+		Name:            aws.String("test_zone"),
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, "InvalidDomainName", err.(awserr.Error).Code())
+	assert.Equal(t, "The domain name is invalid", err.(awserr.Error).Message())
+}
+
+func TestUnmarshalInvalidChangeBatch(t *testing.T) {
+	const errorMessage = `
+Tried to create resource record set duplicate.example.com. type A,
+but it already exists
+`
+	const errorResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<InvalidChangeBatch xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Messages>
+    <Message>` + errorMessage + `</Message>
+  </Messages>
+</InvalidChangeBatch>
+`
+
+	r := makeClientWithResponse(errorResponse)
+
+	req := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String("zoneId"),
+		ChangeBatch: &route53.ChangeBatch{
+			Changes: []*route53.Change{
+				&route53.Change{
+					Action: aws.String("CREATE"),
+					ResourceRecordSet: &route53.ResourceRecordSet{
+						Name: aws.String("domain"),
+						Type: aws.String("CNAME"),
+						TTL:  aws.Int64(120),
+						ResourceRecords: []*route53.ResourceRecord{
+							{
+								Value: aws.String("cname"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := r.ChangeResourceRecordSets(req)
+
+	assert.Error(t, err)
+	assert.Equal(t, "InvalidChangeBatch", err.(awserr.BatchedErrors).Code())
+	assert.Equal(t, errorMessage+"\n", err.(awserr.BatchedErrors).Message())
+}


### PR DESCRIPTION
Certains Route53 calls like ChangeResourceRecordSets will return
specific error types, so we need a custom handler to take those into
account.


Open questions:
- The current `awserr.Error` type doesn't account for "composite" errors, so for now I just join the messages with \n... Is there a better way to solve that issue?
- Due to the API of private/protocol/query, I had to copy paste the unmarshalling for standard XML errors. One option would be to add a `UnmarshalErrorFromData(statusCode int, body []byte) error` function there.